### PR TITLE
feat: modular prompt system with role-based modes

### DIFF
--- a/bot/conversation.py
+++ b/bot/conversation.py
@@ -29,44 +29,32 @@ def build_system_prompt(
     plan_summary: str,
     context_subjects: list[str],
     session_notes: str | None,
+    mode: str = "scheduler",
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
 ) -> str:
     """Assemble the system prompt from modular sections.
 
-    Stable sections (identity, rules) are cheap to cache.
-    Volatile sections (anchor, plan, date) are recomputed each turn
-    but kept short so cache misses are inexpensive.
+    Modes control which sections are included:
+      - "scheduler": full scheduling + backlog focus (default for FULL path)
+      - "coach": brief accountability coaching (for followup nudges)
+      - "planner": detailed planning with structured output
+      - "quick": minimal prompt for simple responses
+      - "followup": followup ping coaching style
+
+    Callers can further customize with include/exclude lists.
     """
-    today = date.today().isoformat()
-    sections = []
+    from bot.prompt_sections import build_prompt
 
-    # --- Identity + rules (stable) ---
-    sections.append(
-        "You are Tether, a daily task management assistant. "
-        "You help the user stay focused, track their plan, and manage their context. "
-        "Be concise and direct. Prefer actions over explanation."
-    )
-
-    # --- Current state (volatile) ---
-    sections.append(
-        f"Today is {today}. Current time block: {anchor_name} (starts {anchor_time})."
-    )
-
-    # --- Plan (semi-stable) ---
-    if plan_summary:
-        sections.append(f"Today's plan:\n{plan_summary}")
-
-    # --- Context index (semi-stable, subjects only — bodies fetched via tools) ---
-    if context_subjects:
-        subjects_list = "\n".join(f"  - {s}" for s in context_subjects)
-        sections.append(
-            f"Available context entries (fetch bodies with get_context_entry tool):\n{subjects_list}"
-        )
-
-    # --- Session notes (injected when available, replaces raw history) ---
-    if session_notes:
-        sections.append(f"Session Notes:\n{session_notes}")
-
-    return "\n\n".join(sections)
+    ctx = {
+        "today": date.today().isoformat(),
+        "anchor_name": anchor_name,
+        "anchor_time": anchor_time,
+        "plan_summary": plan_summary,
+        "context_subjects": context_subjects,
+        "session_notes": session_notes,
+    }
+    return build_prompt(mode=mode, ctx=ctx, include=include, exclude=exclude)
 
 
 # ---------------------------------------------------------------------------

--- a/bot/llm.py
+++ b/bot/llm.py
@@ -519,12 +519,8 @@ class AgentSDKBackend(LLMBackend):
         from claude_agent_sdk.types import McpSSEServerConfig
 
         system_text = system if isinstance(system, str) else "\n".join(system)
-        # Add resource constraints for the Pi
-        system_text += (
-            "\n\nIMPORTANT: You are running on a resource-constrained device. "
-            "Limit parallel subagent dispatches to at most 2 at a time. "
-            "Prefer sequential tool calls when parallelism isn't critical."
-        )
+        # Resource constraints are now in prompt_sections.RESOURCE_CONSTRAINTS
+        # and included by build_system_prompt() for all applicable modes.
         prompt = _format_messages_as_prompt(messages, system)
 
         mcp_servers: dict = {}

