### PR TITLE
feat: kanban drag-drop between columns (Phase 9B)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@vueuse/core": "^14.2.1",
@@ -17,11 +19,14 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.1.4",
+    "@vue/test-utils": "^2.4.6",
     "autoprefixer": "^10.4.27",
+    "happy-dom": "^20.8.9",
     "postcss": "^8.5.8",
     "tailwindcss": "^3.4.19",
     "typescript": "~5.6.2",
     "vite": "^5.4.10",
+    "vitest": "^4.1.4",
     "vue-tsc": "^2.1.8"
   }
 }

--- a/frontend/src/components/KanbanColumn.vue
+++ b/frontend/src/components/KanbanColumn.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import TaskCard from './TaskCard.vue'
 import GroupContainer from './GroupContainer.vue'
 import type { Task } from '../stores/plan'
@@ -12,7 +12,10 @@ const props = defineProps<{
   tasks: Task[]
 }>()
 
-defineEmits<{ (e: 'add-task'): void }>()
+const emit = defineEmits<{
+  (e: 'add-task'): void
+  (e: 'task-drop', taskId: string, columnId: string): void
+}>()
 
 async function onTaskUpdate(task: Task) {
   // Patch via API — status change, text change, etc.
@@ -66,6 +69,49 @@ const grouped = computed(() => {
     }
   })
 })
+
+// ── Drop target (dragenter counter avoids highlight flicker on child elements) ──
+
+const dragEnterCount = ref(0)
+
+function onColumnDragEnter() {
+  dragEnterCount.value++
+}
+
+function onColumnDragOver(evt: DragEvent) {
+  evt.preventDefault()
+  if (evt.dataTransfer) {
+    evt.dataTransfer.dropEffect = 'move'
+  }
+}
+
+function onColumnDragLeave() {
+  dragEnterCount.value = Math.max(0, dragEnterCount.value - 1)
+}
+
+function onColumnDrop(evt: DragEvent) {
+  evt.preventDefault()
+  evt.stopPropagation()
+  dragEnterCount.value = 0
+  const raw = evt.dataTransfer?.getData('text/plain')
+  if (!raw) return
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return // ignore drops from external sources (files, other apps)
+  }
+
+  if (
+    parsed !== null &&
+    typeof parsed === 'object' &&
+    'taskId' in parsed &&
+    typeof (parsed as Record<string, unknown>).taskId === 'string'
+  ) {
+    emit('task-drop', (parsed as { taskId: string }).taskId, props.column.id)
+  }
+}
 </script>
 
 <template>
