### PR TITLE
feat: TaskCard visual overhaul — cards, status pills, sticky headers

### DIFF
--- a/frontend/src/components/GroupContainer.vue
+++ b/frontend/src/components/GroupContainer.vue
@@ -19,10 +19,11 @@ const collapsed = ref(false)
     'rounded-lg transition-all',
     level === 0 ? 'bg-white/5 border border-white/10 p-3' : 'bg-white/[0.03] border border-white/[0.06] p-2 ml-1',
   ]">
-    <!-- Pill heading -->
+    <!-- Pill heading (sticky within scroll containers) -->
     <div
-      class="flex items-center gap-2 cursor-pointer select-none"
-      :class="collapsed ? '' : 'mb-2'"
+      class="flex items-center gap-2 cursor-pointer select-none sticky top-0 z-10 backdrop-blur-sm"
+      :class="[collapsed ? '' : 'mb-2', level === 0 ? 'bg-white/5' : 'bg-gray-900/80']"
+      :style="{ top: level === 1 ? '28px' : '0px' }"
       @click="collapsible && (collapsed = !collapsed)">
       <span v-if="color" class="w-2.5 h-2.5 rounded-full flex-shrink-0" :style="{ background: color }" />
       <span class="text-xs font-medium uppercase tracking-wide px-2 py-0.5 rounded-full"