--- a/bot/prompt_sections.py
+++ b/bot/prompt_sections.py
@@ -1,0 +1,259 @@
+"""Modular prompt sections for Tether v3.
+
+Each section is a named block of system prompt text. Sections are composed
+by build_system_prompt() based on the active mode (e.g., "scheduler",
+"coach", "planner"). Callers can also override with explicit include/exclude
+sets.
+
+Sections fall into two categories:
+  - Static: personality, role definitions, rules (cheap to cache)
+  - Dynamic: require runtime data (anchor, plan, date, etc.)
+
+Static sections are plain strings. Dynamic sections are functions that
+accept a context dict and return a string.
+"""
+
+# ---------------------------------------------------------------------------
+# Static sections — identity, personality, behavioral rules
+# ---------------------------------------------------------------------------
+
+IDENTITY = (
+    "You are Tether, an ADHD accountability coach and daily task manager. "
+    "You help your user stay focused, build momentum, and make steady progress "
+    "across their projects and responsibilities. You live in their Telegram chat "
+    "and have access to their full task system via MCP tools."
+)
+
+PERSONALITY = (
+    "Be concise and direct. Match the user's energy: calm and grounding when "
+    "they're stressed, encouraging when they're checking in, matter-of-fact when "
+    "they're in flow. Prefer actions over explanation. Don't summarize what "
+    "you're about to do — just do it. Two to four sentences is usually right. "
+    "One concrete next action or nudge is better than a paragraph of analysis."
+)
+
+SEPARATION_OF_DUTIES = (
+    "Your primary job is SCHEDULING and DAILY MANAGEMENT. Tasks, milestones, "
+    "and context entries are created and fleshed out by other agents via MCP "
+    "(Claude Code sessions, other tools). Those agents handle descriptions, "
+    "dependencies, milestone links, and context elaboration. Your focus is:\n"
+    "  - Scheduling backlog tasks into daily plans and anchor time blocks\n"
+    "  - Monitoring progress and adjusting the schedule as the day unfolds\n"
+    "  - Tracking what's done, what's slipping, and what to prioritize\n"
+    "  - Keeping the user accountable with timely check-ins\n"
+    "  - Answering questions about their plan, schedule, and priorities\n\n"
+    "You should NOT spend time elaborating task descriptions or restructuring "
+    "context entries unless the user specifically asks. That's the MCP agents' job. "
+    "If the user asks you to create tasks, keep descriptions minimal — the detail "
+    "work happens elsewhere."
+)
+
+TOOL_GUIDANCE = (
+    "You have access to tether MCP tools. Use them to read current state before "
+    "making changes — don't assume the plan hasn't changed since the last message.\n\n"
+    "Key tools:\n"
+    "  - get_today_plan / update_plan_tasks — read and modify daily schedules\n"
+    "  - get_milestones / get_context_entry — understand project state\n"
+    "  - patch_task — update individual task status, descriptions, scheduling\n"
+    "  - search — find tasks across dates and projects\n"
+    "  - list_context_entries — see all tracked projects and areas\n\n"
+    "Always fetch before modifying. Batch related reads in parallel when possible. "
+    "Keep tool calls focused — don't fetch everything if you only need one anchor's tasks."
+)
+
+SESSION_AWARENESS = (
+    "You are in a multi-turn session. You can ask the user clarifying questions "
+    "and they'll respond in the same session — you'll keep your full context "
+    "(tool results, reasoning, prior exchanges) across messages.\n\n"
+    "When you're done with all planned work for this conversation, call the "
+    "session_done tool with a brief summary of what you accomplished. Don't "
+    "call it prematurely — finish your work first.\n\n"
+    "If you need information from the user to proceed, ask clearly and wait. "
+    "Don't guess or make assumptions about their schedule, preferences, or priorities."
+)
+
+SCHEDULING_FOCUS = (
+    "When scheduling tasks from the backlog into daily plans:\n"
+    "  - Respect anchor time block purposes (deep_work for complex tasks, "
+    "grind for steady throughput, flex_time for lighter work)\n"
+    "  - Don't overload any single day — spread work across the week\n"
+    "  - Consider task dependencies and blocking relationships\n"
+    "  - Intersperse rest, leisure, and personal tasks with work\n"
+    "  - Account for fixed commitments (meetings, deadlines)\n"
+    "  - Group related tasks in the same time block when possible\n"
+    "  - Leave buffer for unexpected work and context switching"
+)
+
+RESPONSE_STYLE_COACH = (
+    "You're in coach mode. Keep responses short and action-oriented. "
+    "Acknowledge what's done, point to what's next, give one concrete nudge. "
+    "Don't over-explain. If the user is behind, be direct but not harsh. "
+    "If they're ahead, celebrate briefly and move on."
+)
+
+RESPONSE_STYLE_PLANNER = (
+    "You're in planner mode. Be thorough and structured. Use bullet points "
+    "and clear headings. Show your reasoning about scheduling decisions. "
+    "Present options when trade-offs exist. Summarize what you changed and why. "
+    "It's OK to be longer here — the user asked for detailed planning."
+)
+
+RESPONSE_STYLE_QUICK = (
+    "Keep it brief. One to two sentences. Answer the question or acknowledge "
+    "the message. Don't fetch tools or make changes unless explicitly asked."
+)
+
+RESOURCE_CONSTRAINTS = (
+    "You are running on a resource-constrained device (Raspberry Pi). "
+    "Limit parallel subagent dispatches to at most 2 at a time. "
+    "Prefer sequential tool calls when parallelism isn't critical."
+)
+
+FOLLOWUP_COACHING = (
+    "You're sending a followup check-in during an active time block. "
+    "The user hasn't checked in yet on their scheduled tasks. Be brief, "
+    "warm, and specific — mention the actual tasks. Don't lecture. A gentle "
+    "nudge is more effective than a detailed status report. End with a "
+    "clear action: '/check-in when you're on it' or 'what's blocking you?'"
+)
+
+
+# ---------------------------------------------------------------------------
+# Dynamic sections — require runtime context
+# ---------------------------------------------------------------------------
+
+def current_state(ctx: dict) -> str:
+    """Today's date and active anchor."""
+    return f"Today is {ctx['today']}. Current time block: {ctx['anchor_name']} (starts {ctx['anchor_time']})."
+
+
+def plan_summary(ctx: dict) -> str | None:
+    """Today's plan, if available."""
+    summary = ctx.get("plan_summary", "")
+    if not summary:
+        return None
+    return f"Today's plan:\n{summary}"
+
+
+def context_index(ctx: dict) -> str | None:
+    """List of available context entries (subjects only)."""
+    subjects = ctx.get("context_subjects", [])
+    if not subjects:
+        return None
+    subjects_list = "\n".join(f"  - {s}" for s in subjects)
+    return f"Available context entries (fetch bodies with get_context_entry tool):\n{subjects_list}"
+
+
+def session_notes(ctx: dict) -> str | None:
+    """Session notes from the memory system."""
+    notes = ctx.get("session_notes")
+    if not notes:
+        return None
+    return f"Session Notes:\n{notes}"
+
+
+# ---------------------------------------------------------------------------
+# Mode presets — which sections to include for each mode
+# ---------------------------------------------------------------------------
+
+# Each mode is a list of section keys. Static keys reference module-level
+# constants; dynamic keys reference functions above.
+
+MODES: dict[str, list[str]] = {
+    "scheduler": [
+        "IDENTITY", "PERSONALITY", "SEPARATION_OF_DUTIES", "SCHEDULING_FOCUS",
+        "TOOL_GUIDANCE", "SESSION_AWARENESS", "RESOURCE_CONSTRAINTS",
+        "current_state", "plan_summary", "context_index", "session_notes",
+    ],
+    "coach": [
+        "IDENTITY", "PERSONALITY", "RESPONSE_STYLE_COACH",
+        "TOOL_GUIDANCE", "SESSION_AWARENESS", "RESOURCE_CONSTRAINTS",
+        "current_state", "plan_summary", "context_index", "session_notes",
+    ],
+    "planner": [
+        "IDENTITY", "PERSONALITY", "SEPARATION_OF_DUTIES", "SCHEDULING_FOCUS",
+        "RESPONSE_STYLE_PLANNER", "TOOL_GUIDANCE", "SESSION_AWARENESS",
+        "RESOURCE_CONSTRAINTS",
+        "current_state", "plan_summary", "context_index", "session_notes",
+    ],
+    "quick": [
+        "IDENTITY", "PERSONALITY", "RESPONSE_STYLE_QUICK",
+        "current_state", "plan_summary",
+    ],
+    "followup": [
+        "IDENTITY", "FOLLOWUP_COACHING",
+        "current_state", "plan_summary",
+    ],
+}
+
+# Static section registry — maps key names to their string values
+_STATIC_SECTIONS: dict[str, str] = {
+    "IDENTITY": IDENTITY,
+    "PERSONALITY": PERSONALITY,
+    "SEPARATION_OF_DUTIES": SEPARATION_OF_DUTIES,
+    "TOOL_GUIDANCE": TOOL_GUIDANCE,
+    "SESSION_AWARENESS": SESSION_AWARENESS,
+    "SCHEDULING_FOCUS": SCHEDULING_FOCUS,
+    "RESPONSE_STYLE_COACH": RESPONSE_STYLE_COACH,
+    "RESPONSE_STYLE_PLANNER": RESPONSE_STYLE_PLANNER,
+    "RESPONSE_STYLE_QUICK": RESPONSE_STYLE_QUICK,
+    "RESOURCE_CONSTRAINTS": RESOURCE_CONSTRAINTS,
+    "FOLLOWUP_COACHING": FOLLOWUP_COACHING,
+}
+
+# Dynamic section registry — maps key names to their builder functions
+_DYNAMIC_SECTIONS: dict[str, callable] = {
+    "current_state": current_state,
+    "plan_summary": plan_summary,
+    "context_index": context_index,
+    "session_notes": session_notes,
+}
+
+
+def resolve_sections(
+    mode: str = "scheduler",
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+) -> list[str]:
+    """Return the ordered list of section keys for a mode, with overrides.
+
+    include: additional sections to add (appended after mode defaults)
+    exclude: sections to remove from the mode defaults
+    """
+    sections = list(MODES.get(mode, MODES["scheduler"]))
+    if include:
+        for key in include:
+            if key not in sections:
+                sections.append(key)
+    if exclude:
+        sections = [s for s in sections if s not in exclude]
+    return sections
+
+
+def build_prompt(
+    mode: str = "scheduler",
+    ctx: dict | None = None,
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+) -> str:
+    """Assemble a system prompt from modular sections.
+
+    Args:
+        mode: preset name (scheduler, coach, planner, quick, followup)
+        ctx: runtime context dict with keys like 'today', 'anchor_name', etc.
+        include: extra section keys to add
+        exclude: section keys to remove
+    """
+    ctx = ctx or {}
+    section_keys = resolve_sections(mode, include, exclude)
+    parts = []
+
+    for key in section_keys:
+        if key in _STATIC_SECTIONS:
+            parts.append(_STATIC_SECTIONS[key])
+        elif key in _DYNAMIC_SECTIONS:
+            result = _DYNAMIC_SECTIONS[key](ctx)
+            if result is not None:
+                parts.append(result)
+
+    return "\n\n".join(parts)

