### PR TITLE
fix: activate venv in secrets step (ModuleNotFoundError: yaml)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Write Telegram secrets to config
         run: |
+          cd /home/toast/tether
+          source .venv/bin/activate
           python3 - <<'EOF'
           import yaml, os
           from pathlib import Path


### PR DESCRIPTION
System python3 doesn't have pyyaml. Activate the venv first.