### PR TITLE
feat: tool plugin system (Phase 4)

### DIFF
--- a/bot/tools/__init__.py
+++ b/bot/tools/__init__.py
@@ -1,0 +1,52 @@
+"""Tool plugin registry — auto-discovers all TOOL objects in this package."""
+import importlib
+import logging
+from pathlib import Path
+from typing import Callable, Awaitable
+
+from bot.tools.base import Tool, ToolResult
+from bot.llm import ToolCall
+
+logger = logging.getLogger(__name__)
+
+
+def load_tools(subset: list[str] | None = None) -> list[Tool]:
+    """Load all tools from this package. Failed imports are skipped with a warning."""
+    tools = []
+    tools_dir = Path(__file__).parent
+    for path in sorted(tools_dir.glob("*.py")):
+        if path.name in ("__init__.py", "base.py"):
+            continue
+        module_name = f"bot.tools.{path.stem}"
+        try:
+            mod = importlib.import_module(module_name)
+            if hasattr(mod, "TOOL"):
+                tool = mod.TOOL
+                if subset is None or tool.name in subset:
+                    tools.append(tool)
+        except Exception as e:
+            logger.warning("Tool %s failed to load: %s", path.stem, e)
+    return tools
+
+
+def make_tool_executor(
+    tools: list[Tool],
+    db_path: str,
+) -> Callable[[ToolCall], Awaitable[dict]]:
+    """Return an async callable that dispatches a ToolCall to the right tool."""
+    registry = {t.name: t for t in tools}
+
+    class _Ctx:
+        pass
+
+    ctx = _Ctx()
+    ctx.db_path = db_path
+
+    async def executor(tool_call: ToolCall) -> dict:
+        tool = registry.get(tool_call.name)
+        if tool is None:
+            return {"ok": False, "content": f"Unknown tool: {tool_call.name!r}"}
+        result: ToolResult = await tool.execute(tool_call.input, ctx)
+        return {"ok": result.ok, "content": result.content}
+
+    return executor

--- a/bot/tools/append_context_entry.py
+++ b/bot/tools/append_context_entry.py
@@ -1,0 +1,35 @@
+"""Tool: append_context_entry — add content to an existing context entry."""
+from bot.tools.base import Tool, ToolResult
+from db.queries import get_context_entries, upsert_context_entry
+
+
+async def _execute(inp: dict, ctx) -> ToolResult:
+    subject = inp.get("subject", "").strip()
+    content = inp.get("content", "")
+    if not subject:
+        return ToolResult.error("subject is required")
+    try:
+        entries = get_context_entries(ctx.db_path, prefix=subject)
+        exact = [e for e in entries if e["subject"] == subject]
+        existing_body = exact[0]["body"] if exact else ""
+        new_body = existing_body + content
+        upsert_context_entry(ctx.db_path, subject, new_body)
+        return ToolResult.ok(f"Appended to context entry {subject!r}.")
+    except Exception as e:
+        return ToolResult.error(f"Failed to append context entry: {e}")
+
+
+TOOL = Tool(
+    name="append_context_entry",
+    description="Append content to an existing context entry. Creates it if it doesn't exist.",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "subject": {"type": "string"},
+            "content": {"type": "string", "description": "Text to append"},
+        },
+        "required": ["subject", "content"],
+    },
+    execute=_execute,
+    read_only=False,
+)

