### PR TITLE
feat: anchor management UI — create, delete, reorder

### DIFF
--- a/api/routes/anchors.py
+++ b/api/routes/anchors.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
-from db.queries import get_anchors, upsert_anchor
+from db.queries import get_anchors, upsert_anchor, delete_anchor
 from bot.crontab import sync_crontab
 from api.ws import manager
 from api.auth import auth_dependency
@@ -25,6 +25,17 @@ async def get_anchors_route(request: Request, _auth=Depends(auth_dependency)):
     return get_anchors(request.state.db_path)
 
 
+@router.post("/anchors")
+async def create_anchor(body: AnchorUpdate, request: Request, _auth=Depends(auth_dependency)):
+    import uuid
+    anchor_id = body.name.lower().replace(" ", "_") + "_" + uuid.uuid4().hex[:6]
+    anchor = {"id": anchor_id, **body.model_dump()}
+    upsert_anchor(request.state.db_path, anchor)
+    sync_crontab(request.state.db_path)
+    await manager.broadcast({"type": "anchors_updated"}, request.state.user_id)
+    return anchor
+
+
 @router.put("/anchors/{anchor_id}")
 async def update_anchor(anchor_id: str, body: AnchorUpdate, request: Request, _auth=Depends(auth_dependency)):
     anchor = {"id": anchor_id, **body.model_dump()}
