### PR TITLE
feat: Phase 9 foundation — kanban board, visual consistency, single context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,6 @@ __marimo__/
 # Git worktrees
 .worktrees/
 .serena/
+
+# Internal dev specs (not user-facing docs)
+docs/superpowers/

--- a/api/main.py
+++ b/api/main.py
@@ -14,6 +14,7 @@ from api.routes import links as links_routes
 from api.routes import llm_config as llm_config_routes
 from api.routes import sessions as sessions_routes
 from api.routes import bot as bot_routes
+from api.routes import kanban as kanban_routes
 from api.ws import manager
 from api.auth import decode_jwt
 from db.auth_schema import init_auth_db
@@ -52,6 +53,7 @@ def create_app(db_path: Path | None = None) -> FastAPI:
     app.include_router(llm_config_routes.router, prefix="/api")
     app.include_router(sessions_routes.router, prefix="/api")
     app.include_router(bot_routes.router, prefix="/api")
+    app.include_router(kanban_routes.router, prefix="/api")
 
     @app.post("/api/notify")
     async def notify():

--- a/api/routes/kanban.py
+++ b/api/routes/kanban.py
@@ -10,7 +10,10 @@ router = APIRouter()
 
 @router.get("/kanban/columns")
 async def list_columns(request: Request, _auth=Depends(auth_dependency)):
-    seed_kanban_columns(request.state.db_path)  # ensure defaults exist
+    try:
+        seed_kanban_columns(request.state.db_path)
+    except Exception:
+        pass  # table may not exist yet on unmigrated DB
     return get_kanban_columns(request.state.db_path, user_id=request.state.user_id)
 
 

--- a/api/routes/kanban.py
+++ b/api/routes/kanban.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, Depends, HTTPException, Request
+from db.queries import (
+    get_kanban_columns, create_kanban_column, update_kanban_column,
+    delete_kanban_column, seed_kanban_columns,
+)
+from api.auth import auth_dependency
+
+router = APIRouter()
+
+
+@router.get("/kanban/columns")
+async def list_columns(request: Request, _auth=Depends(auth_dependency)):
+    seed_kanban_columns(request.state.db_path)  # ensure defaults exist
+    return get_kanban_columns(request.state.db_path, user_id=request.state.user_id)
+
+
+@router.post("/kanban/columns")
+async def create_column(body: dict, request: Request, _auth=Depends(auth_dependency)):
+    if "name" not in body:
+        raise HTTPException(status_code=422, detail="'name' is required")
+    return create_kanban_column(
+        request.state.db_path,
+        body["name"],
+        body.get("position", 0),
+        body.get("color"),
+        body.get("match_rules", {}),
+        body.get("entry_rules", {}),
+        request.state.user_id,
+    )
+
+
+@router.patch("/kanban/columns/{column_id}")
+async def patch_column(column_id: str, body: dict, request: Request, _auth=Depends(auth_dependency)):
+    result = update_kanban_column(request.state.db_path, column_id, body)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Column not found")
+    return result
+
+
+@router.delete("/kanban/columns/{column_id}")
+async def remove_column(column_id: str, request: Request, _auth=Depends(auth_dependency)):
+    delete_kanban_column(request.state.db_path, column_id)
+    return {"ok": True}

--- a/api/routes/kanban.py
+++ b/api/routes/kanban.py
@@ -13,8 +13,9 @@ router = APIRouter()
 async def list_columns(request: Request, _auth=Depends(auth_dependency)):
     try:
         seed_kanban_columns(request.state.db_path)
-    except sqlite3.OperationalError:
-        pass  # table may not exist yet on unmigrated DB
+    except sqlite3.OperationalError as e:
+        if "no such table" not in str(e).lower():
+            raise
     return get_kanban_columns(request.state.db_path, user_id=request.state.user_id)
 
 

--- a/api/routes/kanban.py
+++ b/api/routes/kanban.py
@@ -1,3 +1,4 @@
+import sqlite3
 from fastapi import APIRouter, Depends, HTTPException, Request
 from db.queries import (
     get_kanban_columns, create_kanban_column, update_kanban_column,
@@ -12,7 +13,7 @@ router = APIRouter()
 async def list_columns(request: Request, _auth=Depends(auth_dependency)):
     try:
         seed_kanban_columns(request.state.db_path)
-    except Exception:
+    except sqlite3.OperationalError:
         pass  # table may not exist yet on unmigrated DB
     return get_kanban_columns(request.state.db_path, user_id=request.state.user_id)
 

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from db.queries import patch_task_fields, move_task_atomic, \
     add_task_dependency, remove_task_dependency, \
     get_subtasks, create_subtask, update_subtask, delete_subtask, reorder_subtasks, \
-    search_entities, link_task_context, unlink_task_context, get_task_contexts, \
+    search_entities, \
     get_unscheduled_tasks, create_unscheduled_task, get_task_by_uuid
 from api.auth import auth_dependency
 import api.config as cfg
@@ -32,6 +32,7 @@ async def create_unscheduled(body: dict, request: Request, _auth=Depends(auth_de
         request.state.db_path, body["text"],
         description=body.get("description"),
         status=body.get("status", "pending"),
+        context_subject=body.get("context_subject"),
     )
 
 
@@ -113,17 +114,25 @@ async def reorder_task_subtasks(task_uuid: str, body: dict, request: Request, _a
     return {"ok": True}
 
 
-# Task-context linking
+# Task-context linking (single context_subject model)
 @router.get("/tasks/{task_uuid}/contexts")
 async def get_task_context_links(task_uuid: str, request: Request, _auth=Depends(auth_dependency)):
-    return get_task_contexts(request.state.db_path, task_uuid)
+    task = get_task_by_uuid(request.state.db_path, task_uuid)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    ctx = task.get("context_subject")
+    return [ctx] if ctx else []
 
 @router.post("/tasks/{task_uuid}/contexts")
 async def link_task_to_context(task_uuid: str, body: dict, request: Request, _auth=Depends(auth_dependency)):
-    link_task_context(request.state.db_path, task_uuid, body["subject"])
+    result = patch_task_fields(request.state.db_path, task_uuid, {"context_subject": body["subject"]})
+    if result is None:
+        raise HTTPException(status_code=404, detail="Task not found")
     return {"ok": True}
 
 @router.delete("/tasks/{task_uuid}/contexts/{subject:path}")
 async def unlink_task_from_context(task_uuid: str, subject: str, request: Request, _auth=Depends(auth_dependency)):
-    unlink_task_context(request.state.db_path, task_uuid, subject)
+    result = patch_task_fields(request.state.db_path, task_uuid, {"context_subject": None})
+    if result is None:
+        raise HTTPException(status_code=404, detail="Task not found")
     return {"ok": True}

--- a/bot/relationships.py
+++ b/bot/relationships.py
@@ -1,15 +1,13 @@
 """Relationship resolver for the Beacon agent.
 
 Traces links between tasks, milestones, and context entries so the Beacon
-can make relationship-aware decisions. The chain is:
+can make relationship-aware decisions. Two link paths:
 
-    context_entries ← milestones ← milestone_tasks → tasks
+  1. Direct: tasks.context_subject column (single context per task)
+  2. Indirect: milestone_tasks → milestones → context_subject
 
-When a task changes, we trace: task → milestone_tasks → milestone → context_entry
-to determine which context entries are affected and should be reviewed.
-
-This same pattern will extend to direct task_context_links when that table
-is added.
+When a task changes, we trace both paths to determine which context entries
+are affected and should be reviewed.
 """
 import logging
 import sqlite3
@@ -25,7 +23,7 @@ def resolve_task_context(db_path: str, task_id: str) -> list[dict]:
     """Given a task UUID, find all context entries linked to it.
 
     Two link paths:
-      1. Direct: task_context table (task_id → subject)
+      1. Direct: tasks.context_subject column (single context per task)
       2. Indirect: milestone_tasks → milestones → context_subject
 
     Returns a list of dicts with keys:

--- a/bot/relationships.py
+++ b/bot/relationships.py
@@ -36,16 +36,16 @@ def resolve_task_context(db_path: str, task_id: str) -> list[dict]:
     results = []
     seen_subjects = set()
 
-    # --- Path 1: direct task_context links ---
+    # --- Path 1: direct context_subject on task ---
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     try:
-        direct_rows = conn.execute(
-            "SELECT subject FROM task_context WHERE task_id = ?",
+        row = conn.execute(
+            "SELECT context_subject FROM tasks WHERE uuid = ?",
             (task_id,),
-        ).fetchall()
-        for r in direct_rows:
-            subj = r["subject"]
+        ).fetchone()
+        if row and row["context_subject"]:
+            subj = row["context_subject"]
             seen_subjects.add(subj)
             results.append({
                 "context_subject": subj,

--- a/db/migrate_kanban.py
+++ b/db/migrate_kanban.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Migration: add context_subject to tasks, create kanban_columns + user_settings tables."""
+from pathlib import Path
+import sqlite3
+import sys
+
+DB_PATH = Path.home() / ".tether-config" / "tether.db"
+
+
+def migrate(db_path: Path = DB_PATH) -> None:
+    conn = sqlite3.connect(db_path)
+
+    def try_alter(sql):
+        try:
+            conn.execute(sql)
+        except sqlite3.OperationalError as e:
+            if "duplicate column" in str(e).lower():
+                pass
+            else:
+                raise
+
+    # Add context_subject to tasks
+    try_alter("ALTER TABLE tasks ADD COLUMN context_subject TEXT")
+
+    # Populate from task_context (first link per task)
+    try:
+        conn.execute("""
+            UPDATE tasks SET context_subject = (
+                SELECT subject FROM task_context WHERE task_id = tasks.uuid LIMIT 1
+            ) WHERE context_subject IS NULL
+        """)
+    except sqlite3.OperationalError:
+        pass  # task_context may not exist
+
+    # Create kanban_columns table
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS kanban_columns (
+            id          TEXT PRIMARY KEY,
+            name        TEXT NOT NULL,
+            position    INTEGER NOT NULL DEFAULT 0,
+            color       TEXT,
+            match_rules TEXT NOT NULL DEFAULT '{}',
+            entry_rules TEXT NOT NULL DEFAULT '{}',
+            created_by  TEXT
+        )
+    """)
+
+    # Create user_settings table
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS user_settings (
+            user_id TEXT NOT NULL,
+            key     TEXT NOT NULL,
+            value   TEXT NOT NULL,
+            PRIMARY KEY (user_id, key)
+        )
+    """)
+
+    conn.commit()
+    conn.close()
+    print(f"Migration complete — {db_path}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        for path in sys.argv[1:]:
+            migrate(Path(path))
+    else:
+        migrate()

--- a/db/migrate_kanban.py
+++ b/db/migrate_kanban.py
@@ -57,6 +57,11 @@ def migrate(db_path: Path = DB_PATH) -> None:
 
     conn.commit()
     conn.close()
+
+    # Seed default kanban columns
+    from db.queries import seed_kanban_columns
+    seed_kanban_columns(db_path)
+
     print(f"Migration complete — {db_path}")
 
 

--- a/db/migrate_kanban.py
+++ b/db/migrate_kanban.py
@@ -29,8 +29,10 @@ def migrate(db_path: Path = DB_PATH) -> None:
                 SELECT subject FROM task_context WHERE task_id = tasks.uuid LIMIT 1
             ) WHERE context_subject IS NULL
         """)
-    except sqlite3.OperationalError:
-        pass  # task_context may not exist
+    except sqlite3.OperationalError as e:
+        if "no such table" not in str(e).lower():
+            raise RuntimeError(f"Backfill failed: {e}") from e
+        print("  Note: task_context table not found — skipping backfill")
 
     # Create kanban_columns table
     conn.execute("""

--- a/db/migrate_kanban.py
+++ b/db/migrate_kanban.py
@@ -26,7 +26,7 @@ def migrate(db_path: Path = DB_PATH) -> None:
     try:
         conn.execute("""
             UPDATE tasks SET context_subject = (
-                SELECT subject FROM task_context WHERE task_id = tasks.uuid LIMIT 1
+                SELECT subject FROM task_context WHERE task_id = tasks.uuid ORDER BY subject LIMIT 1
             ) WHERE context_subject IS NULL
         """)
     except sqlite3.OperationalError as e:

--- a/db/queries.py
+++ b/db/queries.py
@@ -1030,12 +1030,11 @@ def get_task_contexts(db_path: Path, task_id: str) -> list[str]:
 
 
 def get_context_tasks(db_path: Path, subject: str) -> list[dict]:
-    """Return tasks linked to a context subject."""
+    """Return tasks linked to a context subject (uses context_subject column)."""
     with get_db(db_path) as conn:
         rows = conn.execute(
-            "SELECT t.uuid, t.text, t.status, t.plan_date, t.anchor_id "
-            "FROM tasks t JOIN task_context tc ON t.uuid = tc.task_id "
-            "WHERE tc.subject=? ORDER BY t.plan_date DESC",
+            "SELECT uuid, text, status, plan_date, anchor_id "
+            "FROM tasks WHERE context_subject=? ORDER BY plan_date DESC",
             (subject,),
         ).fetchall()
     return [dict(r) for r in rows]

--- a/db/queries.py
+++ b/db/queries.py
@@ -49,22 +49,33 @@ def get_plan(db_path: Path, date: str) -> dict:
         if not plan_row:
             return {"date": date, "anchors": {}, "acknowledgements": {}, "check_in_log": []}
 
-        # Try with description column; fall back for unmigrated DBs
+        # Try with description + context_subject columns; fall back for unmigrated DBs
         try:
             task_rows = conn.execute(
-                "SELECT uuid, anchor_id, text, status, notes, position, followup_config, description "
+                "SELECT uuid, anchor_id, text, status, notes, position, followup_config, description, context_subject "
                 "FROM tasks WHERE plan_date=? ORDER BY anchor_id, position",
                 (date,)
             ).fetchall()
             has_description = True
+            has_context_subject = True
         except sqlite3.OperationalError:
-            logger.warning("tasks table missing 'description' column — run dashboard migration")
-            task_rows = conn.execute(
-                "SELECT uuid, anchor_id, text, status, notes, position, followup_config "
-                "FROM tasks WHERE plan_date=? ORDER BY anchor_id, position",
-                (date,)
-            ).fetchall()
-            has_description = False
+            try:
+                task_rows = conn.execute(
+                    "SELECT uuid, anchor_id, text, status, notes, position, followup_config, description "
+                    "FROM tasks WHERE plan_date=? ORDER BY anchor_id, position",
+                    (date,)
+                ).fetchall()
+                has_description = True
+                has_context_subject = False
+            except sqlite3.OperationalError:
+                logger.warning("tasks table missing 'description' column — run dashboard migration")
+                task_rows = conn.execute(
+                    "SELECT uuid, anchor_id, text, status, notes, position, followup_config "
+                    "FROM tasks WHERE plan_date=? ORDER BY anchor_id, position",
+                    (date,)
+                ).fetchall()
+                has_description = False
+                has_context_subject = False
 
         anchors: dict = {}
         for row in task_rows:
@@ -79,6 +90,7 @@ def get_plan(db_path: Path, date: str) -> dict:
                 "position": row["position"],
                 "followup_config": json.loads(fc) if fc else None,
                 "description": row["description"] if has_description else None,
+                "context_subject": row["context_subject"] if has_context_subject else None,
                 "blocks": [],
                 "blocked_by": [],
             })