--- a/bot/tools/base.py
+++ b/bot/tools/base.py
@@ -1,0 +1,38 @@
+"""Base classes for the tool plugin system."""
+from dataclasses import dataclass, field
+from typing import Callable, Awaitable, Any
+
+
+class ToolResult:
+    def __init__(self, ok: bool, content: str):
+        self.ok = ok
+        self.content = content
+
+    @staticmethod
+    def ok(content: str) -> "ToolResult":
+        return ToolResult(True, content)
+
+    @staticmethod
+    def error(content: str) -> "ToolResult":
+        return ToolResult(False, content)
+
+    def __repr__(self):
+        return f"ToolResult(ok={self.ok}, content={self.content!r})"
+
+
+@dataclass
+class Tool:
+    name: str
+    description: str
+    input_schema: dict
+    execute: Callable[[dict, Any], Awaitable[ToolResult]]
+    read_only: bool = True
+    guardrails: list[str] = field(default_factory=list)
+
+    def to_api_schema(self) -> dict:
+        """Canonical schema shape for LLM backends."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input_schema": self.input_schema,
+        }

--- a/bot/tools/get_anchors.py
+++ b/bot/tools/get_anchors.py
@@ -1,0 +1,21 @@
+"""Tool: get_anchors — list all anchor definitions."""
+import json
+from bot.tools.base import Tool, ToolResult
+from db.queries import get_anchors
+
+
+async def _execute(inp: dict, ctx) -> ToolResult:
+    try:
+        anchors = get_anchors(ctx.db_path)
+        return ToolResult.ok(json.dumps(anchors, indent=2))
+    except Exception as e:
+        return ToolResult.error(f"Could not fetch anchors: {e}")
+
+
+TOOL = Tool(
+    name="get_anchors",
+    description="List all time-block anchor definitions (id, name, time, duration).",
+    input_schema={"type": "object", "properties": {}},
+    execute=_execute,
+    read_only=True,
+)

--- a/bot/tools/get_context_entry.py
+++ b/bot/tools/get_context_entry.py
@@ -1,0 +1,32 @@
+"""Tool: get_context_entry — fetch the body of a context entry by subject."""
+from bot.tools.base import Tool, ToolResult
+from db.queries import get_context_entries
+
+
+async def _execute(inp: dict, ctx) -> ToolResult:
+    subject = inp.get("subject", "").strip()
+    if not subject:
+        return ToolResult.error("subject is required")
+    try:
+        entries = get_context_entries(ctx.db_path, prefix=subject)
+        exact = [e for e in entries if e["subject"] == subject]
+        if not exact:
+            return ToolResult.error(f"No context entry found for subject: {subject!r}")
+        return ToolResult.ok(exact[0]["body"])
+    except Exception as e:
+        return ToolResult.error(f"Could not fetch context entry: {e}")
+
+
+TOOL = Tool(
+    name="get_context_entry",
+    description="Fetch the full body of a context entry by its exact subject path.",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "subject": {"type": "string", "description": "Exact subject path, e.g. 'Work/Alpha'"},
+        },
+        "required": ["subject"],
+    },
+    execute=_execute,
+    read_only=True,
+)

--- a/bot/tools/get_plan.py
+++ b/bot/tools/get_plan.py
@@ -1,0 +1,28 @@
+"""Tool: get_plan — fetch today's plan with task statuses."""
+import json
+from datetime import date
+from bot.tools.base import Tool, ToolResult
+from db.queries import get_plan
+
+
+async def _execute(inp: dict, ctx) -> ToolResult:
+    target_date = inp.get("date") or date.today().isoformat()
+    try:
+        plan = get_plan(ctx.db_path, target_date)
+        return ToolResult.ok(json.dumps(plan, indent=2))
+    except Exception as e:
+        return ToolResult.error(f"Could not fetch plan: {e}")
+
+
+TOOL = Tool(
+    name="get_plan",
+    description="Get the task plan for a given date (default today). Returns anchors with tasks and statuses.",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "date": {"type": "string", "description": "ISO date YYYY-MM-DD, defaults to today"},
+        },
+    },
+    execute=_execute,
+    read_only=True,
+)

