### PR TITLE
MCP server: switch to SSE transport on port 5001

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,3 +59,6 @@ jobs:
 
       - name: Restart bot service
         run: sudo systemctl restart tether-bot
+
+      - name: Restart MCP service
+        run: sudo systemctl restart tether-mcp

--- a/systemd/tether-mcp.service
+++ b/systemd/tether-mcp.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Tether MCP SSE Server
+After=network.target
+
+[Service]
+Type=simple
+User=toast
+WorkingDirectory=/home/toast/tether
+ExecStart=/home/toast/tether/.venv/bin/python -m tether_mcp.server --sse
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/tether_mcp/claude_mcp_config.json
+++ b/tether_mcp/claude_mcp_config.json
@@ -1,12 +1,8 @@
 {
   "mcpServers": {
     "tether": {
-      "command": "/home/toast/tether/.venv/bin/python",
-      "args": ["-m", "tether_mcp.server"],
-      "cwd": "/home/toast/tether",
-      "env": {
-        "TETHER_DB_PATH": "/home/toast/.tether-config/tether.db"
-      }
+      "type": "sse",
+      "url": "http://raspberrypi:5001/sse"
     }
   }
 }

--- a/tether_mcp/server.py
+++ b/tether_mcp/server.py
@@ -113,4 +113,13 @@ def get_current_anchor() -> dict:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sse", action="store_true", help="Run as SSE server (for network access)")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=5001)
+    args = parser.parse_args()
+    if args.sse:
+        mcp.run(transport="sse", host=args.host, port=args.port)
+    else:
+        mcp.run()


### PR DESCRIPTION
## Summary

- MCP server now supports `--sse` flag to run as an HTTP SSE server (port 5001 by default)
- `systemd/tether-mcp.service` runs it as a daemon on the Pi
- `claude_mcp_config.json` updated to `type: sse, url: http://raspberrypi:5001/sse`
- deploy.yml restarts tether-mcp on every push to main

## After merge — Pi setup

```bash
sudo cp systemd/tether-mcp.service /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl enable --now tether-mcp
```

## Laptop ~/.claude/mcp.json

```json
{
  "mcpServers": {
    "tether": {
      "type": "sse",
      "url": "http://raspberrypi:5001/sse"
    }
  }
}
```