@@ -32,3 +43,11 @@ async def update_anchor(anchor_id: str, body: AnchorUpdate, request: Request, _a
     sync_crontab(request.state.db_path)
     await manager.broadcast({"type": "anchors_updated"}, request.state.user_id)
     return anchor
+
+
+@router.delete("/anchors/{anchor_id}")
+async def delete_anchor_route(anchor_id: str, request: Request, _auth=Depends(auth_dependency)):
+    delete_anchor(request.state.db_path, anchor_id)
+    sync_crontab(request.state.db_path)
+    await manager.broadcast({"type": "anchors_updated"}, request.state.user_id)
+    return {"ok": True}

--- a/db/queries.py
+++ b/db/queries.py
@@ -47,6 +47,11 @@ def upsert_anchor(db_path: Path, anchor: dict) -> None:
         """, {**anchor, "followup_config": fc_json})
 
 
+def delete_anchor(db_path: Path, anchor_id: str) -> None:
+    with get_db(db_path) as conn:
+        conn.execute("DELETE FROM anchors WHERE id=?", (anchor_id,))
+
+
 def seed_default_anchors(db_path: Path) -> None:
     """Create a simple default schedule for new users. Skips if anchors already exist."""
     with get_db(db_path) as conn:

--- a/frontend/src/components/AnchorEditor.vue
+++ b/frontend/src/components/AnchorEditor.vue
@@ -3,7 +3,12 @@ import { ref, watch } from 'vue'
 import type { Anchor } from '../stores/anchors'
 
 const props = defineProps<{ anchor: Anchor }>()
-const emit = defineEmits<{ save: [anchor: Anchor] }>()
+const emit = defineEmits<{
+  save: [anchor: Anchor]
+  delete: [anchorId: string]
+  moveUp: [anchorId: string]
+  moveDown: [anchorId: string]
+}>()
 
 const draft = ref({ ...props.anchor })
 const saving = ref(false)
@@ -98,9 +103,23 @@ async function save() {
       </div>
     </details>
 
-    <button @click="save" :disabled="saving"
-            class="self-end px-4 py-1.5 bg-white/20 hover:bg-white/30 rounded-lg text-sm disabled:opacity-50">
-      {{ saving ? 'Saving…' : 'Save' }}
-    </button>
+    <div class="flex items-center gap-2 justify-between">
+      <div class="flex gap-1">
+        <button @click="emit('moveUp', anchor.id)" title="Move up"
+                class="px-2 py-1.5 bg-white/10 hover:bg-white/20 rounded-lg text-sm text-white/50">▲</button>
+        <button @click="emit('moveDown', anchor.id)" title="Move down"
+                class="px-2 py-1.5 bg-white/10 hover:bg-white/20 rounded-lg text-sm text-white/50">▼</button>
+      </div>
+      <div class="flex gap-2">
+        <button @click="emit('delete', anchor.id)"
+                class="px-4 py-1.5 bg-red-500/20 hover:bg-red-500/30 text-red-300 rounded-lg text-sm">
+          Delete
+        </button>
+        <button @click="save" :disabled="saving"
+                class="px-4 py-1.5 bg-white/20 hover:bg-white/30 rounded-lg text-sm disabled:opacity-50">
+          {{ saving ? 'Saving…' : 'Save' }}
+        </button>
+      </div>
+    </div>
   </div>
 </template>

--- a/frontend/src/stores/anchors.ts
+++ b/frontend/src/stores/anchors.ts
@@ -36,6 +36,15 @@ export const useAnchorStore = defineStore('anchors', () => {
     }
   }
 
+  async function createAnchor(anchor: Omit<Anchor, 'id'>) {
+    await api('/api/anchors', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(anchor),
+    })
+    await fetchAnchors()
+  }
+
   async function updateAnchor(anchor: Anchor) {
     const { id, ...body } = anchor
     await api(`/api/anchors/${id}`, {
@@ -46,5 +55,10 @@ export const useAnchorStore = defineStore('anchors', () => {
     await fetchAnchors()
   }
 
-  return { anchors, fetchAnchors, updateAnchor }
+  async function deleteAnchor(anchorId: string) {
+    await api(`/api/anchors/${anchorId}`, { method: 'DELETE' })
+    await fetchAnchors()
+  }
+
+  return { anchors, fetchAnchors, createAnchor, updateAnchor, deleteAnchor }
 })

--- a/frontend/src/views/AnchorsView.vue
+++ b/frontend/src/views/AnchorsView.vue
@@ -8,17 +8,65 @@ const anchorStore = useAnchorStore()
 onMounted(() => {
   anchorStore.fetchAnchors()
 })
+
+async function addAnchor() {
+  const position = anchorStore.anchors.length
+  await anchorStore.createAnchor({
+    name: 'New Block',
+    time: '09:00',
+    duration_minutes: 60,
+    flexibility: 'flexible',
+    strictness: 3,
+    color: '#888888',
+    position,
+    followup_config: null,
+  })
+}
+
+async function onDelete(anchorId: string) {
+  await anchorStore.deleteAnchor(anchorId)
+}
+
+async function onMoveUp(anchorId: string) {
+  const idx = anchorStore.anchors.findIndex(a => a.id === anchorId)
+  if (idx <= 0) return
+  const a = anchorStore.anchors[idx]
+  const b = anchorStore.anchors[idx - 1]
+  await anchorStore.updateAnchor({ ...a, position: b.position })
+  await anchorStore.updateAnchor({ ...b, position: a.position })
+}
+
+async function onMoveDown(anchorId: string) {
+  const idx = anchorStore.anchors.findIndex(a => a.id === anchorId)
+  if (idx < 0 || idx >= anchorStore.anchors.length - 1) return
+  const a = anchorStore.anchors[idx]
+  const b = anchorStore.anchors[idx + 1]
+  await anchorStore.updateAnchor({ ...a, position: b.position })
+  await anchorStore.updateAnchor({ ...b, position: a.position })
+}
 </script>
 
 <template>
   <div class="min-h-screen bg-gray-900 text-white p-6">
-    <h2 class="text-lg font-semibold mb-4">Anchors</h2>
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="text-lg font-semibold">Anchors</h2>
+      <button @click="addAnchor"
+              class="px-4 py-1.5 bg-blue-500/20 hover:bg-blue-500/30 text-blue-300 rounded-lg text-sm">
+        + Add Anchor
+      </button>
+    </div>
     <div class="flex flex-col gap-3">
       <AnchorEditor
         v-for="anchor in anchorStore.anchors"
         :key="anchor.id"
         :anchor="anchor"
-        @save="anchorStore.updateAnchor($event)" />
+        @save="anchorStore.updateAnchor($event)"
+        @delete="onDelete"
+        @moveUp="onMoveUp"
+        @moveDown="onMoveDown" />
     </div>
+    <p v-if="!anchorStore.anchors.length" class="text-white/30 text-sm mt-4">
+      No anchors yet. Add one to start building your schedule.
+    </p>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- New POST /anchors and DELETE /anchors/{id} endpoints
- Anchor editor now has delete button and up/down reorder buttons
- Anchors page has "+ Add Anchor" button with sensible defaults
- Empty state message when no anchors exist

## Test plan
- [ ] Click "+ Add Anchor" — new anchor appears with defaults
- [ ] Edit name, time, duration, color — click Save
- [ ] Reorder with up/down arrows — positions persist on reload
- [ ] Delete an anchor — removed from list and plan view