--- a/bot/tools/patch_context_entry.py
+++ b/bot/tools/patch_context_entry.py
@@ -1,0 +1,44 @@
+"""Tool: patch_context_entry — targeted find-and-replace in a context entry."""
+from bot.tools.base import Tool, ToolResult
+from db.queries import get_context_entries, upsert_context_entry
+
+
+async def _execute(inp: dict, ctx) -> ToolResult:
+    subject = inp.get("subject", "").strip()
+    old_string = inp.get("old_string", "")
+    new_string = inp.get("new_string", "")
+    if not subject or not old_string:
+        return ToolResult.error("subject and old_string are required")
+    try:
+        entries = get_context_entries(ctx.db_path, prefix=subject)
+        exact = [e for e in entries if e["subject"] == subject]
+        if not exact:
+            return ToolResult.error(f"No context entry found for subject: {subject!r}")
+        body = exact[0]["body"]
+        if old_string not in body:
+            return ToolResult.error(
+                f"old_string not found in {subject!r}. No changes made."
+            )
+        new_body = body.replace(old_string, new_string, 1)
+        upsert_context_entry(ctx.db_path, subject, new_body)
+        return ToolResult.ok(f"Patched context entry {subject!r}.")
+    except Exception as e:
+        return ToolResult.error(f"Failed to patch context entry: {e}")
+
+
+TOOL = Tool(
+    name="patch_context_entry",
+    description="Find and replace an exact string in a context entry. Fails if old_string is not found.",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "subject": {"type": "string"},
+            "old_string": {"type": "string", "description": "Exact text to find"},
+            "new_string": {"type": "string", "description": "Replacement text"},
+        },
+        "required": ["subject", "old_string", "new_string"],
+    },
+    execute=_execute,
+    read_only=False,
+    guardrails=["patch_exact_match"],
+)

--- a/bot/tools/search_context.py
+++ b/bot/tools/search_context.py
@@ -1,0 +1,29 @@
+"""Tool: search_context — list context entry subjects matching a prefix."""
+from bot.tools.base import Tool, ToolResult
+from db.queries import get_context_entries
+
+
+async def _execute(inp: dict, ctx) -> ToolResult:
+    prefix = inp.get("prefix", "")
+    try:
+        entries = get_context_entries(ctx.db_path, prefix=prefix if prefix else None)
+        subjects = [e["subject"] for e in entries]
+        if not subjects:
+            return ToolResult.ok("No context entries found.")
+        return ToolResult.ok("\n".join(subjects))
+    except Exception as e:
+        return ToolResult.error(f"Could not search context: {e}")
+
+
+TOOL = Tool(
+    name="search_context",
+    description="List context entry subject paths, optionally filtered by prefix.",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "prefix": {"type": "string", "description": "Subject prefix to filter by, e.g. 'Work'"},
+        },
+    },
+    execute=_execute,
+    read_only=True,
+)

--- a/bot/tools/update_task_status.py
+++ b/bot/tools/update_task_status.py
@@ -1,0 +1,37 @@
+"""Tool: update_task_status — set the status of an existing task by ID."""
+from bot.tools.base import Tool, ToolResult
+from db.queries import patch_task_fields
+
+VALID_STATUSES = {"pending", "in_progress", "done", "skipped", "blocked"}
+
+
+async def _execute(inp: dict, ctx) -> ToolResult:
+    task_id = inp.get("task_id", "").strip()
+    status = inp.get("status", "").strip()
+    if not task_id:
+        return ToolResult.error("task_id is required")
+    if status not in VALID_STATUSES:
+        return ToolResult.error(f"Invalid status {status!r}. Must be one of: {sorted(VALID_STATUSES)}")
+    try:
+        result = patch_task_fields(ctx.db_path, task_id, {"status": status})
+        if result is None:
+            return ToolResult.error(f"Task not found: {task_id!r}")
+        return ToolResult.ok(f"Task {task_id} status set to {status!r}")
+    except Exception as e:
+        return ToolResult.error(f"Failed to update task status: {e}")
+
+
+TOOL = Tool(
+    name="update_task_status",
+    description="Set the status of an existing task by its UUID.",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "task_id": {"type": "string", "description": "UUID of the task"},
+            "status": {"type": "string", "enum": sorted(VALID_STATUSES)},
+        },
+        "required": ["task_id", "status"],
+    },
+    execute=_execute,
+    read_only=False,
+)

