### PR TITLE
fix: kanban shows all tasks + opaque container backgrounds + schedule tags

### DIFF
--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -3,7 +3,7 @@ from db.queries import patch_task_fields, move_task_atomic, \
     add_task_dependency, remove_task_dependency, \
     get_subtasks, create_subtask, update_subtask, delete_subtask, reorder_subtasks, \
     search_entities, \
-    get_unscheduled_tasks, create_unscheduled_task, get_task_by_uuid
+    get_unscheduled_tasks, create_unscheduled_task, get_task_by_uuid, get_all_tasks
 from api.auth import auth_dependency
 import api.config as cfg
 
@@ -18,6 +18,11 @@ async def search(q: str = "", type: str = "all", request: Request = None, _auth=
 
 
 # --- Literal path routes MUST come before {task_uuid} parameterized routes ---
+
+@router.get("/tasks/all")
+async def list_all_tasks(request: Request, _auth=Depends(auth_dependency)):
+    return get_all_tasks(request.state.db_path)
+
 
 @router.get("/tasks/unscheduled")
 async def list_unscheduled(request: Request, _auth=Depends(auth_dependency)):

--- a/db/queries.py
+++ b/db/queries.py
@@ -935,6 +935,17 @@ def get_unscheduled_tasks(db_path: Path) -> list[dict]:
     return [_row_to_task(r) for r in rows]
 
 
+def get_all_tasks(db_path: Path) -> list[dict]:
+    """Get ALL tasks (scheduled + unscheduled) with schedule info. For kanban board."""
+    with get_db(db_path) as conn:
+        rows = conn.execute(
+            "SELECT uuid, text, status, position, followup_config, description, "
+            "context_subject, plan_date, anchor_id "
+            "FROM tasks ORDER BY plan_date DESC NULLS LAST, position"
+        ).fetchall()
+    return [_row_to_task(r, include_schedule=True) for r in rows]
+
+
 def search_entities(db_path: Path, query: str, entity_type: str = "all") -> list[dict]:
     """Search tasks and/or milestones by text. Returns [{id, label, sublabel, type}]."""
     results = []

--- a/frontend/src/components/GroupContainer.vue
+++ b/frontend/src/components/GroupContainer.vue
@@ -19,15 +19,15 @@ const collapsed = ref(false)
 <template>
   <div :class="[
     'rounded-lg transition-all cursor-pointer',
-    level === 0 ? 'bg-white/5 border border-white/10 p-3' : 'bg-white/[0.03] border border-white/[0.06] p-2 ml-1',
+    level === 0 ? 'border border-white/10 p-3' : 'border border-white/[0.06] p-2 ml-1',
   ]"
-  :style="color ? { backgroundColor: color + '15' } : {}"
+  :style="{ backgroundColor: color ? color + '15' : (level === 0 ? 'rgba(255,255,255,0.03)' : 'rgb(17,24,39)') }"
   @click="collapsible && (collapsed = !collapsed)">
     <!-- Pill heading (sticky within scroll containers) -->
     <div
-      class="flex items-center gap-2 select-none sticky top-0 z-10 backdrop-blur-sm"
-      :class="[collapsed ? '' : 'mb-2', level === 0 ? 'bg-white/5' : 'bg-gray-900/80']"
-      :style="{ top: level === 1 ? '28px' : '0px' }">
+      class="flex items-center gap-2 select-none sticky top-0 z-10"
+      :class="[collapsed ? '' : 'mb-2']"
+      :style="{ backgroundColor: color ? color + '20' : (level === 0 ? 'rgba(255,255,255,0.05)' : 'rgb(17,24,39)'), top: level === 1 ? '28px' : '0px' }">
       <span class="text-xs font-medium uppercase tracking-wide px-2 py-0.5 rounded-full"
             :style="color ? { backgroundColor: color + '22', color } : {}"
             :class="color ? '' : 'text-white/50 bg-white/10'"

