### PR TITLE
fix: detail panel polish — dep titles, milestone colors, append tools

### DIFF
--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -257,6 +257,26 @@ const STATUS_COLORS: Record<string, string> = {
   blocked: 'bg-red-400',
 }
 
+// Resolve dependency entity_id to a display name
+function depLabel(type: string, entityId: string): string {
+  if (type === 'milestone') {
+    const m = milestoneStore.all.find(m => m.id === entityId)
+    if (m) return m.name
+  } else {
+    // Search today's plan tasks
+    if (planStore.plan) {
+      for (const anchor of Object.values(planStore.plan.anchors)) {
+        const t = anchor.tasks.find(t => t.id === entityId)
+        if (t) return t.text
+      }
+    }
+    // Search backlog
+    const bt = backlogStore.tasks.find(t => t.id === entityId)
+    if (bt) return bt.text
+  }
+  return entityId.slice(0, 8) + '…'
+}
+
 onMounted(async () => {
   if (!planStore.plan) await planStore.fetchPlan()
   if (!milestoneStore.all.length) await milestoneStore.fetchAll()
@@ -442,7 +462,7 @@ onMounted(async () => {
               @click="openDep(d.type, d.entity_id)"
               class="flex items-center gap-2 text-left group">
               <span :class="STATUS_COLORS['pending']" class="w-2 h-2 rounded-full flex-shrink-0" />
-              <span class="text-sm text-white/70 hover:text-white flex-1 truncate">{{ d.entity_id }}</span>
+              <span class="text-sm text-white/70 hover:text-white flex-1 truncate">{{ depLabel(d.type, d.entity_id) }}</span>
               <span class="text-xs px-1 py-0.5 rounded bg-white/10 text-white/40">{{ d.type }}</span>
               <button @click.stop="removeDep(d.id)" class="text-white/20 hover:text-red-400 text-xs opacity-0 group-hover:opacity-100">✕</button>
             </button>
@@ -457,7 +477,7 @@ onMounted(async () => {
               @click="openDep(d.type, d.entity_id)"
               class="flex items-center gap-2 text-left group">
               <span :class="STATUS_COLORS['pending']" class="w-2 h-2 rounded-full flex-shrink-0" />
-              <span class="text-sm text-white/70 hover:text-white flex-1 truncate">{{ d.entity_id }}</span>
+              <span class="text-sm text-white/70 hover:text-white flex-1 truncate">{{ depLabel(d.type, d.entity_id) }}</span>
               <span class="text-xs px-1 py-0.5 rounded bg-white/10 text-white/40">{{ d.type }}</span>
               <button @click.stop="removeDep(d.id)" class="text-white/20 hover:text-red-400 text-xs opacity-0 group-hover:opacity-100">✕</button>
             </button>
@@ -474,8 +494,12 @@ onMounted(async () => {
             v-for="m in (milestoneStore.taskMilestones[taskId] ?? [])" :key="m.id"
             @click="openMilestone(m.id)"
             class="flex items-center gap-2 text-left">
-            <span class="text-sm text-white/70 hover:text-white">{{ m.name }}</span>
-            <span class="text-xs px-1 py-0.5 rounded bg-white/10 text-white/40">{{ m.status }}</span>
+            <span v-if="m.color" class="w-2.5 h-2.5 rounded-full flex-shrink-0" :style="{ background: m.color }" />
+            <span class="text-sm text-white/70 hover:text-white"
+                  :style="m.color ? { color: m.color } : {}">{{ m.name }}</span>
+            <span class="text-xs px-1 py-0.5 rounded text-white/40"
+                  :style="m.color ? { backgroundColor: m.color + '33', color: m.color, borderColor: m.color + '66' } : {}"
+                  :class="m.color ? 'border' : 'bg-white/10'">{{ m.status }}</span>
           </button>
           <SearchAutocomplete :search-fn="searchForMilestone" placeholder="Search milestones..." @select="linkMilestoneFromSearch" />
         </div>

--- a/tether_mcp/server.py
+++ b/tether_mcp/server.py
@@ -344,6 +344,35 @@ def patch_task(task_uuid: str, fields: dict) -> dict:
 
 
 @mcp.tool()
+def append_task_description(task_uuid: str, text: str) -> dict:
+    """Append text to a task's description (adds after existing content with double newline).
+    Creates description if none exists."""
+    db = _db()
+    existing = get_task_by_uuid(db, task_uuid)
+    if not existing:
+        return {"error": "Task not found"}
+    current = existing.get("description") or ""
+    new_desc = (current + "\n\n" + text).strip() if current else text
+    return patch_task_fields(db, task_uuid, {"description": new_desc}) or {"error": "Update failed"}
+
+
+@mcp.tool()
+def append_milestone_description(milestone_id: str, text: str) -> dict:
+    """Append text to a milestone's description (adds after existing content with double newline).
+    Creates description if none exists."""
+    db = _db()
+    from db.queries import get_milestones as _get_ms
+    all_ms = _get_ms(db)
+    ms = next((m for m in all_ms if m["id"] == milestone_id), None)
+    if not ms:
+        return {"error": "Milestone not found"}
+    current = ms.get("description") or ""
+    new_desc = (current + "\n\n" + text).strip() if current else text
+    result = patch_milestone(db, milestone_id, {"description": new_desc})
+    return result or {"error": "Update failed"}
+
+
+@mcp.tool()
 def search(query: str, type: str = "all") -> list[dict]:
     """Search tasks and milestones by text. Type: 'task', 'milestone', or 'all'.
     Returns [{id, label, sublabel, type}]."""


### PR DESCRIPTION
## Summary
Three quick fixes:

1. **Dependencies show task title instead of UUID** — `depLabel()` helper resolves entity_id to name from plan/backlog/milestone stores. Falls back to truncated UUID if not found.

2. **Milestone badges in detail panel show color** — colored dot + tinted name + colored status badge matching the milestone's user-set color.

3. **`append_task_description` + `append_milestone_description` MCP tools** — append text to existing descriptions without full rewrite. Double-newline separator.

## Test plan
- [ ] 518 tests pass
- [ ] Open task with dependencies → see task titles not UUIDs
- [ ] Open task linked to colored milestone → see colored badge
- [ ] Use append_task_description MCP tool → description grows without overwriting