--- a/bot/tools/upsert_context_entry.py
+++ b/bot/tools/upsert_context_entry.py
@@ -1,0 +1,31 @@
+"""Tool: upsert_context_entry — full rewrite of a context entry."""
+from bot.tools.base import Tool, ToolResult
+from db.queries import upsert_context_entry
+
+
+async def _execute(inp: dict, ctx) -> ToolResult:
+    subject = inp.get("subject", "").strip()
+    body = inp.get("body", "").strip()
+    if not subject:
+        return ToolResult.error("subject is required")
+    try:
+        upsert_context_entry(ctx.db_path, subject, body)
+        return ToolResult.ok(f"Context entry {subject!r} updated.")
+    except Exception as e:
+        return ToolResult.error(f"Failed to upsert context entry: {e}")
+
+
+TOOL = Tool(
+    name="upsert_context_entry",
+    description="Create or fully overwrite a context entry. Use append_context_entry to add without overwriting.",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "subject": {"type": "string", "description": "Subject path, e.g. 'Work/Alpha'"},
+            "body": {"type": "string", "description": "Full markdown body"},
+        },
+        "required": ["subject", "body"],
+    },
+    execute=_execute,
+    read_only=False,
+)

--- a/bot/tools/upsert_task.py
+++ b/bot/tools/upsert_task.py
@@ -1,0 +1,55 @@
+"""Tool: upsert_task — create or update a task in an anchor."""
+from datetime import date
+from bot.tools.base import Tool, ToolResult
+from db.queries import upsert_tasks, get_anchors
+
+
+async def _execute(inp: dict, ctx) -> ToolResult:
+    anchor_id = inp.get("anchor_id", "").strip()
+    text = inp.get("text", "").strip()
+    if not anchor_id or not text:
+        return ToolResult.error("anchor_id and text are required")
+
+    # Validate anchor exists
+    try:
+        anchors = get_anchors(ctx.db_path)
+        anchor_ids = {a["id"] for a in anchors}
+        if anchor_id not in anchor_ids:
+            return ToolResult.error(f"Unknown anchor_id: {anchor_id!r}")
+    except Exception as e:
+        return ToolResult.error(f"Could not validate anchor: {e}")
+
+    target_date = inp.get("date") or date.today().isoformat()
+    task = {
+        "text": text,
+        "status": inp.get("status", "pending"),
+        "position": inp.get("position"),
+    }
+    if inp.get("task_id"):
+        task["id"] = inp["task_id"]
+
+    try:
+        upsert_tasks(ctx.db_path, target_date, anchor_id, [task])
+        return ToolResult.ok(f"Task upserted in {anchor_id}: {text!r}")
+    except Exception as e:
+        return ToolResult.error(f"Failed to upsert task: {e}")
+
+
+TOOL = Tool(
+    name="upsert_task",
+    description="Create or update a task in an anchor. Provide task_id to update an existing task.",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "anchor_id": {"type": "string"},
+            "text": {"type": "string"},
+            "status": {"type": "string", "enum": ["pending", "in_progress", "done", "skipped", "blocked"]},
+            "position": {"type": "integer"},
+            "task_id": {"type": "string", "description": "UUID of existing task to update"},
+            "date": {"type": "string", "description": "ISO date, defaults to today"},
+        },
+        "required": ["anchor_id", "text"],
+    },
+    execute=_execute,
+    read_only=False,
+)