--- a/tests/bot/test_prompt_sections.py
+++ b/tests/bot/test_prompt_sections.py
@@ -1,0 +1,158 @@
+"""Tests for modular prompt sections."""
+import pytest
+from bot.prompt_sections import (
+    build_prompt, resolve_sections, MODES,
+    IDENTITY, PERSONALITY, SEPARATION_OF_DUTIES,
+    _STATIC_SECTIONS, _DYNAMIC_SECTIONS,
+)
+
+
+@pytest.fixture
+def ctx():
+    return {
+        "today": "2026-04-06",
+        "anchor_name": "Deep Work",
+        "anchor_time": "10:30",
+        "plan_summary": "deep_work: [p] GPU pipeline deploy",
+        "context_subjects": ["Intellipat", "Tether", "Thesis"],
+        "session_notes": "Morning: reviewed GPU test results.",
+    }
+
+
+class TestResolve:
+    def test_default_mode_is_scheduler(self):
+        sections = resolve_sections()
+        assert "IDENTITY" in sections
+        assert "SEPARATION_OF_DUTIES" in sections
+        assert "SCHEDULING_FOCUS" in sections
+
+    def test_all_modes_exist(self):
+        for mode in ["scheduler", "coach", "planner", "quick", "followup"]:
+            sections = resolve_sections(mode)
+            assert "IDENTITY" in sections
+
+    def test_include_adds_section(self):
+        sections = resolve_sections("quick", include=["TOOL_GUIDANCE"])
+        assert "TOOL_GUIDANCE" in sections
+
+    def test_exclude_removes_section(self):
+        sections = resolve_sections("scheduler", exclude=["RESOURCE_CONSTRAINTS"])
+        assert "RESOURCE_CONSTRAINTS" not in sections
+        assert "IDENTITY" in sections  # others untouched
+
+    def test_unknown_mode_falls_back_to_scheduler(self):
+        sections = resolve_sections("nonexistent_mode")
+        assert sections == resolve_sections("scheduler")
+
+
+class TestBuildPrompt:
+    def test_scheduler_contains_identity_and_duties(self, ctx):
+        prompt = build_prompt("scheduler", ctx)
+        assert "Tether" in prompt
+        assert "ADHD accountability coach" in prompt
+        assert "SCHEDULING and DAILY MANAGEMENT" in prompt
+
+    def test_scheduler_contains_dynamic_state(self, ctx):
+        prompt = build_prompt("scheduler", ctx)
+        assert "2026-04-06" in prompt
+        assert "Deep Work" in prompt
+        assert "GPU pipeline deploy" in prompt
+        assert "Intellipat" in prompt
+        assert "Morning: reviewed" in prompt
+
+    def test_coach_is_shorter_than_planner(self, ctx):
+        coach = build_prompt("coach", ctx)
+        planner = build_prompt("planner", ctx)
+        assert len(coach) < len(planner)
+
+    def test_quick_mode_minimal(self, ctx):
+        prompt = build_prompt("quick", ctx)
+        assert "TOOL_GUIDANCE" not in prompt
+        assert "SESSION_AWARENESS" not in prompt
+        assert "Tether" in prompt
+        assert "Deep Work" in prompt
+
+    def test_followup_mode_has_coaching(self, ctx):
+        prompt = build_prompt("followup", ctx)
+        assert "followup check-in" in prompt
+        assert "gentle nudge" in prompt.lower() or "nudge" in prompt.lower()
+
+    def test_planner_has_structured_guidance(self, ctx):
+        prompt = build_prompt("planner", ctx)
+        assert "thorough and structured" in prompt
+        assert "bullet points" in prompt
+
+    def test_missing_dynamic_ctx_omits_section(self):
+        prompt = build_prompt("scheduler", ctx={"today": "2026-04-06",
+                                                 "anchor_name": "General",
+                                                 "anchor_time": "00:00"})
+        assert "Available context entries" not in prompt
+        assert "Session Notes" not in prompt
+        assert "Today's plan" not in prompt
+
+    def test_exclude_separation_of_duties(self, ctx):
+        prompt = build_prompt("scheduler", ctx, exclude=["SEPARATION_OF_DUTIES"])
+        assert "SCHEDULING and DAILY MANAGEMENT" not in prompt
+        assert "Tether" in prompt  # identity still present
+
+    def test_include_custom_section(self, ctx):
+        prompt = build_prompt("quick", ctx, include=["SESSION_AWARENESS"])
+        assert "multi-turn session" in prompt
+
+
+class TestBuildSystemPromptIntegration:
+    """Test that conversation.py's build_system_prompt delegates correctly."""
+
+    def test_default_mode_is_scheduler(self):
+        from bot.conversation import build_system_prompt
+        prompt = build_system_prompt(
+            anchor_name="The Grind",
+            anchor_time="09:00",
+            plan_summary="grind_am: [p] Leetcode",
+            context_subjects=["Job Search"],
+            session_notes=None,
+        )
+        assert "ADHD accountability coach" in prompt
+        assert "SCHEDULING and DAILY MANAGEMENT" in prompt
+
+    def test_quick_mode(self):
+        from bot.conversation import build_system_prompt
+        prompt = build_system_prompt(
+            anchor_name="General",
+            anchor_time="00:00",
+            plan_summary="",
+            context_subjects=[],
+            session_notes=None,
+            mode="quick",
+        )
+        assert "brief" in prompt.lower()
+        assert "SESSION_AWARENESS" not in prompt
+
+    def test_mode_passthrough(self):
+        from bot.conversation import build_system_prompt
+        prompt = build_system_prompt(
+            anchor_name="General",
+            anchor_time="00:00",
+            plan_summary="",
+            context_subjects=[],
+            session_notes=None,
+            mode="planner",
+        )
+        assert "thorough and structured" in prompt
+
+
+class TestSectionRegistries:
+    def test_all_static_keys_are_strings(self):
+        for key, val in _STATIC_SECTIONS.items():
+            assert isinstance(val, str), f"{key} is not a string"
+            assert len(val) > 10, f"{key} is suspiciously short"
+
+    def test_all_dynamic_keys_are_callable(self):
+        for key, fn in _DYNAMIC_SECTIONS.items():
+            assert callable(fn), f"{key} is not callable"
+
+    def test_all_mode_keys_are_registered(self):
+        for mode, keys in MODES.items():
+            for key in keys:
+                assert key in _STATIC_SECTIONS or key in _DYNAMIC_SECTIONS, \
+                    f"Mode '{mode}' references unregistered section '{key}'"


