### PR TITLE
feat: Beacon background agent (Phase 6)

### DIFF
--- a/bot/beacon.py
+++ b/bot/beacon.py
@@ -1,0 +1,157 @@
+"""Beacon background agent for Tether v3.
+
+Two-phase design inspired by the KAIROS pattern in claude-code:
+  Phase 1 — Triage: cheap Haiku call (~200 tokens), YES/NO decision
+  Phase 2 — Action: Haiku with tools, max 3 conservative actions
+
+Beacon is triggered by the state_monitor's weighted scoring ledger,
+not by a time ticker. This keeps LLM costs proportional to real
+activity rather than wall-clock time.
+"""
+import logging
+import sqlite3
+from datetime import datetime, timedelta
+
+from bot.state_monitor import get_pending_score
+
+logger = logging.getLogger(__name__)
+
+_MAX_BEACON_ACTIONS = 3
+
+
+# ---------------------------------------------------------------------------
+# Beacon state — cooldown tracking
+# ---------------------------------------------------------------------------
+
+def record_beacon_invocation(db_path: str) -> None:
+    """Record the current time as the last Beacon invocation."""
+    conn = sqlite3.connect(db_path)
+    try:
+        now = datetime.utcnow().isoformat()
+        conn.execute("UPDATE beacon_state SET last_invoked_at = ? WHERE id = 1", (now,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _get_last_invocation(db_path: str) -> datetime | None:
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT last_invoked_at FROM beacon_state WHERE id = 1"
+        ).fetchone()
+        if row and row[0]:
+            return datetime.fromisoformat(row[0])
+        return None
+    finally:
+        conn.close()
+
+
+def should_trigger_beacon(
+    db_path: str,
+    score_threshold: int = 8,
+    cooldown_minutes: int = 30,
+) -> bool:
+    """Return True if accumulated score >= threshold AND cooldown has passed."""
+    score = get_pending_score(db_path)
+    if score < score_threshold:
+        return False
+
+    last = _get_last_invocation(db_path)
+    if last is None:
+        return True
+    elapsed = datetime.utcnow() - last
+    return elapsed >= timedelta(minutes=cooldown_minutes)
+
+
+# ---------------------------------------------------------------------------
+# run_beacon — two-phase agent
+# ---------------------------------------------------------------------------
+
+async def run_beacon(
+    router,
+    db_path: str,
+    changes: list[dict],
+    model: str = "claude-haiku-4-5-20251001",
+    tools: list | None = None,
+    tool_executor=None,
+) -> dict:
+    """Run the two-phase Beacon agent.
+
+    Returns a dict with keys:
+      triggered: bool — whether Phase 2 ran
+      message: str | None — any message to send to the user
+    """
+    try:
+        change_summary = _format_change_summary(changes)
+
+        # --- Phase 1: Triage ---
+        triage_prompt = (
+            f"These changes were detected in the user's task system:\n{change_summary}\n\n"
+            f"Does this warrant closer review and possible action? "
+            f"Answer YES or NO and one sentence why."
+        )
+        triage_response = await router.complete(
+            messages=[{"role": "user", "content": triage_prompt}],
+            system="You are a background monitoring assistant. Be conservative.",
+            model=model,
+            thinking=False,
+        )
+
+        triage_text = triage_response.content.strip()
+        if not triage_text.upper().startswith("YES"):
+            return {"triggered": False, "message": None}
+
+        # --- Phase 2: Investigation + action ---
+        record_beacon_invocation(db_path)
+
+        action_system = (
+            "You are a quiet background assistant reviewing the user's task system. "
+            "Take conservative, targeted action only when clearly needed. "
+            "Do not send messages unless something genuinely needs the user's attention. "
+            f"Limit yourself to at most {_MAX_BEACON_ACTIONS} actions."
+        )
+        action_prompt = (
+            f"Changes detected:\n{change_summary}\n\n"
+            f"Review the current state and take action if needed. "
+            f"If nothing needs doing, say so briefly."
+        )
+
+        if tools and tool_executor:
+            from bot.conversation import conversation_loop
+            action_response = await conversation_loop(
+                backend=router.active_backend,
+                messages=[{"role": "user", "content": action_prompt}],
+                system=action_system,
+                model=model,
+                tools=tools,
+                tool_executor=tool_executor,
+                max_rounds=_MAX_BEACON_ACTIONS + 1,
+                thinking=False,
+            )
+        else:
+            action_response = await router.complete(
+                messages=[{"role": "user", "content": action_prompt}],
+                system=action_system,
+                model=model,
+                thinking=False,
+            )
+
+        message = action_response.content.strip() or None
+        return {"triggered": True, "message": message}
+
+    except Exception as e:
+        logger.warning("run_beacon failed: %s", e)
+        return {"triggered": False, "message": None}
+
+
+def _format_change_summary(changes: list[dict]) -> str:
+    if not changes:
+        return "No specific changes recorded."
+    lines = []
+    for c in changes:
+        ct = c.get("change_type", "change")
+        eid = c.get("entity_id", "")
+        score = c.get("score", "?")
+        lines.append(f"  - [{ct}] {eid} (weight: {score})")
+    return "\n".join(lines)

--- a/bot/state_monitor.py
+++ b/bot/state_monitor.py
@@ -1,0 +1,73 @@
+"""DB state change monitor for the Beacon background agent.
+
+Records weighted change events to state_monitor_log. The Beacon
+polls get_pending_score() and triggers when the threshold is met.
+Changes are marked consumed after each Beacon invocation so scores
+don't compound across runs.
+"""
+import logging
+import sqlite3
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+CHANGE_WEIGHTS: dict[str, int] = {
+    "task_done":        2,
+    "task_blocked":     2,
+    "context_updated":  3,
+    "plan_restructured": 5,
+    "acknowledgement":  1,
+    "task_created":     1,
+}
+_DEFAULT_WEIGHT = 1
+
+
+def record_change(db_path: str, change_type: str, entity_id: str) -> None:
+    """Record a state change with its weighted score."""
+    score = CHANGE_WEIGHTS.get(change_type, _DEFAULT_WEIGHT)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO state_monitor_log (change_type, entity_id, score) VALUES (?, ?, ?)",
+            (change_type, entity_id, score),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_pending_score(db_path: str) -> int:
+    """Sum of scores for all unconsumed change events."""
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT COALESCE(SUM(score), 0) FROM state_monitor_log WHERE consumed = 0"
+        ).fetchone()
+        return int(row[0])
+    finally:
+        conn.close()
+
+
+def consume_changes(db_path: str) -> list[dict]:
+    """Mark all pending changes as consumed and return their summaries."""
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT id, change_type, entity_id, score, ts "
+            "FROM state_monitor_log WHERE consumed = 0 ORDER BY ts"
+        ).fetchall()
+        changes = [
+            {"id": r[0], "change_type": r[1], "entity_id": r[2],
+             "score": r[3], "ts": r[4]}
+            for r in rows
+        ]
+        if changes:
+            ids = [c["id"] for c in changes]
+            conn.execute(
+                f"UPDATE state_monitor_log SET consumed = 1 WHERE id IN ({','.join('?' * len(ids))})",
+                ids,
+            )
+            conn.commit()
+        return changes
+    finally:
+        conn.close()

