### PR TITLE
feat: structured JSON output for bot DB mutations

### DIFF
--- a/bot/message_handler.py
+++ b/bot/message_handler.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
+import json
 import logging
+import re
 import subprocess
 import time
 from datetime import date as date_type
@@ -20,6 +22,7 @@ from db.queries import (
     get_context_entries,
     get_plan,
     insert_check_in,
+    patch_anchor,
     upsert_context_entry,
     upsert_plan,
     upsert_tasks,
@@ -43,6 +46,46 @@ def load_config() -> dict:
 def call_claude(prompt: str) -> str:
     result = subprocess.run(["claude", "-p", prompt], capture_output=True, text=True, check=True)
     return result.stdout.strip()
+
+
+def parse_claude_response(raw: str) -> tuple[str, list[dict]]:
+    """Extract message and mutations from Claude's JSON response.
+    Falls back to treating raw output as the message with no mutations."""
+    try:
+        data = json.loads(raw.strip())
+        return data.get("message", raw), data.get("mutations", [])
+    except (json.JSONDecodeError, AttributeError):
+        pass
+    match = re.search(r'\{.*\}', raw, re.DOTALL)
+    if match:
+        try:
+            data = json.loads(match.group())
+            return data.get("message", raw), data.get("mutations", [])
+        except (json.JSONDecodeError, AttributeError):
+            pass
+    return raw, []
+
+
+def apply_mutations(mutations: list[dict], db_path: Path, today: str) -> None:
+    for m in mutations:
+        op = m.get("op")
+        try:
+            if op == "update_anchor":
+                fields = {k: v for k, v in m.items() if k not in ("op", "anchor_id")}
+                patch_anchor(db_path, m["anchor_id"], **fields)
+            elif op == "update_plan_tasks":
+                date = m.get("date", today)
+                upsert_plan(db_path, date)
+                upsert_tasks(db_path, date, m["anchor_id"], m["tasks"], notes="")
+            elif op == "update_context":
+                upsert_context_entry(db_path, m["subject"], m["body"])
+            elif op == "insert_check_in":
+                insert_check_in(db_path, today, m["anchor_id"],
+                                m["accomplished"], m["current_status"])
+            else:
+                logger.warning("Unknown mutation op: %s", op)
+        except Exception as e:
+            logger.error("Failed to apply mutation %s: %s", m, e)
 
 
 def _build_prompt(user_message: str, db_path: Path) -> str:
@@ -89,8 +132,10 @@ def handle_message(text: str) -> str:
         upsert_plan(db_path, today)
         upsert_tasks(db_path, today, anchor_id, tasks, notes="")
 
-    prompt = _build_prompt(text, db_path)
-    return call_claude(prompt)
+    raw = call_claude(_build_prompt(text, db_path))
+    message, mutations = parse_claude_response(raw)
+    apply_mutations(mutations, db_path, today)
+    return message
 
 
 def _send_telegram(token: str, chat_id: str, text: str) -> None:

--- a/db/queries.py
+++ b/db/queries.py
@@ -95,6 +95,21 @@ def delete_context_entry(db_path: Path, subject: str) -> None:
         conn.execute("DELETE FROM context_entries WHERE subject=?", (subject,))
 
 
+def patch_anchor(db_path: Path, anchor_id: str, **fields) -> None:
+    """Update only the provided fields on an existing anchor."""
+    allowed = {"name", "time", "duration_minutes", "flexibility", "strictness", "color"}
+    updates = {k: v for k, v in fields.items() if k in allowed}
+    if not updates:
+        return
+    with get_db(db_path) as conn:
+        row = conn.execute("SELECT * FROM anchors WHERE id=?", (anchor_id,)).fetchone()
+        if not row:
+            raise ValueError(f"Anchor {anchor_id!r} not found")
+        anchor = dict(row)
+    anchor.update(updates)
+    upsert_anchor(db_path, anchor)
+
+
 def insert_check_in(db_path: Path, date: str, anchor_id: str,
                     accomplished: str, current_status: str) -> None:
     now = datetime.now(timezone.utc).isoformat(timespec="seconds")

--- a/prompts/message_handler.md
+++ b/prompts/message_handler.md
@@ -32,3 +32,27 @@ Respond helpfully and briefly. Rules:
 3. End every response with one clear next action.
 4. If you haven't heard from the user in 90+ minutes, proactively request a check-in.
 5. Use /check-in, /what-now, /update-plan to structure your suggestions when relevant.
+
+---
+
+## Output Format
+
+Always respond with a JSON object. Never return plain text.
+
+```json
+{
+  "message": "The text to send the user.",
+  "mutations": []
+}
+```
+
+If the user asks you to change their schedule or data, include the operations in `mutations`. Supported ops:
+
+- `{"op": "update_anchor", "anchor_id": "...", "time": "HH:MM"}` — change an anchor's start time
+- `{"op": "update_anchor", "anchor_id": "...", "duration_minutes": 90}` — change duration
+- `{"op": "update_anchor", "anchor_id": "...", "name": "...", "color": "#rrggbb", "flexibility": "locked|flexible|soft"}` — change other fields
+- `{"op": "update_plan_tasks", "anchor_id": "...", "tasks": ["task 1", "task 2"]}` — replace today's tasks for an anchor
+- `{"op": "update_context", "subject": "...", "body": "..."}` — upsert a context entry
+- `{"op": "insert_check_in", "anchor_id": "...", "accomplished": "...", "current_status": "..."}` — log a check-in
+
+Only include mutations when the user explicitly asks for a change. For normal conversation, return `"mutations": []`.

--- a/tests/bot/test_message_handler.py
+++ b/tests/bot/test_message_handler.py
@@ -1,9 +1,10 @@
+import json
 import pytest
 from datetime import date
 from unittest.mock import patch
 from pathlib import Path
 from db.schema import init_db
-from db.queries import upsert_anchor, upsert_plan, upsert_tasks, upsert_context_entry
+from db.queries import get_anchors, upsert_anchor, upsert_plan, upsert_tasks, upsert_context_entry
 
 TODAY = str(date.today())
 
@@ -23,11 +24,41 @@ def db_path(tmp_path):
 
 def test_handle_message_calls_claude_and_returns_text(db_path):
     from bot.message_handler import handle_message
-    with patch("bot.message_handler.call_claude", return_value="Focus on job apps.") as mock_claude:
+    response = json.dumps({"message": "Focus on job apps.", "mutations": []})
+    with patch("bot.message_handler.call_claude", return_value=response) as mock_claude:
         with patch("bot.message_handler.DB_PATH", db_path):
             result = handle_message("Hello, what should I do?")
     mock_claude.assert_called_once()
     assert result == "Focus on job apps."
+
+
+def test_parse_claude_response_valid_json():
+    from bot.message_handler import parse_claude_response
+    raw = json.dumps({"message": "Got it.", "mutations": [{"op": "update_context", "subject": "X", "body": "Y"}]})
+    message, mutations = parse_claude_response(raw)
+    assert message == "Got it."
+    assert mutations == [{"op": "update_context", "subject": "X", "body": "Y"}]
+
+
+def test_parse_claude_response_plain_text_fallback():
+    from bot.message_handler import parse_claude_response
+    message, mutations = parse_claude_response("Just a plain reply.")
+    assert message == "Just a plain reply."
+    assert mutations == []
+
+
+def test_handle_message_applies_anchor_mutation(db_path):
+    from bot.message_handler import handle_message
+    response = json.dumps({
+        "message": "Moved grind block to 9am.",
+        "mutations": [{"op": "update_anchor", "anchor_id": "grind_am", "time": "09:00"}],
+    })
+    with patch("bot.message_handler.call_claude", return_value=response):
+        with patch("bot.message_handler.DB_PATH", db_path):
+            result = handle_message("Move my grind block to 9am")
+    assert result == "Moved grind block to 9am."
+    anchors = {a["id"]: a for a in get_anchors(db_path)}
+    assert anchors["grind_am"]["time"] == "09:00"
 
 
 def test_handle_check_in_inserts_db_row(db_path):


### PR DESCRIPTION
Closes #13.

## What changed
Instead of requiring `--dangerously-skip-permissions` for Claude to edit schedules, the bot now uses a structured JSON response envelope:

\`\`\`json
{"message": "Moved grind block to 9am.", "mutations": [{"op": "update_anchor", "anchor_id": "grind_am", "time": "09:00"}]}
\`\`\`

Python parses the mutations and applies them directly to the DB. No tool access needed.

## Supported mutation ops
- `update_anchor` — patch any field on an anchor definition (time, duration, name, color, flexibility)
- `update_plan_tasks` — replace today's tasks for an anchor
- `update_context` — upsert a context entry
- `insert_check_in` — log a check-in

## Changes
- `db/queries.py` — add `patch_anchor()` for partial anchor updates
- `prompts/message_handler.md` — add JSON output schema and op definitions
- `bot/message_handler.py` — add `parse_claude_response()`, `apply_mutations()`, update `handle_message()`
- `tests/bot/test_message_handler.py` — add tests for JSON parsing, fallback, and anchor mutation