--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -146,8 +146,14 @@ function toggleFollowup(enabled: boolean) {
         :class="task.status === 'done' ? 'line-through opacity-40' : ''">{{ task.text }}</span>
     </div>
 
-    <!-- Tags row (milestone + context) — hidden when inside a GroupContainer that shows them -->
-    <div v-if="!hideTags && (milestoneStore.taskMilestones[task.id]?.length || task.context_subject)" class="flex flex-wrap gap-1">
+    <!-- Tags row (milestone + context + schedule) — hidden when inside a GroupContainer that shows them -->
+    <div v-if="!hideTags && (milestoneStore.taskMilestones[task.id]?.length || task.context_subject || (task as any).plan_date)" class="flex flex-wrap gap-1">
+      <span
+        v-if="(task as any).plan_date"
+        @click.stop
+        class="text-[10px] px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-300">
+        {{ (task as any).plan_date }}{{ (task as any).anchor_id ? ' · ' + (task as any).anchor_id : '' }}
+      </span>
       <span
         v-if="task.context_subject"
         @click.stop

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
-import { onMounted, computed } from 'vue'
+import { onMounted, computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import KanbanColumn from '../components/KanbanColumn.vue'
-import { usePlanStore } from '../stores/plan'
 import { useKanbanStore } from '../stores/kanban'
 import { useMilestoneStore } from '../stores/milestones'
-import { useBacklogStore } from '../stores/backlog'
 import type { Task } from '../stores/plan'
+import { api } from '../lib/api'
 
 interface KanbanTask extends Task {
   plan_date: string | null
@@ -14,55 +13,46 @@ interface KanbanTask extends Task {
 }
 
 const router = useRouter()
-const planStore = usePlanStore()
 const kanbanStore = useKanbanStore()
 const milestoneStore = useMilestoneStore()
-const backlogStore = useBacklogStore()
+
+const allTasks = ref<KanbanTask[]>([])
+const tasksLoading = ref(false)
+
+async function fetchAllTasks() {
+  tasksLoading.value = true
+  try {
+    const resp = await api('/api/tasks/all')
+    if (!resp.ok) throw new Error(`${resp.status}`)
+    allTasks.value = await resp.json()
+  } catch (e) {
+    console.error('fetchAllTasks error:', e)
+  } finally {
+    tasksLoading.value = false
+  }
+}
 
 onMounted(() => {
-  planStore.fetchPlan()
   kanbanStore.fetchColumns()
   milestoneStore.fetchAll()
-  backlogStore.fetchTasks()
+  fetchAllTasks()
 })
 
 async function onAddTask() {
   try {
-    const task = await backlogStore.createTask('New task')
+    const resp = await api('/api/tasks/unscheduled', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'New task' }),
+    })
+    if (!resp.ok) throw new Error(`${resp.status}`)
+    const task = await resp.json()
+    await fetchAllTasks() // refresh
     router.push({ name: 'kanban-task', params: { taskId: task.id } })
   } catch (e) {
     console.error('Failed to create task:', e)
   }
 }
-
-/** Combine all tasks (plan + backlog) into a single list with scheduling info */
-const allTasks = computed<KanbanTask[]>(() => {
-  const tasks: KanbanTask[] = []
-
-  // Plan tasks — have plan_date and anchor_id
-  if (planStore.plan) {
-    for (const [anchorId, anchor] of Object.entries(planStore.plan.anchors)) {
-      for (const task of anchor.tasks) {
-        tasks.push({
-          ...task,
-          plan_date: planStore.plan.date,
-          anchor_id: anchorId,
-        })
-      }
-    }
-  }
-
-  // Backlog tasks — no schedule
-  for (const task of backlogStore.tasks) {
-    tasks.push({
-      ...task,
-      plan_date: null,
-      anchor_id: null,
-    })
-  }
-
-  return tasks
-})
 
 /** For each column, evaluate match rules against all tasks. First matching column wins. */
 const columnTasks = computed(() => {
@@ -88,7 +78,7 @@ const KNOWN_RULE_KEYS = new Set(['status', 'plan_date'])
 
 function matchesRules(task: KanbanTask, rules: Record<string, unknown>): boolean {
   for (const [key, value] of Object.entries(rules)) {
-    if (!KNOWN_RULE_KEYS.has(key)) return false // unknown keys fail closed
+    if (!KNOWN_RULE_KEYS.has(key)) return false
     if (key === 'status') {
       if (task.status !== value) return false
     } else if (key === 'plan_date') {
@@ -97,7 +87,7 @@ function matchesRules(task: KanbanTask, rules: Record<string, unknown>): boolean
       } else if (value === 'not_null') {
         if (task.plan_date === null) return false
       } else {
-        return false // unknown plan_date value — fail closed
+        return false
       }
     }
   }
@@ -109,7 +99,7 @@ function matchesRules(task: KanbanTask, rules: Record<string, unknown>): boolean
   <div class="min-h-screen bg-gray-900 text-white p-6">
     <h1 class="text-2xl font-bold mb-4">Kanban</h1>
 
-    <div v-if="kanbanStore.loading" class="text-white/40 text-sm">Loading columns...</div>
+    <div v-if="kanbanStore.loading || tasksLoading" class="text-white/40 text-sm">Loading...</div>
     <div v-else-if="kanbanStore.error" class="text-red-400 text-sm">{{ kanbanStore.error }}</div>
 
     <div v-else class="flex gap-4 overflow-x-auto pb-4" style="min-height: calc(100vh - 140px);">


### PR DESCRIPTION
## Critical fix
Kanban board now fetches ALL tasks via `GET /api/tasks/all` instead of merging today's plan + backlog. Previously, tasks from other days were invisible until you navigated to those days in plan view.

## Other fixes
- **Opaque GroupContainer backgrounds** — child containers use opaque bg colors (rgb instead of rgba) so parent color tints don't bleed through
- **Schedule tags** — scheduled tasks show date + anchor_id as purple tags in the kanban view
- **Sticky header bg** — matches container bg color for clean scroll behavior

## New endpoint
`GET /api/tasks/all` — returns every task (scheduled + unscheduled) with `plan_date` and `anchor_id` included. Uses `_row_to_task(include_schedule=True)`.

## Test plan
- [ ] 543 tests pass
- [ ] Kanban shows ALL tasks immediately on load (not just today + backlog)
- [ ] Scheduled tasks show purple date/anchor tags
- [ ] Container tinting doesn't bleed to child containers
- [ ] Refreshing kanban page keeps tasks in correct columns