### PR TITLE
feat: LLM abstraction layer (Phase 1)

### DIFF
--- a/bot/llm.py
+++ b/bot/llm.py
@@ -1,0 +1,356 @@
+"""LLM abstraction layer for Tether v3.
+
+Provides a vendor-agnostic interface for LLM completions.
+LLMRouter selects the best available backend at startup with
+PipelineBackend (claude -p) always available as fallback.
+"""
+import os
+import json
+import time
+import subprocess
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CREDENTIALS_PATH = os.path.expanduser("~/.claude/.credentials.json")
+
+
+@dataclass
+class ToolCall:
+    id: str
+    name: str
+    input: dict
+
+
+@dataclass
+class LLMResponse:
+    content: str
+    tool_calls: list[ToolCall]
+    stop_reason: str        # "end_turn" | "tool_use" | "max_tokens"
+    input_tokens: int
+    output_tokens: int
+
+
+class LLMBackend(ABC):
+    @abstractmethod
+    async def complete(
+        self,
+        messages: list[dict],
+        system: str | list[str],
+        model: str,
+        tools: list[dict] | None = None,
+        thinking: bool = False,
+        thinking_budget: int = 8000,
+        max_tokens: int = 8096,
+    ) -> LLMResponse: ...
+
+    @abstractmethod
+    def is_available(self) -> bool: ...
+
+
+# ---------------------------------------------------------------------------
+# PipelineBackend — always available, wraps claude -p subprocess
+# ---------------------------------------------------------------------------
+
+class PipelineBackend(LLMBackend):
+    """Invokes claude -p as a subprocess. Always available as fallback."""
+
+    def is_available(self) -> bool:
+        return True
+
+    async def complete(
+        self,
+        messages: list[dict],
+        system: str | list[str],
+        model: str,
+        tools: list[dict] | None = None,
+        thinking: bool = False,
+        thinking_budget: int = 8000,
+        max_tokens: int = 8096,
+    ) -> LLMResponse:
+        # Collapse messages into a single prompt string for -p mode
+        prompt_parts = []
+        if isinstance(system, list):
+            prompt_parts.append("\n".join(system))
+        else:
+            prompt_parts.append(system)
+        for msg in messages:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+            prompt_parts.append(f"\n[{role}]\n{content}")
+        prompt = "\n".join(prompt_parts)
+
+        cmd = ["claude", "-p", "--strict-mcp-config", "--model", model, prompt]
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=180)
+        return LLMResponse(
+            content=result.stdout.strip(),
+            tool_calls=[],
+            stop_reason="end_turn",
+            input_tokens=0,
+            output_tokens=0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# AnthropicBackend — native tool_use via SDK, OAuth or API key
+# ---------------------------------------------------------------------------
+
+class AnthropicBackend(LLMBackend):
+    """Uses the Anthropic Python SDK. Prefers OAuth subscription billing,
+    falls back to ANTHROPIC_API_KEY env var."""
+
+    def __init__(self, credentials_path: str = _DEFAULT_CREDENTIALS_PATH):
+        self._credentials_path = credentials_path
+
+    def _read_oauth_token(self) -> str | None:
+        try:
+            with open(self._credentials_path) as f:
+                data = json.load(f)
+            oauth = data.get("claudeAiOauth", {})
+            expires_at_ms = oauth.get("expiresAt", 0)
+            # Require 5-minute buffer before expiry
+            if time.time() * 1000 < expires_at_ms - 300_000:
+                return oauth.get("accessToken")
+        except (FileNotFoundError, json.JSONDecodeError, KeyError):
+            pass
+        return None
+
+    def is_available(self) -> bool:
+        if self._read_oauth_token():
+            return True
+        return bool(os.environ.get("ANTHROPIC_API_KEY"))
+
+    async def complete(
+        self,
+        messages: list[dict],
+        system: str | list[str],
+        model: str,
+        tools: list[dict] | None = None,
+        thinking: bool = False,
+        thinking_budget: int = 8000,
+        max_tokens: int = 8096,
+    ) -> LLMResponse:
+        import anthropic
+        from bot.llm_adapters import to_anthropic_schema
+
+        oauth_token = self._read_oauth_token()
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+
+        if oauth_token:
+            client = anthropic.Anthropic(
+                auth_token=oauth_token,
+                default_headers={"anthropic-beta": "oauth-2025-04-20"},
+            )
+        else:
+            client = anthropic.Anthropic(api_key=api_key)
+
+        kwargs: dict = dict(
+            model=model,
+            max_tokens=max_tokens,
+            system=system if isinstance(system, str) else "\n".join(system),
+            messages=messages,
+        )
+        if tools:
+            kwargs["tools"] = [to_anthropic_schema(t) for t in tools]
+        if thinking:
+            kwargs["thinking"] = {"type": "enabled", "budget_tokens": thinking_budget}
+            kwargs.setdefault("betas", [])
+            kwargs["betas"].append("interleaved-thinking-2025-05-14")
+
+        response = client.messages.create(**kwargs)
+
+        content_text = ""
+        tool_calls = []
+        for block in response.content:
+            if block.type == "text":
+                content_text += block.text
+            elif block.type == "tool_use":
+                tool_calls.append(ToolCall(
+                    id=block.id,
+                    name=block.name,
+                    input=block.input,
+                ))
+
+        return LLMResponse(
+            content=content_text,
+            tool_calls=tool_calls,
+            stop_reason=response.stop_reason,
+            input_tokens=response.usage.input_tokens,
+            output_tokens=response.usage.output_tokens,
+        )
+
+
+# ---------------------------------------------------------------------------
+# OpenAIBackend — OpenAI-compatible API
+# ---------------------------------------------------------------------------
+
+class OpenAIBackend(LLMBackend):
+    def __init__(self, api_key: str | None = None, base_url: str | None = None):
+        self._api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        self._base_url = base_url
+
+    def is_available(self) -> bool:
+        return bool(self._api_key)
+
+    async def complete(
+        self,
+        messages: list[dict],
+        system: str | list[str],
+        model: str,
+        tools: list[dict] | None = None,
+        thinking: bool = False,
+        thinking_budget: int = 8000,
+        max_tokens: int = 8096,
+    ) -> LLMResponse:
+        import openai
+        from bot.llm_adapters import to_openai_schema
+
+        system_text = system if isinstance(system, str) else "\n".join(system)
+        full_messages = [{"role": "system", "content": system_text}] + messages
+
+        kwargs: dict = dict(
+            model=model,
+            max_tokens=max_tokens,
+            messages=full_messages,
+        )
+        if self._base_url:
+            client = openai.AsyncOpenAI(api_key=self._api_key, base_url=self._base_url)
+        else:
+            client = openai.AsyncOpenAI(api_key=self._api_key)
+
+        if tools:
+            kwargs["tools"] = [to_openai_schema(t) for t in tools]
+
+        response = await client.chat.completions.create(**kwargs)
+        msg = response.choices[0].message
+
+        tool_calls = []
+        if msg.tool_calls:
+            for tc in msg.tool_calls:
+                tool_calls.append(ToolCall(
+                    id=tc.id,
+                    name=tc.function.name,
+                    input=json.loads(tc.function.arguments),
+                ))
+
+        return LLMResponse(
+            content=msg.content or "",
+            tool_calls=tool_calls,
+            stop_reason=response.choices[0].finish_reason or "end_turn",
+            input_tokens=response.usage.prompt_tokens if response.usage else 0,
+            output_tokens=response.usage.completion_tokens if response.usage else 0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# OpenRouterBackend — OpenAI-compatible, different base URL + API key env
+# ---------------------------------------------------------------------------
+
+class OpenRouterBackend(OpenAIBackend):
+    def __init__(self, api_key: str | None = None):
+        super().__init__(
+            api_key=api_key or os.environ.get("OPENROUTER_API_KEY"),
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+    def is_available(self) -> bool:
+        return bool(self._api_key)
+
+
+# ---------------------------------------------------------------------------
+# AWSBedrockBackend — via boto3 bedrock-runtime, ambient AWS credentials
+# ---------------------------------------------------------------------------
+
+class AWSBedrockBackend(LLMBackend):
+    def __init__(self, region: str = "us-east-1"):
+        self._region = region
+
+    def is_available(self) -> bool:
+        try:
+            import boto3
+            session = boto3.Session()
+            creds = session.get_credentials()
+            if creds is None:
+                return False
+            frozen = creds.get_frozen_credentials()
+            return bool(frozen.access_key)
+        except Exception:
+            return False
+
+    async def complete(
+        self,
+        messages: list[dict],
+        system: str | list[str],
+        model: str,
+        tools: list[dict] | None = None,
+        thinking: bool = False,
+        thinking_budget: int = 8000,
+        max_tokens: int = 8096,
+    ) -> LLMResponse:
+        import boto3
+        from bot.llm_adapters import to_bedrock_schema
+
+        client = boto3.client("bedrock-runtime", region_name=self._region)
+        system_text = system if isinstance(system, str) else "\n".join(system)
+
+        kwargs: dict = dict(
+            modelId=model,
+            system=[{"text": system_text}],
+            messages=messages,
+            inferenceConfig={"maxTokens": max_tokens},
+        )
+        if tools:
+            kwargs["toolConfig"] = {"tools": [to_bedrock_schema(t) for t in tools]}
+
+        response = client.converse(**kwargs)
+        output = response["output"]["message"]
+
+        content_text = ""
+        tool_calls = []
+        for block in output.get("content", []):
+            if "text" in block:
+                content_text += block["text"]
+            elif "toolUse" in block:
+                tu = block["toolUse"]
+                tool_calls.append(ToolCall(id=tu["toolUseId"], name=tu["name"], input=tu["input"]))
+
+        usage = response.get("usage", {})
+        return LLMResponse(
+            content=content_text,
+            tool_calls=tool_calls,
+            stop_reason=response["stopReason"],
+            input_tokens=usage.get("inputTokens", 0),
+            output_tokens=usage.get("outputTokens", 0),
+        )
+
+
+# ---------------------------------------------------------------------------
+# LLMRouter — selects best available backend
+# ---------------------------------------------------------------------------
+
+class LLMRouter:
+    """Picks the best available LLM backend at construction time.
+    Priority: AnthropicBackend → configured vendor → PipelineBackend.
+    """
+
+    def __init__(self, credentials_path: str = _DEFAULT_CREDENTIALS_PATH):
+        self.active_backend = self._select(credentials_path)
+
+    def _select(self, credentials_path: str) -> LLMBackend:
+        candidates: list[LLMBackend] = [
+            AnthropicBackend(credentials_path=credentials_path),
+            OpenAIBackend(),
+            OpenRouterBackend(),
+            AWSBedrockBackend(),
+            PipelineBackend(),
+        ]
+        for backend in candidates:
+            if backend.is_available():
+                logger.info("LLMRouter selected backend: %s", type(backend).__name__)
+                return backend
+        return PipelineBackend()  # unreachable — Pipeline is always available
+
+    async def complete(self, **kwargs) -> LLMResponse:
+        return await self.active_backend.complete(**kwargs)

--- a/bot/llm_adapters.py
+++ b/bot/llm_adapters.py
@@ -1,0 +1,39 @@
+"""Tool schema adapters: canonical Anthropic format → vendor-specific format.
+
+Canonical schema (Anthropic shape):
+  {
+    "name": "tool_name",
+    "description": "what it does",
+    "input_schema": { "type": "object", "properties": {...} }
+  }
+"""
+
+
+def to_anthropic_schema(tool: dict) -> dict:
+    """Pass-through — canonical IS Anthropic's format."""
+    return tool
+
+
+def to_openai_schema(tool: dict) -> dict:
+    """Convert canonical → OpenAI function-calling format."""
+    return {
+        "type": "function",
+        "function": {
+            "name": tool["name"],
+            "description": tool.get("description", ""),
+            "parameters": tool["input_schema"],
+        },
+    }
+
+
+def to_bedrock_schema(tool: dict) -> dict:
+    """Convert canonical → AWS Bedrock converse API toolSpec format."""
+    return {
+        "toolSpec": {
+            "name": tool["name"],
+            "description": tool.get("description", ""),
+            "inputSchema": {
+                "json": tool["input_schema"],
+            },
+        }
+    }

--- a/tests/bot/test_llm.py
+++ b/tests/bot/test_llm.py
@@ -1,0 +1,331 @@
+"""Tests for bot/llm.py — LLM abstraction layer."""
+import pytest
+from dataclasses import fields
+from abc import ABC
+
+
+# ---------------------------------------------------------------------------
+# Dataclass structure
+# ---------------------------------------------------------------------------
+
+class TestLLMResponseDataclass:
+    def test_has_required_fields(self):
+        from bot.llm import LLMResponse
+        field_names = {f.name for f in fields(LLMResponse)}
+        assert field_names >= {"content", "tool_calls", "stop_reason",
+                               "input_tokens", "output_tokens"}
+
+    def test_can_be_constructed(self):
+        from bot.llm import LLMResponse
+        r = LLMResponse(
+            content="hello",
+            tool_calls=[],
+            stop_reason="end_turn",
+            input_tokens=10,
+            output_tokens=5,
+        )
+        assert r.content == "hello"
+        assert r.stop_reason == "end_turn"
+        assert r.input_tokens == 10
+        assert r.output_tokens == 5
+
+
+class TestToolCallDataclass:
+    def test_has_required_fields(self):
+        from bot.llm import ToolCall
+        field_names = {f.name for f in fields(ToolCall)}
+        assert field_names >= {"id", "name", "input"}
+
+    def test_can_be_constructed(self):
+        from bot.llm import ToolCall
+        tc = ToolCall(id="call_1", name="get_plan", input={"date": "today"})
+        assert tc.id == "call_1"
+        assert tc.name == "get_plan"
+        assert tc.input == {"date": "today"}
+
+
+# ---------------------------------------------------------------------------
+# LLMBackend ABC
+# ---------------------------------------------------------------------------
+
+class TestLLMBackendABC:
+    def test_cannot_be_instantiated_directly(self):
+        from bot.llm import LLMBackend
+        with pytest.raises(TypeError):
+            LLMBackend()
+
+    def test_is_abstract_base_class(self):
+        from bot.llm import LLMBackend
+        assert issubclass(LLMBackend, ABC)
+
+    def test_complete_is_abstract(self):
+        from bot.llm import LLMBackend
+        import inspect
+        assert "complete" in LLMBackend.__abstractmethods__
+
+    def test_is_available_is_abstract(self):
+        from bot.llm import LLMBackend
+        assert "is_available" in LLMBackend.__abstractmethods__
+
+    def test_concrete_subclass_must_implement_both_methods(self):
+        from bot.llm import LLMBackend
+        class Incomplete(LLMBackend):
+            pass
+        with pytest.raises(TypeError):
+            Incomplete()
+
+
+# ---------------------------------------------------------------------------
+# PipelineBackend
+# ---------------------------------------------------------------------------
+
+class TestPipelineBackend:
+    def test_is_always_available(self):
+        from bot.llm import PipelineBackend
+        b = PipelineBackend()
+        assert b.is_available() is True
+
+    def test_complete_raises_on_missing_claude_cli(self, monkeypatch):
+        """complete() should raise RuntimeError if claude binary not found."""
+        from bot.llm import PipelineBackend
+        import subprocess
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *a, **kw: (_ for _ in ()).throw(FileNotFoundError("claude not found")),
+        )
+        b = PipelineBackend()
+        with pytest.raises((RuntimeError, FileNotFoundError)):
+            import asyncio
+            asyncio.run(b.complete(
+                messages=[{"role": "user", "content": "hi"}],
+                system="you are helpful",
+                model="claude-haiku-4-5-20251001",
+            ))
+
+    def test_complete_returns_llm_response(self, monkeypatch):
+        from bot.llm import PipelineBackend, LLMResponse
+        import subprocess
+
+        fake_result = type("R", (), {"stdout": "hello from claude\n", "returncode": 0})()
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: fake_result)
+
+        b = PipelineBackend()
+        import asyncio
+        resp = asyncio.run(b.complete(
+            messages=[{"role": "user", "content": "hi"}],
+            system="you are helpful",
+            model="claude-haiku-4-5-20251001",
+        ))
+        assert isinstance(resp, LLMResponse)
+        assert resp.content == "hello from claude"
+        assert resp.tool_calls == []
+        assert resp.stop_reason == "end_turn"
+
+
+# ---------------------------------------------------------------------------
+# AnthropicBackend
+# ---------------------------------------------------------------------------
+
+class TestAnthropicBackend:
+    def test_unavailable_when_no_token_and_no_api_key(self, monkeypatch, tmp_path):
+        from bot.llm import AnthropicBackend
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        b = AnthropicBackend(credentials_path=str(tmp_path / "nonexistent.json"))
+        assert b.is_available() is False
+
+    def test_available_when_api_key_set(self, monkeypatch, tmp_path):
+        from bot.llm import AnthropicBackend
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+        b = AnthropicBackend(credentials_path=str(tmp_path / "nonexistent.json"))
+        assert b.is_available() is True
+
+    def test_available_when_valid_credentials_file_exists(self, tmp_path):
+        import json, time
+        from bot.llm import AnthropicBackend
+        creds = {"claudeAiOauth": {
+            "accessToken": "tok",
+            "refreshToken": "ref",
+            "expiresAt": int(time.time() * 1000) + 3_600_000,  # 1h from now
+        }}
+        creds_file = tmp_path / ".credentials.json"
+        creds_file.write_text(json.dumps(creds))
+        b = AnthropicBackend(credentials_path=str(creds_file))
+        assert b.is_available() is True
+
+    def test_unavailable_when_credentials_expired(self, tmp_path, monkeypatch):
+        import json, time
+        from bot.llm import AnthropicBackend
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        creds = {"claudeAiOauth": {
+            "accessToken": "tok",
+            "refreshToken": "ref",
+            "expiresAt": int(time.time() * 1000) - 1000,  # expired
+        }}
+        creds_file = tmp_path / ".credentials.json"
+        creds_file.write_text(json.dumps(creds))
+        b = AnthropicBackend(credentials_path=str(creds_file))
+        assert b.is_available() is False
+
+
+# ---------------------------------------------------------------------------
+# OpenAI / OpenRouter backends
+# ---------------------------------------------------------------------------
+
+class TestOpenAIBackend:
+    def test_unavailable_without_api_key(self, monkeypatch):
+        from bot.llm import OpenAIBackend
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        b = OpenAIBackend()
+        assert b.is_available() is False
+
+    def test_available_with_api_key(self, monkeypatch):
+        from bot.llm import OpenAIBackend
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        b = OpenAIBackend()
+        assert b.is_available() is True
+
+    def test_available_with_explicit_key(self):
+        from bot.llm import OpenAIBackend
+        b = OpenAIBackend(api_key="sk-explicit")
+        assert b.is_available() is True
+
+
+class TestOpenRouterBackend:
+    def test_unavailable_without_api_key(self, monkeypatch):
+        from bot.llm import OpenRouterBackend
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        b = OpenRouterBackend()
+        assert b.is_available() is False
+
+    def test_available_with_api_key(self, monkeypatch):
+        from bot.llm import OpenRouterBackend
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        b = OpenRouterBackend()
+        assert b.is_available() is True
+
+
+# ---------------------------------------------------------------------------
+# AWSBedrockBackend
+# ---------------------------------------------------------------------------
+
+class TestAWSBedrockBackend:
+    def test_available_with_ambient_credentials(self):
+        import sys
+        import unittest.mock as mock
+        from bot.llm import AWSBedrockBackend
+
+        class FakeCreds:
+            def get_frozen_credentials(self):
+                class C:
+                    access_key = "AKIA"
+                return C()
+
+        class FakeSession:
+            def get_credentials(self):
+                return FakeCreds()
+
+        fake_boto3 = mock.MagicMock()
+        fake_boto3.Session.return_value = FakeSession()
+        with mock.patch.dict(sys.modules, {"boto3": fake_boto3}):
+            b = AWSBedrockBackend()
+            assert b.is_available() is True
+
+    def test_unavailable_without_credentials(self):
+        import sys
+        import unittest.mock as mock
+        from bot.llm import AWSBedrockBackend
+
+        class FakeSession:
+            def get_credentials(self):
+                return None
+
+        fake_boto3 = mock.MagicMock()
+        fake_boto3.Session.return_value = FakeSession()
+        with mock.patch.dict(sys.modules, {"boto3": fake_boto3}):
+            b = AWSBedrockBackend()
+            assert b.is_available() is False
+
+
+# ---------------------------------------------------------------------------
+# LLMRouter — backend selection
+# ---------------------------------------------------------------------------
+
+class TestLLMRouter:
+    def test_falls_back_to_pipeline_when_nothing_else_available(self, monkeypatch, tmp_path):
+        # boto3 is not installed in this env → AWSBedrockBackend.is_available() returns False
+        # via its except Exception handler, so no mocking needed
+        from bot.llm import LLMRouter, PipelineBackend
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        router = LLMRouter(credentials_path=str(tmp_path / "nope.json"))
+        assert isinstance(router.active_backend, PipelineBackend)
+
+    def test_prefers_anthropic_when_api_key_available(self, monkeypatch, tmp_path):
+        from bot.llm import LLMRouter, AnthropicBackend
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        router = LLMRouter(credentials_path=str(tmp_path / "nope.json"))
+        assert isinstance(router.active_backend, AnthropicBackend)
+
+    def test_complete_delegates_to_active_backend(self, monkeypatch, tmp_path):
+        from bot.llm import LLMRouter, LLMResponse
+        import unittest.mock as mock
+        import asyncio
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        router = LLMRouter(credentials_path=str(tmp_path / "nope.json"))
+        fake_resp = LLMResponse("hi", [], "end_turn", 1, 1)
+        async def fake_complete(**kwargs):
+            return fake_resp
+        with mock.patch.object(router.active_backend, "complete", side_effect=fake_complete):
+            result = asyncio.run(router.complete(
+                messages=[{"role": "user", "content": "hi"}],
+                system="sys",
+                model="claude-haiku-4-5-20251001",
+            ))
+        assert result.content == "hi"
+
+
+# ---------------------------------------------------------------------------
+# Tool schema adapters
+# ---------------------------------------------------------------------------
+
+class TestToolSchemaAdapters:
+    def test_to_anthropic_schema_is_identity(self):
+        """Anthropic canonical schema should pass through unchanged."""
+        from bot.llm_adapters import to_anthropic_schema
+        tool = {
+            "name": "get_plan",
+            "description": "Get today's plan",
+            "input_schema": {"type": "object", "properties": {"date": {"type": "string"}}},
+        }
+        result = to_anthropic_schema(tool)
+        assert result == tool
+
+    def test_to_openai_schema_converts_input_schema(self):
+        """OpenAI uses 'parameters' instead of 'input_schema'."""
+        from bot.llm_adapters import to_openai_schema
+        tool = {
+            "name": "get_plan",
+            "description": "Get today's plan",
+            "input_schema": {"type": "object", "properties": {"date": {"type": "string"}}},
+        }
+        result = to_openai_schema(tool)
+        assert result["type"] == "function"
+        assert result["function"]["name"] == "get_plan"
+        assert result["function"]["parameters"] == tool["input_schema"]
+        assert "input_schema" not in result["function"]
+
+    def test_to_bedrock_schema_uses_toolSpec(self):
+        """Bedrock converse API uses 'toolSpec' wrapper."""
+        from bot.llm_adapters import to_bedrock_schema
+        tool = {
+            "name": "get_plan",
+            "description": "Get today's plan",
+            "input_schema": {"type": "object", "properties": {}},
+        }
+        result = to_bedrock_schema(tool)
+        assert "toolSpec" in result
+        assert result["toolSpec"]["name"] == "get_plan"
+        assert result["toolSpec"]["inputSchema"]["json"] == tool["input_schema"]


### PR DESCRIPTION
## Summary
- `bot/llm.py`: `LLMBackend` ABC, `LLMResponse`/`ToolCall` dataclasses, 5 vendor backends (Anthropic, OpenAI, OpenRouter, Bedrock, Pipeline), `LLMRouter`
- `bot/llm_adapters.py`: canonical→vendor tool schema conversion (Anthropic pass-through, OpenAI `parameters`, Bedrock `toolSpec`)
- 29 new tests, all passing

## Test plan
- [x] 29 unit tests: dataclasses, ABC enforcement, each backend's `is_available()`, LLMRouter selection, tool schema adapters
- [x] Full regression: 215 tests pass