--- a/frontend/src/components/KanbanColumn.vue
+++ b/frontend/src/components/KanbanColumn.vue
@@ -56,7 +56,7 @@ const grouped = computed(() => {
 </script>
 
 <template>
-  <div class="flex flex-col min-w-[280px] max-w-[320px] bg-white/[0.03] border border-white/10 rounded-xl flex-shrink-0">
+  <div class="flex flex-col min-w-[320px] max-w-[380px] bg-white/[0.03] border border-white/10 rounded-xl flex-shrink-0">
     <!-- Column header -->
     <div class="flex items-center gap-2 px-3 py-2.5 border-b border-white/10">
       <span v-if="column.color" class="w-2.5 h-2.5 rounded-full flex-shrink-0" :style="{ background: column.color }" />
@@ -95,7 +95,7 @@ const grouped = computed(() => {
                 :editable="false"
                 :showRemove="false"
                 :showDetailLink="false"
-                :compact="true" />
+                :compact="true" :hideTags="true" />
             </ul>
           </GroupContainer>
 
@@ -108,7 +108,7 @@ const grouped = computed(() => {
               :editable="false"
               :showRemove="false"
               :showDetailLink="false"
-              :compact="true" />
+              :compact="true" :hideTags="true" />
           </ul>
         </GroupContainer>
       </template>

--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import type { Task, TaskStatus } from '../stores/plan'
 import type { FollowupConfig } from '../stores/anchors'
@@ -15,28 +15,41 @@ const props = withDefaults(defineProps<{
   showRemove?: boolean
   showDetailLink?: boolean
   compact?: boolean
+  hideTags?: boolean  // hide milestone/context tags (when inside a GroupContainer that already shows them)
 }>(), {
   editable: true,
   showRemove: true,
   showDetailLink: true,
   compact: false,
+  hideTags: false,
 })
 const emit = defineEmits<{
   (e: 'update', task: Task): void
   (e: 'remove'): void
 }>()
 
-const STATUS_CYCLE: TaskStatus[] = ['pending', 'in_progress', 'done']
-const STATUS_COLORS: Record<TaskStatus, string> = {
-  pending:     'bg-white/20 hover:bg-white/40',
-  in_progress: 'bg-blue-400 hover:bg-blue-300',
-  done:        'bg-green-400 hover:bg-green-300',
-  skipped:     'bg-orange-400 hover:bg-orange-300',
-  blocked:     'bg-red-400 hover:bg-red-300',
+// Status pill colors (text + bg for the clickable pill)
+const STATUS_PILL: Record<TaskStatus, { bg: string; text: string; label: string }> = {
+  pending:     { bg: 'bg-white/10', text: 'text-white/50', label: 'todo' },
+  in_progress: { bg: 'bg-blue-500/20', text: 'text-blue-300', label: 'doing' },
+  done:        { bg: 'bg-green-500/20', text: 'text-green-300', label: 'done' },
+  skipped:     { bg: 'bg-orange-500/20', text: 'text-orange-300', label: 'skip' },
+  blocked:     { bg: 'bg-red-500/20', text: 'text-red-300', label: 'blocked' },
+}
+
+// Card background tint derived from status
+const STATUS_CARD_BG: Record<TaskStatus, string> = {
+  pending:     'bg-white/[0.04]',
+  in_progress: 'bg-blue-500/[0.06]',
+  done:        'bg-green-500/[0.04] opacity-70',
+  skipped:     'bg-orange-500/[0.04] opacity-50',
+  blocked:     'bg-red-500/[0.06]',
 }
 
 const showFollowup = ref(false)
+const showStatusDropdown = ref(false)
 const popoverStyle = ref({ top: '0px', right: '0px' })
+const statusDropdownStyle = ref({ top: '0px', left: '0px' })
 
 function openFollowup(e: MouseEvent) {
   const btn = e.currentTarget as HTMLElement
@@ -48,11 +61,22 @@ function openFollowup(e: MouseEvent) {
   showFollowup.value = !showFollowup.value
 }
 
-function cycleStatus() {
-  const idx = STATUS_CYCLE.indexOf(props.task.status)
-  const next = STATUS_CYCLE[idx === -1 ? 0 : (idx + 1) % STATUS_CYCLE.length]
-  emit('update', { ...props.task, status: next })
+function openStatusDropdown(e: MouseEvent) {
+  const btn = e.currentTarget as HTMLElement
+  const rect = btn.getBoundingClientRect()
+  statusDropdownStyle.value = {
+    top: `${rect.bottom + 4}px`,
+    left: `${rect.left}px`,
+  }
+  showStatusDropdown.value = !showStatusDropdown.value
 }
+
+function setStatus(status: TaskStatus) {
+  emit('update', { ...props.task, status })
+  showStatusDropdown.value = false
+}
+
+const ALL_STATUSES: TaskStatus[] = ['pending', 'in_progress', 'done', 'skipped', 'blocked']
 
 function updateText(e: Event) {
   emit('update', { ...props.task, text: (e.target as HTMLInputElement).value })
@@ -69,56 +93,76 @@ function toggleFollowup(enabled: boolean) {
   emit('update', { ...props.task, followup_config: enabled ? fc : null })
 }
 
-const milestoneColors = computed(() =>
-  (milestoneStore.taskMilestones[props.task.id] ?? [])
-    .map(m => m.color)
-    .filter((c): c is string => c !== null)
-)
 </script>
 
 <template>
-  <li class="group rounded-lg transition-colors"
-      :style="milestoneColors.length ? {
-        border: `2px solid ${milestoneColors[0]}`,
-        padding: compact ? '2px 4px' : '4px 8px',
-        outline: milestoneColors.length > 1
-          ? `2px solid ${milestoneColors[1]}`
-          : undefined,
-        outlineOffset: milestoneColors.length > 1 ? '1px' : undefined,
-      } : { padding: compact ? '2px 4px' : '4px 8px' }">
-    <div class="flex gap-2 items-center">
-    <button
-      @click="cycleStatus"
-      :class="STATUS_COLORS[task.status]"
-      :title="task.status"
-      class="w-2.5 h-2.5 rounded-full flex-shrink-0 mt-0.5 transition-colors cursor-pointer" />
-    <input
-      v-if="editable"
-      :value="task.text"
-      :class="task.status === 'done' ? 'line-through opacity-40' : ''"
-      @change="updateText"
-      class="flex-1 bg-transparent border-b border-white/20 focus:border-white/60 outline-none text-sm py-0.5" />
-    <span
-      v-else
-      class="flex-1 text-sm"
-      :class="task.status === 'done' ? 'line-through opacity-40' : ''">{{ task.text }}</span>
-    <span
-      v-for="m in (milestoneStore.taskMilestones[task.id] ?? [])" :key="m.id"
-      @click="router.push(`/plan/day/${planStore.activeDate}/milestone/${m.id}`)"
-      :style="m.color ? { backgroundColor: m.color + '33', color: m.color, borderColor: m.color + '66' } : {}"
-      class="text-xs px-1 py-0.5 rounded border flex-shrink-0 cursor-pointer"
-      :class="m.color ? '' : 'bg-white/10 text-white/50 border-transparent hover:bg-white/20'">
-      {{ m.name }}
-    </span>
-    <button
-      v-if="showRemove"
-      @click="emit('remove')"
-      class="text-white/30 hover:text-white/70 text-xs opacity-0 group-hover:opacity-100 transition-opacity">✕</button>
-    <button
-      v-if="showDetailLink"
-      @click="router.push(`/plan/day/${planStore.activeDate}/task/${task.id}`)"
-      class="text-white/20 hover:text-white/50 text-xs opacity-0 group-hover:opacity-100 transition-opacity"
-      title="Open details">↗</button>
+  <li class="group rounded-lg transition-colors border border-white/[0.08] cursor-pointer relative"
+      :class="STATUS_CARD_BG[task.status]"
+      @click="showDetailLink && task.id && router.push(`/plan/day/${planStore.activeDate}/task/${task.id}`)">
+    <div class="flex flex-col gap-1 p-2">
+    <!-- Status pill (top-right, dropdown) -->
+    <div class="absolute top-1.5 right-1.5">
+      <button
+        @click.stop="openStatusDropdown"
+        :class="[STATUS_PILL[task.status].bg, STATUS_PILL[task.status].text]"
+        class="text-[10px] px-1.5 py-0.5 rounded-full font-medium uppercase tracking-wider leading-none">
+        {{ STATUS_PILL[task.status].label }}
+      </button>
+      <Teleport to="body">
+        <div v-if="showStatusDropdown"
+             class="fixed z-50 bg-gray-800 border border-white/20 rounded-lg shadow-xl py-1 min-w-[100px]"
+             :style="statusDropdownStyle">
+          <button
+            v-for="s in ALL_STATUSES" :key="s"
+            @click.stop="setStatus(s)"
+            :class="[STATUS_PILL[s].bg, STATUS_PILL[s].text, s === task.status ? 'ring-1 ring-white/30' : '']"
+            class="block w-full text-left text-xs px-3 py-1.5 hover:bg-white/10 transition-colors">
+            {{ STATUS_PILL[s].label }}
+          </button>
+        </div>
+      </Teleport>
+    </div>
+
+    <!-- Title -->
+    <div class="pr-14">
+      <input
+        v-if="editable"
+        :value="task.text"
+        :class="task.status === 'done' ? 'line-through opacity-40' : ''"
+        @click.stop
+        @change="updateText"
+        class="w-full bg-transparent border-b border-white/20 focus:border-white/60 outline-none text-sm py-0.5" />
+      <span
+        v-else
+        class="text-sm break-words"
+        :class="task.status === 'done' ? 'line-through opacity-40' : ''">{{ task.text }}</span>
+    </div>
+
+    <!-- Tags row (milestone + context) — hidden when inside a GroupContainer that shows them -->
+    <div v-if="!hideTags && (milestoneStore.taskMilestones[task.id]?.length || task.context_subject)" class="flex flex-wrap gap-1">
+      <span
+        v-if="task.context_subject"
+        @click.stop
+        class="text-[10px] px-1.5 py-0.5 rounded bg-white/10 text-white/40">
+        {{ task.context_subject }}
+      </span>
+      <span
+        v-for="m in (milestoneStore.taskMilestones[task.id] ?? [])" :key="m.id"
+        @click.stop="router.push(`/plan/day/${planStore.activeDate}/milestone/${m.id}`)"
+        :style="m.color ? { backgroundColor: m.color + '33', color: m.color, borderColor: m.color + '66' } : {}"
+        class="text-[10px] px-1.5 py-0.5 rounded border cursor-pointer"
+        :class="m.color ? '' : 'bg-white/10 text-white/50 border-transparent hover:bg-white/20'">
+        {{ m.name }}
+      </span>
+    </div>
+
+    <!-- Action buttons (visible on hover) -->
+    <div v-if="showRemove || (showDetailLink && !compact)" class="flex gap-1 justify-end">
+      <button
+        v-if="showRemove"
+        @click.stop="emit('remove')"
+        class="text-white/30 hover:text-white/70 text-xs opacity-0 group-hover:opacity-100 transition-opacity">✕</button>
+    </div>
     <div v-if="showDetailLink && !compact">
       <button
         @click="openFollowup"

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,3 +1,24 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Subtle scrollbars matching dark theme */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+/* Firefox */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.1) transparent;
+}

--- a/frontend/src/views/BacklogView.vue
+++ b/frontend/src/views/BacklogView.vue
@@ -85,13 +85,13 @@ async function addTask() {
               <GroupContainer :label="mg.milestone.name" :color="mg.milestone.color ?? undefined" :level="1">
                 <ul class="flex flex-col gap-1.5">
                   <TaskCard v-for="task in mg.tasks" :key="task.id"
-                    :task="task" :editable="false" :show-remove="false" :show-detail-link="false" :compact="true" />
+                    :task="task" :editable="false" :show-remove="false" :show-detail-link="false" :compact="true" :hide-tags="true" />
                 </ul>
               </GroupContainer>
             </template>
             <ul v-if="tasksByMilestone(tasks).ungrouped.length" class="flex flex-col gap-1.5">
               <TaskCard v-for="task in tasksByMilestone(tasks).ungrouped" :key="task.id"
-                :task="task" :editable="false" :show-remove="false" :show-detail-link="false" :compact="true" />
+                :task="task" :editable="false" :show-remove="false" :show-detail-link="false" :compact="true" :hide-tags="true" />
             </ul>
           </GroupContainer>
         </div>


### PR DESCRIPTION
## Summary
Major visual polish for the card-based task system. Changes apply to ALL views (plan, kanban, backlog, dashboard) since everything uses TaskCard.

- **Task cards** — each task is now a distinct card with status-derived background tint (blue for in-progress, green for done, red for blocked, etc.)
- **Status dropdown pill** — top-right of each card, shows current status as colored pill. Click opens dropdown to change status (replaces the old bullet dot + cycle-on-click)
- **Tags below title** — milestone and context tags moved below the task title for better space usage. Title takes full card width.
- **`hideTags` prop** — tags hidden when inside a GroupContainer that already shows the context/milestone (no redundant labels)
- **Sticky group headers** — context and milestone pill headings stick to top of scroll viewport as you scroll past them
- **Subtle scrollbars** — transparent track, thin thumb matching dark theme (webkit + Firefox)
- **Wider kanban columns** — 320-380px instead of 280-320px
- **Clickable cards** — entire card opens detail panel (not just the arrow button)
- **Removed** — old status bullet dot, old milestone border outline, `STATUS_CYCLE`, `milestoneColors` computed

## Test plan
- [ ] 543 tests pass
- [ ] Build clean
- [ ] Plan view: cards with status-tinted bg, status pill top-right, tags below title
- [ ] Kanban: wider columns, cards without redundant tags, sticky headers on scroll
- [ ] Backlog: same card style with context/milestone grouping
- [ ] Dashboard Now box: compact cards
- [ ] Status dropdown: click pill → dropdown → select new status → card bg changes
- [ ] Scrollbars: subtle on both kanban horizontal scroll and column vertical scroll