### PR TITLE
fix: MCP SSE server crash — port in constructor not run()

### DIFF
--- a/tether_mcp/server.py
+++ b/tether_mcp/server.py
@@ -15,7 +15,7 @@ from db.queries import (
     upsert_tasks,
 )
 
-mcp = FastMCP("tether")
+mcp = FastMCP("tether", port=5001)
 
 
 def _db() -> Path:
@@ -116,10 +116,5 @@ if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument("--sse", action="store_true", help="Run as SSE server (for network access)")
-    parser.add_argument("--host", default="0.0.0.0")
-    parser.add_argument("--port", type=int, default=5001)
     args = parser.parse_args()
-    if args.sse:
-        mcp.run(transport="sse", host=args.host, port=args.port)
-    else:
-        mcp.run()
+    mcp.run(transport="sse" if args.sse else "stdio")


### PR DESCRIPTION
FastMCP.run() does not accept host/port kwargs. Pass port=5001 to FastMCP() constructor instead and simplify the __main__ block.