@@ -81,7 +127,12 @@ const grouped = computed(() => {
     </div>
 
     <!-- Scrollable body (fills remaining column height) -->
-    <div class="flex-1 overflow-y-auto p-2 space-y-2 min-h-0">
+    <div class="flex-1 overflow-y-auto p-2 space-y-2 min-h-0 transition-all"
+         :class="dragEnterCount > 0 ? 'ring-2 ring-blue-400/50 bg-blue-400/5' : ''"
+         @dragenter="onColumnDragEnter"
+         @dragover="onColumnDragOver"
+         @dragleave="onColumnDragLeave"
+         @drop="onColumnDrop">
       <template v-if="!tasks.length">
         <p class="text-white/20 text-xs text-center py-4">No tasks</p>
       </template>
@@ -127,7 +178,7 @@ const grouped = computed(() => {
         </GroupContainer>
       </template>
 
-      <button @click="$emit('add-task')" class="mt-2 text-xs text-white/40 hover:text-white/70 w-full text-left">
+      <button @click="emit('add-task')" class="mt-2 text-xs text-white/40 hover:text-white/70 w-full text-left">
         + Add task
       </button>
     </div>

--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -90,6 +90,17 @@ function updateText(e: Event) {
   emit('update', { ...props.task, text: (e.target as HTMLInputElement).value })
 }
 
+function onDragStart(evt: DragEvent) {
+  if (!props.task.id) {
+    console.warn('[TaskCard] dragstart blocked: task has no id', props.task)
+    evt.preventDefault()
+    return
+  }
+  if (!evt.dataTransfer) return
+  evt.dataTransfer.effectAllowed = 'move'
+  evt.dataTransfer.setData('text/plain', JSON.stringify({ taskId: props.task.id }))
+}
+
 function toggleFollowup(enabled: boolean) {
   const fc: FollowupConfig = {
     enabled,
@@ -106,6 +117,8 @@ function toggleFollowup(enabled: boolean) {
 <template>
   <div class="group rounded-lg transition-colors border border-white/[0.08] cursor-pointer relative"
       :style="STATUS_CARD_STYLE[task.status]"
+      :draggable="!editable && !!task.id"
+      @dragstart="onDragStart"
       @click="task.id && router.push(`${routeBase}/task/${task.id}`)">
     <div class="flex flex-col gap-1 p-2">
     <!-- Status pill (top-right) — dropdown only in editable mode (plan view) -->

--- a/frontend/src/components/__tests__/KanbanColumn.test.ts
+++ b/frontend/src/components/__tests__/KanbanColumn.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import type { KanbanColumn as KanbanColumnType } from '../../stores/kanban'
+import KanbanColumn from '../KanbanColumn.vue'
+
+// Mock api module (KanbanColumn imports it for onTaskUpdate)
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) })),
+}))
+
+const testColumn: KanbanColumnType = {
+  id: 'col_done',
+  name: 'Done',
+  position: 3,
+  color: '#22c55e',
+  match_rules: { status: 'done' },
+  entry_rules: { set_status: 'done' },
+  created_by: null,
+}
+
+describe('KanbanColumn drop target', () => {
+  let wrapper: ReturnType<typeof mount>
+  let body: ReturnType<typeof wrapper.find>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    wrapper = mount(KanbanColumn, { props: { column: testColumn, tasks: [] } })
+    body = wrapper.find('.flex-1.overflow-y-auto')
+  })
+
+  it('emits task-drop with taskId and columnId on valid drop', async () => {
+    await body.trigger('drop', {
+      dataTransfer: {
+        getData: () => JSON.stringify({ taskId: 'task-1' }),
+      },
+    })
+    expect(wrapper.emitted('task-drop')).toBeTruthy()
+    expect(wrapper.emitted('task-drop')![0]).toEqual(['task-1', 'col_done'])
+  })
+
+  it('does not emit on drop with malformed JSON', async () => {
+    await body.trigger('drop', {
+      dataTransfer: { getData: () => 'not-json' },
+    })
+    expect(wrapper.emitted('task-drop')).toBeFalsy()
+  })
+
+  it('does not emit when taskId is not a string', async () => {
+    await body.trigger('drop', {
+      dataTransfer: { getData: () => JSON.stringify({ taskId: 123 }) },
+    })
+    expect(wrapper.emitted('task-drop')).toBeFalsy()
+  })
+
+  it('does not emit when taskId is missing from payload', async () => {
+    await body.trigger('drop', {
+      dataTransfer: { getData: () => JSON.stringify({}) },
+    })
+    expect(wrapper.emitted('task-drop')).toBeFalsy()
+  })
+
+  it('applies highlight class on dragenter', async () => {
+    await body.trigger('dragenter')
+    expect(body.classes()).toContain('ring-2')
+  })
+
+  it('removes highlight after final dragleave (counter pattern)', async () => {
+    await body.trigger('dragenter')
+    await body.trigger('dragenter')
+    await body.trigger('dragleave')
+    expect(body.classes()).toContain('ring-2')
+    await body.trigger('dragleave')
+    expect(body.classes()).not.toContain('ring-2')
+  })
+})