@@ -181,6 +193,7 @@ def upsert_tasks(
                     raise ValueError("New tasks must have 'text'")
                 uid = str(uuid.uuid4())
                 status = status or "pending"
+                context_subject = task.get("context_subject")
                 max_pos = conn.execute(
                     "SELECT COALESCE(MAX(position), -1) FROM tasks "
                     "WHERE plan_date=? AND anchor_id=?",
@@ -188,8 +201,8 @@ def upsert_tasks(
                 ).fetchone()[0]
                 conn.execute(
                     "INSERT INTO tasks (uuid, plan_date, anchor_id, position, text, status, "
-                    "followup_config, notes) VALUES (?,?,?,?,?,?,?,?)",
-                    (uid, date, anchor_id, max_pos + 1, text, status, fc_json, notes),
+                    "followup_config, notes, context_subject) VALUES (?,?,?,?,?,?,?,?,?)",
+                    (uid, date, anchor_id, max_pos + 1, text, status, fc_json, notes, context_subject),
                 )
                 touched_uuids.add(uid)
 
@@ -201,7 +214,7 @@ def upsert_tasks(
 
         # Return ALL tasks for this anchor (including untouched ones)
         all_rows = conn.execute(
-            "SELECT uuid, text, status, position, followup_config, description "
+            "SELECT uuid, text, status, position, followup_config, description, context_subject "
             "FROM tasks WHERE plan_date=? AND anchor_id=? ORDER BY position",
             (date, anchor_id),
         ).fetchall()
@@ -210,6 +223,7 @@ def upsert_tasks(
              "position": r["position"],
              "followup_config": json.loads(r["followup_config"]) if r["followup_config"] else None,
              "description": r["description"],
+             "context_subject": r["context_subject"],
              "blocks": [], "blocked_by": []}
             for r in all_rows
         ]
@@ -217,7 +231,7 @@ def upsert_tasks(
 
 def patch_task_fields(db_path: Path, task_uuid: str, fields: dict) -> dict | None:
     """Update allowed fields on a task. Returns updated task dict or None if not found."""
-    allowed = {"text", "status", "position", "followup_config", "description"}
+    allowed = {"text", "status", "position", "followup_config", "description", "context_subject"}
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:
         return None
@@ -232,7 +246,7 @@ def patch_task_fields(db_path: Path, task_uuid: str, fields: dict) -> dict | Non
             (*updates.values(), task_uuid),
         )
         row = conn.execute(
-            "SELECT uuid, text, status, position, followup_config, description FROM tasks WHERE uuid=?",
+            "SELECT uuid, text, status, position, followup_config, description, context_subject FROM tasks WHERE uuid=?",
             (task_uuid,),
         ).fetchone()
     if not row:
@@ -243,6 +257,7 @@ def patch_task_fields(db_path: Path, task_uuid: str, fields: dict) -> dict | Non
         "position": row["position"],
         "followup_config": json.loads(fc) if fc else None,
         "description": row["description"],
+        "context_subject": row["context_subject"],
         "blocks": [], "blocked_by": [],
     }
 
@@ -251,7 +266,7 @@ def get_task_by_uuid(db_path: Path, task_uuid: str) -> dict | None:
     """Get a single task by UUID."""
     with get_db(db_path) as conn:
         row = conn.execute(
-            "SELECT uuid, plan_date, anchor_id, text, status, position, followup_config, description "
+            "SELECT uuid, plan_date, anchor_id, text, status, position, followup_config, description, context_subject "
             "FROM tasks WHERE uuid=?", (task_uuid,)
         ).fetchone()
     if not row:
@@ -260,6 +275,7 @@ def get_task_by_uuid(db_path: Path, task_uuid: str) -> dict | None:
     return {
         "id": row["uuid"], "text": row["text"], "status": row["status"],
         "position": row["position"], "description": row["description"],
+        "context_subject": row["context_subject"],
         "plan_date": row["plan_date"], "anchor_id": row["anchor_id"],
         "followup_config": json.loads(fc) if fc else None,
         "blocks": [], "blocked_by": [],
@@ -922,46 +938,33 @@ def resolve_followup_config(db_path: Path, anchor_id: str, task_id: str) -> dict
 
 def create_unscheduled_task(
     db_path: Path, text: str, description: str | None = None,
-    status: str = "pending",
+    status: str = "pending", context_subject: str | None = None,
 ) -> dict:
     """Create a task with no plan_date or anchor_id (backlog task)."""
     task_uuid = str(uuid.uuid4())
     with get_db(db_path) as conn:
         conn.execute(
-            "INSERT INTO tasks (uuid, plan_date, anchor_id, text, status, description) "
-            "VALUES (?,NULL,NULL,?,?,?)",
-            (task_uuid, text, status, description),
+            "INSERT INTO tasks (uuid, plan_date, anchor_id, text, status, description, context_subject) "
+            "VALUES (?,NULL,NULL,?,?,?,?)",
+            (task_uuid, text, status, description, context_subject),
         )
     return {"id": task_uuid, "text": text, "status": status, "description": description,
+            "context_subject": context_subject,
             "position": 0, "followup_config": None, "blocks": [], "blocked_by": []}
 
 
 def get_unscheduled_tasks(db_path: Path) -> list[dict]:
-    """Get all tasks with no plan_date (backlog), with context subjects."""
+    """Get all tasks with no plan_date (backlog), with context_subject."""
     with get_db(db_path) as conn:
         rows = conn.execute(
-            "SELECT uuid, text, status, position, followup_config, description "
+            "SELECT uuid, text, status, position, followup_config, description, context_subject "
             "FROM tasks WHERE plan_date IS NULL ORDER BY position, id"
         ).fetchall()
-        task_uuids = [r["uuid"] for r in rows]
-        # Fetch context links for all backlog tasks in one query
-        ctx_map: dict[str, list[str]] = {}
-        if task_uuids:
-            try:
-                ph = ",".join("?" for _ in task_uuids)
-                ctx_rows = conn.execute(
-                    f"SELECT task_id, subject FROM task_context WHERE task_id IN ({ph})",
-                    task_uuids,
-                ).fetchall()
-                for cr in ctx_rows:
-                    ctx_map.setdefault(cr["task_id"], []).append(cr["subject"])
-            except sqlite3.OperationalError as e:
-                logger.warning("task_context query failed: %s", e)
     return [
         {"id": r["uuid"], "text": r["text"], "status": r["status"],
          "position": r["position"], "description": r["description"],
          "followup_config": json.loads(r["followup_config"]) if r["followup_config"] else None,
-         "contexts": ctx_map.get(r["uuid"], []),
+         "context_subject": r["context_subject"],
          "blocks": [], "blocked_by": []}
         for r in rows
     ]

--- a/db/queries.py
+++ b/db/queries.py
@@ -11,6 +11,27 @@ from db.schema import get_db
 logger = logging.getLogger(__name__)
 
 
+def _row_to_task(row, *, include_schedule: bool = False) -> dict:
+    """Convert a DB row to a task dict. Shared by all task-returning functions."""
+    r = dict(row)  # sqlite3.Row -> dict so .get() works
+    fc = r.get("followup_config")
+    d = {
+        "id": r["uuid"],
+        "text": r["text"],
+        "status": r["status"] or "pending",
+        "position": r.get("position", 0),
+        "description": r.get("description"),
+        "context_subject": r.get("context_subject"),
+        "followup_config": json.loads(fc) if fc else None,
+        "blocks": [],
+        "blocked_by": [],
+    }
+    if include_schedule:
+        d["plan_date"] = r.get("plan_date")
+        d["anchor_id"] = r.get("anchor_id")
+    return d
+
+
 def upsert_anchor(db_path: Path, anchor: dict) -> None:
     fc_json = json.dumps(anchor.get("followup_config")) if anchor.get("followup_config") is not None else None
     with get_db(db_path) as conn:
@@ -49,51 +70,25 @@ def get_plan(db_path: Path, date: str) -> dict:
         if not plan_row:
             return {"date": date, "anchors": {}, "acknowledgements": {}, "check_in_log": []}
 
-        # Try with description + context_subject columns; fall back for unmigrated DBs
-        try:
-            task_rows = conn.execute(
-                "SELECT uuid, anchor_id, text, status, notes, position, followup_config, description, context_subject "
-                "FROM tasks WHERE plan_date=? ORDER BY anchor_id, position",
-                (date,)
-            ).fetchall()
-            has_description = True
-            has_context_subject = True
-        except sqlite3.OperationalError:
-            try:
-                task_rows = conn.execute(
-                    "SELECT uuid, anchor_id, text, status, notes, position, followup_config, description "
-                    "FROM tasks WHERE plan_date=? ORDER BY anchor_id, position",
-                    (date,)
-                ).fetchall()
-                has_description = True
-                has_context_subject = False
-            except sqlite3.OperationalError:
-                logger.warning("tasks table missing 'description' column — run dashboard migration")
-                task_rows = conn.execute(
-                    "SELECT uuid, anchor_id, text, status, notes, position, followup_config "
-                    "FROM tasks WHERE plan_date=? ORDER BY anchor_id, position",
-                    (date,)
-                ).fetchall()
-                has_description = False
-                has_context_subject = False
+        # Detect available columns so we work on unmigrated DBs too
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(tasks)").fetchall()}
+        select_cols = "uuid, anchor_id, text, status, notes, position, followup_config"
+        if "description" in cols:
+            select_cols += ", description"
+        if "context_subject" in cols:
+            select_cols += ", context_subject"
+
+        task_rows = conn.execute(
+            f"SELECT {select_cols} FROM tasks WHERE plan_date=? ORDER BY anchor_id, position",
+            (date,),
+        ).fetchall()
 
         anchors: dict = {}
         for row in task_rows:
             aid = row["anchor_id"]
             if aid not in anchors:
                 anchors[aid] = {"tasks": [], "notes": row["notes"]}
-            fc = row["followup_config"]
-            anchors[aid]["tasks"].append({
-                "id": row["uuid"],
-                "text": row["text"],
-                "status": row["status"] or "pending",
-                "position": row["position"],
-                "followup_config": json.loads(fc) if fc else None,
-                "description": row["description"] if has_description else None,
-                "context_subject": row["context_subject"] if has_context_subject else None,
-                "blocks": [],
-                "blocked_by": [],
-            })
+            anchors[aid]["tasks"].append(_row_to_task(row))
 
         # Populate dependency fields from the dependencies table
         all_uuids = [t["id"] for a in anchors.values() for t in a["tasks"] if t["id"]]
@@ -218,15 +213,7 @@ def upsert_tasks(
             "FROM tasks WHERE plan_date=? AND anchor_id=? ORDER BY position",
             (date, anchor_id),
         ).fetchall()
-        return [
-            {"id": r["uuid"], "text": r["text"], "status": r["status"] or "pending",
-             "position": r["position"],
-             "followup_config": json.loads(r["followup_config"]) if r["followup_config"] else None,
-             "description": r["description"],
-             "context_subject": r["context_subject"],
-             "blocks": [], "blocked_by": []}
-            for r in all_rows
-        ]
+        return [_row_to_task(r) for r in all_rows]
 
 
 def patch_task_fields(db_path: Path, task_uuid: str, fields: dict) -> dict | None:
@@ -251,15 +238,7 @@ def patch_task_fields(db_path: Path, task_uuid: str, fields: dict) -> dict | Non
         ).fetchone()
     if not row:
         return None
-    fc = row["followup_config"]
-    return {
-        "id": row["uuid"], "text": row["text"], "status": row["status"],
-        "position": row["position"],
-        "followup_config": json.loads(fc) if fc else None,
-        "description": row["description"],
-        "context_subject": row["context_subject"],
-        "blocks": [], "blocked_by": [],
-    }
+    return _row_to_task(row)
 
 
 def get_task_by_uuid(db_path: Path, task_uuid: str) -> dict | None:
@@ -271,15 +250,7 @@ def get_task_by_uuid(db_path: Path, task_uuid: str) -> dict | None:
         ).fetchone()
     if not row:
         return None