--- a/db/schema.py
+++ b/db/schema.py
@@ -139,6 +139,22 @@ CREATE TABLE IF NOT EXISTS invocation_log (
     error       TEXT,
     ts          DATETIME DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS state_monitor_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    change_type TEXT NOT NULL,
+    entity_id   TEXT NOT NULL DEFAULT '',
+    score       INTEGER NOT NULL DEFAULT 1,
+    consumed    INTEGER NOT NULL DEFAULT 0,
+    ts          DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS beacon_state (
+    id               INTEGER PRIMARY KEY CHECK (id = 1),
+    last_invoked_at  DATETIME
+);
+
+INSERT OR IGNORE INTO beacon_state (id, last_invoked_at) VALUES (1, NULL);
 """
 
 

--- a/tests/bot/test_beacon.py
+++ b/tests/bot/test_beacon.py
@@ -1,0 +1,250 @@
+"""Tests for bot/state_monitor.py and bot/beacon.py — Beacon background agent."""
+import asyncio
+import time
+import pytest
+import unittest.mock as mock
+from datetime import date, datetime, timedelta
+from db.schema import init_db
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    p = tmp_path / "test.db"
+    init_db(str(p))
+    return str(p)
+
+
+@pytest.fixture
+def seeded_db(db_path):
+    from db.queries import upsert_anchor, upsert_plan, upsert_tasks, upsert_context_entry
+    today = date.today().isoformat()
+    upsert_anchor(db_path, {
+        "id": "morning", "name": "Morning", "time": "07:00",
+        "duration_minutes": 60, "flexibility": "locked",
+        "strictness": 3, "color": "#fff", "position": 0,
+    })
+    upsert_plan(db_path, today)
+    upsert_tasks(db_path, today, "morning", [
+        {"text": "Exercise", "status": "done", "position": 0},
+    ])
+    upsert_context_entry(db_path, "Work/Alpha", "Ongoing project.")
+    return db_path
+
+
+def make_router(triage_response="NO", action_response="Done."):
+    """Router that returns triage_response for the first call, action_response for subsequent."""
+    from bot.llm import LLMResponse
+    call_count = 0
+
+    async def fake_complete(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        content = triage_response if call_count == 1 else action_response
+        return LLMResponse(content=content, tool_calls=[], stop_reason="end_turn",
+                           input_tokens=10, output_tokens=5)
+
+    router = mock.MagicMock()
+    router.complete = mock.AsyncMock(side_effect=fake_complete)
+    router.active_backend = mock.MagicMock()
+    router.active_backend.complete = mock.AsyncMock(side_effect=fake_complete)
+    return router
+
+
+# ---------------------------------------------------------------------------
+# State monitor — change recording
+# ---------------------------------------------------------------------------
+
+class TestRecordChange:
+    def test_records_change_to_db(self, db_path):
+        from bot.state_monitor import record_change, get_pending_score
+        record_change(db_path, "task_done", "task-uuid-1")
+        score = get_pending_score(db_path)
+        assert score > 0
+
+    def test_task_done_has_weight_2(self, db_path):
+        from bot.state_monitor import record_change, get_pending_score, CHANGE_WEIGHTS
+        record_change(db_path, "task_done", "t1")
+        assert get_pending_score(db_path) == CHANGE_WEIGHTS["task_done"]
+
+    def test_context_updated_has_weight_3(self, db_path):
+        from bot.state_monitor import record_change, get_pending_score, CHANGE_WEIGHTS
+        record_change(db_path, "context_updated", "Work/Alpha")
+        assert get_pending_score(db_path) == CHANGE_WEIGHTS["context_updated"]
+
+    def test_multiple_changes_accumulate(self, db_path):
+        from bot.state_monitor import record_change, get_pending_score
+        record_change(db_path, "task_done", "t1")
+        record_change(db_path, "context_updated", "Work/Alpha")
+        record_change(db_path, "task_created", "t2")
+        score = get_pending_score(db_path)
+        assert score >= 6  # 2 + 3 + 1
+
+    def test_unknown_change_type_uses_default_weight(self, db_path):
+        from bot.state_monitor import record_change, get_pending_score
+        record_change(db_path, "unknown_type", "x")
+        assert get_pending_score(db_path) >= 1
+
+
+class TestConsumeChanges:
+    def test_consume_resets_pending_score_to_zero(self, db_path):
+        from bot.state_monitor import record_change, consume_changes, get_pending_score
+        record_change(db_path, "task_done", "t1")
+        record_change(db_path, "context_updated", "c1")
+        summary = consume_changes(db_path)
+        assert get_pending_score(db_path) == 0
+
+    def test_consume_returns_summary_of_changes(self, db_path):
+        from bot.state_monitor import record_change, consume_changes
+        record_change(db_path, "task_done", "task-123")
+        record_change(db_path, "context_updated", "Work/Alpha")
+        summary = consume_changes(db_path)
+        assert isinstance(summary, list)
+        assert len(summary) == 2
+        types = [c["change_type"] for c in summary]
+        assert "task_done" in types
+        assert "context_updated" in types
+
+    def test_consume_only_returns_unconsumed(self, db_path):
+        from bot.state_monitor import record_change, consume_changes, get_pending_score
+        record_change(db_path, "task_done", "t1")
+        consume_changes(db_path)                  # consume first batch
+        record_change(db_path, "task_created", "t2")
+        second = consume_changes(db_path)
+        assert len(second) == 1
+        assert second[0]["change_type"] == "task_created"
+
+
+class TestChangeWeights:
+    def test_all_expected_types_defined(self):
+        from bot.state_monitor import CHANGE_WEIGHTS
+        expected = {"task_done", "task_blocked", "context_updated",
+                    "plan_restructured", "acknowledgement", "task_created"}
+        assert expected <= set(CHANGE_WEIGHTS.keys())
+
+    def test_weights_are_positive_integers(self):
+        from bot.state_monitor import CHANGE_WEIGHTS
+        for k, v in CHANGE_WEIGHTS.items():
+            assert isinstance(v, int) and v > 0
+
+
+# ---------------------------------------------------------------------------
+# should_trigger_beacon
+# ---------------------------------------------------------------------------
+
+class TestShouldTriggerBeacon:
+    def test_false_when_score_below_threshold(self, db_path):
+        from bot.state_monitor import record_change
+        from bot.beacon import should_trigger_beacon
+        record_change(db_path, "task_created", "t1")  # weight=1
+        assert should_trigger_beacon(db_path, score_threshold=8, cooldown_minutes=0) is False
+
+    def test_true_when_score_at_threshold(self, db_path):
+        from bot.state_monitor import record_change
+        from bot.beacon import should_trigger_beacon
+        # plan_restructured = 5, context_updated = 3 → total 8
+        record_change(db_path, "plan_restructured", "today")
+        record_change(db_path, "context_updated", "Work/Alpha")
+        assert should_trigger_beacon(db_path, score_threshold=8, cooldown_minutes=0) is True
+
+    def test_false_within_cooldown(self, db_path):
+        from bot.state_monitor import record_change
+        from bot.beacon import should_trigger_beacon, record_beacon_invocation
+        # Score is high enough
+        record_change(db_path, "plan_restructured", "today")
+        record_change(db_path, "context_updated", "Work/Alpha")
+        # But beacon was just invoked
+        record_beacon_invocation(db_path)
+        assert should_trigger_beacon(db_path, score_threshold=8, cooldown_minutes=30) is False
+
+    def test_true_after_cooldown_expires(self, db_path):
+        from bot.state_monitor import record_change
+        from bot.beacon import should_trigger_beacon, record_beacon_invocation
+        import sqlite3
+        record_change(db_path, "plan_restructured", "today")
+        record_change(db_path, "context_updated", "Work/Alpha")
+        # Record a beacon invocation 31 minutes ago
+        old_ts = (datetime.utcnow() - timedelta(minutes=31)).isoformat()
+        conn = sqlite3.connect(db_path)
+        conn.execute("UPDATE beacon_state SET last_invoked_at = ? WHERE id = 1", (old_ts,))
+        conn.commit()
+        conn.close()
+        assert should_trigger_beacon(db_path, score_threshold=8, cooldown_minutes=30) is True
+
+
+# ---------------------------------------------------------------------------
+# run_beacon — two-phase agent
+# ---------------------------------------------------------------------------
+
+class TestRunBeacon:
+    def test_does_not_invoke_action_when_triage_says_no(self, seeded_db):
+        from bot.beacon import run_beacon
+        router = make_router(triage_response="NO nothing to do")
+
+        changes = [
+            {"change_type": "task_done", "entity_id": "t1", "score": 2},
+        ]
+        asyncio.run(run_beacon(
+            router=router,
+            db_path=seeded_db,
+            changes=changes,
+            model="claude-haiku-4-5-20251001",
+        ))
+        # Only one LLM call (triage), no action phase
+        assert router.complete.call_count == 1
+
+    def test_invokes_action_when_triage_says_yes(self, seeded_db):
+        from bot.beacon import run_beacon
+        router = make_router(triage_response="YES needs attention")
+
+        changes = [
+            {"change_type": "context_updated", "entity_id": "Work/Alpha", "score": 3},
+            {"change_type": "plan_restructured", "entity_id": "today", "score": 5},
+        ]
+        asyncio.run(run_beacon(
+            router=router,
+            db_path=seeded_db,
+            changes=changes,
+            model="claude-haiku-4-5-20251001",
+        ))
+        # Two calls: triage + action
+        assert router.complete.call_count >= 2
+
+    def test_returns_result_dict(self, seeded_db):
+        from bot.beacon import run_beacon
+        router = make_router(triage_response="NO")
+
+        result = asyncio.run(run_beacon(
+            router=router,
+            db_path=seeded_db,
+            changes=[{"change_type": "task_done", "entity_id": "t1", "score": 2}],
+            model="claude-haiku-4-5-20251001",
+        ))
+        assert isinstance(result, dict)
+        assert "triggered" in result
+        assert "message" in result
+
+    def test_does_not_raise_on_llm_failure(self, seeded_db):
+        from bot.beacon import run_beacon
+        router = mock.MagicMock()
+        router.complete = mock.AsyncMock(side_effect=RuntimeError("LLM down"))
+
+        result = asyncio.run(run_beacon(
+            router=router,
+            db_path=seeded_db,
+            changes=[{"change_type": "task_done", "entity_id": "t1", "score": 2}],
+            model="claude-haiku-4-5-20251001",
+        ))
+        assert isinstance(result, dict)
+        assert result.get("triggered") is False
+
+    def test_triage_checks_for_yes_case_insensitively(self, seeded_db):
+        from bot.beacon import run_beacon
+        router = make_router(triage_response="yes, this needs review")
+        changes = [{"change_type": "context_updated", "entity_id": "x", "score": 3}]
+        asyncio.run(run_beacon(
+            router=router,
+            db_path=seeded_db,
+            changes=changes,
+            model="claude-haiku-4-5-20251001",
+        ))
+        assert router.complete.call_count >= 2


### PR DESCRIPTION
## Summary
- `db/schema.py`: added `state_monitor_log` (change events + scores) and `beacon_state` (cooldown tracking) tables
- `bot/state_monitor.py`: `record_change()`, `get_pending_score()`, `consume_changes()`, `CHANGE_WEIGHTS` dict
- `bot/beacon.py`: `should_trigger_beacon()` (score threshold + cooldown), `run_beacon()` two-phase (triage → action), `record_beacon_invocation()`
- Triage: single cheap Haiku call, YES/NO — action phase only runs on YES
- All errors swallowed; never crashes the main bot loop

## Test plan
- [x] 19 unit tests: change recording, weight accumulation, consume/reset, cooldown logic, triage gating, LLM failure resilience
- [x] Full regression: 317 tests pass