--- a/tests/bot/test_tools.py
+++ b/tests/bot/test_tools.py
@@ -1,0 +1,347 @@
+"""Tests for bot/tools/ — tool plugin system."""
+import asyncio
+import json
+import pytest
+from pathlib import Path
+from db.schema import init_db
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    p = tmp_path / "test.db"
+    init_db(str(p))
+    return str(p)
+
+
+@pytest.fixture
+def seeded_db(db_path):
+    """DB with one anchor, a plan for today, and a context entry."""
+    from db.queries import upsert_anchor, upsert_plan, upsert_tasks, upsert_context_entry
+    from datetime import date
+    today = date.today().isoformat()
+    upsert_anchor(db_path, {
+        "id": "morning", "name": "Morning", "time": "07:00",
+        "duration_minutes": 60, "flexibility": "locked",
+        "strictness": 3, "color": "#fff", "position": 0,
+    })
+    upsert_plan(db_path, today)
+    upsert_tasks(db_path, today, "morning", [
+        {"text": "Do the thing", "status": "pending", "position": 0},
+    ])
+    upsert_context_entry(db_path, "Work/Alpha", "Working on project alpha.")
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# Tool registry — auto-discovery
+# ---------------------------------------------------------------------------
+
+class TestToolRegistry:
+    def test_load_tools_returns_list(self):
+        from bot.tools import load_tools
+        tools = load_tools()
+        assert isinstance(tools, list)
+        assert len(tools) > 0
+
+    def test_each_tool_has_required_fields(self):
+        from bot.tools import load_tools
+        for tool in load_tools():
+            assert hasattr(tool, "name")
+            assert hasattr(tool, "description")
+            assert hasattr(tool, "input_schema")
+            assert hasattr(tool, "execute")
+            assert hasattr(tool, "read_only")
+
+    def test_to_api_schema_returns_canonical_shape(self):
+        from bot.tools import load_tools
+        for tool in load_tools():
+            schema = tool.to_api_schema()
+            assert schema["name"] == tool.name
+            assert "description" in schema
+            assert "input_schema" in schema
+
+    def test_subset_filtering(self):
+        from bot.tools import load_tools
+        all_tools = load_tools()
+        if not all_tools:
+            pytest.skip("No tools loaded")
+        first_name = all_tools[0].name
+        subset = load_tools(subset=[first_name])
+        assert len(subset) == 1
+        assert subset[0].name == first_name
+
+    def test_broken_tool_skipped_gracefully(self, tmp_path, monkeypatch):
+        """A tool file that raises on import should be skipped, not crash load_tools."""
+        from bot.tools import load_tools
+        import importlib
+        original_import = importlib.import_module
+
+        def patched_import(name, *args, **kwargs):
+            if name == "bot.tools.broken_tool":
+                raise ImportError("simulated import error")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(importlib, "import_module", patched_import)
+        tools = load_tools()
+        assert isinstance(tools, list)
+
+
+# ---------------------------------------------------------------------------
+# Tool base class
+# ---------------------------------------------------------------------------
+
+class TestToolBase:
+    def test_tool_dataclass_construction(self):
+        from bot.tools.base import Tool, ToolResult
+
+        async def noop(inp, ctx):
+            return ToolResult.ok("done")
+
+        t = Tool(
+            name="test_tool",
+            description="A test tool",
+            input_schema={"type": "object", "properties": {}},
+            execute=noop,
+        )
+        assert t.name == "test_tool"
+        assert t.read_only is True  # default
+
+    def test_tool_result_ok(self):
+        from bot.tools.base import ToolResult
+        r = ToolResult.ok("great")
+        assert r.ok is True
+        assert r.content == "great"
+
+    def test_tool_result_error(self):
+        from bot.tools.base import ToolResult
+        r = ToolResult.error("boom")
+        assert r.ok is False
+        assert r.content == "boom"
+
+
+# ---------------------------------------------------------------------------
+# Read tools
+# ---------------------------------------------------------------------------
+
+class TestGetPlanTool:
+    def test_returns_plan_for_today(self, seeded_db):
+        from bot.tools.get_plan import TOOL
+        result = asyncio.run(TOOL.execute({"date": ""}, ctx_db(seeded_db)))
+        assert result.ok is True
+        assert "morning" in result.content.lower() or "Morning" in result.content
+        assert "Do the thing" in result.content
+
+    def test_returns_error_for_missing_date(self, db_path):
+        from bot.tools.get_plan import TOOL
+        # No plan seeded for this db — should still return ok with empty plan
+        result = asyncio.run(TOOL.execute({}, ctx_db(db_path)))
+        assert isinstance(result.ok, bool)
+
+
+class TestGetContextEntryTool:
+    def test_returns_body_for_known_subject(self, seeded_db):
+        from bot.tools.get_context_entry import TOOL
+        result = asyncio.run(TOOL.execute({"subject": "Work/Alpha"}, ctx_db(seeded_db)))
+        assert result.ok is True
+        assert "project alpha" in result.content.lower()
+
+    def test_returns_error_for_unknown_subject(self, seeded_db):
+        from bot.tools.get_context_entry import TOOL
+        result = asyncio.run(TOOL.execute({"subject": "Nonexistent/Entry"}, ctx_db(seeded_db)))
+        assert result.ok is False
+
+
+class TestSearchContextTool:
+    def test_lists_matching_subjects(self, seeded_db):
+        from bot.tools.search_context import TOOL
+        result = asyncio.run(TOOL.execute({"prefix": "Work"}, ctx_db(seeded_db)))
+        assert result.ok is True
+        assert "Work/Alpha" in result.content
+
+    def test_empty_prefix_lists_all(self, seeded_db):
+        from bot.tools.search_context import TOOL
+        result = asyncio.run(TOOL.execute({"prefix": ""}, ctx_db(seeded_db)))
+        assert result.ok is True
+        assert "Work/Alpha" in result.content
+
+
+class TestGetAnchorsTool:
+    def test_returns_anchor_list(self, seeded_db):
+        from bot.tools.get_anchors import TOOL
+        result = asyncio.run(TOOL.execute({}, ctx_db(seeded_db)))
+        assert result.ok is True
+        assert "morning" in result.content.lower() or "Morning" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Write tools
+# ---------------------------------------------------------------------------
+
+class TestUpsertTaskTool:
+    def test_creates_new_task(self, seeded_db):
+        from bot.tools.upsert_task import TOOL
+        from db.queries import get_plan
+        from datetime import date
+        today = date.today().isoformat()
+
+        result = asyncio.run(TOOL.execute({
+            "anchor_id": "morning",
+            "text": "Brand new task",
+            "status": "pending",
+        }, ctx_db(seeded_db)))
+        assert result.ok is True
+
+        plan = get_plan(seeded_db, today)
+        tasks = plan.get("anchors", {}).get("morning", {}).get("tasks", [])
+        texts = [t["text"] for t in tasks]
+        assert "Brand new task" in texts
+
+    def test_returns_error_for_unknown_anchor(self, db_path):
+        from bot.tools.upsert_task import TOOL
+        result = asyncio.run(TOOL.execute({
+            "anchor_id": "nonexistent_anchor",
+            "text": "task",
+        }, ctx_db(db_path)))
+        assert result.ok is False
+
+
+class TestUpdateTaskStatusTool:
+    def test_updates_existing_task_status(self, seeded_db):
+        from bot.tools.update_task_status import TOOL
+        from db.queries import get_plan
+        from datetime import date
+        today = date.today().isoformat()
+
+        # Get the task id first
+        plan = get_plan(seeded_db, today)
+        task = plan["anchors"]["morning"]["tasks"][0]
+        task_id = task["id"]
+
+        result = asyncio.run(TOOL.execute({
+            "task_id": task_id,
+            "status": "done",
+        }, ctx_db(seeded_db)))
+        assert result.ok is True
+
+        plan_after = get_plan(seeded_db, today)
+        updated = plan_after["anchors"]["morning"]["tasks"][0]
+        assert updated["status"] == "done"
+
+    def test_returns_error_for_unknown_task(self, seeded_db):
+        from bot.tools.update_task_status import TOOL
+        result = asyncio.run(TOOL.execute({
+            "task_id": "00000000-0000-0000-0000-000000000000",
+            "status": "done",
+        }, ctx_db(seeded_db)))
+        assert result.ok is False
+
+
+class TestUpsertContextEntryTool:
+    def test_creates_new_entry(self, seeded_db):
+        from bot.tools.upsert_context_entry import TOOL
+        from db.queries import get_context_entries
+        result = asyncio.run(TOOL.execute({
+            "subject": "Health/Sleep",
+            "body": "Sleep at 10pm.",
+        }, ctx_db(seeded_db)))
+        assert result.ok is True
+
+        entries = get_context_entries(seeded_db)
+        subjects = [e["subject"] for e in entries]
+        assert "Health/Sleep" in subjects
+
+    def test_overwrites_existing_entry(self, seeded_db):
+        from bot.tools.upsert_context_entry import TOOL
+        from db.queries import get_context_entries
+        asyncio.run(TOOL.execute({
+            "subject": "Work/Alpha",
+            "body": "Updated content.",
+        }, ctx_db(seeded_db)))
+
+        entries = {e["subject"]: e for e in get_context_entries(seeded_db)}
+        assert entries["Work/Alpha"]["body"] == "Updated content."
+
+
+class TestAppendContextEntryTool:
+    def test_appends_to_existing_entry(self, seeded_db):
+        from bot.tools.append_context_entry import TOOL
+        from db.queries import get_context_entries
+        result = asyncio.run(TOOL.execute({
+            "subject": "Work/Alpha",
+            "content": "\nNew note added.",
+        }, ctx_db(seeded_db)))
+        assert result.ok is True
+
+        entries = {e["subject"]: e for e in get_context_entries(seeded_db)}
+        assert "New note added." in entries["Work/Alpha"]["body"]
+        assert "project alpha" in entries["Work/Alpha"]["body"].lower()
+
+    def test_creates_entry_if_missing(self, seeded_db):
+        from bot.tools.append_context_entry import TOOL
+        from db.queries import get_context_entries
+        result = asyncio.run(TOOL.execute({
+            "subject": "New/Topic",
+            "content": "First note.",
+        }, ctx_db(seeded_db)))
+        assert result.ok is True
+        entries = {e["subject"]: e for e in get_context_entries(seeded_db)}
+        assert "New/Topic" in entries
+
+
+class TestPatchContextEntryTool:
+    def test_replaces_exact_string(self, seeded_db):
+        from bot.tools.patch_context_entry import TOOL
+        from db.queries import get_context_entries
+        result = asyncio.run(TOOL.execute({
+            "subject": "Work/Alpha",
+            "old_string": "project alpha",
+            "new_string": "project beta",
+        }, ctx_db(seeded_db)))
+        assert result.ok is True
+        entries = {e["subject"]: e for e in get_context_entries(seeded_db)}
+        assert "project beta" in entries["Work/Alpha"]["body"]
+
+    def test_returns_error_when_old_string_not_found(self, seeded_db):
+        from bot.tools.patch_context_entry import TOOL
+        result = asyncio.run(TOOL.execute({
+            "subject": "Work/Alpha",
+            "old_string": "DOES NOT EXIST",
+            "new_string": "replacement",
+        }, ctx_db(seeded_db)))
+        assert result.ok is False
+
+
+# ---------------------------------------------------------------------------
+# Tool executor (wires tools to conversation loop)
+# ---------------------------------------------------------------------------
+
+class TestToolExecutor:
+    def test_dispatches_to_correct_tool(self, seeded_db):
+        from bot.tools import make_tool_executor, load_tools
+        from bot.llm import ToolCall
+        tools = load_tools()
+        executor = make_tool_executor(tools, db_path=seeded_db)
+        tc = ToolCall(id="c1", name="get_anchors", input={})
+        result = asyncio.run(executor(tc))
+        assert result["ok"] is True
+
+    def test_returns_error_for_unknown_tool(self, seeded_db):
+        from bot.tools import make_tool_executor, load_tools
+        from bot.llm import ToolCall
+        executor = make_tool_executor(load_tools(), db_path=seeded_db)
+        tc = ToolCall(id="c2", name="nonexistent_tool", input={})
+        result = asyncio.run(executor(tc))
+        assert result["ok"] is False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def ctx_db(db_path: str):
+    """Minimal context object carrying db_path for tool execution."""
+    class Ctx:
+        pass
+    ctx = Ctx()
+    ctx.db_path = db_path
+    return ctx


### PR DESCRIPTION
## Summary
- `bot/tools/base.py`: `Tool` dataclass, `ToolResult` with `.ok()`/`.error()` factory methods
- `bot/tools/__init__.py`: `load_tools()` auto-discovery (failed imports skipped with warning), `make_tool_executor()` dispatcher
- 7 tools: `get_plan`, `get_context_entry`, `search_context`, `get_anchors` (read); `upsert_task`, `update_task_status`, `upsert_context_entry`, `append_context_entry`, `patch_context_entry` (write)
- DB schema changes in other sessions only break specific tools, not the conversation loop

## Test plan
- [x] 27 unit tests: registry auto-discovery, graceful broken-tool skip, all tool CRUD operations against real SQLite
- [x] Full regression: 277 tests pass