### PR TITLE
feat: SDK conversation loop (Phase 3)

### DIFF
--- a/bot/conversation.py
+++ b/bot/conversation.py
@@ -1,0 +1,251 @@
+"""SDK conversation loop for Tether v3.
+
+Replaces the orchestrator→meta-eval→subagent pipeline when a native
+SDK backend (AnthropicBackend, OpenAIBackend, etc.) is available.
+
+The model sees tool results before deciding the next action, eliminating
+the one-shot mutation planning problem of the old claude -p approach.
+"""
+import asyncio
+import json
+import logging
+from datetime import date
+from typing import Callable, Awaitable
+
+from bot.llm import LLMBackend, LLMResponse, LLMRouter, ToolCall
+
+logger = logging.getLogger(__name__)
+
+MAX_CONVERSATION_ROUNDS = 10
+
+
+# ---------------------------------------------------------------------------
+# System prompt assembly
+# ---------------------------------------------------------------------------
+
+def build_system_prompt(
+    anchor_name: str,
+    anchor_time: str,
+    plan_summary: str,
+    context_subjects: list[str],
+    session_notes: str | None,
+) -> str:
+    """Assemble the system prompt from modular sections.
+
+    Stable sections (identity, rules) are cheap to cache.
+    Volatile sections (anchor, plan, date) are recomputed each turn
+    but kept short so cache misses are inexpensive.
+    """
+    today = date.today().isoformat()
+    sections = []
+
+    # --- Identity + rules (stable) ---
+    sections.append(
+        "You are Tether, a daily task management assistant. "
+        "You help the user stay focused, track their plan, and manage their context. "
+        "Be concise and direct. Prefer actions over explanation."
+    )
+
+    # --- Current state (volatile) ---
+    sections.append(
+        f"Today is {today}. Current time block: {anchor_name} (starts {anchor_time})."
+    )
+
+    # --- Plan (semi-stable) ---
+    if plan_summary:
+        sections.append(f"Today's plan:\n{plan_summary}")
+
+    # --- Context index (semi-stable, subjects only — bodies fetched via tools) ---
+    if context_subjects:
+        subjects_list = "\n".join(f"  - {s}" for s in context_subjects)
+        sections.append(
+            f"Available context entries (fetch bodies with get_context_entry tool):\n{subjects_list}"
+        )
+
+    # --- Session notes (injected when available, replaces raw history) ---
+    if session_notes:
+        sections.append(f"Session Notes:\n{session_notes}")
+
+    return "\n\n".join(sections)
+
+
+# ---------------------------------------------------------------------------
+# Tool result formatting
+# ---------------------------------------------------------------------------
+
+def format_tool_result_message(
+    tool_call: ToolCall,
+    result: dict,
+    is_error: bool = False,
+) -> dict:
+    """Format a tool result as an Anthropic-style tool_result message.
+
+    Anthropic's API expects tool results as a user turn with
+    content blocks of type tool_result.
+    """
+    content_str = result.get("content", str(result))
+    return {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": tool_call.id,
+                "content": content_str,
+                "is_error": is_error,
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Core conversation loop
+# ---------------------------------------------------------------------------
+
+async def conversation_loop(
+    backend: LLMBackend,
+    messages: list[dict],
+    system: str,
+    model: str,
+    tools: list[dict],
+    tool_executor: Callable[[ToolCall], Awaitable[dict]] | None,
+    max_rounds: int = MAX_CONVERSATION_ROUNDS,
+    thinking: bool = False,
+    thinking_budget: int = 8000,
+) -> LLMResponse:
+    """Run the tool-use conversation loop until end_turn or max_rounds.
+
+    Each round:
+      1. Call the LLM backend with current messages
+      2. If stop_reason == "end_turn": return the response
+      3. If stop_reason == "tool_use": execute each tool call,
+         append assistant message + tool results, loop
+    """
+    current_messages = list(messages)
+
+    for round_num in range(max_rounds):
+        response = await backend.complete(
+            messages=current_messages,
+            system=system,
+            model=model,
+            tools=tools if tools else None,
+            thinking=thinking,
+            thinking_budget=thinking_budget,
+        )
+
+        if response.stop_reason == "end_turn" or not response.tool_calls:
+            return response
+
+        # Append the assistant's message (with tool_use blocks)
+        assistant_content = []
+        if response.content:
+            assistant_content.append({"type": "text", "text": response.content})
+        for tc in response.tool_calls:
+            assistant_content.append({
+                "type": "tool_use",
+                "id": tc.id,
+                "name": tc.name,
+                "input": tc.input,
+            })
+        current_messages.append({"role": "assistant", "content": assistant_content})
+
+        # Execute each tool call and collect results
+        tool_result_blocks = []
+        for tc in response.tool_calls:
+            try:
+                if tool_executor:
+                    result = await tool_executor(tc)
+                else:
+                    result = {"ok": False, "content": f"No executor registered for {tc.name}"}
+                is_error = not result.get("ok", True)
+            except Exception as e:
+                logger.warning("Tool %s raised: %s", tc.name, e)
+                result = {"ok": False, "content": f"Tool error: {e}"}
+                is_error = True
+
+            tool_result_blocks.append({
+                "type": "tool_result",
+                "tool_use_id": tc.id,
+                "content": result.get("content", str(result)),
+                "is_error": is_error,
+            })
+
+        current_messages.append({"role": "user", "content": tool_result_blocks})
+
+    # Max rounds reached — return whatever the last response was
+    logger.warning("conversation_loop hit max_rounds=%d", max_rounds)
+    return response
+
+
+# ---------------------------------------------------------------------------
+# handle_message — top-level entry point
+# ---------------------------------------------------------------------------
+
+async def handle_message(
+    user_text: str,
+    router: LLMRouter,
+    db_path: str,
+    force_quick: bool = False,
+    force_full: bool = False,
+    model_quick: str = "claude-haiku-4-5-20251001",
+    model_full: str = "claude-sonnet-4-6",
+    tools: list[dict] | None = None,
+    tool_executor: Callable[[ToolCall], Awaitable[dict]] | None = None,
+    anchor_name: str = "General",
+    anchor_time: str = "00:00",
+    plan_summary: str = "",
+    context_subjects: list[str] | None = None,
+    session_notes: str | None = None,
+    conversation_history: list[dict] | None = None,
+) -> str:
+    """Route an incoming message through quick or full conversation path.
+
+    Quick path: single complete() call, no tools, returns text directly.
+    Full path: conversation_loop() with tools + extended thinking.
+
+    Returns the final text response to send to the user.
+    """
+    system = build_system_prompt(
+        anchor_name=anchor_name,
+        anchor_time=anchor_time,
+        plan_summary=plan_summary,
+        context_subjects=context_subjects or [],
+        session_notes=session_notes,
+    )
+
+    history = list(conversation_history or [])
+    history.append({"role": "user", "content": user_text})
+
+    use_quick = force_quick or (not force_full and _classify_quick(user_text))
+
+    if use_quick:
+        response = await router.complete(
+            messages=history,
+            system=system,
+            model=model_quick,
+            tools=None,
+            thinking=False,
+        )
+        return response.content
+
+    # Full path — tool loop with optional extended thinking
+    response = await conversation_loop(
+        backend=router.active_backend,
+        messages=history,
+        system=system,
+        model=model_full,
+        tools=tools or [],
+        tool_executor=tool_executor,
+        thinking=True,
+    )
+    return response.content
+
+
+def _classify_quick(text: str) -> bool:
+    """Heuristic quick/full classifier. Phase 3 uses simple rules;
+    Phase 7 will replace this with a real Haiku classifier call."""
+    text_lower = text.strip().lower()
+    # Very short messages or greetings → quick
+    if len(text_lower) < 15:
+        return True
+    quick_patterns = ("hi", "hello", "thanks", "ok", "yes", "no", "sure", "what time")
+    return any(text_lower.startswith(p) for p in quick_patterns)

--- a/tests/bot/test_conversation.py
+++ b/tests/bot/test_conversation.py
@@ -1,0 +1,335 @@
+"""Tests for bot/conversation.py — SDK conversation loop."""
+import asyncio
+import pytest
+import unittest.mock as mock
+from dataclasses import dataclass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_llm_response(content="ok", tool_calls=None, stop_reason="end_turn",
+                      input_tokens=10, output_tokens=5):
+    from bot.llm import LLMResponse, ToolCall
+    return LLMResponse(
+        content=content,
+        tool_calls=tool_calls or [],
+        stop_reason=stop_reason,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+
+
+def make_tool_call(name="get_plan", input=None, id="call_1"):
+    from bot.llm import ToolCall
+    return ToolCall(id=id, name=name, input=input or {})
+
+
+# ---------------------------------------------------------------------------
+# build_system_prompt
+# ---------------------------------------------------------------------------
+
+class TestBuildSystemPrompt:
+    def test_returns_non_empty_string(self):
+        from bot.conversation import build_system_prompt
+        result = build_system_prompt(
+            anchor_name="Morning",
+            anchor_time="07:00",
+            plan_summary="[ ] Task one",
+            context_subjects=["Work/Project"],
+            session_notes=None,
+        )
+        assert isinstance(result, str)
+        assert len(result) > 50
+
+    def test_includes_anchor_name(self):
+        from bot.conversation import build_system_prompt
+        result = build_system_prompt(
+            anchor_name="Deep Work",
+            anchor_time="09:00",
+            plan_summary="[ ] Task one",
+            context_subjects=[],
+            session_notes=None,
+        )
+        assert "Deep Work" in result
+
+    def test_includes_context_subjects(self):
+        from bot.conversation import build_system_prompt
+        result = build_system_prompt(
+            anchor_name="Morning",
+            anchor_time="07:00",
+            plan_summary="",
+            context_subjects=["Work/Alpha", "Health"],
+            session_notes=None,
+        )
+        assert "Work/Alpha" in result
+        assert "Health" in result
+
+    def test_injects_session_notes_when_provided(self):
+        from bot.conversation import build_system_prompt
+        result = build_system_prompt(
+            anchor_name="Morning",
+            anchor_time="07:00",
+            plan_summary="",
+            context_subjects=[],
+            session_notes="## Session Notes\nWorking on feature X.",
+        )
+        assert "Working on feature X" in result
+
+    def test_session_notes_absent_when_none(self):
+        from bot.conversation import build_system_prompt
+        result = build_system_prompt(
+            anchor_name="Morning",
+            anchor_time="07:00",
+            plan_summary="",
+            context_subjects=[],
+            session_notes=None,
+        )
+        assert "Session Notes" not in result
+
+
+# ---------------------------------------------------------------------------
+# conversation_loop
+# ---------------------------------------------------------------------------
+
+class TestConversationLoop:
+    def test_returns_content_on_end_turn(self):
+        from bot.conversation import conversation_loop
+
+        async def fake_complete(**kwargs):
+            return make_llm_response(content="Done!", stop_reason="end_turn")
+
+        backend = mock.MagicMock()
+        backend.complete = fake_complete
+
+        result = asyncio.run(conversation_loop(
+            backend=backend,
+            messages=[{"role": "user", "content": "hello"}],
+            system="sys",
+            model="claude-haiku-4-5-20251001",
+            tools=[],
+            tool_executor=None,
+        ))
+        assert result.content == "Done!"
+
+    def test_executes_tool_and_continues(self):
+        from bot.conversation import conversation_loop
+
+        call_sequence = [
+            make_llm_response(
+                content="",
+                tool_calls=[make_tool_call("get_plan", {})],
+                stop_reason="tool_use",
+            ),
+            make_llm_response(content="Plan fetched!", stop_reason="end_turn"),
+        ]
+        responses = iter(call_sequence)
+
+        async def fake_complete(**kwargs):
+            return next(responses)
+
+        async def fake_executor(tool_call):
+            return {"ok": True, "content": "[ ] task one"}
+
+        backend = mock.MagicMock()
+        backend.complete = fake_complete
+
+        result = asyncio.run(conversation_loop(
+            backend=backend,
+            messages=[{"role": "user", "content": "what's my plan?"}],
+            system="sys",
+            model="claude-haiku-4-5-20251001",
+            tools=[{"name": "get_plan", "description": "get plan", "input_schema": {}}],
+            tool_executor=fake_executor,
+        ))
+        assert result.content == "Plan fetched!"
+
+    def test_tool_result_appended_to_messages(self):
+        from bot.conversation import conversation_loop
+
+        captured_messages = []
+
+        call_sequence = [
+            make_llm_response(
+                content="",
+                tool_calls=[make_tool_call("get_plan", {}, id="c1")],
+                stop_reason="tool_use",
+            ),
+            make_llm_response(content="done", stop_reason="end_turn"),
+        ]
+        responses = iter(call_sequence)
+
+        async def fake_complete(**kwargs):
+            captured_messages.append(kwargs["messages"])
+            return next(responses)
+
+        async def fake_executor(tc):
+            return {"ok": True, "content": "plan data"}
+
+        backend = mock.MagicMock()
+        backend.complete = fake_complete
+
+        asyncio.run(conversation_loop(
+            backend=backend,
+            messages=[{"role": "user", "content": "hi"}],
+            system="sys",
+            model="claude-haiku-4-5-20251001",
+            tools=[],
+            tool_executor=fake_executor,
+        ))
+
+        # Second call should have tool result in messages
+        second_call_msgs = captured_messages[1]
+        roles = [m["role"] for m in second_call_msgs]
+        assert "tool" in roles or "user" in roles  # tool result added
+
+    def test_stops_at_max_rounds(self):
+        from bot.conversation import conversation_loop
+
+        async def fake_complete(**kwargs):
+            return make_llm_response(
+                content="",
+                tool_calls=[make_tool_call("get_plan", {})],
+                stop_reason="tool_use",
+            )
+
+        async def fake_executor(tc):
+            return {"ok": True, "content": "data"}
+
+        backend = mock.MagicMock()
+        backend.complete = fake_complete
+
+        result = asyncio.run(conversation_loop(
+            backend=backend,
+            messages=[{"role": "user", "content": "hi"}],
+            system="sys",
+            model="claude-haiku-4-5-20251001",
+            tools=[],
+            tool_executor=fake_executor,
+            max_rounds=3,
+        ))
+        # Should return whatever content exists rather than looping forever
+        assert isinstance(result.content, str)
+
+    def test_handles_failed_tool_gracefully(self):
+        from bot.conversation import conversation_loop
+
+        call_sequence = [
+            make_llm_response(
+                content="",
+                tool_calls=[make_tool_call("bad_tool", {})],
+                stop_reason="tool_use",
+            ),
+            make_llm_response(content="recovered", stop_reason="end_turn"),
+        ]
+        responses = iter(call_sequence)
+
+        async def fake_complete(**kwargs):
+            return next(responses)
+
+        async def failing_executor(tc):
+            raise RuntimeError("tool exploded")
+
+        backend = mock.MagicMock()
+        backend.complete = fake_complete
+
+        # Should not propagate the tool error — loop continues with error result
+        result = asyncio.run(conversation_loop(
+            backend=backend,
+            messages=[{"role": "user", "content": "hi"}],
+            system="sys",
+            model="claude-haiku-4-5-20251001",
+            tools=[],
+            tool_executor=failing_executor,
+        ))
+        assert isinstance(result.content, str)
+
+
+# ---------------------------------------------------------------------------
+# format_tool_result_message
+# ---------------------------------------------------------------------------
+
+class TestFormatToolResultMessage:
+    def test_success_result_has_correct_shape(self):
+        from bot.conversation import format_tool_result_message
+        from bot.llm import ToolCall
+        tc = ToolCall(id="c1", name="get_plan", input={})
+        msg = format_tool_result_message(tc, {"ok": True, "content": "data"})
+        assert msg["role"] in ("tool", "user")
+        # Content must reference the tool call id
+        assert "c1" in str(msg)
+
+    def test_error_result_is_marked_as_error(self):
+        from bot.conversation import format_tool_result_message
+        from bot.llm import ToolCall
+        tc = ToolCall(id="c2", name="bad_tool", input={})
+        msg = format_tool_result_message(tc, {"ok": False, "content": "boom"}, is_error=True)
+        assert "c2" in str(msg)
+        assert "boom" in str(msg)
+
+
+# ---------------------------------------------------------------------------
+# handle_message — top-level entry point
+# ---------------------------------------------------------------------------
+
+class TestHandleMessage:
+    def _make_mock_router(self, response_content="I updated your tasks."):
+        """Returns a mock LLMRouter whose backend returns a fixed response."""
+        from bot.llm import LLMResponse
+        fake_resp = LLMResponse(
+            content=response_content,
+            tool_calls=[],
+            stop_reason="end_turn",
+            input_tokens=10,
+            output_tokens=5,
+        )
+        router = mock.MagicMock()
+        router.complete = mock.AsyncMock(return_value=fake_resp)
+        router.active_backend = mock.MagicMock()
+        router.active_backend.complete = mock.AsyncMock(return_value=fake_resp)
+        return router
+
+    def test_returns_string_response(self, tmp_path):
+        from bot.conversation import handle_message
+        router = self._make_mock_router("All done!")
+        result = asyncio.run(handle_message(
+            user_text="What's on my plan?",
+            router=router,
+            db_path=str(tmp_path / "test.db"),
+        ))
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_uses_quick_path_for_simple_message(self, tmp_path):
+        """Quick path should skip tool loop and return faster."""
+        from bot.conversation import handle_message
+        router = self._make_mock_router("Hi there!")
+        # complete should be called exactly once for a quick response
+        call_count = 0
+        original = router.complete
+        async def counting_complete(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            return await original(**kwargs)
+        router.complete = counting_complete
+
+        result = asyncio.run(handle_message(
+            user_text="hi",
+            router=router,
+            db_path=str(tmp_path / "test.db"),
+            force_quick=True,
+        ))
+        assert isinstance(result, str)
+        assert call_count == 1
+
+    def test_full_path_invoked_when_forced(self, tmp_path):
+        from bot.conversation import handle_message
+        router = self._make_mock_router("Processed.")
+        result = asyncio.run(handle_message(
+            user_text="Update task 3 to done",
+            router=router,
+            db_path=str(tmp_path / "test.db"),
+            force_full=True,
+        ))
+        assert isinstance(result, str)


### PR DESCRIPTION
## Summary
- `bot/conversation.py`: `conversation_loop()` — tool_use → execute → append results → repeat until end_turn or max_rounds
- `build_system_prompt()` — modular sections (identity, anchor, plan, context index, session notes)
- `handle_message()` — quick/full routing, delegates to loop or single complete()
- Tool errors caught per-call and returned as error results; loop never crashes on a bad tool

## Test plan
- [x] 15 unit tests: system prompt content, loop termination, tool execution, error handling, routing
- [x] Full regression: 250 tests pass