-    fc = row["followup_config"]
-    return {
-        "id": row["uuid"], "text": row["text"], "status": row["status"],
-        "position": row["position"], "description": row["description"],
-        "context_subject": row["context_subject"],
-        "plan_date": row["plan_date"], "anchor_id": row["anchor_id"],
-        "followup_config": json.loads(fc) if fc else None,
-        "blocks": [], "blocked_by": [],
-    }
+    return _row_to_task(row, include_schedule=True)
 
 
 def delete_task_by_uuid(db_path: Path, task_uuid: str) -> None:
@@ -554,6 +525,18 @@ def rename_context_subject(db_path: Path, old_subject: str, new_subject: str) ->
             new_child = new_subject + row["subject"][len(old_subject):]
             conn.execute(
                 "UPDATE milestones SET context_subject=? WHERE context_subject=?",
+                (new_child, row["subject"]),
+            )
+        # cascade tasks.context_subject (exact match)
+        conn.execute(
+            "UPDATE tasks SET context_subject=? WHERE context_subject=?",
+            (new_subject, old_subject),
+        )
+        # cascade tasks.context_subject (child subjects)
+        for row in children:
+            new_child = new_subject + row["subject"][len(old_subject):]
+            conn.execute(
+                "UPDATE tasks SET context_subject=? WHERE context_subject=?",
                 (new_child, row["subject"]),
             )
         conn.execute("PRAGMA foreign_keys = ON")
@@ -947,9 +930,11 @@ def create_unscheduled_task(
             "VALUES (?,NULL,NULL,?,?,?,?)",
             (task_uuid, text, status, description, context_subject),
         )
-    return {"id": task_uuid, "text": text, "status": status, "description": description,
-            "context_subject": context_subject,
-            "position": 0, "followup_config": None, "blocks": [], "blocked_by": []}
+        row = conn.execute(
+            "SELECT uuid, text, status, position, followup_config, description, context_subject "
+            "FROM tasks WHERE uuid=?", (task_uuid,)
+        ).fetchone()
+    return _row_to_task(row)
 
 
 def get_unscheduled_tasks(db_path: Path) -> list[dict]:
@@ -959,14 +944,7 @@ def get_unscheduled_tasks(db_path: Path) -> list[dict]:
             "SELECT uuid, text, status, position, followup_config, description, context_subject "
             "FROM tasks WHERE plan_date IS NULL ORDER BY position, id"
         ).fetchall()
-    return [
-        {"id": r["uuid"], "text": r["text"], "status": r["status"],
-         "position": r["position"], "description": r["description"],
-         "followup_config": json.loads(r["followup_config"]) if r["followup_config"] else None,
-         "context_subject": r["context_subject"],
-         "blocks": [], "blocked_by": []}
-        for r in rows
-    ]
+    return [_row_to_task(r) for r in rows]
 
 
 def search_entities(db_path: Path, query: str, entity_type: str = "all") -> list[dict]:
@@ -1002,31 +980,6 @@ def search_entities(db_path: Path, query: str, entity_type: str = "all") -> list
 # ---------------------------------------------------------------------------
 # Task-context linking
 # ---------------------------------------------------------------------------
-
-def link_task_context(db_path: Path, task_id: str, subject: str) -> None:
-    with get_db(db_path) as conn:
-        conn.execute(
-            "INSERT OR IGNORE INTO task_context (task_id, subject) VALUES (?,?)",
-            (task_id, subject),
-        )
-
-
-def unlink_task_context(db_path: Path, task_id: str, subject: str) -> None:
-    with get_db(db_path) as conn:
-        conn.execute(
-            "DELETE FROM task_context WHERE task_id=? AND subject=?",
-            (task_id, subject),
-        )
-
-
-def get_task_contexts(db_path: Path, task_id: str) -> list[str]:
-    """Return list of context subjects linked to a task."""
-    with get_db(db_path) as conn:
-        rows = conn.execute(
-            "SELECT subject FROM task_context WHERE task_id=? ORDER BY subject",
-            (task_id,),
-        ).fetchall()
-    return [r["subject"] for r in rows]
 
 
 def get_context_tasks(db_path: Path, subject: str) -> list[dict]:

--- a/db/queries.py
+++ b/db/queries.py
@@ -289,7 +289,6 @@ def delete_task_by_uuid(db_path: Path, task_uuid: str) -> None:
         conn.execute("DELETE FROM links WHERE parent_type='tasks' AND parent_id=?", (task_uuid,))
         conn.execute("DELETE FROM dependencies WHERE (blocker_type='task' AND blocker_id=?) OR (blocked_type='task' AND blocked_id=?)", (task_uuid, task_uuid))
         conn.execute("DELETE FROM milestone_tasks WHERE task_id=?", (task_uuid,))
-        conn.execute("DELETE FROM task_context WHERE task_id=?", (task_uuid,))
         conn.execute("DELETE FROM followup_state WHERE task_id=?", (task_uuid,))
         conn.execute("DELETE FROM tasks WHERE uuid=?", (task_uuid,))
 

--- a/db/queries.py
+++ b/db/queries.py
@@ -152,10 +152,6 @@ def upsert_tasks(
         ):
             existing_by_uuid[row["uuid"]] = dict(row)
 
-        # Track which existing tasks were referenced so we can compute new positions
-        touched_uuids: set[str] = set()
-
-        result = []
         for task in task_dicts:
             uid = task.get("id") or ""
             text = task.get("text")
@@ -181,7 +177,6 @@ def upsert_tasks(
                     "followup_config=?, notes=? WHERE uuid=?",
                     (date, anchor_id, text, status, fc_json, notes, uid),
                 )
-                touched_uuids.add(uid)
             else:
                 # New task — must have text
                 if not text:
@@ -199,13 +194,6 @@ def upsert_tasks(
                     "followup_config, notes, context_subject) VALUES (?,?,?,?,?,?,?,?,?)",
                     (uid, date, anchor_id, max_pos + 1, text, status, fc_json, notes, context_subject),
                 )
