### PR TITLE
fix: deploy workflow absolute paths

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,11 +10,12 @@ jobs:
     steps:
       - name: Pull latest code
         run: |
-          cd ${{ github.workspace }}
+          cd /home/toast/tether
           git pull origin main
 
       - name: Install Python dependencies
         run: |
+          cd /home/toast/tether
           source .venv/bin/activate
           pip install -q -e .
 
@@ -45,12 +46,13 @@ jobs:
 
       - name: Verify bot can run
         run: |
+          cd /home/toast/tether
           source .venv/bin/activate
           python -c "from bot.anchor_trigger import load_anchors; print('[ok] imports work')"
 
       - name: Build Vue frontend
         run: |
-          cd frontend
+          cd /home/toast/tether/frontend
           npm ci
           npm run build
 


### PR DESCRIPTION
The self-hosted runner's `\${{ github.workspace }}` resolves to the runner workspace directory, not `/home/toast/tether` where the services actually run. All steps now use absolute paths.