--- a/frontend/src/components/__tests__/TaskCard.test.ts
+++ b/frontend/src/components/__tests__/TaskCard.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import type { Task } from '../../stores/plan'
+import TaskCard from '../TaskCard.vue'
+
+// Mock vue-router (TaskCard uses useRouter + useRoute)
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ path: '/kanban' }),
+}))
+
+const baseTask: Task = {
+  id: 'task-1',
+  text: 'Test task',
+  description: null,
+  status: 'pending',
+  position: 0,
+  followup_config: null,
+  blocks: [],
+  blocked_by: [],
+  context_subject: null,
+}
+
+describe('TaskCard drag behavior', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('sets draggable="true" when editable is false (kanban mode)', () => {
+    const wrapper = mount(TaskCard, {
+      props: { task: baseTask, editable: false },
+    })
+    expect(wrapper.attributes('draggable')).toBe('true')
+  })
+
+  it('sets draggable="false" when editable is true (plan mode)', () => {
+    const wrapper = mount(TaskCard, {
+      props: { task: baseTask, editable: true },
+    })
+    expect(wrapper.attributes('draggable')).toBe('false')
+  })
+
+  it('sets draggable="false" when task has no id', () => {
+    const wrapper = mount(TaskCard, {
+      props: { task: { ...baseTask, id: '' }, editable: false },
+    })
+    expect(wrapper.attributes('draggable')).toBe('false')
+  })
+
+  it('serializes taskId as text/plain on dragstart', async () => {
+    const wrapper = mount(TaskCard, {
+      props: { task: baseTask, editable: false },
+    })
+    const setData = vi.fn()
+    await wrapper.trigger('dragstart', {
+      dataTransfer: { setData, effectAllowed: '' },
+    })
+    expect(setData).toHaveBeenCalledWith(
+      'text/plain',
+      JSON.stringify({ taskId: 'task-1' }),
+    )
+  })
+
+  it('does not serialize data when task has no id', async () => {
+    const wrapper = mount(TaskCard, {
+      props: { task: { ...baseTask, id: '' }, editable: false },
+    })
+    const setData = vi.fn()
+    await wrapper.trigger('dragstart', {
+      dataTransfer: { setData, effectAllowed: '' },
+    })
+    expect(setData).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/__tests__/smoke.test.ts
+++ b/frontend/src/components/__tests__/smoke.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+
+describe('vitest setup', () => {
+  it('can mount a Vue component', () => {
+    const Comp = defineComponent({ template: '<div>hello</div>' })
+    const wrapper = mount(Comp)
+    expect(wrapper.text()).toBe('hello')
+  })
+})

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -4,7 +4,7 @@ import { useRouter } from 'vue-router'
 import KanbanColumn from '../components/KanbanColumn.vue'
 import { useKanbanStore } from '../stores/kanban'
 import { useMilestoneStore } from '../stores/milestones'
-import type { Task } from '../stores/plan'
+import type { Task, TaskStatus } from '../stores/plan'
 import { api } from '../lib/api'
 
 interface KanbanTask extends Task {
@@ -51,6 +51,47 @@ async function onAddTask() {
     router.push({ name: 'kanban-task', params: { taskId: task.id } })
   } catch (e) {
     console.error('Failed to create task:', e)
+  }
+}
+
+const VALID_STATUSES: Set<string> = new Set(['pending', 'in_progress', 'done', 'skipped', 'blocked'])
+const pendingDrops = new Set<string>()
+
+async function onTaskDrop(taskId: string, columnId: string) {
+  if (pendingDrops.has(taskId)) return // ignore while a drop is in-flight for this task
+
+  const column = kanbanStore.columns.find(c => c.id === columnId)
+  if (!column) return
+
+  const task = allTasks.value.find(t => t.id === taskId)
+  if (!task) return
+
+  // Read entry_rules — only handle set_status for now
+  const setStatus = column.entry_rules['set_status']
+  if (typeof setStatus !== 'string') return
+  if (!VALID_STATUSES.has(setStatus)) return
+
+  // No-op if task already has this status
+  if (task.status === setStatus) return
+
+  // Optimistic update — card moves instantly
+  const oldStatus = task.status
+  task.status = setStatus as TaskStatus
+  pendingDrops.add(taskId)
+
+  try {
+    const resp = await api(`/api/tasks/${taskId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: setStatus }),
+    })
+    if (!resp.ok) throw new Error(`PATCH failed: ${resp.status}`)
+  } catch (e) {
+    console.error('Failed to update task status:', e)
+    task.status = oldStatus
+    await fetchAllTasks()
+  } finally {
+    pendingDrops.delete(taskId)
   }
 }
 
@@ -108,7 +149,8 @@ function matchesRules(task: KanbanTask, rules: Record<string, unknown>): boolean
         :key="col.id"
         :column="col"
         :tasks="columnTasks[col.id] ?? []"
-        @add-task="onAddTask" />
+        @add-task="onAddTask"
+        @task-drop="onTaskDrop" />
     </div>
 
     <router-view />

--- a/frontend/src/views/__tests__/KanbanView.test.ts
+++ b/frontend/src/views/__tests__/KanbanView.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+import type { TaskStatus } from '../../stores/plan'
+
+// Test the onTaskDrop logic in isolation.
+// KanbanView is complex to mount (router, stores, API), so we test
+// the handler logic directly with a portable helper that mirrors
+// the implementation. Field coverage is partial (only id + status).
+
+interface MockTask {
+  id: string
+  status: TaskStatus
+}
+
+interface MockColumn {
+  id: string
+  entry_rules: Record<string, unknown>
+}
+
+const VALID_STATUSES: Set<string> = new Set(['pending', 'in_progress', 'done', 'skipped', 'blocked'])
+
+function createTaskDropHandler(
+  allTasks: { value: MockTask[] },
+  columns: MockColumn[],
+  patchFn: (taskId: string, status: string) => Promise<{ ok: boolean }>,
+  refetchFn: () => Promise<void>,
+) {
+  const pendingDrops = new Set<string>()
+
+  return async function onTaskDrop(taskId: string, columnId: string) {
+    if (pendingDrops.has(taskId)) return
+
+    const column = columns.find(c => c.id === columnId)
+    if (!column) return
+
+    const task = allTasks.value.find(t => t.id === taskId)
+    if (!task) return
+
+    const setStatus = column.entry_rules['set_status']
+    if (typeof setStatus !== 'string') return
+    if (!VALID_STATUSES.has(setStatus)) return
+
+    if (task.status === setStatus) return
+
+    const oldStatus = task.status
+    task.status = setStatus as TaskStatus
+    pendingDrops.add(taskId)
+
+    try {
+      const resp = await patchFn(taskId, setStatus)
+      if (!resp.ok) throw new Error('PATCH failed')
+    } catch {
+      task.status = oldStatus
+      await refetchFn()
+    } finally {
+      pendingDrops.delete(taskId)
+    }
+  }
+}
+
+describe('onTaskDrop logic', () => {
+  const columns: MockColumn[] = [
+    { id: 'col_backlog', entry_rules: {} },
+    { id: 'col_pending', entry_rules: { set_status: 'pending', prompt_schedule: true } },
+    { id: 'col_in_progress', entry_rules: { set_status: 'in_progress' } },
+    { id: 'col_done', entry_rules: { set_status: 'done' } },
+    { id: 'col_invalid', entry_rules: { set_status: 'nonexistent_status' } },
+  ]
+
+  let allTasks: { value: MockTask[] }
+  let patchFn: Mock<(taskId: string, status: string) => Promise<{ ok: boolean }>>
+  let refetchFn: Mock<() => Promise<void>>
+  let onTaskDrop: (taskId: string, columnId: string) => Promise<void>
+
+  beforeEach(() => {
+    allTasks = { value: [{ id: 'task-1', status: 'pending' }] }
+    patchFn = vi.fn(() => Promise.resolve({ ok: true }))
+    refetchFn = vi.fn(() => Promise.resolve())
+    onTaskDrop = createTaskDropHandler(allTasks, columns, patchFn, refetchFn)
+  })
+
+  it('updates task status and calls PATCH on cross-column drop', async () => {
+    await onTaskDrop('task-1', 'col_done')
+    expect(allTasks.value[0].status).toBe('done')
+    expect(patchFn).toHaveBeenCalledWith('task-1', 'done')
+  })
+
+  it('is a no-op when dropping on same-status column', async () => {
+    await onTaskDrop('task-1', 'col_pending')
+    expect(patchFn).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when dropping on column with no set_status (Backlog)', async () => {
+    await onTaskDrop('task-1', 'col_backlog')
+    expect(patchFn).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when column has invalid set_status value', async () => {
+    await onTaskDrop('task-1', 'col_invalid')
+    expect(patchFn).not.toHaveBeenCalled()
+  })
+
+  it('reverts status and refetches on PATCH failure', async () => {
+    patchFn.mockRejectedValueOnce(new Error('network'))
+    await onTaskDrop('task-1', 'col_done')
+    expect(allTasks.value[0].status).toBe('pending')
+    expect(refetchFn).toHaveBeenCalled()
+  })
+
+  it('reverts status on non-ok response', async () => {
+    patchFn.mockResolvedValueOnce({ ok: false })
+    await onTaskDrop('task-1', 'col_done')
+    expect(allTasks.value[0].status).toBe('pending')
+    expect(refetchFn).toHaveBeenCalled()
+  })
+
+  it('is a no-op for unknown task id', async () => {
+    await onTaskDrop('nonexistent', 'col_done')
+    expect(patchFn).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op for unknown column id', async () => {
+    await onTaskDrop('task-1', 'nonexistent')
+    expect(patchFn).not.toHaveBeenCalled()
+  })
+
+  it('ignores concurrent drops on the same task (in-flight guard)', async () => {
+    // Make patchFn slow so we can fire a second drop while first is in-flight
+    let resolvePatch!: () => void
+    patchFn.mockImplementationOnce(() => new Promise(resolve => {
+      resolvePatch = () => resolve({ ok: true })
+    }))
+
+    const p1 = onTaskDrop('task-1', 'col_done')
+    // Task is now in-flight — second drop should be ignored
+    await onTaskDrop('task-1', 'col_in_progress')
+    expect(patchFn).toHaveBeenCalledTimes(1)
+    expect(patchFn).toHaveBeenCalledWith('task-1', 'done')
+
+    // Resolve first drop
+    resolvePatch()
+    await p1
+    expect(allTasks.value[0].status).toBe('done')
+  })
+})

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    environment: 'happy-dom',
+  },
+})


### PR DESCRIPTION
## Summary

- Drag task cards between kanban columns to change status via `entry_rules`
- Native HTML5 DnD (matches existing AnchorBlock pattern) — `text/plain` MIME type
- Optimistic update: card moves instantly, PATCH in background, reverts on error
- Blue ring highlight on column during dragover (dragenter counter prevents flicker)
- Vitest + @vue/test-utils infrastructure (21 tests)

## Changes

**TaskCard.vue** — draggable in kanban mode (`!editable && !!task.id`), `onDragStart` serializes `{taskId}` to dataTransfer with null guard

**KanbanColumn.vue** — drop target with dragenter/dragleave counter, type-safe JSON parsing of drop payload, emits `task-drop(taskId, columnId)`

**KanbanView.vue** — `onTaskDrop` handler: looks up column `entry_rules.set_status`, validates against `VALID_STATUSES` set, optimistic status mutation, PATCH, revert + refetch on error. In-flight guard prevents race conditions on rapid drops.

**Test infrastructure** — vitest + @vue/test-utils + happy-dom added. Separate `vitest.config.ts` (avoids vue-tsc -b conflict).

## Not included

- `prompt_schedule: true` handling (Pending column) — future work
- `package-lock.json` — run `npm install` in `frontend/` to regenerate
- Within-column reorder, cross-view drag, mobile/touch support

## Test plan

- [ ] `cd frontend && npm install && npm test` — 21 tests pass
- [ ] `npm run build` — no type errors
- [ ] Dev server: drag card to different column → card moves, status updates
- [ ] Same-column drop → no-op (no PATCH fired)
- [ ] Backlog column drop → no-op (no `set_status`)
- [ ] Plan view cards → not draggable