-                touched_uuids.add(uid)
-
-            result.append({
-                "id": uid, "text": text, "status": status,
-                "position": 0, "followup_config": fc,
-                "blocks": [], "blocked_by": [],
-            })
 
         # Return ALL tasks for this anchor (including untouched ones)
         all_rows = conn.execute(
@@ -1093,6 +1081,9 @@ def seed_kanban_columns(db_path: Path) -> None:
             ("col_skipped", "Skipped", 4, "#94a3b8",
              json.dumps({"status": "skipped"}),
              json.dumps({"set_status": "skipped"})),
+            ("col_blocked", "Blocked", 5, "#ef4444",
+             json.dumps({"status": "blocked"}),
+             json.dumps({"set_status": "blocked"})),
         ]
         conn.executemany(
             "INSERT INTO kanban_columns (id, name, position, color, match_rules, entry_rules) "

--- a/db/queries.py
+++ b/db/queries.py
@@ -1113,3 +1113,105 @@ def get_stale_sessions(db_path: Path, timeout_minutes: int = 15) -> list[dict]:
             (interval,),
         ).fetchall()
     return [dict(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Kanban columns
+# ---------------------------------------------------------------------------
+
+def seed_kanban_columns(db_path: Path) -> None:
+    """Create default kanban columns if none exist."""
+    with get_db(db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM kanban_columns").fetchone()[0]
+        if count > 0:
+            return
+        defaults = [
+            ("col_backlog", "Backlog", 0, None,
+             json.dumps({"plan_date": None}),
+             json.dumps({})),
+            ("col_pending", "Pending", 1, "#3b82f6",
+             json.dumps({"status": "pending", "plan_date": "not_null"}),
+             json.dumps({"set_status": "pending", "prompt_schedule": True})),
+            ("col_in_progress", "In Progress", 2, "#f59e0b",
+             json.dumps({"status": "in_progress"}),
+             json.dumps({"set_status": "in_progress"})),
+            ("col_done", "Done", 3, "#22c55e",
+             json.dumps({"status": "done"}),
+             json.dumps({"set_status": "done"})),
+            ("col_skipped", "Skipped", 4, "#94a3b8",
+             json.dumps({"status": "skipped"}),
+             json.dumps({"set_status": "skipped"})),
+        ]
+        conn.executemany(
+            "INSERT INTO kanban_columns (id, name, position, color, match_rules, entry_rules) "
+            "VALUES (?,?,?,?,?,?)",
+            defaults,
+        )
+
+
+def get_kanban_columns(db_path: Path, user_id: str | None = None) -> list[dict]:
+    """Get columns visible to user: built-in (created_by IS NULL) + user's own."""
+    with get_db(db_path) as conn:
+        if user_id:
+            rows = conn.execute(
+                "SELECT * FROM kanban_columns WHERE created_by IS NULL OR created_by=? ORDER BY position",
+                (user_id,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM kanban_columns WHERE created_by IS NULL ORDER BY position"
+            ).fetchall()
+    return [
+        {"id": r["id"], "name": r["name"], "position": r["position"],
+         "color": r["color"],
+         "match_rules": json.loads(r["match_rules"]),
+         "entry_rules": json.loads(r["entry_rules"]),
+         "created_by": r["created_by"]}
+        for r in rows
+    ]
+
+
+def create_kanban_column(
+    db_path: Path, name: str, position: int, color: str | None,
+    match_rules: dict, entry_rules: dict, created_by: str,
+) -> dict:
+    col_id = str(uuid.uuid4())
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO kanban_columns (id, name, position, color, match_rules, entry_rules, created_by) "
+            "VALUES (?,?,?,?,?,?,?)",
+            (col_id, name, position, color, json.dumps(match_rules), json.dumps(entry_rules), created_by),
+        )
+    return {"id": col_id, "name": name, "position": position, "color": color,
+            "match_rules": match_rules, "entry_rules": entry_rules, "created_by": created_by}
+
+
+def update_kanban_column(db_path: Path, column_id: str, fields: dict) -> dict | None:
+    allowed = {"name", "position", "color", "match_rules", "entry_rules"}
+    updates = {}
+    for k, v in fields.items():
+        if k not in allowed:
+            continue
+        if k in ("match_rules", "entry_rules"):
+            updates[k] = json.dumps(v) if isinstance(v, dict) else v
+        else:
+            updates[k] = v
+    if not updates:
+        return None
+    set_clause = ", ".join(f"{k}=?" for k in updates)
+    with get_db(db_path) as conn:
+        conn.execute(f"UPDATE kanban_columns SET {set_clause} WHERE id=?",
+                     (*updates.values(), column_id))
+        row = conn.execute("SELECT * FROM kanban_columns WHERE id=?", (column_id,)).fetchone()
+    if not row:
+        return None
+    return {"id": row["id"], "name": row["name"], "position": row["position"],
+            "color": row["color"],
+            "match_rules": json.loads(row["match_rules"]),
+            "entry_rules": json.loads(row["entry_rules"]),
+            "created_by": row["created_by"]}
+
+
+def delete_kanban_column(db_path: Path, column_id: str) -> None:
+    with get_db(db_path) as conn:
+        conn.execute("DELETE FROM kanban_columns WHERE id=?", (column_id,))

--- a/db/queries.py
+++ b/db/queries.py
@@ -971,14 +971,16 @@ def search_entities(db_path: Path, query: str, entity_type: str = "all") -> list
 
 
 def get_context_tasks(db_path: Path, subject: str) -> list[dict]:
-    """Return tasks linked to a context subject (uses context_subject column)."""
+    """Return tasks linked to a context subject (uses context_subject column).
+    Returns [{id, text, status, plan_date, anchor_id}] — 'id' matches _row_to_task convention."""
     with get_db(db_path) as conn:
         rows = conn.execute(
             "SELECT uuid, text, status, plan_date, anchor_id "
             "FROM tasks WHERE context_subject=? ORDER BY plan_date DESC",
             (subject,),
         ).fetchall()
-    return [dict(r) for r in rows]
+    return [{"id": r["uuid"], "text": r["text"], "status": r["status"],
+             "plan_date": r["plan_date"], "anchor_id": r["anchor_id"]} for r in rows]
 
 
 # ---------------------------------------------------------------------------
@@ -1086,7 +1088,7 @@ def seed_kanban_columns(db_path: Path) -> None:
              json.dumps({"set_status": "blocked"})),
         ]
         conn.executemany(
-            "INSERT INTO kanban_columns (id, name, position, color, match_rules, entry_rules) "
+            "INSERT OR IGNORE INTO kanban_columns (id, name, position, color, match_rules, entry_rules) "
             "VALUES (?,?,?,?,?,?)",
             defaults,
         )

--- a/db/schema.py
+++ b/db/schema.py
@@ -30,7 +30,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     status TEXT NOT NULL DEFAULT 'pending',
     followup_config TEXT,
     notes TEXT NOT NULL DEFAULT '',
-    description TEXT
+    description TEXT,
+    context_subject TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_dependencies (

--- a/db/schema.py
+++ b/db/schema.py
@@ -191,6 +191,23 @@ CREATE TABLE IF NOT EXISTS beacon_state (
 );
 
 INSERT OR IGNORE INTO beacon_state (id, last_invoked_at) VALUES (1, NULL);
+
+CREATE TABLE IF NOT EXISTS kanban_columns (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    position    INTEGER NOT NULL DEFAULT 0,
+    color       TEXT,
+    match_rules TEXT NOT NULL DEFAULT '{}',
+    entry_rules TEXT NOT NULL DEFAULT '{}',
+    created_by  TEXT
+);
+
+CREATE TABLE IF NOT EXISTS user_settings (
+    user_id TEXT NOT NULL,
+    key     TEXT NOT NULL,
+    value   TEXT NOT NULL,
+    PRIMARY KEY (user_id, key)
+);
 """
 
 _SESSIONS_DDL = """

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -47,6 +47,11 @@ async function logout() {
                        :class="$route.path.startsWith('/backlog') ? 'bg-white/20 text-white' : 'text-white/60'">
             Backlog
           </router-link>
+          <router-link to="/kanban"
+                       class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-white/10"
+                       :class="$route.path.startsWith('/kanban') ? 'bg-white/20 text-white' : 'text-white/60'">
+            Kanban
+          </router-link>
         </div>
       </div>
       <div class="flex items-center gap-2">

--- a/frontend/src/components/AnchorBlock.vue
+++ b/frontend/src/components/AnchorBlock.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { computed, nextTick, ref } from 'vue'
-import TaskItem from './TaskCard.vue'
+import TaskCard from './TaskCard.vue'
+import GroupContainer from './GroupContainer.vue'
 import { usePlanStore } from '../stores/plan'
 import type { Task } from '../stores/plan'
+import { useMilestoneStore } from '../stores/milestones'
+import type { Milestone } from '../stores/milestones'
 
 const props = defineProps<{
   anchorId: string
@@ -18,6 +21,26 @@ const dragOver = ref(false)
 const effectiveDate = computed(() => props.date ?? store.activeDate)
 const dayPlan = computed(() => props.date ? store.plans[props.date] : store.plan)
 const anchorPlan = computed(() => dayPlan.value?.anchors[props.anchorId] ?? { tasks: [], notes: '' })
+
+const milestoneStore = useMilestoneStore()
+
+const groupedTasks = computed(() => {
+  const byMilestone: Record<string, { milestone: Milestone; tasks: { task: Task; index: number }[] }> = {}
+  const ungrouped: { task: Task; index: number }[] = []
+
+  anchorPlan.value.tasks.forEach((task, index) => {
+    const milestones = milestoneStore.taskMilestones[task.id]
+    if (milestones?.length) {
+      const m = milestones[0]
+      if (!byMilestone[m.id]) byMilestone[m.id] = { milestone: m, tasks: [] }
+      byMilestone[m.id].tasks.push({ task, index })
+    } else {
+      ungrouped.push({ task, index })
+    }
+  })
+
+  return { milestoneGroups: Object.values(byMilestone), ungrouped }
+})
 
 function onUpdate(task: Task, index: number) {
   const updated = [...anchorPlan.value.tasks]
@@ -113,42 +136,70 @@ function onDrop(evt: DragEvent, toIndex: number) {
 </script>
 
 <template>
-  <div class="flex rounded-xl overflow-hidden">
-    <div class="flex flex-col justify-center px-4 py-3 min-w-[110px] text-white"
-         :style="{ background: color }">
-      <span class="text-xs opacity-75">{{ time }}</span>
-      <span class="font-bold text-sm mt-0.5">{{ anchorName }}</span>
-    </div>
-    <div class="flex-1 bg-white/5 border border-white/10 border-l-0 px-4 py-3">
-      <ul
-        ref="ulRef"
-        class="space-y-1 min-h-[2rem] rounded transition-colors"
-        :class="dragOver ? 'bg-white/10 ring-2 ring-white/30' : ''"
+  <GroupContainer :label="`${anchorName} · ${time}`" :color="color" :collapsible="true" :level="0">
+    <template #header-right>
+      <span class="text-xs text-white/30">{{ anchorPlan.tasks.length }}</span>
+    </template>
+
+    <!-- Milestone groups -->
+    <GroupContainer
+      v-for="group in groupedTasks.milestoneGroups"
+      :key="group.milestone.id"
+      :label="group.milestone.name"
+      :color="group.milestone.color ?? undefined"
+      :level="1"
+      class="mb-2">
+      <div
+        v-for="{ task, index: i } in group.tasks"
+        :key="task.id || i"
+        :data-task-id="task.id"
+        class="group flex items-center"
+        @dragstart="onDragStart($event, task)"
+        @dragend="onDragEnd"
         @dragover.prevent="onDragOver"
         @dragleave="onDragLeave"
-        @drop.prevent="onDrop($event, anchorPlan.tasks.length)">
-        <div
-          v-for="(task, i) in anchorPlan.tasks"
-          :key="task.id || i"
-          :data-task-id="task.id"
-          class="group flex items-center"
-          @dragstart="onDragStart($event, task)"
-          @dragend="onDragEnd"
-          @dragover.prevent="onDragOver"
-          @dragleave="onDragLeave"
-          @drop.stop.prevent="onDrop($event, i)">
-          <span
-            class="cursor-grab text-white/30 hover:text-white/60 select-none px-1 flex-shrink-0 leading-none"
-            @mousedown="onHandleMouseDown">⠿</span>
-          <TaskItem
-            class="flex-1 min-w-0"
-            :task="task"
-            @update="onUpdate($event, i)"
-            @remove="onRemove(i)" />
-        </div>
-      </ul>
-      <button type="button" @click="onAddNewTask"
-              class="mt-2 text-xs text-white/40 hover:text-white/70">+ Add task</button>
-    </div>
-  </div>
+        @drop.stop.prevent="onDrop($event, i)">
+        <span
+          class="cursor-grab text-white/30 hover:text-white/60 select-none px-1 flex-shrink-0 leading-none"
+          @mousedown="onHandleMouseDown">⠿</span>
+        <TaskCard
+          class="flex-1 min-w-0"
+          :task="task"
+          @update="onUpdate($event, i)"
+          @remove="onRemove(i)" />
+      </div>
+    </GroupContainer>
+
+    <!-- Ungrouped tasks -->
+    <ul
+      ref="ulRef"
+      class="space-y-1 min-h-[2rem] rounded transition-colors"
+      :class="dragOver ? 'bg-white/10 ring-2 ring-white/30' : ''"
+      @dragover.prevent="onDragOver"
+      @dragleave="onDragLeave"
+      @drop.prevent="onDrop($event, anchorPlan.tasks.length)">
+      <div
+        v-for="{ task, index: i } in groupedTasks.ungrouped"
+        :key="task.id || i"
+        :data-task-id="task.id"
+        class="group flex items-center"
+        @dragstart="onDragStart($event, task)"
+        @dragend="onDragEnd"
+        @dragover.prevent="onDragOver"
+        @dragleave="onDragLeave"
+        @drop.stop.prevent="onDrop($event, i)">
+        <span
+          class="cursor-grab text-white/30 hover:text-white/60 select-none px-1 flex-shrink-0 leading-none"
+          @mousedown="onHandleMouseDown">⠿</span>
+        <TaskCard
+          class="flex-1 min-w-0"
+          :task="task"
+          @update="onUpdate($event, i)"
+          @remove="onRemove(i)" />
+      </div>
+    </ul>
+
+    <button type="button" @click="onAddNewTask"
+            class="mt-2 text-xs text-white/40 hover:text-white/70">+ Add task</button>
+  </GroupContainer>
 </template>

--- a/frontend/src/components/AnchorBlock.vue
+++ b/frontend/src/components/AnchorBlock.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, ref } from 'vue'
-import TaskItem from './TaskItem.vue'
+import TaskItem from './TaskCard.vue'
 import { usePlanStore } from '../stores/plan'
 import type { Task } from '../stores/plan'
 

--- a/frontend/src/components/AnchorBlock.vue
+++ b/frontend/src/components/AnchorBlock.vue
@@ -44,6 +44,7 @@ function onAddNewTask() {
   tasks.push({
     id: '', text: '', description: null, status: 'pending' as const,
     position: tasks.length, followup_config: null, blocks: [], blocked_by: [],
+    context_subject: null,
   })
   nextTick(() => {
     const inputs = ulRef.value?.querySelectorAll('input')

--- a/frontend/src/components/GroupContainer.vue
+++ b/frontend/src/components/GroupContainer.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+withDefaults(defineProps<{
+  label: string
+  color?: string
+  collapsible?: boolean
+  level?: number  // 0 = top-level (anchor/context), 1 = nested (milestone)
+}>(), {
+  collapsible: true,
+  level: 0,
+})
+
+const collapsed = ref(false)
+</script>
+
+<template>
+  <div :class="[
+    'rounded-lg transition-all',
+    level === 0 ? 'bg-white/5 border border-white/10 p-3' : 'bg-white/[0.03] border border-white/[0.06] p-2 ml-1',
+  ]">
+    <!-- Pill heading -->
+    <div
+      class="flex items-center gap-2 cursor-pointer select-none"
+      :class="collapsed ? '' : 'mb-2'"
+      @click="collapsible && (collapsed = !collapsed)">
+      <span v-if="color" class="w-2.5 h-2.5 rounded-full flex-shrink-0" :style="{ background: color }" />
+      <span class="text-xs font-medium uppercase tracking-wide px-2 py-0.5 rounded-full"
+            :style="color ? { backgroundColor: color + '22', color } : {}"
+            :class="color ? '' : 'text-white/50 bg-white/10'">
+        {{ label }}
+      </span>
+      <span v-if="collapsible" class="text-white/30 text-xs transition-transform"
+            :class="collapsed ? '' : 'rotate-90'">▸</span>
+      <slot name="header-right" />
+    </div>
+    <!-- Content -->
+    <div v-show="!collapsed">
+      <slot />
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/KanbanColumn.vue
+++ b/frontend/src/components/KanbanColumn.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import TaskCard from './TaskCard.vue'
+import GroupContainer from './GroupContainer.vue'
+import type { Task } from '../stores/plan'
+import { useMilestoneStore } from '../stores/milestones'
+import type { KanbanColumn } from '../stores/kanban'
+
+const props = defineProps<{
+  column: KanbanColumn
+  tasks: Task[]
+}>()
+
+const milestoneStore = useMilestoneStore()
+
+/** Group tasks by context_subject, then by milestone within each context */
+const grouped = computed(() => {
+  const byContext: Record<string, Task[]> = {}
+  for (const task of props.tasks) {
+    const ctx = task.context_subject ?? '__uncategorized__'
+    if (!byContext[ctx]) byContext[ctx] = []
+    byContext[ctx].push(task)
+  }
+  // Sort: Uncategorized last
+  const sorted = Object.entries(byContext).sort(([a], [b]) => {
+    if (a === '__uncategorized__') return 1
+    if (b === '__uncategorized__') return -1
+    return a.localeCompare(b)
+  })
+
+  return sorted.map(([ctx, tasks]) => {
+    const label = ctx === '__uncategorized__' ? 'Uncategorized' : ctx
+    // Sub-group by milestone
+    const byMilestone: Record<string, { name: string; color: string | null; tasks: Task[] }> = {}
+    const ungrouped: Task[] = []
+
+    for (const task of tasks) {
+      const milestones = milestoneStore.taskMilestones[task.id]
+      if (milestones?.length) {
+        const m = milestones[0]
+        if (!byMilestone[m.id]) byMilestone[m.id] = { name: m.name, color: m.color, tasks: [] }
+        byMilestone[m.id].tasks.push(task)
+      } else {
+        ungrouped.push(task)
+      }
+    }
+
+    return {
+      label,
+      tasks,
+      milestoneGroups: Object.values(byMilestone),
+      ungrouped,
+    }
+  })
+})
+</script>
+
+<template>
+  <div class="flex flex-col min-w-[280px] max-w-[320px] bg-white/[0.03] border border-white/10 rounded-xl flex-shrink-0">
+    <!-- Column header -->
+    <div class="flex items-center gap-2 px-3 py-2.5 border-b border-white/10">
+      <span v-if="column.color" class="w-2.5 h-2.5 rounded-full flex-shrink-0" :style="{ background: column.color }" />
+      <span class="text-sm font-semibold uppercase tracking-wide"
+            :style="column.color ? { color: column.color } : {}">
+        {{ column.name }}
+      </span>
+      <span class="text-xs text-white/30 ml-auto">{{ tasks.length }}</span>
+    </div>
+
+    <!-- Scrollable body -->
+    <div class="flex-1 overflow-y-auto p-2 space-y-2" style="max-height: calc(100vh - 140px);">
+      <template v-if="!tasks.length">
+        <p class="text-white/20 text-xs text-center py-4">No tasks</p>
+      </template>
+
+      <template v-for="group in grouped" :key="group.label">
+        <GroupContainer :label="group.label" :collapsible="true" :level="0">
+          <template #header-right>
+            <span class="text-xs text-white/30">{{ group.tasks.length }}</span>
+          </template>
+
+          <!-- Milestone sub-groups -->
+          <GroupContainer
+            v-for="mg in group.milestoneGroups"
+            :key="mg.name"
+            :label="mg.name"
+            :color="mg.color ?? undefined"
+            :level="1"
+            class="mb-1">
+            <ul class="space-y-0.5">
+              <TaskCard
+                v-for="task in mg.tasks"
+                :key="task.id"
+                :task="task"
+                :editable="false"
+                :showRemove="false"
+                :showDetailLink="false"
+                :compact="true" />
+            </ul>
+          </GroupContainer>
+
+          <!-- Ungrouped tasks -->
+          <ul v-if="group.ungrouped.length" class="space-y-0.5">
+            <TaskCard
+              v-for="task in group.ungrouped"
+              :key="task.id"
+              :task="task"
+              :editable="false"
+              :showRemove="false"
+              :showDetailLink="false"
+              :compact="true" />
+          </ul>
+        </GroupContainer>
+      </template>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -9,7 +9,18 @@ const milestoneStore = useMilestoneStore()
 const planStore = usePlanStore()
 const router = useRouter()
 
-const props = defineProps<{ task: Task }>()
+const props = withDefaults(defineProps<{
+  task: Task
+  editable?: boolean
+  showRemove?: boolean
+  showDetailLink?: boolean
+  compact?: boolean
+}>(), {
+  editable: true,
+  showRemove: true,
+  showDetailLink: true,
+  compact: false,
+})
 const emit = defineEmits<{
   (e: 'update', task: Task): void
   (e: 'remove'): void
@@ -69,12 +80,12 @@ const milestoneColors = computed(() =>
   <li class="group rounded-lg transition-colors"
       :style="milestoneColors.length ? {
         border: `2px solid ${milestoneColors[0]}`,
-        padding: '4px 8px',
+        padding: compact ? '2px 4px' : '4px 8px',
         outline: milestoneColors.length > 1
           ? `2px solid ${milestoneColors[1]}`
           : undefined,
         outlineOffset: milestoneColors.length > 1 ? '1px' : undefined,
-      } : { padding: '4px 8px' }">
+      } : { padding: compact ? '2px 4px' : '4px 8px' }">
     <div class="flex gap-2 items-center">
     <button
       @click="cycleStatus"
@@ -82,10 +93,15 @@ const milestoneColors = computed(() =>
       :title="task.status"
       class="w-2.5 h-2.5 rounded-full flex-shrink-0 mt-0.5 transition-colors cursor-pointer" />
     <input
+      v-if="editable"
       :value="task.text"
       :class="task.status === 'done' ? 'line-through opacity-40' : ''"
       @change="updateText"
       class="flex-1 bg-transparent border-b border-white/20 focus:border-white/60 outline-none text-sm py-0.5" />
+    <span
+      v-else
+      class="flex-1 text-sm"
+      :class="task.status === 'done' ? 'line-through opacity-40' : ''">{{ task.text }}</span>
     <span
       v-for="m in (milestoneStore.taskMilestones[task.id] ?? [])" :key="m.id"
       @click="router.push(`/plan/day/${planStore.activeDate}/milestone/${m.id}`)"
@@ -95,13 +111,15 @@ const milestoneColors = computed(() =>
       {{ m.name }}
     </span>
     <button
+      v-if="showRemove"
       @click="emit('remove')"
       class="text-white/30 hover:text-white/70 text-xs opacity-0 group-hover:opacity-100 transition-opacity">✕</button>
     <button
+      v-if="showDetailLink"
       @click="router.push(`/plan/day/${planStore.activeDate}/task/${task.id}`)"
       class="text-white/20 hover:text-white/50 text-xs opacity-0 group-hover:opacity-100 transition-opacity"
       title="Open details">↗</button>
-    <div>
+    <div v-if="showDetailLink && !compact">
       <button
         @click="openFollowup"
         class="text-white/20 hover:text-white/50 text-xs opacity-0 group-hover:opacity-100 transition-opacity ml-1">

--- a/frontend/src/components/TaskList.vue
+++ b/frontend/src/components/TaskList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Task } from '../stores/plan'
-import TaskItem from './TaskItem.vue'
+import TaskItem from './TaskCard.vue'
 
 const props = defineProps<{ tasks: Task[] }>()
 const emit = defineEmits<{ (e: 'update', tasks: Task[]): void }>()

--- a/frontend/src/components/TaskList.vue
+++ b/frontend/src/components/TaskList.vue
@@ -12,7 +12,7 @@ function add() {
   emit('update', [
     ...props.tasks,
     { id: '', text: '', description: null, status: 'pending', position: props.tasks.length,
-      followup_config: null, blocks: [], blocked_by: [] },
+      followup_config: null, blocks: [], blocked_by: [], context_subject: null },
   ])
 }
 function remove(i: number) {

--- a/frontend/src/components/TaskList.vue
+++ b/frontend/src/components/TaskList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Task } from '../stores/plan'
-import TaskItem from './TaskCard.vue'
+import TaskCard from './TaskCard.vue'
 
 const props = defineProps<{ tasks: Task[] }>()
 const emit = defineEmits<{ (e: 'update', tasks: Task[]): void }>()
@@ -22,7 +22,7 @@ function remove(i: number) {
 
 <template>
   <ul class="space-y-1">
-    <TaskItem
+    <TaskCard
       v-for="(task, i) in tasks"
       :key="task.id || i"
       :task="task"

--- a/frontend/src/composables/useTaskContexts.ts
+++ b/frontend/src/composables/useTaskContexts.ts
@@ -6,10 +6,12 @@ export function useTaskContexts(taskId: () => string) {
 
   async function fetch() {
     const resp = await api(`/api/tasks/${taskId()}/contexts`)
+    // API returns [] or [subject] (single-context model)
     contexts.value = resp.ok ? await resp.json() : []
   }
 
   async function link(subject: string) {
+    // POST replaces existing context_subject
     await api(`/api/tasks/${taskId()}/contexts`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -19,6 +21,7 @@ export function useTaskContexts(taskId: () => string) {
   }
 
   async function unlink(subject: string) {
+    // DELETE clears context_subject (subject param kept for API compat)
     await api(`/api/tasks/${taskId()}/contexts/${encodeURIComponent(subject)}`, {
       method: 'DELETE',
     })

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -64,6 +64,15 @@ const router = createRouter({
         { path: 'task/:taskId', name: 'backlog-task', component: () => import('./components/TaskDetailPanel.vue'), props: true },
       ],
     },
+    {
+      path: '/kanban',
+      name: 'kanban',
+      component: () => import('./views/KanbanView.vue'),
+      children: [
+        { path: 'task/:taskId', name: 'kanban-task', component: () => import('./components/TaskDetailPanel.vue'), props: true },
+        { path: 'milestone/:milestoneId', name: 'kanban-milestone', component: () => import('./components/MilestoneDetailPanel.vue'), props: true },
+      ],
+    },
     { path: '/', redirect: '/dashboard' },
     { path: '/:pathMatch(.*)*', redirect: '/dashboard' },
   ],

--- a/frontend/src/stores/kanban.ts
+++ b/frontend/src/stores/kanban.ts
@@ -1,0 +1,33 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { api } from '../lib/api'
+
+export interface KanbanColumn {
+  id: string
+  name: string
+  position: number
+  color: string | null
+  match_rules: Record<string, unknown>
+  entry_rules: Record<string, unknown>
+  created_by: string | null
+}
+
+export const useKanbanStore = defineStore('kanban', () => {
+  const columns = ref<KanbanColumn[]>([])
+  const loading = ref(false)
+
+  async function fetchColumns() {
+    loading.value = true
+    try {
+      const resp = await api('/api/kanban/columns')
+      if (!resp.ok) throw new Error(`${resp.status}`)
+      columns.value = await resp.json()
+    } catch (e) {
+      console.error('fetchKanbanColumns error:', e)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { columns, loading, fetchColumns }
+})

--- a/frontend/src/stores/kanban.ts
+++ b/frontend/src/stores/kanban.ts
@@ -15,19 +15,24 @@ export interface KanbanColumn {
 export const useKanbanStore = defineStore('kanban', () => {
   const columns = ref<KanbanColumn[]>([])
   const loading = ref(false)
+  const error = ref<string | null>(null)
 
   async function fetchColumns() {
     loading.value = true
+    error.value = null
     try {
       const resp = await api('/api/kanban/columns')
-      if (!resp.ok) throw new Error(`${resp.status}`)
-      columns.value = await resp.json()
+      if (!resp.ok) throw new Error(`Failed to load columns (HTTP ${resp.status})`)
+      const data = await resp.json()
+      if (Array.isArray(data)) columns.value = data
     } catch (e) {
       console.error('fetchKanbanColumns error:', e)
+      error.value = e instanceof Error ? e.message : 'Failed to load kanban columns'
+      columns.value = []
     } finally {
       loading.value = false
     }
   }
 
-  return { columns, loading, fetchColumns }
+  return { columns, loading, error, fetchColumns }
 })

--- a/frontend/src/stores/plan.ts
+++ b/frontend/src/stores/plan.ts
@@ -16,7 +16,7 @@ export interface Task {
   followup_config: FollowupConfig | null
   blocks: string[]
   blocked_by: string[]
-  contexts?: string[]
+  context_subject: string | null
 }
 
 export interface AnchorPlan { tasks: Task[]; notes: string }

--- a/frontend/src/views/BacklogView.vue
+++ b/frontend/src/views/BacklogView.vue
@@ -3,6 +3,10 @@ import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useBacklogStore } from '../stores/backlog'
 import { useMilestoneStore } from '../stores/milestones'
+import type { Milestone } from '../stores/milestones'
+import type { Task } from '../stores/plan'
+import TaskCard from '../components/TaskCard.vue'
+import GroupContainer from '../components/GroupContainer.vue'
 
 const router = useRouter()
 const backlogStore = useBacklogStore()
@@ -30,6 +34,19 @@ const grouped = computed(() => {
   })
   return sorted
 })
+
+function tasksByMilestone(tasks: Task[]) {
+  const byMs = new Map<string, { milestone: Milestone; tasks: Task[] }>()
+  const noMs: Task[] = []
+  for (const t of tasks) {
+    const ms = milestoneStore.taskMilestones[t.id]
+    if (!ms?.length) { noMs.push(t); continue }
+    const m = ms[0]
+    if (!byMs.has(m.id)) byMs.set(m.id, { milestone: m, tasks: [] })
+    byMs.get(m.id)!.tasks.push(t)
+  }
+  return { milestoneGroups: [...byMs.values()], ungrouped: noMs }
+}
 
 async function addTask() {
   const text = newTaskText.value.trim()
@@ -63,21 +80,20 @@ async function addTask() {
       <!-- Grouped task list -->
       <template v-else-if="grouped.length">
         <div v-for="[context, tasks] in grouped" :key="context" class="mb-5">
-          <h2 class="text-xs text-white/40 uppercase tracking-wide mb-2 flex items-center gap-2">
-            <span>{{ context }}</span>
-            <span class="text-white/20">{{ tasks.length }}</span>
-          </h2>
-          <ul class="flex flex-col gap-1.5">
-            <li v-for="task in tasks" :key="task.id"
-                class="flex items-center gap-3 bg-white/5 rounded-lg px-3 py-2 hover:bg-white/10 cursor-pointer transition-colors group"
-                @click="router.push(`/backlog/task/${task.id}`)">
-              <span class="w-2 h-2 rounded-full flex-shrink-0"
-                    :class="task.status === 'done' ? 'bg-green-400' : task.status === 'in_progress' ? 'bg-blue-400' : 'bg-white/20'" />
-              <span class="flex-1 text-sm" :class="task.status === 'done' ? 'line-through opacity-40' : ''">{{ task.text }}</span>
-              <span v-if="task.description" class="text-white/20 text-xs flex-shrink-0">has description</span>
-              <span class="text-white/20 text-xs opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0">↗</span>
-            </li>
-          </ul>
+          <GroupContainer :label="context" :level="0">
+            <template v-for="mg in tasksByMilestone(tasks).milestoneGroups" :key="mg.milestone.id">
+              <GroupContainer :label="mg.milestone.name" :color="mg.milestone.color ?? undefined" :level="1">
+                <ul class="flex flex-col gap-1.5">
+                  <TaskCard v-for="task in mg.tasks" :key="task.id"
+                    :task="task" :editable="false" :show-remove="false" :show-detail-link="false" :compact="true" />
+                </ul>
+              </GroupContainer>
+            </template>
+            <ul v-if="tasksByMilestone(tasks).ungrouped.length" class="flex flex-col gap-1.5">
+              <TaskCard v-for="task in tasksByMilestone(tasks).ungrouped" :key="task.id"
+                :task="task" :editable="false" :show-remove="false" :show-detail-link="false" :compact="true" />
+            </ul>
+          </GroupContainer>
         </div>
       </template>
 

--- a/frontend/src/views/BacklogView.vue
+++ b/frontend/src/views/BacklogView.vue
@@ -18,7 +18,7 @@ onMounted(() => {
 const grouped = computed(() => {
   const groups: Record<string, typeof backlogStore.tasks> = {}
   for (const task of backlogStore.tasks) {
-    const ctx = task.contexts?.[0] ?? 'Uncategorized'
+    const ctx = task.context_subject ?? 'Uncategorized'
     if (!groups[ctx]) groups[ctx] = []
     groups[ctx].push(task)
   }

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -4,6 +4,7 @@ import { api } from '../lib/api'
 import { usePlanStore } from '../stores/plan'
 import { useAnchorStore } from '../stores/anchors'
 import { useMilestoneStore } from '../stores/milestones'
+import TaskCard from '../components/TaskCard.vue'
 
 const planStore = usePlanStore()
 const anchorStore = useAnchorStore()
@@ -74,11 +75,8 @@ const dayStats = computed(() => {
           <span class="text-white/40 text-sm ml-auto">{{ currentAnchor?.time }}</span>
         </div>
         <ul class="flex flex-col gap-1.5">
-          <li v-for="task in currentTasks" :key="task.id" class="flex items-center gap-2 text-sm">
-            <span class="w-2 h-2 rounded-full flex-shrink-0"
-                  :class="task.status === 'done' ? 'bg-green-400' : task.status === 'in_progress' ? 'bg-blue-400' : 'bg-white/20'" />
-            <span :class="task.status === 'done' ? 'line-through opacity-40' : ''">{{ task.text }}</span>
-          </li>
+          <TaskCard v-for="task in currentTasks" :key="task.id"
+            :task="task" :editable="false" :show-remove="false" :show-detail-link="false" :compact="true" />
           <li v-if="!currentTasks.length" class="text-white/30 text-sm">No tasks</li>
         </ul>
       </div>

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -2,7 +2,6 @@
 import { onMounted, computed } from 'vue'
 import KanbanColumn from '../components/KanbanColumn.vue'
 import { usePlanStore } from '../stores/plan'
-import { useAnchorStore } from '../stores/anchors'
 import { useKanbanStore } from '../stores/kanban'
 import { useMilestoneStore } from '../stores/milestones'
 import { useBacklogStore } from '../stores/backlog'
@@ -14,14 +13,12 @@ interface KanbanTask extends Task {
 }
 
 const planStore = usePlanStore()
-const anchorStore = useAnchorStore()
 const kanbanStore = useKanbanStore()
 const milestoneStore = useMilestoneStore()
 const backlogStore = useBacklogStore()
 
 onMounted(() => {
   planStore.fetchPlan()
-  anchorStore.fetchAnchors()
   kanbanStore.fetchColumns()
   milestoneStore.fetchAll()
   backlogStore.fetchTasks()
@@ -76,8 +73,11 @@ const columnTasks = computed(() => {
   return result
 })
 
+const KNOWN_RULE_KEYS = new Set(['status', 'plan_date'])
+
 function matchesRules(task: KanbanTask, rules: Record<string, unknown>): boolean {
   for (const [key, value] of Object.entries(rules)) {
+    if (!KNOWN_RULE_KEYS.has(key)) return false // unknown keys fail closed
     if (key === 'status') {
       if (task.status !== value) return false
     } else if (key === 'plan_date') {

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -1,0 +1,111 @@
+<script setup lang="ts">
+import { onMounted, computed } from 'vue'
+import KanbanColumn from '../components/KanbanColumn.vue'
+import { usePlanStore } from '../stores/plan'
+import { useAnchorStore } from '../stores/anchors'
+import { useKanbanStore } from '../stores/kanban'
+import { useMilestoneStore } from '../stores/milestones'
+import { useBacklogStore } from '../stores/backlog'
+import type { Task } from '../stores/plan'
+
+interface KanbanTask extends Task {
+  plan_date: string | null
+  anchor_id: string | null
+}
+
+const planStore = usePlanStore()
+const anchorStore = useAnchorStore()
+const kanbanStore = useKanbanStore()
+const milestoneStore = useMilestoneStore()
+const backlogStore = useBacklogStore()
+
+onMounted(() => {
+  planStore.fetchPlan()
+  anchorStore.fetchAnchors()
+  kanbanStore.fetchColumns()
+  milestoneStore.fetchAll()
+  backlogStore.fetchTasks()
+})
+
+/** Combine all tasks (plan + backlog) into a single list with scheduling info */
+const allTasks = computed<KanbanTask[]>(() => {
+  const tasks: KanbanTask[] = []
+
+  // Plan tasks — have plan_date and anchor_id
+  if (planStore.plan) {
+    for (const [anchorId, anchor] of Object.entries(planStore.plan.anchors)) {
+      for (const task of anchor.tasks) {
+        tasks.push({
+          ...task,
+          plan_date: planStore.plan.date,
+          anchor_id: anchorId,
+        })
+      }
+    }
+  }
+
+  // Backlog tasks — no schedule
+  for (const task of backlogStore.tasks) {
+    tasks.push({
+      ...task,
+      plan_date: null,
+      anchor_id: null,
+    })
+  }
+
+  return tasks
+})
+
+/** For each column, evaluate match rules against all tasks. First matching column wins. */
+const columnTasks = computed(() => {
+  const cols = kanbanStore.columns
+  const result: Record<string, KanbanTask[]> = {}
+  for (const col of cols) {
+    result[col.id] = []
+  }
+
+  for (const task of allTasks.value) {
+    for (const col of cols) {
+      if (matchesRules(task, col.match_rules)) {
+        result[col.id].push(task)
+        break
+      }
+    }
+  }
+
+  return result
+})
+
+function matchesRules(task: KanbanTask, rules: Record<string, unknown>): boolean {
+  for (const [key, value] of Object.entries(rules)) {
+    if (key === 'status') {
+      if (task.status !== value) return false
+    } else if (key === 'plan_date') {
+      if (value === null) {
+        if (task.plan_date !== null) return false
+      } else if (value === 'not_null') {
+        if (task.plan_date === null) return false
+      }
+    }
+  }
+  return true
+}
+</script>
+
+<template>
+  <div class="min-h-screen bg-gray-900 text-white p-6">
+    <h1 class="text-2xl font-bold mb-4">Kanban</h1>
+
+    <div v-if="kanbanStore.loading" class="text-white/40 text-sm">Loading columns...</div>
+
+    <div v-else class="flex gap-4 overflow-x-auto pb-4" style="min-height: calc(100vh - 140px);">
+      <KanbanColumn
+        v-for="col in kanbanStore.columns"
+        :key="col.id"
+        :column="col"
+        :tasks="columnTasks[col.id] ?? []" />
+    </div>
+
+    <router-view />
+  </div>
+</template>

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -85,6 +85,8 @@ function matchesRules(task: KanbanTask, rules: Record<string, unknown>): boolean
         if (task.plan_date !== null) return false
       } else if (value === 'not_null') {
         if (task.plan_date === null) return false
+      } else {
+        return false // unknown plan_date value — fail closed
       }
     }
   }
@@ -97,6 +99,7 @@ function matchesRules(task: KanbanTask, rules: Record<string, unknown>): boolean
     <h1 class="text-2xl font-bold mb-4">Kanban</h1>
 
     <div v-if="kanbanStore.loading" class="text-white/40 text-sm">Loading columns...</div>
+    <div v-else-if="kanbanStore.error" class="text-red-400 text-sm">{{ kanbanStore.error }}</div>
 
     <div v-else class="flex gap-4 overflow-x-auto pb-4" style="min-height: calc(100vh - 140px);">
       <KanbanColumn

--- a/tests/api/test_task_context_routes.py
+++ b/tests/api/test_task_context_routes.py
@@ -1,0 +1,119 @@
+"""Tests for task context routes using the single context_subject model."""
+import pytest
+from db.schema import init_db
+from db.queries import create_unscheduled_task, upsert_context_entry
+from api.main import create_app
+from tests.api.conftest import make_authenticated_client
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "tether.db"
+    init_db(path)
+    upsert_context_entry(path, "Tether", "Tether ADHD planner project.")
+    upsert_context_entry(path, "Job Applications", "ML engineer roles.")
+    return path
+
+
+@pytest.fixture
+def app(db_path):
+    return create_app(db_path=db_path)
+
+
+# ---------------------------------------------------------------------------
+# GET /tasks/{uuid}/contexts — backward compat: returns a list
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_task_contexts_returns_list_with_subject(app, db_path):
+    task = create_unscheduled_task(db_path, "Deploy backend", context_subject="Tether")
+    async with make_authenticated_client(app, db_path) as client:
+        resp = await client.get(f"/api/tasks/{task['id']}/contexts")
+    assert resp.status_code == 200
+    assert resp.json() == ["Tether"]
+
+
+@pytest.mark.asyncio
+async def test_get_task_contexts_returns_empty_list_when_no_context(app, db_path):
+    task = create_unscheduled_task(db_path, "Some backlog task")
+    async with make_authenticated_client(app, db_path) as client:
+        resp = await client.get(f"/api/tasks/{task['id']}/contexts")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_get_task_contexts_404_for_unknown_task(app, db_path):
+    async with make_authenticated_client(app, db_path) as client:
+        resp = await client.get("/api/tasks/nonexistent-uuid/contexts")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /tasks/{uuid}/contexts — sets context_subject (replaces)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_post_context_sets_context_subject(app, db_path):
+    task = create_unscheduled_task(db_path, "Write tests")
+    async with make_authenticated_client(app, db_path) as client:
+        resp = await client.post(
+            f"/api/tasks/{task['id']}/contexts",
+            json={"subject": "Tether"},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+    # Verify it was set
+    from db.queries import get_task_by_uuid
+    updated = get_task_by_uuid(db_path, task["id"])
+    assert updated["context_subject"] == "Tether"
+
+
+@pytest.mark.asyncio
+async def test_post_context_replaces_existing_context(app, db_path):
+    task = create_unscheduled_task(db_path, "Write tests", context_subject="Tether")
+    async with make_authenticated_client(app, db_path) as client:
+        resp = await client.post(
+            f"/api/tasks/{task['id']}/contexts",
+            json={"subject": "Job Applications"},
+        )
+    assert resp.status_code == 200
+
+    from db.queries import get_task_by_uuid
+    updated = get_task_by_uuid(db_path, task["id"])
+    assert updated["context_subject"] == "Job Applications"
+
+
+# ---------------------------------------------------------------------------
+# DELETE /tasks/{uuid}/contexts/{subject} — clears context_subject
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_delete_context_clears_context_subject(app, db_path):
+    task = create_unscheduled_task(db_path, "Write tests", context_subject="Tether")
+    async with make_authenticated_client(app, db_path) as client:
+        resp = await client.delete(f"/api/tasks/{task['id']}/contexts/Tether")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+    from db.queries import get_task_by_uuid
+    updated = get_task_by_uuid(db_path, task["id"])
+    assert updated["context_subject"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_contexts_after_set_then_clear(app, db_path):
+    """Round-trip: set via POST, confirm GET returns list, clear via DELETE, confirm empty."""
+    task = create_unscheduled_task(db_path, "Round trip task")
+    async with make_authenticated_client(app, db_path) as client:
+        # Set
+        await client.post(f"/api/tasks/{task['id']}/contexts", json={"subject": "Tether"})
+        # Confirm
+        resp = await client.get(f"/api/tasks/{task['id']}/contexts")
+        assert resp.json() == ["Tether"]
+        # Clear
+        await client.delete(f"/api/tasks/{task['id']}/contexts/Tether")
+        # Confirm empty
+        resp = await client.get(f"/api/tasks/{task['id']}/contexts")
+        assert resp.json() == []

--- a/tests/bot/test_relationships.py
+++ b/tests/bot/test_relationships.py
@@ -5,7 +5,7 @@ from datetime import date
 from db.schema import init_db
 from db.queries import (
     upsert_anchor, upsert_plan, upsert_tasks, upsert_context_entry,
-    create_milestone, link_milestone_task, link_task_context, get_plan, get_milestones,
+    create_milestone, link_milestone_task, get_plan, get_milestones,
 )
 
 
@@ -55,10 +55,11 @@ def rich_db(db_path):
     link_milestone_task(db_path, m1["id"], t2_id)
     link_milestone_task(db_path, m2["id"], t3_id)
 
-    # Direct task→context links (new task_context table)
-    link_task_context(db_path, t1_id, "Work/Alpha")    # also linked via milestone — dedup test
-    link_task_context(db_path, t3_id, "Work/Beta")     # also linked via milestone
-    link_task_context(db_path, t2_id, "Work/Beta")     # cross-link: alpha_tests → Beta context
+    # Direct task→context links (context_subject column on tasks)
+    from db.queries import patch_task_fields
+    patch_task_fields(db_path, t1_id, {"context_subject": "Work/Alpha"})  # also linked via milestone — dedup test
+    patch_task_fields(db_path, t3_id, {"context_subject": "Work/Beta"})   # also linked via milestone
+    patch_task_fields(db_path, t2_id, {"context_subject": "Work/Beta"})   # cross-link: alpha_tests → Beta context
 
     return {
         "db_path": db_path,

--- a/tests/db/test_context_subject.py
+++ b/tests/db/test_context_subject.py
@@ -1,0 +1,122 @@
+"""Tests for context_subject migration onto the tasks table."""
+import pytest
+from pathlib import Path
+from db.schema import init_db
+from db.queries import (
+    upsert_plan,
+    upsert_tasks,
+    get_plan,
+    patch_task_fields,
+    get_task_by_uuid,
+    create_unscheduled_task,
+    get_unscheduled_tasks,
+    upsert_context_entry,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "tether.db"
+    init_db(path)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# create_unscheduled_task: context_subject param
+# ---------------------------------------------------------------------------
+
+def test_create_unscheduled_task_with_context_subject(db_path):
+    task = create_unscheduled_task(db_path, "Fix login bug", context_subject="Backend")
+    assert task["context_subject"] == "Backend"
+    assert task["id"] is not None
+
+
+def test_create_unscheduled_task_without_context_subject(db_path):
+    task = create_unscheduled_task(db_path, "Some task")
+    assert task["context_subject"] is None
+
+
+# ---------------------------------------------------------------------------
+# get_unscheduled_tasks: returns context_subject directly (no JOIN)
+# ---------------------------------------------------------------------------
+
+def test_get_unscheduled_tasks_returns_context_subject(db_path):
+    create_unscheduled_task(db_path, "Task A", context_subject="Tether")
+    create_unscheduled_task(db_path, "Task B", context_subject=None)
+
+    tasks = get_unscheduled_tasks(db_path)
+    by_text = {t["text"]: t for t in tasks}
+
+    assert by_text["Task A"]["context_subject"] == "Tether"
+    assert by_text["Task B"]["context_subject"] is None
+
+
+def test_get_unscheduled_tasks_no_contexts_key(db_path):
+    """The old 'contexts' key should not appear — only context_subject."""
+    create_unscheduled_task(db_path, "Task X")
+    tasks = get_unscheduled_tasks(db_path)
+    for task in tasks:
+        assert "contexts" not in task
+        assert "context_subject" in task
+
+
+# ---------------------------------------------------------------------------
+# get_plan: returns context_subject on tasks
+# ---------------------------------------------------------------------------
+
+def test_get_plan_returns_context_subject(db_path):
+    upsert_plan(db_path, "2026-04-11")
+    upsert_tasks(db_path, "2026-04-11", "morning", [
+        {"text": "Deploy API", "context_subject": "Tether"},
+        {"text": "Review PR"},
+    ])
+    plan = get_plan(db_path, "2026-04-11")
+    tasks = plan["anchors"]["morning"]["tasks"]
+    by_text = {t["text"]: t for t in tasks}
+
+    assert by_text["Deploy API"]["context_subject"] == "Tether"
+    assert by_text["Review PR"]["context_subject"] is None
+
+
+# ---------------------------------------------------------------------------
+# patch_task_fields: can set and clear context_subject
+# ---------------------------------------------------------------------------
+
+def test_patch_task_fields_set_context_subject(db_path):
+    task = create_unscheduled_task(db_path, "Do something")
+    result = patch_task_fields(db_path, task["id"], {"context_subject": "Job Applications"})
+    assert result is not None
+    assert result["context_subject"] == "Job Applications"
+
+
+def test_patch_task_fields_clear_context_subject(db_path):
+    task = create_unscheduled_task(db_path, "Do something", context_subject="Job Applications")
+    result = patch_task_fields(db_path, task["id"], {"context_subject": None})
+    assert result is not None
+    assert result["context_subject"] is None
+
+
+def test_patch_task_fields_context_subject_persists(db_path):
+    """Setting an unrelated field should not clobber context_subject."""
+    task = create_unscheduled_task(db_path, "Do something", context_subject="Tether")
+    patch_task_fields(db_path, task["id"], {"status": "done"})
+    updated = get_task_by_uuid(db_path, task["id"])
+    assert updated["context_subject"] == "Tether"
+    assert updated["status"] == "done"
+
+
+# ---------------------------------------------------------------------------
+# get_task_by_uuid: includes context_subject
+# ---------------------------------------------------------------------------
+
+def test_get_task_by_uuid_includes_context_subject(db_path):
+    task = create_unscheduled_task(db_path, "Some task", context_subject="5D Multiverse")
+    fetched = get_task_by_uuid(db_path, task["id"])
+    assert fetched is not None
+    assert fetched["context_subject"] == "5D Multiverse"
+
+
+def test_get_task_by_uuid_context_subject_none_when_not_set(db_path):
+    task = create_unscheduled_task(db_path, "No context task")
+    fetched = get_task_by_uuid(db_path, task["id"])
+    assert fetched["context_subject"] is None

--- a/tests/db/test_context_subject.py
+++ b/tests/db/test_context_subject.py
@@ -120,3 +120,30 @@ def test_get_task_by_uuid_context_subject_none_when_not_set(db_path):
     task = create_unscheduled_task(db_path, "No context task")
     fetched = get_task_by_uuid(db_path, task["id"])
     assert fetched["context_subject"] is None
+
+
+def test_rename_context_cascades_to_tasks(db_path):
+    from db.queries import create_unscheduled_task, get_task_by_uuid, rename_context_subject
+    upsert_context_entry(db_path, "OldProj", "body")
+    upsert_context_entry(db_path, "OldProj/Sub", "child body")
+    task1 = create_unscheduled_task(db_path, "top-level task", context_subject="OldProj")
+    task2 = create_unscheduled_task(db_path, "child task", context_subject="OldProj/Sub")
+    rename_context_subject(db_path, "OldProj", "NewProj")
+    t1 = get_task_by_uuid(db_path, task1["id"])
+    t2 = get_task_by_uuid(db_path, task2["id"])
+    assert t1["context_subject"] == "NewProj"
+    assert t2["context_subject"] == "NewProj/Sub"
+
+
+def test_get_context_tasks_returns_linked_tasks(db_path):
+    from db.queries import create_unscheduled_task, get_context_tasks
+    upsert_context_entry(db_path, "TestProj", "body")
+    create_unscheduled_task(db_path, "linked task", context_subject="TestProj")
+    create_unscheduled_task(db_path, "other task", context_subject="OtherProj")
+    create_unscheduled_task(db_path, "no context task")
+    tasks = get_context_tasks(db_path, "TestProj")
+    assert len(tasks) == 1
+    assert tasks[0]["text"] == "linked task"
+    assert tasks[0]["id"] is not None
+    # Should not return tasks from other contexts
+    assert all(t["text"] != "other task" for t in tasks)

--- a/tests/db/test_kanban.py
+++ b/tests/db/test_kanban.py
@@ -15,28 +15,29 @@ def db_path(tmp_path):
 def test_seed_creates_default_columns(db_path):
     seed_kanban_columns(db_path)
     cols = get_kanban_columns(db_path)
-    assert len(cols) == 5
+    assert len(cols) == 6
     names = [c["name"] for c in cols]
     assert "Backlog" in names
     assert "Pending" in names
     assert "In Progress" in names
     assert "Done" in names
     assert "Skipped" in names
+    assert "Blocked" in names
 
 def test_seed_is_idempotent(db_path):
     seed_kanban_columns(db_path)
     seed_kanban_columns(db_path)
-    assert len(get_kanban_columns(db_path)) == 5
+    assert len(get_kanban_columns(db_path)) == 6
 
 def test_get_kanban_columns_filters_by_user(db_path):
     seed_kanban_columns(db_path)
-    create_kanban_column(db_path, "Custom", 10, "#ff0000", {"status": "blocked"}, {"set_status": "blocked"}, "user1")
-    # All visible to user1: 5 built-in + 1 user-defined
+    create_kanban_column(db_path, "Custom", 10, "#ff0000", {"status": "review"}, {"set_status": "review"}, "user1")
+    # All visible to user1: 6 built-in + 1 user-defined
     cols = get_kanban_columns(db_path, user_id="user1")
-    assert len(cols) == 6
+    assert len(cols) == 7
     # User2 sees only built-in
     cols2 = get_kanban_columns(db_path, user_id="user2")
-    assert len(cols2) == 5
+    assert len(cols2) == 6
 
 def test_create_kanban_column(db_path):
     col = create_kanban_column(db_path, "Blocked", 5, "#ef4444",

--- a/tests/db/test_kanban.py
+++ b/tests/db/test_kanban.py
@@ -1,0 +1,60 @@
+import pytest
+from pathlib import Path
+from db.schema import init_db
+from db.queries import (
+    seed_kanban_columns, get_kanban_columns,
+    create_kanban_column, update_kanban_column, delete_kanban_column,
+)
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "test.db"
+    init_db(path)
+    return path
+
+def test_seed_creates_default_columns(db_path):
+    seed_kanban_columns(db_path)
+    cols = get_kanban_columns(db_path)
+    assert len(cols) == 5
+    names = [c["name"] for c in cols]
+    assert "Backlog" in names
+    assert "Pending" in names
+    assert "In Progress" in names
+    assert "Done" in names
+    assert "Skipped" in names
+
+def test_seed_is_idempotent(db_path):
+    seed_kanban_columns(db_path)
+    seed_kanban_columns(db_path)
+    assert len(get_kanban_columns(db_path)) == 5
+
+def test_get_kanban_columns_filters_by_user(db_path):
+    seed_kanban_columns(db_path)
+    create_kanban_column(db_path, "Custom", 10, "#ff0000", {"status": "blocked"}, {"set_status": "blocked"}, "user1")
+    # All visible to user1: 5 built-in + 1 user-defined
+    cols = get_kanban_columns(db_path, user_id="user1")
+    assert len(cols) == 6
+    # User2 sees only built-in
+    cols2 = get_kanban_columns(db_path, user_id="user2")
+    assert len(cols2) == 5
+
+def test_create_kanban_column(db_path):
+    col = create_kanban_column(db_path, "Blocked", 5, "#ef4444",
+                                {"status": "blocked"}, {"set_status": "blocked"}, "user1")
+    assert col["id"]
+    assert col["name"] == "Blocked"
+    assert col["created_by"] == "user1"
+
+def test_update_kanban_column(db_path):
+    seed_kanban_columns(db_path)
+    cols = get_kanban_columns(db_path)
+    col_id = cols[0]["id"]
+    updated = update_kanban_column(db_path, col_id, {"name": "Renamed", "color": "#000"})
+    assert updated["name"] == "Renamed"
+    assert updated["color"] == "#000"
+
+def test_delete_kanban_column(db_path):
+    col = create_kanban_column(db_path, "Temp", 99, None, {}, {}, "user1")
+    delete_kanban_column(db_path, col["id"])
+    cols = get_kanban_columns(db_path, user_id="user1")
+    assert not any(c["id"] == col["id"] for c in cols)

--- a/tests/tether_mcp/test_server.py
+++ b/tests/tether_mcp/test_server.py
@@ -167,14 +167,14 @@ def test_get_current_anchor_returns_dict():
 def test_upsert_task_create_backlog(db_path):
     from tether_mcp.server import upsert_task
     result = upsert_task(text="Backlog item", description="Details here",
-                         context_subjects=["Intellipat"])
+                         context_subject="Intellipat")
     assert result["id"]
     assert result["text"] == "Backlog item"
     assert result["description"] == "Details here"
-    # Verify context link
-    from db.queries import get_task_contexts
-    contexts = get_task_contexts(db_path, result["id"])
-    assert "Intellipat" in contexts
+    # Verify context_subject set directly on task
+    from db.queries import get_task_by_uuid
+    task = get_task_by_uuid(db_path, result["id"])
+    assert task["context_subject"] == "Intellipat"
 
 
 def test_upsert_task_create_scheduled(db_path):
@@ -190,7 +190,7 @@ def test_upsert_task_create_with_milestone(db_path):
     from db.queries import create_milestone
     m = create_milestone(db_path, "Intellipat", "Test MS")
     result = upsert_task(text="Linked task", milestone_ids=[m["id"]],
-                         context_subjects=["Intellipat"])
+                         context_subject="Intellipat")
     assert result["id"]
     from db.queries import get_milestones
     ms = get_milestones(db_path, "Intellipat")

--- a/tether_mcp/server.py
+++ b/tether_mcp/server.py
@@ -32,6 +32,8 @@ from db.queries import (
     create_unscheduled_task,
     get_task_by_uuid,
     move_task_atomic,
+    delete_task_by_uuid,
+    get_milestones as _db_get_milestones,
 )
 
 mcp = FastMCP("tether", host="0.0.0.0", port=5001)
@@ -274,7 +276,6 @@ def update_plan_tasks(anchor_id: str, tasks: list, date: str = "") -> dict:
 @mcp.tool()
 def remove_task(task_uuid: str) -> dict:
     """Permanently delete a task by UUID. Cascades to subtasks, links, dependencies, milestones."""
-    from db.queries import delete_task_by_uuid
     delete_task_by_uuid(_db(), task_uuid)
     return {"ok": True, "deleted": task_uuid}
 
@@ -282,7 +283,6 @@ def remove_task(task_uuid: str) -> dict:
 @mcp.tool()
 def move_to_backlog(task_uuid: str) -> dict:
     """Move a task to the backlog (unschedule it). Preserves all milestone/context/dep links."""
-    from db.queries import move_task_atomic
     move_task_atomic(_db(), task_uuid, None, None)
     return {"ok": True, "moved": task_uuid}
 
@@ -290,7 +290,6 @@ def move_to_backlog(task_uuid: str) -> dict:
 @mcp.tool()
 def schedule_task(task_uuid: str, date: str, anchor_id: str) -> dict:
     """Schedule a backlog task onto a specific date and anchor."""
-    from db.queries import move_task_atomic
     move_task_atomic(_db(), task_uuid, date, anchor_id)
     return {"ok": True, "scheduled": task_uuid, "date": date, "anchor_id": anchor_id}
 
@@ -319,8 +318,7 @@ def get_bot_log(n: int = 5) -> list[dict]:
 async def get_milestones(context_subject: str | None = None) -> str:
     """Get milestones for a context subject (or all if omitted).
     Returns list with id, name, status, task_count, done_count, task_ids."""
-    from db.queries import get_milestones as _get_milestones
-    return json.dumps(_get_milestones(_db(), context_subject), indent=2)
+    return json.dumps(_db_get_milestones(_db(), context_subject), indent=2)
 
 
 @mcp.tool()
@@ -351,8 +349,7 @@ def append_milestone_description(milestone_id: str, text: str) -> dict:
     """Append text to a milestone's description (adds after existing content with double newline).
     Creates description if none exists."""
     db = _db()
-    from db.queries import get_milestones as _get_ms
-    all_ms = _get_ms(db)
+    all_ms = _db_get_milestones(db)
     ms = next((m for m in all_ms if m["id"] == milestone_id), None)
     if not ms:
         return {"error": "Milestone not found"}

--- a/tether_mcp/server.py
+++ b/tether_mcp/server.py
@@ -179,7 +179,7 @@ def upsert_task(
     date: str = "",
     anchor_id: str = "",
     backlog: bool = False,
-    context_subjects: list[str] = [],
+    context_subject: str = "",
     milestone_ids: list[str] = [],
     blocked_by: list[str] = [],
 ) -> dict:
@@ -194,7 +194,7 @@ def upsert_task(
     - description: detailed description text
     - date + anchor_id: schedule to a specific day+anchor
     - backlog: True to unschedule (move to backlog)
-    - context_subjects: list of context entry subjects to link (additive)
+    - context_subject: context entry subject to link (replaces existing)
     - milestone_ids: list of milestone IDs to link (additive)
     - blocked_by: list of task/milestone UUIDs that block this task (additive)
 
@@ -229,7 +229,8 @@ def upsert_task(
             # Scheduled task
             upsert_plan(db, date)
             tasks_result = upsert_tasks(db, date, anchor_id, [
-                {"text": text, "status": status or "pending"}
+                {"text": text, "status": status or "pending",
+                 "context_subject": context_subject or None}
             ])
             new_task = next((t for t in tasks_result if t["text"] == text), tasks_result[-1])
             task_uuid = new_task["id"]
@@ -237,7 +238,8 @@ def upsert_task(
             # Backlog task
             new_task = create_unscheduled_task(db, text,
                                                description=description or None,
-                                               status=status or "pending")
+                                               status=status or "pending",
+                                               context_subject=context_subject or None)
             task_uuid = new_task["id"]
 
         if description and date and anchor_id:
@@ -246,12 +248,9 @@ def upsert_task(
 
         result_task = get_task_by_uuid(db, task_uuid)
 
-    # Link contexts (additive)
-    for subject in context_subjects:
-        try:
-            link_task_context(db, task_uuid, subject)
-        except Exception:
-            pass  # already linked
+    # Set context (replaces existing)
+    if context_subject and task_uuid:
+        patch_task_fields(db, task_uuid, {"context_subject": context_subject})
 
     # Link milestones (additive)
     for mid in milestone_ids:

--- a/tether_mcp/server.py
+++ b/tether_mcp/server.py
@@ -249,19 +249,13 @@ def upsert_task(
     if context_subject and task_uuid:
         patch_task_fields(db, task_uuid, {"context_subject": context_subject})
 
-    # Link milestones (additive)
+    # Link milestones (additive — INSERT OR IGNORE handles duplicates)
     for mid in milestone_ids:
-        try:
-            link_milestone_task(db, mid, task_uuid)
-        except Exception:
-            pass  # already linked
+        link_milestone_task(db, mid, task_uuid)
 
-    # Add blockers (additive)
+    # Add blockers (additive — INSERT OR IGNORE handles duplicates)
     for blocker_id in blocked_by:
-        try:
-            add_dependency(db, "task", blocker_id, "task", task_uuid)
-        except Exception:
-            pass  # already exists
+        add_dependency(db, "task", blocker_id, "task", task_uuid)
 
     return result_task or {"id": task_uuid, "text": text, "status": status or "pending"}
 
@@ -455,14 +449,18 @@ def update_milestone(milestone_id: str, fields: dict) -> dict:
 @mcp.tool()
 def link_task_to_context(task_uuid: str, subject: str) -> dict:
     """Set a task's context entry (single context per task)."""
-    patch_task_fields(_db(), task_uuid, {"context_subject": subject})
+    result = patch_task_fields(_db(), task_uuid, {"context_subject": subject})
+    if result is None:
+        return {"error": f"Task {task_uuid} not found"}
     return {"ok": True}
 
 
 @mcp.tool()
 def unlink_task_from_context(task_uuid: str, subject: str) -> dict:
     """Clear a task's context entry."""
-    patch_task_fields(_db(), task_uuid, {"context_subject": None})
+    result = patch_task_fields(_db(), task_uuid, {"context_subject": None})
+    if result is None:
+        return {"error": f"Task {task_uuid} not found"}
     return {"ok": True}
 
 

--- a/tether_mcp/server.py
+++ b/tether_mcp/server.py
@@ -27,9 +27,6 @@ from db.queries import (
     link_milestone_task,
     unlink_milestone_task,
     create_milestone,
-    link_task_context,
-    unlink_task_context,
-    get_task_contexts,
     get_context_tasks,
     patch_milestone,
     create_unscheduled_task,
@@ -457,22 +454,26 @@ def update_milestone(milestone_id: str, fields: dict) -> dict:
 
 @mcp.tool()
 def link_task_to_context(task_uuid: str, subject: str) -> dict:
-    """Link a task to a context entry by subject."""
-    link_task_context(_db(), task_uuid, subject)
+    """Set a task's context entry (single context per task)."""
+    patch_task_fields(_db(), task_uuid, {"context_subject": subject})
     return {"ok": True}
 
 
 @mcp.tool()
 def unlink_task_from_context(task_uuid: str, subject: str) -> dict:
-    """Unlink a task from a context entry."""
-    unlink_task_context(_db(), task_uuid, subject)
+    """Clear a task's context entry."""
+    patch_task_fields(_db(), task_uuid, {"context_subject": None})
     return {"ok": True}
 
 
 @mcp.tool()
 def get_task_context_links(task_uuid: str) -> list[str]:
-    """Get context subjects linked to a task."""
-    return get_task_contexts(_db(), task_uuid)
+    """Get context subject for a task (returns list for backward compat)."""
+    task = get_task_by_uuid(_db(), task_uuid)
+    if not task:
+        return []
+    ctx = task.get("context_subject")
+    return [ctx] if ctx else []
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary

Phase 9 foundation: programmable kanban board infrastructure + visual consistency across all views.

### Phase 0: Visual Consistency
- **TaskItem → TaskCard** rename with feature props (editable, compact, showRemove, showDetailLink)
- **GroupContainer.vue** — reusable pill-heading + card container for nested grouping
- **AnchorBlock refactor** — pill headings replace sidebar rectangles, milestone sub-grouping within anchors
- **context_subject** migrated from junction table to direct column on tasks (single context per task)
- **BacklogView + DashboardView** use TaskCard + GroupContainer for consistent rendering

### Phase A: Kanban Infrastructure
- **kanban_columns** DB table with match/entry rules JSON
- **user_settings** DB table for future preferences
- 6 default lifecycle columns: Backlog, Pending, In Progress, Done, Skipped, Blocked
- Column CRUD API (`GET/POST/PATCH/DELETE /api/kanban/columns`)
- **KanbanView** — horizontal scroll board with client-side match-rule task distribution
- **KanbanColumn** — context + milestone sub-grouping with GroupContainer nesting
- `/kanban` route with task/milestone detail panel child routes

### Fixes
- `rename_context_subject` cascades to `tasks.context_subject`
- `get_plan` PRAGMA column detection replaces 3-level try/except
- `_row_to_task()` helper eliminates 6x manual dict construction
- Dead `task_context` junction-table code removed from MCP tools + queries
- `INSERT OR IGNORE` for kanban seed (concurrent-safe)
- Fail-closed unknown match_rules keys
- Error state in kanban store (no silent empty board)
- 2 new tests for rename cascade + get_context_tasks

## Post-deploy
```bash
for f in ~/.tether-config/users/*.db; do python3 db/migrate_kanban.py "$f"; done
```

## Test plan
- [ ] 543 tests pass
- [ ] Frontend builds cleanly
- [ ] `/kanban` shows 6 columns with tasks distributed by status
- [ ] `/plan/day` shows pill headings with milestone sub-groups
- [ ] `/backlog` uses TaskCard + GroupContainer with context/milestone grouping
- [ ] Dashboard Now box uses TaskCard
- [ ] Drag-drop still works in plan view
- [ ] Task detail panel context shows single value