### PR TITLE
fix: opaque container bg, sticky below nav, status dropdown plan-only

### DIFF
--- a/frontend/src/components/GroupContainer.vue
+++ b/frontend/src/components/GroupContainer.vue
@@ -1,19 +1,49 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 
-withDefaults(defineProps<{
+const props = withDefaults(defineProps<{
   label: string
   color?: string
   collapsible?: boolean
   level?: number  // 0 = top-level (anchor/context), 1 = nested (milestone)
+  stickyOffset?: number // px offset for sticky headers (e.g., nav bar height)
 }>(), {
   collapsible: true,
   level: 0,
+  stickyOffset: 52,
 })
 
 const emit = defineEmits<{ (e: 'header-click'): void }>()
 
 const collapsed = ref(false)
+
+// Opaque background colors — mix color with base dark bg to prevent bleed-through
+// Base dark bg is approximately rgb(17, 24, 39) — gray-900
+function mixWithDark(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  const base = { r: 17, g: 24, b: 39 }
+  const mr = Math.round(base.r * (1 - alpha) + r * alpha)
+  const mg = Math.round(base.g * (1 - alpha) + g * alpha)
+  const mb = Math.round(base.b * (1 - alpha) + b * alpha)
+  return `rgb(${mr},${mg},${mb})`
+}
+
+const containerBg = computed(() => {
+  if (props.color) return mixWithDark(props.color, 0.08)
+  return props.level === 0 ? 'rgb(20,27,42)' : 'rgb(17,24,39)'
+})
+
+const headerBg = computed(() => {
+  if (props.color) return mixWithDark(props.color, 0.12)
+  return props.level === 0 ? 'rgb(22,29,44)' : 'rgb(17,24,39)'
+})
+
+const stickyTop = computed(() => {
+  if (props.level === 0) return `${props.stickyOffset}px`
+  return `${props.stickyOffset + 28}px`
+})
 </script>
 
 <template>
@@ -21,13 +51,13 @@ const collapsed = ref(false)
     'rounded-lg transition-all cursor-pointer',
     level === 0 ? 'border border-white/10 p-3' : 'border border-white/[0.06] p-2 ml-1',
   ]"
-  :style="{ backgroundColor: color ? color + '15' : (level === 0 ? 'rgba(255,255,255,0.03)' : 'rgb(17,24,39)') }"
+  :style="{ backgroundColor: containerBg }"
   @click="collapsible && (collapsed = !collapsed)">
-    <!-- Pill heading (sticky within scroll containers) -->
+    <!-- Pill heading (sticky below nav bar) -->
     <div
-      class="flex items-center gap-2 select-none sticky top-0 z-10"
+      class="flex items-center gap-2 select-none sticky z-10 rounded py-0.5"
       :class="[collapsed ? '' : 'mb-2']"
-      :style="{ backgroundColor: color ? color + '20' : (level === 0 ? 'rgba(255,255,255,0.05)' : 'rgb(17,24,39)'), top: level === 1 ? '28px' : '0px' }">
+      :style="{ backgroundColor: headerBg, top: stickyTop }">
       <span class="text-xs font-medium uppercase tracking-wide px-2 py-0.5 rounded-full"
             :style="color ? { backgroundColor: color + '22', color } : {}"
             :class="color ? '' : 'text-white/50 bg-white/10'"

--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -108,12 +108,13 @@ function toggleFollowup(enabled: boolean) {
       :class="STATUS_CARD_BG[task.status]"
       @click="task.id && router.push(`${routeBase}/task/${task.id}`)">
     <div class="flex flex-col gap-1 p-2">
-    <!-- Status pill (top-right, dropdown) -->
+    <!-- Status pill (top-right) — dropdown only in editable mode (plan view) -->
     <div class="absolute top-1.5 right-1.5">
       <button
-        @click.stop="openStatusDropdown"
+        @click.stop="editable && openStatusDropdown($event)"
         :class="[STATUS_PILL[task.status].bg, STATUS_PILL[task.status].text]"
-        class="text-[10px] px-1.5 py-0.5 rounded-full font-medium uppercase tracking-wider leading-none">
+        class="text-[10px] px-1.5 py-0.5 rounded-full font-medium uppercase tracking-wider leading-none"
+        :title="editable ? 'Change status' : task.status">
         {{ STATUS_PILL[task.status].label }}
       </button>
       <Teleport to="body">


### PR DESCRIPTION
3 fixes:
- GroupContainer uses opaque mixed colors (mixWithDark helper) instead of transparent alpha — child containers no longer inherit parent tint
- Sticky headers offset by nav bar height (stickyOffset prop, default 52px)  
- Status dropdown only opens in editable mode (plan view). Kanban shows read-only status pill — drag-drop for status changes coming in Phase 9B