### PR DESCRIPTION
## Summary
- Replaces the hardcoded 3-line system prompt with a composable section-based prompt system
- 5 modes: scheduler (default), coach, planner, quick, followup — each assembles different section combinations
- 11 static sections (identity, personality, separation of duties, tool guidance, session awareness, scheduling focus, 3 response styles, resource constraints, followup coaching)
- 4 dynamic sections (current state, plan summary, context index, session notes)
- Callers can override with `include`/`exclude` lists for one-off customization
- Inherits ADHD accountability coach personality from v2 prompts
- Adds separation of duties: bot focuses on scheduling, MCP agents handle task elaboration
- Removes duplicated resource constraints from llm.py (now in prompt section)

## Files
- `bot/prompt_sections.py` — new: section definitions, mode presets, `build_prompt()` 
- `bot/conversation.py` — `build_system_prompt()` now accepts `mode=`, delegates to prompt_sections
- `bot/llm.py` — removed hardcoded resource constraint string from AgentSDKBackend
- `tests/bot/test_prompt_sections.py` — 20 tests covering modes, composition, registries, integration

## Test plan
- [ ] 530 tests pass, 0 regressions
- [ ] All 5 modes produce valid prompts with correct sections
- [ ] Include/exclude overrides work
- [ ] Dynamic sections omitted when context data is missing
- [ ] All mode keys reference registered sections (registry integrity test)
- [ ] build_system_prompt() in conversation.py delegates correctly