### PR TITLE
feat: context tree system — Phase A (schema, API, MCP, frontend)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,6 +1,8 @@
+import sqlite3
 from pathlib import Path
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from api.routes import plan as plan_routes
 from api.routes import anchors as anchor_routes
@@ -41,6 +43,19 @@ def create_app(db_path: Path | None = None) -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    @app.exception_handler(ValueError)
+    async def value_error_handler(request, exc):
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    @app.exception_handler(sqlite3.IntegrityError)
+    async def integrity_error_handler(request, exc):
+        msg = str(exc)
+        if "FOREIGN KEY" in msg:
+            return JSONResponse(status_code=404, content={"detail": "Referenced resource not found"})
+        if "UNIQUE" in msg:
+            return JSONResponse(status_code=409, content={"detail": "Resource already exists (duplicate)"})
+        return JSONResponse(status_code=400, content={"detail": "Database constraint violated"})
 
     app.include_router(auth_routes.router)  # No /api prefix — OAuth callbacks need clean /auth URLs
     app.include_router(plan_routes.router, prefix="/api")

--- a/api/main.py
+++ b/api/main.py
@@ -15,6 +15,7 @@ from api.routes import llm_config as llm_config_routes
 from api.routes import sessions as sessions_routes
 from api.routes import bot as bot_routes
 from api.routes import kanban as kanban_routes
+from api.routes import nodes as nodes_routes
 from api.ws import manager
 from api.auth import decode_jwt
 from db.auth_schema import init_auth_db
@@ -54,6 +55,7 @@ def create_app(db_path: Path | None = None) -> FastAPI:
     app.include_router(sessions_routes.router, prefix="/api")
     app.include_router(bot_routes.router, prefix="/api")
     app.include_router(kanban_routes.router, prefix="/api")
+    app.include_router(nodes_routes.router, prefix="/api")
 
     @app.post("/api/notify")
     async def notify():

--- a/api/routes/nodes.py
+++ b/api/routes/nodes.py
@@ -1,14 +1,12 @@
-from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from db.queries import (
     create_node, get_node, get_node_by_path, get_node_path,
-    get_children, get_subtree, move_node, rename_node, delete_node,
-    archive_node, unarchive_node,
+    get_children, get_subtree, move_node, delete_node,
+    patch_node_fields,
     get_sections, get_section, upsert_section, append_section, delete_section,
     search_sections,
-    link_task_to_node, unlink_task_from_node, get_node_tasks, get_task_nodes,
-    get_milestone_nodes,
+    link_task_to_node, unlink_task_from_node, get_node_tasks,
 )
 from api.ws import manager
 from api.auth import auth_dependency
@@ -73,13 +71,9 @@ async def create_node_route(
     request: Request,
     _auth=Depends(auth_dependency),
 ):
-    kwargs = {}
-    if body.target_date is not None:
-        kwargs["target_date"] = body.target_date
+    kwargs = {"target_date": body.target_date, "color": body.color}
     if body.status is not None:
         kwargs["status"] = body.status
-    if body.color is not None:
-        kwargs["color"] = body.color
     result = create_node(
         request.state.db_path, body.parent_id, body.name,
         node_type=body.node_type, **kwargs,
@@ -131,50 +125,17 @@ async def patch_node_route(
     request: Request,
     _auth=Depends(auth_dependency),
 ):
-    # Verify node exists
     node = get_node(request.state.db_path, node_id)
     if not node:
         raise HTTPException(status_code=404, detail="Node not found")
 
-    changed = False
+    fields = body.model_dump(exclude_unset=True)
+    updated = patch_node_fields(request.state.db_path, node_id, fields)
 
-    if body.name is not None:
-        rename_node(request.state.db_path, node_id, body.name)
-        changed = True
-
-    if body.archived is True:
-        archive_node(request.state.db_path, node_id)
-        changed = True
-    elif body.archived is False:
-        unarchive_node(request.state.db_path, node_id)
-        changed = True
-
-    # Handle fields that need direct SQL (target_date, status, color)
-    direct_updates: dict[str, str | None] = {}
-    if body.target_date is not None:
-        direct_updates["target_date"] = body.target_date
-    if body.status is not None:
-        direct_updates["status"] = body.status
-        direct_updates["status_override"] = "1"
-    if body.color is not None:
-        direct_updates["color"] = body.color
-
-    if direct_updates:
-        from db.schema import get_db
-        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
-        direct_updates["updated_at"] = now
-        set_clause = ", ".join(f"{k}=?" for k in direct_updates)
-        with get_db(request.state.db_path) as conn:
-            conn.execute(
-                f"UPDATE context_nodes SET {set_clause} WHERE id=?",
-                (*direct_updates.values(), node_id),
-            )
-        changed = True
-
-    if changed:
+    if fields:
         await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
 
-    return get_node(request.state.db_path, node_id)
+    return updated
 
 
 @router.delete("/nodes/{node_id}")
@@ -198,6 +159,9 @@ async def get_node_children(
     _auth=Depends(auth_dependency),
     include_archived: bool = False,
 ):
+    node = get_node(request.state.db_path, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
     return get_children(request.state.db_path, parent_id=node_id, include_archived=include_archived)
 
 
@@ -208,6 +172,9 @@ async def get_node_subtree(
     _auth=Depends(auth_dependency),
     include_archived: bool = False,
 ):
+    node = get_node(request.state.db_path, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
     return get_subtree(request.state.db_path, node_id, include_archived=include_archived)
 
 
@@ -249,6 +216,9 @@ async def list_sections(
     request: Request,
     _auth=Depends(auth_dependency),
 ):
+    node = get_node(request.state.db_path, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
     return get_sections(request.state.db_path, node_id)
 
 
@@ -273,6 +243,9 @@ async def upsert_section_route(
     request: Request,
     _auth=Depends(auth_dependency),
 ):
+    node = get_node(request.state.db_path, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
     result = upsert_section(request.state.db_path, node_id, section_type, body.body)
     await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
     return result
@@ -286,6 +259,9 @@ async def append_section_route(
     request: Request,
     _auth=Depends(auth_dependency),
 ):
+    node = get_node(request.state.db_path, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
     result = append_section(request.state.db_path, node_id, section_type, body.content)
     await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
     return result
@@ -313,6 +289,9 @@ async def list_node_tasks(
     request: Request,
     _auth=Depends(auth_dependency),
 ):
+    node = get_node(request.state.db_path, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
     return get_node_tasks(request.state.db_path, node_id)
 
 
@@ -323,6 +302,9 @@ async def link_task_route(
     request: Request,
     _auth=Depends(auth_dependency),
 ):
+    node = get_node(request.state.db_path, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
     link_task_to_node(request.state.db_path, node_id, body.task_id)
     await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
     return {"ok": True}

--- a/api/routes/nodes.py
+++ b/api/routes/nodes.py
@@ -1,0 +1,340 @@
+from datetime import datetime, timezone
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+from db.queries import (
+    create_node, get_node, get_node_by_path, get_node_path,
+    get_children, get_subtree, move_node, rename_node, delete_node,
+    archive_node, unarchive_node,
+    get_sections, get_section, upsert_section, append_section, delete_section,
+    search_sections,
+    link_task_to_node, unlink_task_from_node, get_node_tasks, get_task_nodes,
+    get_milestone_nodes,
+)
+from api.ws import manager
+from api.auth import auth_dependency
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Pydantic request bodies
+# ---------------------------------------------------------------------------
+
+class CreateNodeBody(BaseModel):
+    parent_id: str | None = None
+    name: str
+    node_type: str = "context"
+    target_date: str | None = None
+    status: str | None = None
+    color: str | None = None
+
+
+class PatchNodeBody(BaseModel):
+    name: str | None = None
+    archived: bool | None = None
+    target_date: str | None = None
+    status: str | None = None
+    color: str | None = None
+
+
+class UpsertSectionBody(BaseModel):
+    body: str
+
+
+class AppendSectionBody(BaseModel):
+    content: str
+
+
+class LinkTaskBody(BaseModel):
+    task_id: str
+
+
+class MoveNodeBody(BaseModel):
+    new_parent_id: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Node CRUD
+# ---------------------------------------------------------------------------
+
+@router.get("/nodes")
+async def list_nodes(
+    request: Request,
+    _auth=Depends(auth_dependency),
+    parent_id: str | None = None,
+    include_archived: bool = False,
+):
+    return get_children(request.state.db_path, parent_id=parent_id, include_archived=include_archived)
+
+
+@router.post("/nodes")
+async def create_node_route(
+    body: CreateNodeBody,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    kwargs = {}
+    if body.target_date is not None:
+        kwargs["target_date"] = body.target_date
+    if body.status is not None:
+        kwargs["status"] = body.status
+    if body.color is not None:
+        kwargs["color"] = body.color
+    result = create_node(
+        request.state.db_path, body.parent_id, body.name,
+        node_type=body.node_type, **kwargs,
+    )
+    await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
+    return result
+
+
+@router.get("/nodes/by-path/{path:path}")
+async def resolve_node_by_path(
+    path: str,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    node = get_node_by_path(request.state.db_path, path)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found at path")
+    return node
+
+
+@router.get("/search/sections")
+async def search_sections_route(
+    request: Request,
+    _auth=Depends(auth_dependency),
+    q: str = "",
+    node_id: str | None = None,
+):
+    if not q.strip():
+        return []
+    return search_sections(request.state.db_path, q.strip(), node_id=node_id)
+
+
+@router.get("/nodes/{node_id}")
+async def get_node_route(
+    node_id: str,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    node = get_node(request.state.db_path, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    return node
+
+
+@router.patch("/nodes/{node_id}")
+async def patch_node_route(
+    node_id: str,
+    body: PatchNodeBody,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    # Verify node exists
+    node = get_node(request.state.db_path, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+
+    changed = False
+
+    if body.name is not None:
+        rename_node(request.state.db_path, node_id, body.name)
+        changed = True
+
+    if body.archived is True:
+        archive_node(request.state.db_path, node_id)
+        changed = True
+    elif body.archived is False:
+        unarchive_node(request.state.db_path, node_id)
+        changed = True
+
+    # Handle fields that need direct SQL (target_date, status, color)
+    direct_updates: dict[str, str | None] = {}
+    if body.target_date is not None:
+        direct_updates["target_date"] = body.target_date
+    if body.status is not None:
+        direct_updates["status"] = body.status
+        direct_updates["status_override"] = "1"
+    if body.color is not None:
+        direct_updates["color"] = body.color
+
+    if direct_updates:
+        from db.schema import get_db
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        direct_updates["updated_at"] = now
+        set_clause = ", ".join(f"{k}=?" for k in direct_updates)
+        with get_db(request.state.db_path) as conn:
+            conn.execute(
+                f"UPDATE context_nodes SET {set_clause} WHERE id=?",
+                (*direct_updates.values(), node_id),
+            )
+        changed = True
+
+    if changed:
+        await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
+
+    return get_node(request.state.db_path, node_id)
+
+
+@router.delete("/nodes/{node_id}")
+async def delete_node_route(
+    node_id: str,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    node = get_node(request.state.db_path, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    delete_node(request.state.db_path, node_id)
+    await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
+    return {"ok": True}
+
+
+@router.get("/nodes/{node_id}/children")
+async def get_node_children(
+    node_id: str,
+    request: Request,
+    _auth=Depends(auth_dependency),
+    include_archived: bool = False,
+):
+    return get_children(request.state.db_path, parent_id=node_id, include_archived=include_archived)
+
+
+@router.get("/nodes/{node_id}/subtree")
+async def get_node_subtree(
+    node_id: str,
+    request: Request,
+    _auth=Depends(auth_dependency),
+    include_archived: bool = False,
+):
+    return get_subtree(request.state.db_path, node_id, include_archived=include_archived)
+
+
+@router.post("/nodes/{node_id}/move")
+async def move_node_route(
+    node_id: str,
+    body: MoveNodeBody,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    node = get_node(request.state.db_path, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    move_node(request.state.db_path, node_id, body.new_parent_id)
+    await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
+    return {"ok": True}
+
+
+@router.get("/nodes/{node_id}/path")
+async def get_node_path_route(
+    node_id: str,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    node = get_node(request.state.db_path, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    path = get_node_path(request.state.db_path, node_id)
+    return {"path": path}
+
+
+# ---------------------------------------------------------------------------
+# Sections
+# ---------------------------------------------------------------------------
+
+@router.get("/nodes/{node_id}/sections")
+async def list_sections(
+    node_id: str,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    return get_sections(request.state.db_path, node_id)
+
+
+@router.get("/nodes/{node_id}/sections/{section_type}")
+async def get_section_route(
+    node_id: str,
+    section_type: str,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    section = get_section(request.state.db_path, node_id, section_type)
+    if not section:
+        raise HTTPException(status_code=404, detail="Section not found")
+    return section
+
+
+@router.put("/nodes/{node_id}/sections/{section_type}")
+async def upsert_section_route(
+    node_id: str,
+    section_type: str,
+    body: UpsertSectionBody,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    result = upsert_section(request.state.db_path, node_id, section_type, body.body)
+    await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
+    return result
+
+
+@router.post("/nodes/{node_id}/sections/{section_type}/append")
+async def append_section_route(
+    node_id: str,
+    section_type: str,
+    body: AppendSectionBody,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    result = append_section(request.state.db_path, node_id, section_type, body.content)
+    await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
+    return result
+
+
+@router.delete("/nodes/{node_id}/sections/{section_type}")
+async def delete_section_route(
+    node_id: str,
+    section_type: str,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    delete_section(request.state.db_path, node_id, section_type)
+    await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
+    return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# Task linking
+# ---------------------------------------------------------------------------
+
+@router.get("/nodes/{node_id}/tasks")
+async def list_node_tasks(
+    node_id: str,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    return get_node_tasks(request.state.db_path, node_id)
+
+
+@router.post("/nodes/{node_id}/tasks")
+async def link_task_route(
+    node_id: str,
+    body: LinkTaskBody,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    link_task_to_node(request.state.db_path, node_id, body.task_id)
+    await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
+    return {"ok": True}
+
+
+@router.delete("/nodes/{node_id}/tasks/{task_id}")
+async def unlink_task_route(
+    node_id: str,
+    task_id: str,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    unlink_task_from_node(request.state.db_path, node_id, task_id)
+    await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
+    return {"ok": True}

--- a/db/migrate_context_tree.py
+++ b/db/migrate_context_tree.py
@@ -12,146 +12,145 @@ def migrate_context_tree(db_path: Path) -> None:
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA foreign_keys = OFF")
 
-    # 1. Check if already migrated
-    count = conn.execute("SELECT COUNT(*) FROM context_nodes").fetchone()[0]
-    if count > 0:
-        print("  context_nodes already populated — skipping migration")
-        conn.close()
-        return
-
-    # 2. Add context_node_id column to tasks (idempotent)
     try:
-        conn.execute("ALTER TABLE tasks ADD COLUMN context_node_id TEXT")
-    except sqlite3.OperationalError as e:
-        if "duplicate column" not in str(e).lower():
-            raise
+        # 1. Check if already migrated
+        count = conn.execute("SELECT COUNT(*) FROM context_nodes").fetchone()[0]
+        if count > 0:
+            print("  context_nodes already populated — skipping migration")
+            return
 
-    # --- Begin single transaction ---
-    conn.execute("BEGIN")
+        # 2. Add context_node_id column to tasks (idempotent)
+        try:
+            conn.execute("ALTER TABLE tasks ADD COLUMN context_node_id TEXT")
+        except sqlite3.OperationalError as e:
+            if "duplicate column" not in str(e).lower():
+                raise
 
-    # Cache: slash-separated path → node_id
-    path_to_node: dict[str, str] = {}
+        # --- Begin single transaction ---
+        conn.execute("BEGIN")
 
-    def ensure_path(path: str, updated_at: str | None = None) -> str:
-        """Walk the slash-separated path, creating intermediate nodes as needed.
-        Returns the node_id for the final segment."""
-        if path in path_to_node:
+        # Cache: slash-separated path → node_id
+        path_to_node: dict[str, str] = {}
+
+        def ensure_path(path: str, updated_at: str | None = None) -> str:
+            """Walk the slash-separated path, creating intermediate nodes as needed."""
+            if path in path_to_node:
+                return path_to_node[path]
+
+            parts = [p.strip() for p in path.split("/") if p.strip()]
+            if not parts:
+                raise ValueError(f"Invalid context path (empty after normalization): {path!r}")
+            current_path = ""
+            parent_id = None
+
+            for segment in parts:
+                current_path = f"{current_path}/{segment}" if current_path else segment
+                if current_path in path_to_node:
+                    parent_id = path_to_node[current_path]
+                    continue
+
+                node_id = str(uuid.uuid4())
+                ts = updated_at if current_path == path else None
+                conn.execute(
+                    """INSERT INTO context_nodes (id, parent_id, name, node_type, updated_at)
+                       VALUES (?, ?, ?, 'context', COALESCE(?, CURRENT_TIMESTAMP))""",
+                    (node_id, parent_id, segment, ts),
+                )
+                path_to_node[current_path] = node_id
+                parent_id = node_id
+
             return path_to_node[path]
 
-        parts = path.split("/")
-        current_path = ""
-        parent_id = None
+        # 3. Migrate context_entries → context_nodes + node_sections
+        rows = conn.execute("SELECT subject, body, updated_at FROM context_entries").fetchall()
+        for row in rows:
+            subject, body, updated_at = row["subject"], row["body"], row["updated_at"]
+            node_id = ensure_path(subject, updated_at=updated_at)
 
-        for segment in parts:
-            current_path = f"{current_path}/{segment}" if current_path else segment
-            if current_path in path_to_node:
-                parent_id = path_to_node[current_path]
+            conn.execute(
+                "UPDATE context_nodes SET updated_at = ? WHERE id = ?",
+                (updated_at, node_id),
+            )
+
+            if body:
+                conn.execute(
+                    """INSERT OR REPLACE INTO node_sections (node_id, section_type, body, updated_at)
+                       VALUES (?, 'details', ?, ?)""",
+                    (node_id, body, updated_at),
+                )
+
+        # 4. Migrate milestones → context_nodes (node_type='milestone')
+        milestones = conn.execute(
+            "SELECT id, context_subject, name, description, target_date, "
+            "status, status_override, color, created_at, updated_at FROM milestones"
+        ).fetchall()
+        for ms in milestones:
+            parent_node_id = path_to_node.get(ms["context_subject"])
+            if parent_node_id is None:
+                print(f"  WARNING: milestone '{ms['name']}' references unknown "
+                      f"context_subject '{ms['context_subject']}' — skipping")
                 continue
 
-            node_id = str(uuid.uuid4())
-            ts = updated_at if current_path == path else None
             conn.execute(
-                """INSERT INTO context_nodes (id, parent_id, name, node_type, updated_at)
-                   VALUES (?, ?, ?, 'context', COALESCE(?, CURRENT_TIMESTAMP))""",
-                (node_id, parent_id, segment, ts),
-            )
-            path_to_node[current_path] = node_id
-            parent_id = node_id
-
-        return path_to_node[path]
-
-    # 3. Migrate context_entries → context_nodes + node_sections
-    rows = conn.execute("SELECT subject, body, updated_at FROM context_entries").fetchall()
-    for row in rows:
-        subject, body, updated_at = row["subject"], row["body"], row["updated_at"]
-        node_id = ensure_path(subject, updated_at=updated_at)
-
-        # Update updated_at on the leaf node (ensure_path may have been called
-        # earlier as an intermediate, so force the correct timestamp)
-        conn.execute(
-            "UPDATE context_nodes SET updated_at = ? WHERE id = ?",
-            (updated_at, node_id),
-        )
-
-        # Insert body into node_sections
-        if body:
-            conn.execute(
-                """INSERT OR REPLACE INTO node_sections (node_id, section_type, body, updated_at)
-                   VALUES (?, 'details', ?, ?)""",
-                (node_id, body, updated_at),
+                """INSERT INTO context_nodes
+                   (id, parent_id, name, node_type, target_date, status,
+                    status_override, color, created_at, updated_at)
+                   VALUES (?, ?, ?, 'milestone', ?, ?, ?, ?, ?, ?)""",
+                (ms["id"], parent_node_id, ms["name"], ms["target_date"],
+                 ms["status"], ms["status_override"], ms["color"],
+                 ms["created_at"], ms["updated_at"]),
             )
 
-    # 4. Migrate milestones → context_nodes (node_type='milestone')
-    milestones = conn.execute(
-        "SELECT id, context_subject, name, description, target_date, "
-        "status, status_override, color, created_at, updated_at FROM milestones"
-    ).fetchall()
-    for ms in milestones:
-        parent_node_id = path_to_node.get(ms["context_subject"])
-        if parent_node_id is None:
-            print(f"  WARNING: milestone '{ms['name']}' references unknown context_subject "
-                  f"'{ms['context_subject']}' — skipping")
-            continue
+            if ms["description"]:
+                conn.execute(
+                    """INSERT INTO node_sections (node_id, section_type, body, updated_at)
+                       VALUES (?, 'details', ?, ?)""",
+                    (ms["id"], ms["description"], ms["updated_at"]),
+                )
 
-        conn.execute(
-            """INSERT INTO context_nodes
-               (id, parent_id, name, node_type, target_date, status,
-                status_override, color, created_at, updated_at)
-               VALUES (?, ?, ?, 'milestone', ?, ?, ?, ?, ?, ?)""",
-            (
-                ms["id"],
-                parent_node_id,
-                ms["name"],
-                ms["target_date"],
-                ms["status"],
-                ms["status_override"],
-                ms["color"],
-                ms["created_at"],
-                ms["updated_at"],
-            ),
-        )
+        # 5. Migrate milestone_tasks → node_tasks
+        mt_rows = conn.execute("SELECT milestone_id, task_id FROM milestone_tasks").fetchall()
+        for mt in mt_rows:
+            exists = conn.execute(
+                "SELECT 1 FROM context_nodes WHERE id = ?", (mt["milestone_id"],)
+            ).fetchone()
+            if exists:
+                conn.execute(
+                    "INSERT INTO node_tasks (node_id, task_id) VALUES (?, ?)",
+                    (mt["milestone_id"], mt["task_id"]),
+                )
 
-        if ms["description"]:
-            conn.execute(
-                """INSERT INTO node_sections (node_id, section_type, body, updated_at)
-                   VALUES (?, 'details', ?, ?)""",
-                (ms["id"], ms["description"], ms["updated_at"]),
-            )
+        # 6. Migrate tasks.context_subject → tasks.context_node_id
+        tasks_with_ctx = conn.execute(
+            "SELECT uuid, context_subject FROM tasks WHERE context_subject IS NOT NULL"
+        ).fetchall()
+        for task in tasks_with_ctx:
+            node_id = path_to_node.get(task["context_subject"])
+            if node_id:
+                conn.execute(
+                    "UPDATE tasks SET context_node_id = ? WHERE uuid = ?",
+                    (node_id, task["uuid"]),
+                )
+            else:
+                print(f"  WARNING: task '{task['uuid']}' references unknown "
+                      f"context_subject '{task['context_subject']}' — context_node_id will be NULL")
 
-    # 5. Migrate milestone_tasks → node_tasks
-    mt_rows = conn.execute("SELECT milestone_id, task_id FROM milestone_tasks").fetchall()
-    for mt in mt_rows:
-        # Only migrate if the milestone was actually migrated (not skipped)
-        exists = conn.execute(
-            "SELECT 1 FROM context_nodes WHERE id = ?", (mt["milestone_id"],)
-        ).fetchone()
-        if exists:
-            conn.execute(
-                "INSERT INTO node_tasks (node_id, task_id) VALUES (?, ?)",
-                (mt["milestone_id"], mt["task_id"]),
-            )
+        # 7. Rebuild FTS index
+        try:
+            conn.execute("INSERT INTO node_sections_fts(node_sections_fts) VALUES('rebuild')")
+        except sqlite3.OperationalError as e:
+            if "no such table" in str(e).lower():
+                print("  INFO: node_sections_fts table does not exist — skipping FTS rebuild")
+            else:
+                raise
 
-    # 6. Migrate tasks.context_subject → tasks.context_node_id
-    tasks_with_ctx = conn.execute(
-        "SELECT uuid, context_subject FROM tasks WHERE context_subject IS NOT NULL"
-    ).fetchall()
-    for task in tasks_with_ctx:
-        node_id = path_to_node.get(task["context_subject"])
-        if node_id:
-            conn.execute(
-                "UPDATE tasks SET context_node_id = ? WHERE uuid = ?",
-                (node_id, task["uuid"]),
-            )
-
-    # 7. Rebuild FTS index
-    try:
-        conn.execute("INSERT INTO node_sections_fts(node_sections_fts) VALUES('rebuild')")
-    except sqlite3.OperationalError:
-        pass  # FTS table may not exist in older schemas
-
-    conn.execute("COMMIT")
-    conn.execute("PRAGMA foreign_keys = ON")
-    conn.close()
+        conn.execute("COMMIT")
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+    finally:
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.close()
 
 
 if __name__ == "__main__":

--- a/db/migrate_context_tree.py
+++ b/db/migrate_context_tree.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""One-time migration: flat context_entries + milestones → context_nodes tree."""
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from pathlib import Path
+
+
+def migrate_context_tree(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = OFF")
+
+    # 1. Check if already migrated
+    count = conn.execute("SELECT COUNT(*) FROM context_nodes").fetchone()[0]
+    if count > 0:
+        print("  context_nodes already populated — skipping migration")
+        conn.close()
+        return
+
+    # 2. Add context_node_id column to tasks (idempotent)
+    try:
+        conn.execute("ALTER TABLE tasks ADD COLUMN context_node_id TEXT")
+    except sqlite3.OperationalError as e:
+        if "duplicate column" not in str(e).lower():
+            raise
+
+    # --- Begin single transaction ---
+    conn.execute("BEGIN")
+
+    # Cache: slash-separated path → node_id
+    path_to_node: dict[str, str] = {}
+
+    def ensure_path(path: str, updated_at: str | None = None) -> str:
+        """Walk the slash-separated path, creating intermediate nodes as needed.
+        Returns the node_id for the final segment."""
+        if path in path_to_node:
+            return path_to_node[path]
+
+        parts = path.split("/")
+        current_path = ""
+        parent_id = None
+
+        for segment in parts:
+            current_path = f"{current_path}/{segment}" if current_path else segment
+            if current_path in path_to_node:
+                parent_id = path_to_node[current_path]
+                continue
+
+            node_id = str(uuid.uuid4())
+            ts = updated_at if current_path == path else None
+            conn.execute(
+                """INSERT INTO context_nodes (id, parent_id, name, node_type, updated_at)
+                   VALUES (?, ?, ?, 'context', COALESCE(?, CURRENT_TIMESTAMP))""",
+                (node_id, parent_id, segment, ts),
+            )
+            path_to_node[current_path] = node_id
+            parent_id = node_id
+
+        return path_to_node[path]
+
+    # 3. Migrate context_entries → context_nodes + node_sections
+    rows = conn.execute("SELECT subject, body, updated_at FROM context_entries").fetchall()
+    for row in rows:
+        subject, body, updated_at = row["subject"], row["body"], row["updated_at"]
+        node_id = ensure_path(subject, updated_at=updated_at)
+
+        # Update updated_at on the leaf node (ensure_path may have been called
+        # earlier as an intermediate, so force the correct timestamp)
+        conn.execute(
+            "UPDATE context_nodes SET updated_at = ? WHERE id = ?",
+            (updated_at, node_id),
+        )
+
+        # Insert body into node_sections
+        if body:
+            conn.execute(
+                """INSERT OR REPLACE INTO node_sections (node_id, section_type, body, updated_at)
+                   VALUES (?, 'details', ?, ?)""",
+                (node_id, body, updated_at),
+            )
+
+    # 4. Migrate milestones → context_nodes (node_type='milestone')
+    milestones = conn.execute(
+        "SELECT id, context_subject, name, description, target_date, "
+        "status, status_override, color, created_at, updated_at FROM milestones"
+    ).fetchall()
+    for ms in milestones:
+        parent_node_id = path_to_node.get(ms["context_subject"])
+        if parent_node_id is None:
+            print(f"  WARNING: milestone '{ms['name']}' references unknown context_subject "
+                  f"'{ms['context_subject']}' — skipping")
+            continue
+
+        conn.execute(
+            """INSERT INTO context_nodes
+               (id, parent_id, name, node_type, target_date, status,
+                status_override, color, created_at, updated_at)
+               VALUES (?, ?, ?, 'milestone', ?, ?, ?, ?, ?, ?)""",
+            (
+                ms["id"],
+                parent_node_id,
+                ms["name"],
+                ms["target_date"],
+                ms["status"],
+                ms["status_override"],
+                ms["color"],
+                ms["created_at"],
+                ms["updated_at"],
+            ),
+        )
+
+        if ms["description"]:
+            conn.execute(
+                """INSERT INTO node_sections (node_id, section_type, body, updated_at)
+                   VALUES (?, 'details', ?, ?)""",
+                (ms["id"], ms["description"], ms["updated_at"]),
+            )
+
+    # 5. Migrate milestone_tasks → node_tasks
+    mt_rows = conn.execute("SELECT milestone_id, task_id FROM milestone_tasks").fetchall()
+    for mt in mt_rows:
+        # Only migrate if the milestone was actually migrated (not skipped)
+        exists = conn.execute(
+            "SELECT 1 FROM context_nodes WHERE id = ?", (mt["milestone_id"],)
+        ).fetchone()
+        if exists:
+            conn.execute(
+                "INSERT INTO node_tasks (node_id, task_id) VALUES (?, ?)",
+                (mt["milestone_id"], mt["task_id"]),
+            )
+
+    # 6. Migrate tasks.context_subject → tasks.context_node_id
+    tasks_with_ctx = conn.execute(
+        "SELECT uuid, context_subject FROM tasks WHERE context_subject IS NOT NULL"
+    ).fetchall()
+    for task in tasks_with_ctx:
+        node_id = path_to_node.get(task["context_subject"])
+        if node_id:
+            conn.execute(
+                "UPDATE tasks SET context_node_id = ? WHERE uuid = ?",
+                (node_id, task["uuid"]),
+            )
+
+    # 7. Rebuild FTS index
+    try:
+        conn.execute("INSERT INTO node_sections_fts(node_sections_fts) VALUES('rebuild')")
+    except sqlite3.OperationalError:
+        pass  # FTS table may not exist in older schemas
+
+    conn.execute("COMMIT")
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.close()
+
+
+if __name__ == "__main__":
+    import sys
+    for path in sys.argv[1:]:
+        print(f"Migrating {path}...")
+        migrate_context_tree(Path(path))
+        print("  done")

--- a/db/queries.py
+++ b/db/queries.py
@@ -1082,6 +1082,29 @@ def unarchive_node(db_path: Path, node_id: str) -> None:
         )
 
 
+def patch_node_fields(db_path: Path, node_id: str, fields: dict) -> dict | None:
+    """Update allowed fields on a context node. Returns updated node dict or None."""
+    allowed = {"name", "target_date", "status", "color", "archived"}
+    updates = {k: v for k, v in fields.items() if k in allowed}
+    if not updates:
+        return get_node(db_path, node_id)
+    # Convert archived bool to int for SQLite
+    if "archived" in updates:
+        updates["archived"] = int(updates["archived"])
+    # Setting status implies a manual override
+    if "status" in updates:
+        updates["status_override"] = 1
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    updates["updated_at"] = now
+    set_clause = ", ".join(f"{k}=?" for k in updates)
+    with get_db(db_path) as conn:
+        conn.execute(
+            f"UPDATE context_nodes SET {set_clause} WHERE id=?",
+            (*updates.values(), node_id),
+        )
+    return get_node(db_path, node_id)
+
+
 # ---------------------------------------------------------------------------
 # Section operations (node_sections)
 # ---------------------------------------------------------------------------

--- a/db/queries.py
+++ b/db/queries.py
@@ -865,6 +865,430 @@ def unlink_milestone_task(db_path: Path, milestone_id: str, task_id: str) -> Non
         )
 
 
+# ---------------------------------------------------------------------------
+# Context-tree operations (context_nodes, node_sections, node_tasks)
+# ---------------------------------------------------------------------------
+
+
+def create_node(
+    db_path: Path, parent_id: str | None, name: str,
+    node_type: str = "context", **kwargs,
+) -> dict:
+    """Create a context node or milestone.
+
+    kwargs: target_date, status, color, status_override.
+    Returns the created node dict.
+    """
+    node_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    target_date = kwargs.get("target_date")
+    status = kwargs.get("status", "pending")
+    status_override = kwargs.get("status_override", 0)
+    color = kwargs.get("color")
+    with get_db(db_path) as conn:
+        conn.execute(
+            """INSERT INTO context_nodes
+               (id, parent_id, name, node_type, target_date, status,
+                status_override, color, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (node_id, parent_id, name, node_type, target_date, status,
+             status_override, color, now, now),
+        )
+    return {
+        "id": node_id, "parent_id": parent_id, "name": name,
+        "node_type": node_type, "archived": 0,
+        "target_date": target_date, "status": status,
+        "status_override": status_override, "color": color,
+        "created_at": now, "updated_at": now,
+    }
+
+
+def get_node(db_path: Path, node_id: str) -> dict | None:
+    """Get a single node by ID, including section_types list and children_count."""
+    with get_db(db_path) as conn:
+        row = conn.execute(
+            "SELECT * FROM context_nodes WHERE id = ?", (node_id,)
+        ).fetchone()
+        if not row:
+            return None
+        d = dict(row)
+        sections = conn.execute(
+            "SELECT section_type FROM node_sections WHERE node_id = ? ORDER BY section_type",
+            (node_id,),
+        ).fetchall()
+        d["section_types"] = [s["section_type"] for s in sections]
+        children = conn.execute(
+            "SELECT COUNT(*) FROM context_nodes WHERE parent_id = ?", (node_id,)
+        ).fetchone()[0]
+        d["children_count"] = children
+    return d
+
+
+def get_node_by_path(db_path: Path, path: str) -> dict | None:
+    """Resolve 'School/ML/Project' to a node. Walk the tree from root."""
+    parts = path.split("/")
+    with get_db(db_path) as conn:
+        # First segment: parent_id IS NULL
+        row = conn.execute(
+            "SELECT * FROM context_nodes WHERE parent_id IS NULL AND name = ?",
+            (parts[0],),
+        ).fetchone()
+        if not row:
+            return None
+        current = dict(row)
+        for segment in parts[1:]:
+            row = conn.execute(
+                "SELECT * FROM context_nodes WHERE parent_id = ? AND name = ?",
+                (current["id"], segment),
+            ).fetchone()
+            if not row:
+                return None
+            current = dict(row)
+    return current
+
+
+def get_node_path(db_path: Path, node_id: str) -> str:
+    """Get human-readable path for a node: 'School/ML/Project'."""
+    with get_db(db_path) as conn:
+        rows = conn.execute(
+            """WITH RECURSIVE ancestors(id, parent_id, name, depth) AS (
+                   SELECT id, parent_id, name, 0 FROM context_nodes WHERE id = ?
+                   UNION ALL
+                   SELECT cn.id, cn.parent_id, cn.name, a.depth + 1
+                   FROM context_nodes cn
+                   JOIN ancestors a ON cn.id = a.parent_id
+               )
+               SELECT name FROM ancestors ORDER BY depth DESC""",
+            (node_id,),
+        ).fetchall()
+    return "/".join(r["name"] for r in rows)
+
+
+def get_children(
+    db_path: Path, parent_id: str | None = None, include_archived: bool = False,
+) -> list[dict]:
+    """Get immediate children of a node (or root nodes if parent_id=None)."""
+    with get_db(db_path) as conn:
+        if parent_id is None:
+            if include_archived:
+                rows = conn.execute(
+                    "SELECT * FROM context_nodes WHERE parent_id IS NULL ORDER BY name"
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM context_nodes WHERE parent_id IS NULL AND archived = 0 ORDER BY name"
+                ).fetchall()
+        else:
+            if include_archived:
+                rows = conn.execute(
+                    "SELECT * FROM context_nodes WHERE parent_id = ? ORDER BY name",
+                    (parent_id,),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM context_nodes WHERE parent_id = ? AND archived = 0 ORDER BY name",
+                    (parent_id,),
+                ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def get_subtree(
+    db_path: Path, node_id: str, include_archived: bool = False,
+) -> list[dict]:
+    """Get all descendants of a node using recursive CTE (excludes the node itself)."""
+    with get_db(db_path) as conn:
+        if include_archived:
+            rows = conn.execute(
+                """WITH RECURSIVE descendants(id) AS (
+                       SELECT id FROM context_nodes WHERE parent_id = ?
+                       UNION ALL
+                       SELECT cn.id FROM context_nodes cn
+                       JOIN descendants d ON cn.parent_id = d.id
+                   )
+                   SELECT cn.* FROM context_nodes cn
+                   JOIN descendants d ON cn.id = d.id
+                   ORDER BY cn.name""",
+                (node_id,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """WITH RECURSIVE descendants(id) AS (
+                       SELECT id FROM context_nodes WHERE parent_id = ? AND archived = 0
+                       UNION ALL
+                       SELECT cn.id FROM context_nodes cn
+                       JOIN descendants d ON cn.parent_id = d.id
+                       WHERE cn.archived = 0
+                   )
+                   SELECT cn.* FROM context_nodes cn
+                   JOIN descendants d ON cn.id = d.id
+                   ORDER BY cn.name""",
+                (node_id,),
+            ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def move_node(db_path: Path, node_id: str, new_parent_id: str | None) -> None:
+    """Move a node to a new parent (or to root if new_parent_id is None)."""
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    with get_db(db_path) as conn:
+        conn.execute(
+            "UPDATE context_nodes SET parent_id = ?, updated_at = ? WHERE id = ?",
+            (new_parent_id, now, node_id),
+        )
+
+
+def rename_node(db_path: Path, node_id: str, new_name: str) -> None:
+    """Rename a node."""
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    with get_db(db_path) as conn:
+        conn.execute(
+            "UPDATE context_nodes SET name = ?, updated_at = ? WHERE id = ?",
+            (new_name, now, node_id),
+        )
+
+
+def delete_node(db_path: Path, node_id: str) -> None:
+    """Delete a node. CASCADE handles children, sections, task links."""
+    with get_db(db_path) as conn:
+        conn.execute("DELETE FROM context_nodes WHERE id = ?", (node_id,))
+
+
+def archive_node(db_path: Path, node_id: str) -> None:
+    """Set archived=1."""
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    with get_db(db_path) as conn:
+        conn.execute(
+            "UPDATE context_nodes SET archived = 1, updated_at = ? WHERE id = ?",
+            (now, node_id),
+        )
+
+
+def unarchive_node(db_path: Path, node_id: str) -> None:
+    """Set archived=0."""
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    with get_db(db_path) as conn:
+        conn.execute(
+            "UPDATE context_nodes SET archived = 0, updated_at = ? WHERE id = ?",
+            (now, node_id),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Section operations (node_sections)
+# ---------------------------------------------------------------------------
+
+
+def get_sections(db_path: Path, node_id: str) -> list[dict]:
+    """Get all sections for a node."""
+    with get_db(db_path) as conn:
+        rows = conn.execute(
+            "SELECT section_type, body, updated_at FROM node_sections "
+            "WHERE node_id = ? ORDER BY section_type",
+            (node_id,),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def get_section(db_path: Path, node_id: str, section_type: str) -> dict | None:
+    """Get a single section by type."""
+    with get_db(db_path) as conn:
+        row = conn.execute(
+            "SELECT section_type, body, updated_at FROM node_sections "
+            "WHERE node_id = ? AND section_type = ?",
+            (node_id, section_type),
+        ).fetchone()
+    return dict(row) if row else None
+
+
+def upsert_section(db_path: Path, node_id: str, section_type: str, body: str) -> dict:
+    """Insert or update a section. Also update node's updated_at."""
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    with get_db(db_path) as conn:
+        conn.execute(
+            """INSERT INTO node_sections (node_id, section_type, body, updated_at)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT(node_id, section_type) DO UPDATE SET
+                   body = excluded.body, updated_at = excluded.updated_at""",
+            (node_id, section_type, body, now),
+        )
+        conn.execute(
+            "UPDATE context_nodes SET updated_at = ? WHERE id = ?",
+            (now, node_id),
+        )
+    return {"section_type": section_type, "body": body, "updated_at": now}
+
+
+def append_section(db_path: Path, node_id: str, section_type: str, content: str) -> dict:
+    """Append text to a section with '\\n\\n' separator. Create if missing."""
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    with get_db(db_path) as conn:
+        existing = conn.execute(
+            "SELECT body FROM node_sections WHERE node_id = ? AND section_type = ?",
+            (node_id, section_type),
+        ).fetchone()
+        if existing and existing["body"]:
+            new_body = existing["body"] + "\n\n" + content
+        else:
+            new_body = content
+        conn.execute(
+            """INSERT INTO node_sections (node_id, section_type, body, updated_at)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT(node_id, section_type) DO UPDATE SET
+                   body = excluded.body, updated_at = excluded.updated_at""",
+            (node_id, section_type, new_body, now),
+        )
+        conn.execute(
+            "UPDATE context_nodes SET updated_at = ? WHERE id = ?",
+            (now, node_id),
+        )
+    return {"section_type": section_type, "body": new_body, "updated_at": now}
+
+
+def delete_section(db_path: Path, node_id: str, section_type: str) -> None:
+    """Delete a section."""
+    with get_db(db_path) as conn:
+        conn.execute(
+            "DELETE FROM node_sections WHERE node_id = ? AND section_type = ?",
+            (node_id, section_type),
+        )
+
+
+def search_sections(
+    db_path: Path, query: str, node_id: str | None = None,
+) -> list[dict]:
+    """FTS5 search across node_sections.
+
+    Returns [{node_id, section_type, snippet}].
+    If node_id is provided, filter to that node's subtree.
+    """
+    with get_db(db_path) as conn:
+        if node_id is not None:
+            # Get subtree node ids (including the node itself)
+            subtree_ids = conn.execute(
+                """WITH RECURSIVE descendants(id) AS (
+                       SELECT ?
+                       UNION ALL
+                       SELECT cn.id FROM context_nodes cn
+                       JOIN descendants d ON cn.parent_id = d.id
+                   )
+                   SELECT id FROM descendants""",
+                (node_id,),
+            ).fetchall()
+            id_set = [r["id"] for r in subtree_ids]
+            if not id_set:
+                return []
+            ph = ",".join("?" for _ in id_set)
+            rows = conn.execute(
+                f"""SELECT ns.node_id, ns.section_type,
+                           snippet(node_sections_fts, 0, '<b>', '</b>', '...', 32) AS snippet
+                    FROM node_sections_fts fts
+                    JOIN node_sections ns ON ns.id = fts.rowid
+                    WHERE fts.body MATCH ?
+                      AND ns.node_id IN ({ph})
+                    ORDER BY fts.rank""",
+                (query, *id_set),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """SELECT ns.node_id, ns.section_type,
+                          snippet(node_sections_fts, 0, '<b>', '</b>', '...', 32) AS snippet
+                   FROM node_sections_fts fts
+                   JOIN node_sections ns ON ns.id = fts.rowid
+                   WHERE fts.body MATCH ?
+                   ORDER BY fts.rank""",
+                (query,),
+            ).fetchall()
+    return [dict(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Node-task linking (node_tasks)
+# ---------------------------------------------------------------------------
+
+
+def link_task_to_node(db_path: Path, node_id: str, task_id: str) -> None:
+    """Link a task to a context node."""
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO node_tasks (node_id, task_id) VALUES (?, ?)",
+            (node_id, task_id),
+        )
+
+
+def unlink_task_from_node(db_path: Path, node_id: str, task_id: str) -> None:
+    """Unlink a task from a context node."""
+    with get_db(db_path) as conn:
+        conn.execute(
+            "DELETE FROM node_tasks WHERE node_id = ? AND task_id = ?",
+            (node_id, task_id),
+        )
+
+
+def get_node_tasks(db_path: Path, node_id: str) -> list[dict]:
+    """Get tasks linked to a node (with task details)."""
+    with get_db(db_path) as conn:
+        rows = conn.execute(
+            """SELECT t.uuid, t.text, t.status, t.plan_date, t.anchor_id
+               FROM node_tasks nt
+               JOIN tasks t ON t.uuid = nt.task_id
+               WHERE nt.node_id = ?
+               ORDER BY t.plan_date DESC NULLS LAST, t.text""",
+            (node_id,),
+        ).fetchall()
+    return [{"id": r["uuid"], "text": r["text"], "status": r["status"],
+             "plan_date": r["plan_date"], "anchor_id": r["anchor_id"]}
+            for r in rows]
+
+
+def get_task_nodes(db_path: Path, task_id: str) -> list[dict]:
+    """Get all nodes linked to a task."""
+    with get_db(db_path) as conn:
+        rows = conn.execute(
+            """SELECT cn.* FROM context_nodes cn
+               JOIN node_tasks nt ON nt.node_id = cn.id
+               WHERE nt.task_id = ?
+               ORDER BY cn.name""",
+            (task_id,),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Milestone-specific helpers (context_nodes with node_type='milestone')
+# ---------------------------------------------------------------------------
+
+
+def get_milestone_nodes(
+    db_path: Path, parent_id: str | None = None, include_archived: bool = False,
+) -> list[dict]:
+    """Get milestone nodes, optionally under a specific parent.
+
+    Includes task_count and done_count derived from node_tasks + tasks.
+    """
+    conditions = ["cn.node_type = 'milestone'"]
+    params: list = []
+    if parent_id is not None:
+        conditions.append("cn.parent_id = ?")
+        params.append(parent_id)
+    if not include_archived:
+        conditions.append("cn.archived = 0")
+    where = " AND ".join(conditions)
+    with get_db(db_path) as conn:
+        rows = conn.execute(
+            f"""SELECT cn.*,
+                       COUNT(nt.task_id) AS task_count,
+                       SUM(CASE WHEN t.status = 'done' THEN 1 ELSE 0 END) AS done_count
+                FROM context_nodes cn
+                LEFT JOIN node_tasks nt ON nt.node_id = cn.id
+                LEFT JOIN tasks t ON t.uuid = nt.task_id
+                WHERE {where}
+                GROUP BY cn.id
+                ORDER BY cn.name""",
+            params,
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
 def init_followup_state(
     db_path: Path, date: str, anchor_id: str, task_id: str, now: datetime,
 ) -> None:

--- a/db/queries.py
+++ b/db/queries.py
@@ -22,6 +22,7 @@ def _row_to_task(row, *, include_schedule: bool = False) -> dict:
         "position": r.get("position", 0),
         "description": r.get("description"),
         "context_subject": r.get("context_subject"),
+        "context_node_id": r.get("context_node_id"),
         "followup_config": json.loads(fc) if fc else None,
         "blocks": [],
         "blocked_by": [],
@@ -222,7 +223,7 @@ def upsert_tasks(
 
         # Return ALL tasks for this anchor (including untouched ones)
         all_rows = conn.execute(
-            "SELECT uuid, text, status, position, followup_config, description, context_subject "
+            "SELECT uuid, text, status, position, followup_config, description, context_subject, context_node_id "
             "FROM tasks WHERE plan_date=? AND anchor_id=? ORDER BY position",
             (date, anchor_id),
         ).fetchall()
@@ -258,7 +259,7 @@ def get_task_by_uuid(db_path: Path, task_uuid: str) -> dict | None:
     """Get a single task by UUID."""
     with get_db(db_path) as conn:
         row = conn.execute(
-            "SELECT uuid, plan_date, anchor_id, text, status, position, followup_config, description, context_subject "
+            "SELECT uuid, plan_date, anchor_id, text, status, position, followup_config, description, context_subject, context_node_id "
             "FROM tasks WHERE uuid=?", (task_uuid,)
         ).fetchone()
     if not row:
@@ -1386,7 +1387,7 @@ def create_unscheduled_task(
             (task_uuid, text, status, description, context_subject),
         )
         row = conn.execute(
-            "SELECT uuid, text, status, position, followup_config, description, context_subject "
+            "SELECT uuid, text, status, position, followup_config, description, context_subject, context_node_id "
             "FROM tasks WHERE uuid=?", (task_uuid,)
         ).fetchone()
     return _row_to_task(row)
@@ -1396,7 +1397,7 @@ def get_unscheduled_tasks(db_path: Path) -> list[dict]:
     """Get all tasks with no plan_date (backlog), with context_subject."""
     with get_db(db_path) as conn:
         rows = conn.execute(
-            "SELECT uuid, text, status, position, followup_config, description, context_subject "
+            "SELECT uuid, text, status, position, followup_config, description, context_subject, context_node_id "
             "FROM tasks WHERE plan_date IS NULL ORDER BY position, id"
         ).fetchall()
     return [_row_to_task(r) for r in rows]
@@ -1407,7 +1408,7 @@ def get_all_tasks(db_path: Path) -> list[dict]:
     with get_db(db_path) as conn:
         rows = conn.execute(
             "SELECT uuid, text, status, position, followup_config, description, "
-            "context_subject, plan_date, anchor_id "
+            "context_subject, context_node_id, plan_date, anchor_id "
             "FROM tasks ORDER BY plan_date DESC NULLS LAST, position"
         ).fetchall()
     return [_row_to_task(r, include_schedule=True) for r in rows]

--- a/db/queries.py
+++ b/db/queries.py
@@ -872,19 +872,20 @@ def unlink_milestone_task(db_path: Path, milestone_id: str, task_id: str) -> Non
 
 def create_node(
     db_path: Path, parent_id: str | None, name: str,
-    node_type: str = "context", **kwargs,
+    node_type: str = "context",
+    target_date: str | None = None,
+    status: str = "pending",
+    status_override: int = 0,
+    color: str | None = None,
 ) -> dict:
     """Create a context node or milestone.
 
-    kwargs: target_date, status, color, status_override.
     Returns the created node dict.
     """
+    if node_type not in ("context", "milestone"):
+        raise ValueError(f"Invalid node_type: {node_type!r}. Must be 'context' or 'milestone'.")
     node_id = str(uuid.uuid4())
     now = datetime.now(timezone.utc).isoformat(timespec="seconds")
-    target_date = kwargs.get("target_date")
-    status = kwargs.get("status", "pending")
-    status_override = kwargs.get("status_override", 0)
-    color = kwargs.get("color")
     with get_db(db_path) as conn:
         conn.execute(
             """INSERT INTO context_nodes
@@ -926,29 +927,34 @@ def get_node(db_path: Path, node_id: str) -> dict | None:
 
 def get_node_by_path(db_path: Path, path: str) -> dict | None:
     """Resolve 'School/ML/Project' to a node. Walk the tree from root."""
-    parts = path.split("/")
+    parts = [p for p in path.split("/") if p]
+    if not parts:
+        return None
     with get_db(db_path) as conn:
         # First segment: parent_id IS NULL
         row = conn.execute(
-            "SELECT * FROM context_nodes WHERE parent_id IS NULL AND name = ?",
+            "SELECT id FROM context_nodes WHERE parent_id IS NULL AND name = ?",
             (parts[0],),
         ).fetchone()
         if not row:
             return None
-        current = dict(row)
+        resolved_id = row["id"]
         for segment in parts[1:]:
             row = conn.execute(
-                "SELECT * FROM context_nodes WHERE parent_id = ? AND name = ?",
-                (current["id"], segment),
+                "SELECT id FROM context_nodes WHERE parent_id = ? AND name = ?",
+                (resolved_id, segment),
             ).fetchone()
             if not row:
                 return None
-            current = dict(row)
-    return current
+            resolved_id = row["id"]
+    return get_node(db_path, resolved_id)
 
 
-def get_node_path(db_path: Path, node_id: str) -> str:
-    """Get human-readable path for a node: 'School/ML/Project'."""
+def get_node_path(db_path: Path, node_id: str) -> str | None:
+    """Get human-readable path for a node: 'School/ML/Project'.
+
+    Returns None if the node does not exist.
+    """
     with get_db(db_path) as conn:
         rows = conn.execute(
             """WITH RECURSIVE ancestors(id, parent_id, name, depth) AS (
@@ -961,6 +967,8 @@ def get_node_path(db_path: Path, node_id: str) -> str:
                SELECT name FROM ancestors ORDER BY depth DESC""",
             (node_id,),
         ).fetchall()
+    if not rows:
+        return None
     return "/".join(r["name"] for r in rows)
 
 
@@ -968,27 +976,21 @@ def get_children(
     db_path: Path, parent_id: str | None = None, include_archived: bool = False,
 ) -> list[dict]:
     """Get immediate children of a node (or root nodes if parent_id=None)."""
+    conditions: list[str] = []
+    params: list = []
+    if parent_id is None:
+        conditions.append("parent_id IS NULL")
+    else:
+        conditions.append("parent_id = ?")
+        params.append(parent_id)
+    if not include_archived:
+        conditions.append("archived = 0")
+    where = " AND ".join(conditions)
     with get_db(db_path) as conn:
-        if parent_id is None:
-            if include_archived:
-                rows = conn.execute(
-                    "SELECT * FROM context_nodes WHERE parent_id IS NULL ORDER BY name"
-                ).fetchall()
-            else:
-                rows = conn.execute(
-                    "SELECT * FROM context_nodes WHERE parent_id IS NULL AND archived = 0 ORDER BY name"
-                ).fetchall()
-        else:
-            if include_archived:
-                rows = conn.execute(
-                    "SELECT * FROM context_nodes WHERE parent_id = ? ORDER BY name",
-                    (parent_id,),
-                ).fetchall()
-            else:
-                rows = conn.execute(
-                    "SELECT * FROM context_nodes WHERE parent_id = ? AND archived = 0 ORDER BY name",
-                    (parent_id,),
-                ).fetchall()
+        rows = conn.execute(
+            f"SELECT * FROM context_nodes WHERE {where} ORDER BY name",
+            params,
+        ).fetchall()
     return [dict(r) for r in rows]
 
 
@@ -996,39 +998,46 @@ def get_subtree(
     db_path: Path, node_id: str, include_archived: bool = False,
 ) -> list[dict]:
     """Get all descendants of a node using recursive CTE (excludes the node itself)."""
+    seed_filter = "" if include_archived else " AND archived = 0"
+    recurse_filter = "" if include_archived else " WHERE cn.archived = 0"
+    sql = f"""WITH RECURSIVE descendants(id) AS (
+                  SELECT id FROM context_nodes WHERE parent_id = ?{seed_filter}
+                  UNION ALL
+                  SELECT cn.id FROM context_nodes cn
+                  JOIN descendants d ON cn.parent_id = d.id{recurse_filter}
+              )
+              SELECT cn.* FROM context_nodes cn
+              JOIN descendants d ON cn.id = d.id
+              ORDER BY cn.name"""
     with get_db(db_path) as conn:
-        if include_archived:
-            rows = conn.execute(
-                """WITH RECURSIVE descendants(id) AS (
-                       SELECT id FROM context_nodes WHERE parent_id = ?
-                       UNION ALL
-                       SELECT cn.id FROM context_nodes cn
-                       JOIN descendants d ON cn.parent_id = d.id
-                   )
-                   SELECT cn.* FROM context_nodes cn
-                   JOIN descendants d ON cn.id = d.id
-                   ORDER BY cn.name""",
-                (node_id,),
-            ).fetchall()
-        else:
-            rows = conn.execute(
-                """WITH RECURSIVE descendants(id) AS (
-                       SELECT id FROM context_nodes WHERE parent_id = ? AND archived = 0
-                       UNION ALL
-                       SELECT cn.id FROM context_nodes cn
-                       JOIN descendants d ON cn.parent_id = d.id
-                       WHERE cn.archived = 0
-                   )
-                   SELECT cn.* FROM context_nodes cn
-                   JOIN descendants d ON cn.id = d.id
-                   ORDER BY cn.name""",
-                (node_id,),
-            ).fetchall()
+        rows = conn.execute(sql, (node_id,)).fetchall()
     return [dict(r) for r in rows]
 
 
 def move_node(db_path: Path, node_id: str, new_parent_id: str | None) -> None:
-    """Move a node to a new parent (or to root if new_parent_id is None)."""
+    """Move a node to a new parent (or to root if new_parent_id is None).
+
+    Raises ValueError if new_parent_id would create a cycle (i.e. it is the
+    node itself or one of its descendants).
+    """
+    if new_parent_id is not None:
+        if new_parent_id == node_id:
+            raise ValueError("Cannot move a node under itself.")
+        # Walk ancestors of new_parent_id; if node_id appears, it's a cycle.
+        with get_db(db_path) as conn:
+            ancestors = conn.execute(
+                """WITH RECURSIVE ancestors(id) AS (
+                       SELECT parent_id FROM context_nodes WHERE id = ?
+                       UNION ALL
+                       SELECT cn.parent_id FROM context_nodes cn
+                       JOIN ancestors a ON cn.id = a.id
+                       WHERE cn.parent_id IS NOT NULL
+                   )
+                   SELECT id FROM ancestors""",
+                (new_parent_id,),
+            ).fetchall()
+            if any(a["id"] == node_id for a in ancestors):
+                raise ValueError("Cannot move a node under one of its own descendants.")
     now = datetime.now(timezone.utc).isoformat(timespec="seconds")
     with get_db(db_path) as conn:
         conn.execute(
@@ -1120,28 +1129,12 @@ def upsert_section(db_path: Path, node_id: str, section_type: str, body: str) ->
 
 def append_section(db_path: Path, node_id: str, section_type: str, content: str) -> dict:
     """Append text to a section with '\\n\\n' separator. Create if missing."""
-    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
-    with get_db(db_path) as conn:
-        existing = conn.execute(
-            "SELECT body FROM node_sections WHERE node_id = ? AND section_type = ?",
-            (node_id, section_type),
-        ).fetchone()
-        if existing and existing["body"]:
-            new_body = existing["body"] + "\n\n" + content
-        else:
-            new_body = content
-        conn.execute(
-            """INSERT INTO node_sections (node_id, section_type, body, updated_at)
-               VALUES (?, ?, ?, ?)
-               ON CONFLICT(node_id, section_type) DO UPDATE SET
-                   body = excluded.body, updated_at = excluded.updated_at""",
-            (node_id, section_type, new_body, now),
-        )
-        conn.execute(
-            "UPDATE context_nodes SET updated_at = ? WHERE id = ?",
-            (now, node_id),
-        )
-    return {"section_type": section_type, "body": new_body, "updated_at": now}
+    existing = get_section(db_path, node_id, section_type)
+    if existing and existing["body"]:
+        new_body = existing["body"] + "\n\n" + content
+    else:
+        new_body = content
+    return upsert_section(db_path, node_id, section_type, new_body)
 
 
 def delete_section(db_path: Path, node_id: str, section_type: str) -> None:
@@ -1161,6 +1154,8 @@ def search_sections(
     Returns [{node_id, section_type, snippet}].
     If node_id is provided, filter to that node's subtree.
     """
+    # Wrap in double quotes for literal matching; escape embedded quotes.
+    safe_query = '"' + query.replace('"', '""') + '"'
     with get_db(db_path) as conn:
         if node_id is not None:
             # Get subtree node ids (including the node itself)
@@ -1186,7 +1181,7 @@ def search_sections(
                     WHERE fts.body MATCH ?
                       AND ns.node_id IN ({ph})
                     ORDER BY fts.rank""",
-                (query, *id_set),
+                (safe_query, *id_set),
             ).fetchall()
         else:
             rows = conn.execute(
@@ -1196,7 +1191,7 @@ def search_sections(
                    JOIN node_sections ns ON ns.id = fts.rowid
                    WHERE fts.body MATCH ?
                    ORDER BY fts.rank""",
-                (query,),
+                (safe_query,),
             ).fetchall()
     return [dict(r) for r in rows]
 

--- a/db/schema.py
+++ b/db/schema.py
@@ -208,6 +208,36 @@ CREATE TABLE IF NOT EXISTS user_settings (
     value   TEXT NOT NULL,
     PRIMARY KEY (user_id, key)
 );
+
+CREATE TABLE IF NOT EXISTS context_nodes (
+    id TEXT PRIMARY KEY,
+    parent_id TEXT REFERENCES context_nodes(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    node_type TEXT NOT NULL DEFAULT 'context',
+    archived INTEGER NOT NULL DEFAULT 0,
+    target_date TEXT,
+    status TEXT DEFAULT 'pending',
+    status_override INTEGER NOT NULL DEFAULT 0,
+    color TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(parent_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS node_sections (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    node_id TEXT NOT NULL REFERENCES context_nodes(id) ON DELETE CASCADE,
+    section_type TEXT NOT NULL,
+    body TEXT NOT NULL DEFAULT '',
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(node_id, section_type)
+);
+
+CREATE TABLE IF NOT EXISTS node_tasks (
+    node_id TEXT NOT NULL REFERENCES context_nodes(id) ON DELETE CASCADE,
+    task_id TEXT NOT NULL,
+    PRIMARY KEY (node_id, task_id)
+);
 """
 
 _SESSIONS_DDL = """
@@ -238,4 +268,11 @@ def get_db(db_path: Path) -> sqlite3.Connection:
 def init_db(db_path: Path) -> None:
     with get_db(db_path) as conn:
         conn.executescript(DDL)
+        conn.execute("""
+            CREATE VIRTUAL TABLE IF NOT EXISTS node_sections_fts USING fts5(
+                body,
+                content='node_sections',
+                content_rowid='id'
+            )
+        """)
         conn.executescript(_SESSIONS_DDL)

--- a/db/schema.py
+++ b/db/schema.py
@@ -275,4 +275,29 @@ def init_db(db_path: Path) -> None:
                 content_rowid='id'
             )
         """)
+        # FTS5 external content sync triggers
+        conn.executescript("""
+            CREATE TRIGGER IF NOT EXISTS node_sections_fts_ai
+            AFTER INSERT ON node_sections BEGIN
+                INSERT INTO node_sections_fts(rowid, body) VALUES (new.id, new.body);
+            END;
+
+            CREATE TRIGGER IF NOT EXISTS node_sections_fts_ad
+            AFTER DELETE ON node_sections BEGIN
+                INSERT INTO node_sections_fts(node_sections_fts, rowid, body)
+                VALUES ('delete', old.id, old.body);
+            END;
+
+            CREATE TRIGGER IF NOT EXISTS node_sections_fts_au
+            AFTER UPDATE ON node_sections BEGIN
+                INSERT INTO node_sections_fts(node_sections_fts, rowid, body)
+                VALUES ('delete', old.id, old.body);
+                INSERT INTO node_sections_fts(rowid, body) VALUES (new.id, new.body);
+            END;
+        """)
+        # Partial unique index for root node names (NULL parent_id)
+        conn.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_root_node_name
+            ON context_nodes(name) WHERE parent_id IS NULL
+        """)
         conn.executescript(_SESSIONS_DDL)

--- a/db/schema.py
+++ b/db/schema.py
@@ -31,7 +31,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     followup_config TEXT,
     notes TEXT NOT NULL DEFAULT '',
     description TEXT,
-    context_subject TEXT
+    context_subject TEXT,
+    context_node_id TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_dependencies (

--- a/frontend/src/components/AnchorBlock.vue
+++ b/frontend/src/components/AnchorBlock.vue
@@ -30,13 +30,18 @@ type TaskWithIndex = { task: Task; index: number }
 
 const groupedByContext = computed(() => {
   const byContext: Record<string, {
+    label: string
     milestoneGroups: { milestone: Milestone; tasks: TaskWithIndex[] }[]
     ungrouped: TaskWithIndex[]
   }> = {}
 
   anchorPlan.value.tasks.forEach((task, index) => {
-    const ctx = task.context_subject ?? 'Uncategorized'
-    if (!byContext[ctx]) byContext[ctx] = { milestoneGroups: [], ungrouped: [] }
+    const key = task.context_node_id ?? task.context_subject ?? '__uncategorized__'
+    if (!byContext[key]) {
+      const label = task.context_subject ?? (key === '__uncategorized__' ? 'Uncategorized' : key)
+      byContext[key] = { label, milestoneGroups: [], ungrouped: [] }
+    }
+    const ctx = key
 
     const milestones = milestoneStore.taskMilestones[task.id]
     if (milestones?.length) {
@@ -52,10 +57,10 @@ const groupedByContext = computed(() => {
     }
   })
 
-  return Object.entries(byContext).sort(([a], [b]) => {
-    if (a === 'Uncategorized') return 1
-    if (b === 'Uncategorized') return -1
-    return a.localeCompare(b)
+  return Object.entries(byContext).sort(([, a], [, b]) => {
+    if (a.label === 'Uncategorized') return 1
+    if (b.label === 'Uncategorized') return -1
+    return a.label.localeCompare(b.label)
   })
 })
 
@@ -89,6 +94,7 @@ function onAddNewTask() {
     id: '', text: '', description: null, status: 'pending' as const,
     position: tasks.length, followup_config: null, blocks: [], blocked_by: [],
     context_subject: null,
+    context_node_id: null,
   })
   nextTick(() => {
     const inputs = tasksRef.value?.querySelectorAll('input')
@@ -155,7 +161,7 @@ function onDrop(evt: DragEvent, toIndex: number) {
         </template>
 
         <!-- Context has >1 task — wrap in context GroupContainer -->
-        <GroupContainer v-else :label="ctxName" :collapsible="true" :level="1" class="mb-2">
+        <GroupContainer v-else :label="ctx.label" :collapsible="true" :level="1" class="mb-2">
           <!-- Milestone sub-groups -->
           <template v-for="mg in ctx.milestoneGroups" :key="mg.milestone.id">
             <!-- Milestone group has 1 task — show standalone with tags visible -->

--- a/frontend/src/components/ContextEditor.vue
+++ b/frontend/src/components/ContextEditor.vue
@@ -1,20 +1,21 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useContextStore } from '../stores/context'
+import type { ContextNode } from '../stores/context'
 import MilestoneDetail from './MilestoneDetail.vue'
 import { useMilestoneStore } from '../stores/milestones'
 
 const store = useContextStore()
-const editing = ref<string | null>(null)
+const editing = ref<string | null>(null) // node id being edited
 const editBody = ref('')
-const renaming = ref<string | null>(null)
+const renaming = ref<string | null>(null) // node id being renamed
 const renameValue = ref('')
 const newSubject = ref('')
-const expandedGroups = ref<Set<string>>(new Set())
+const expandedGroups = ref<Set<string>>(new Set()) // node ids
 
 const milestoneStore = useMilestoneStore()
 const expandedMilestones = ref<Set<string>>(new Set())
-const addingMilestoneFor = ref<string | null>(null)
+const addingMilestoneFor = ref<string | null>(null) // node id
 const newMilestoneName = ref('')
 
 function toggleMilestone(id: string) {
@@ -23,76 +24,103 @@ function toggleMilestone(id: string) {
   expandedMilestones.value = next
 }
 
-async function addMilestone(subject: string) {
+async function addMilestone(nodeName: string) {
   if (!newMilestoneName.value.trim()) return
-  await milestoneStore.createMilestone(subject, newMilestoneName.value.trim())
+  await milestoneStore.createMilestone(nodeName, newMilestoneName.value.trim())
   newMilestoneName.value = ''
   addingMilestoneFor.value = null
 }
 
-const topLevel = computed(() =>
-  store.entries.filter(e => !e.subject.includes('/'))
-)
-
-function childrenOf(subject: string) {
-  return store.entries.filter(e =>
-    e.subject.startsWith(subject + '/') &&
-    e.subject.slice(subject.length + 1).indexOf('/') === -1
-  )
-}
-
-function toggle(subject: string) {
-  if (expandedGroups.value.has(subject)) {
-    expandedGroups.value.delete(subject)
+async function toggleExpand(node: ContextNode) {
+  if (expandedGroups.value.has(node.id)) {
+    expandedGroups.value.delete(node.id)
   } else {
-    expandedGroups.value.add(subject)
+    // Fetch children and their details sections when expanding
+    const children = await store.fetchChildren(node.id)
+    await Promise.allSettled(children.map(c => store.fetchSection(c.id, 'details')))
+    expandedGroups.value.add(node.id)
   }
 }
 
-function startEdit(subject: string, body: string) {
-  editing.value = subject
-  editBody.value = body
+async function startEdit(nodeId: string) {
+  editing.value = nodeId
+  // Fetch the 'details' section for this node
+  const section = await store.fetchSection(nodeId, 'details')
+  editBody.value = section?.body ?? ''
 }
 
 async function saveEdit() {
   if (!editing.value) return
-  await store.saveEntry(editing.value, editBody.value)
+  await store.saveSection(editing.value, 'details', editBody.value)
   editing.value = null
 }
 
-function startRename(subject: string) {
-  renaming.value = subject
-  renameValue.value = subject
+function startRename(nodeId: string, currentName: string) {
+  renaming.value = nodeId
+  renameValue.value = currentName
 }
 
 async function saveRename() {
-  if (!renaming.value || renameValue.value.trim() === renaming.value) {
+  if (!renaming.value || !renameValue.value.trim()) {
     renaming.value = null
     return
   }
-  await store.renameEntry(renaming.value, renameValue.value.trim())
+  const node = store.nodes[renaming.value]
+  if (!node || renameValue.value.trim() === node.name) {
+    renaming.value = null
+    return
+  }
+  await store.patchNode(renaming.value, { name: renameValue.value.trim() })
   renaming.value = null
 }
 
 async function addEntry() {
   if (!newSubject.value.trim()) return
-  await store.saveEntry(newSubject.value.trim(), '')
+  const parts = newSubject.value.trim().split('/')
+  if (parts.length === 1) {
+    // Root node
+    await store.createNode(null, parts[0])
+  } else {
+    // Nested: find or create parent, then create child
+    const parentName = parts[0]
+    let parent = store.nodeByName(parentName, null)
+    if (!parent) {
+      parent = await store.createNode(null, parentName)
+    }
+    const childName = parts.slice(1).join('/')
+    await store.createNode(parent.id, childName)
+  }
+  await store.fetchRootNodes()
   newSubject.value = ''
 }
 
-function prefillSubEntry(parent: string) {
-  newSubject.value = parent + '/'
+function prefillSubEntry(parentName: string) {
+  newSubject.value = parentName + '/'
 }
 
-function deleteWithConfirm(subject: string, childCount: number) {
+async function deleteWithConfirm(node: ContextNode) {
+  const children = store.childrenOf(node.id)
+  const childCount = children.length
   const msg = childCount > 0
-    ? `Delete "${subject}" and ${childCount} sub-entr${childCount === 1 ? 'y' : 'ies'}?`
-    : `Delete "${subject}"?`
-  if (confirm(msg)) store.deleteEntry(subject)
+    ? `Delete "${node.name}" and ${childCount} sub-entr${childCount === 1 ? 'y' : 'ies'}?`
+    : `Delete "${node.name}"?`
+  if (confirm(msg)) await store.deleteNode(node.id)
 }
 
-onMounted(() => {
-  store.fetchEntries()
+/** Get the cached details body for display (without fetching) */
+function nodeBody(nodeId: string): string {
+  return store.sectionCache[`${nodeId}::details`]?.body ?? ''
+}
+
+/** Load sections for all root context nodes (for display bodies) */
+async function loadRootSections() {
+  const nodes = store.rootContextNodes
+  await Promise.allSettled(nodes.map(n => store.fetchSection(n.id, 'details')))
+}
+
+onMounted(async () => {
+  await store.fetchRootNodes()
+  await loadRootSections()
   milestoneStore.fetchAll()
 })
 </script>
@@ -100,44 +128,44 @@ onMounted(() => {
 <template>
   <div class="min-h-screen bg-gray-900 text-white p-6">
   <div class="space-y-3">
-    <template v-for="entry in topLevel" :key="entry.subject">
+    <template v-for="node in store.rootContextNodes" :key="node.id">
       <!-- Top-level entry -->
       <div class="bg-white/5 border border-white/10 rounded-xl p-4">
         <div class="flex justify-between items-center mb-2">
           <div class="flex items-center gap-2 flex-1 min-w-0">
-            <button v-if="childrenOf(entry.subject).length > 0"
-                    @click="toggle(entry.subject)"
+            <button v-if="store.childrenOf(node.id).length > 0 || (node.children_count ?? 0) > 0"
+                    @click="toggleExpand(node)"
                     class="text-white/40 hover:text-white/80 text-xs w-4 shrink-0">
-              {{ expandedGroups.has(entry.subject) ? '▼' : '▶' }}
+              {{ expandedGroups.has(node.id) ? '\u25BC' : '\u25B6' }}
             </button>
             <span v-else class="w-4 shrink-0" />
 
-            <template v-if="renaming === entry.subject">
+            <template v-if="renaming === node.id">
               <input v-model="renameValue" @keyup.enter="saveRename" @keyup.escape="renaming = null"
                      class="flex-1 bg-transparent border-b border-white/40 text-sm outline-none" />
-              <span v-if="childrenOf(entry.subject).length > 0"
+              <span v-if="store.childrenOf(node.id).length > 0"
                     class="text-xs text-yellow-400/70 ml-1">
-                (renames {{ childrenOf(entry.subject).length }} sub-entr{{ childrenOf(entry.subject).length === 1 ? 'y' : 'ies' }})
+                (renames node, {{ store.childrenOf(node.id).length }} children unaffected)
               </span>
             </template>
-            <h3 v-else class="font-semibold text-sm truncate">{{ entry.subject }}</h3>
+            <h3 v-else class="font-semibold text-sm truncate">{{ node.name }}</h3>
           </div>
 
           <div class="flex gap-2 shrink-0">
-            <button @click="startEdit(entry.subject, entry.body)"
+            <button @click="startEdit(node.id)"
                     class="text-xs text-white/50 hover:text-white">Edit</button>
-            <template v-if="renaming === entry.subject">
+            <template v-if="renaming === node.id">
               <button @click="saveRename" class="text-xs text-green-400/70 hover:text-green-400">Save</button>
               <button @click="renaming = null" class="text-xs text-white/40 hover:text-white/70">Cancel</button>
             </template>
-            <button v-else @click="startRename(entry.subject)"
+            <button v-else @click="startRename(node.id, node.name)"
                     class="text-xs text-white/50 hover:text-white">Rename</button>
-            <button @click="deleteWithConfirm(entry.subject, childrenOf(entry.subject).length)"
+            <button @click="deleteWithConfirm(node)"
                     class="text-xs text-red-400/60 hover:text-red-400">Delete</button>
           </div>
         </div>
 
-        <div v-if="editing === entry.subject">
+        <div v-if="editing === node.id">
           <textarea v-model="editBody" rows="4"
                     class="w-full bg-transparent border border-white/20 rounded p-2 text-sm outline-none focus:border-white/50 resize-none" />
           <div class="flex gap-2 mt-2">
@@ -145,12 +173,12 @@ onMounted(() => {
             <button @click="editing = null" class="text-xs text-white/40 hover:text-white/70">Cancel</button>
           </div>
         </div>
-        <p v-else class="text-xs text-white/50 line-clamp-2">{{ entry.body || '(empty)' }}</p>
+        <p v-else class="text-xs text-white/50 line-clamp-2">{{ nodeBody(node.id) || '(empty)' }}</p>
 
         <!-- Milestone chips -->
-        <div v-if="milestoneStore.bySubject[entry.subject]?.length" class="mt-2 flex flex-wrap gap-1">
+        <div v-if="milestoneStore.bySubject[node.name]?.length" class="mt-2 flex flex-wrap gap-1">
           <button
-            v-for="m in milestoneStore.bySubject[entry.subject]" :key="m.id"
+            v-for="m in milestoneStore.bySubject[node.name]" :key="m.id"
             @click="toggleMilestone(m.id)"
             :style="m.color ? { backgroundColor: m.color + '33', color: m.color, borderColor: m.color + '66' } : {}"
             class="text-xs px-1.5 py-0.5 rounded border flex items-center gap-1"
@@ -162,49 +190,49 @@ onMounted(() => {
             {{ m.name }} {{ m.done_count }}/{{ m.task_count }}
           </button>
         </div>
-        <template v-for="m in milestoneStore.bySubject[entry.subject]" :key="'detail-' + m.id">
+        <template v-for="m in milestoneStore.bySubject[node.name]" :key="'detail-' + m.id">
           <MilestoneDetail
             v-if="expandedMilestones.has(m.id)"
             :milestone="m"
             @close="toggleMilestone(m.id)" />
         </template>
-        <div v-if="addingMilestoneFor === entry.subject" class="mt-2 flex gap-2">
-          <input v-model="newMilestoneName" placeholder="Milestone name…"
-                 @keydown.enter="addMilestone(entry.subject)"
+        <div v-if="addingMilestoneFor === node.id" class="mt-2 flex gap-2">
+          <input v-model="newMilestoneName" placeholder="Milestone name..."
+                 @keydown.enter="addMilestone(node.name)"
                  class="flex-1 bg-transparent border-b border-white/30 outline-none text-xs" />
-          <button @click="addMilestone(entry.subject)" class="text-xs text-white/60 hover:text-white">Add</button>
+          <button @click="addMilestone(node.name)" class="text-xs text-white/60 hover:text-white">Add</button>
           <button @click="addingMilestoneFor = null; newMilestoneName = ''"
                   class="text-xs text-white/40">cancel</button>
         </div>
-        <button v-else @click="addingMilestoneFor = entry.subject"
+        <button v-else @click="addingMilestoneFor = node.id"
                 class="mt-1 text-xs text-white/30 hover:text-white/60">+ milestone</button>
 
         <!-- Children (expanded) -->
-        <template v-if="expandedGroups.has(entry.subject)">
-          <div v-for="child in childrenOf(entry.subject)" :key="child.subject"
+        <template v-if="expandedGroups.has(node.id)">
+          <div v-for="child in store.childrenOf(node.id)" :key="child.id"
                class="mt-2 ml-6 bg-white/5 border border-white/10 rounded-lg p-3">
             <div class="flex justify-between items-center mb-1">
-              <template v-if="renaming === child.subject">
+              <template v-if="renaming === child.id">
                 <input v-model="renameValue" @keyup.enter="saveRename" @keyup.escape="renaming = null"
                        class="flex-1 bg-transparent border-b border-white/40 text-sm outline-none" />
               </template>
               <h4 v-else class="font-medium text-sm truncate">
-                {{ child.subject.split('/').slice(-1)[0] }}
+                {{ child.name }}
               </h4>
               <div class="flex gap-2 shrink-0">
-                <button @click="startEdit(child.subject, child.body)"
+                <button @click="startEdit(child.id)"
                         class="text-xs text-white/50 hover:text-white">Edit</button>
-                <template v-if="renaming === child.subject">
+                <template v-if="renaming === child.id">
                   <button @click="saveRename" class="text-xs text-green-400/70 hover:text-green-400">Save</button>
                   <button @click="renaming = null" class="text-xs text-white/40 hover:text-white/70">Cancel</button>
                 </template>
-                <button v-else @click="startRename(child.subject)"
+                <button v-else @click="startRename(child.id, child.name)"
                         class="text-xs text-white/50 hover:text-white">Rename</button>
-                <button @click="deleteWithConfirm(child.subject, 0)"
+                <button @click="deleteWithConfirm(child)"
                         class="text-xs text-red-400/60 hover:text-red-400">Delete</button>
               </div>
             </div>
-            <div v-if="editing === child.subject">
+            <div v-if="editing === child.id">
               <textarea v-model="editBody" rows="3"
                         class="w-full bg-transparent border border-white/20 rounded p-2 text-sm outline-none focus:border-white/50 resize-none" />
               <div class="flex gap-2 mt-2">
@@ -212,11 +240,11 @@ onMounted(() => {
                 <button @click="editing = null" class="text-xs text-white/40 hover:text-white/70">Cancel</button>
               </div>
             </div>
-            <p v-else class="text-xs text-white/50 line-clamp-2">{{ child.body || '(empty)' }}</p>
+            <p v-else class="text-xs text-white/50 line-clamp-2">{{ nodeBody(child.id) || '(empty)' }}</p>
           </div>
 
           <!-- Add sub-entry button -->
-          <button @click="prefillSubEntry(entry.subject)"
+          <button @click="prefillSubEntry(node.name)"
                   class="mt-2 ml-6 text-xs text-white/40 hover:text-white/70">
             + Add sub-entry
           </button>
@@ -225,7 +253,7 @@ onMounted(() => {
     </template>
 
     <div class="flex gap-2 mt-4">
-      <input v-model="newSubject" placeholder="New subject (or Parent/Child)..."
+      <input v-model="newSubject" placeholder="New name (or Parent/Child)..."
              class="flex-1 bg-white/5 border border-white/20 rounded px-3 py-2 text-sm outline-none focus:border-white/50" />
       <button @click="addEntry" class="bg-white/10 hover:bg-white/20 px-4 py-2 rounded text-sm">Add</button>
     </div>

--- a/frontend/src/components/ContextEditor.vue
+++ b/frontend/src/components/ContextEditor.vue
@@ -12,6 +12,7 @@ const renaming = ref<string | null>(null) // node id being renamed
 const renameValue = ref('')
 const newSubject = ref('')
 const expandedGroups = ref<Set<string>>(new Set()) // node ids
+const error = ref<string | null>(null)
 
 const milestoneStore = useMilestoneStore()
 const expandedMilestones = ref<Set<string>>(new Set())
@@ -26,19 +27,32 @@ function toggleMilestone(id: string) {
 
 async function addMilestone(nodeName: string) {
   if (!newMilestoneName.value.trim()) return
-  await milestoneStore.createMilestone(nodeName, newMilestoneName.value.trim())
-  newMilestoneName.value = ''
-  addingMilestoneFor.value = null
+  try {
+    error.value = null
+    await milestoneStore.createMilestone(nodeName, newMilestoneName.value.trim())
+    newMilestoneName.value = ''
+    addingMilestoneFor.value = null
+  } catch (e) {
+    console.error('addMilestone error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to add milestone'
+  }
 }
 
 async function toggleExpand(node: ContextNode) {
   if (expandedGroups.value.has(node.id)) {
     expandedGroups.value.delete(node.id)
   } else {
-    // Fetch children and their details sections when expanding
-    const children = await store.fetchChildren(node.id)
-    await Promise.allSettled(children.map(c => store.fetchSection(c.id, 'details')))
+    // Optimistic: add to expanded set before fetch
     expandedGroups.value.add(node.id)
+    try {
+      const children = await store.fetchChildren(node.id)
+      await Promise.allSettled(children.map(c => store.fetchSection(c.id, 'details')))
+    } catch (e) {
+      // Rollback on error
+      expandedGroups.value.delete(node.id)
+      console.error('toggleExpand error:', e)
+      error.value = e instanceof Error ? e.message : 'Failed to expand node'
+    }
   }
 }
 
@@ -51,8 +65,14 @@ async function startEdit(nodeId: string) {
 
 async function saveEdit() {
   if (!editing.value) return
-  await store.saveSection(editing.value, 'details', editBody.value)
-  editing.value = null
+  try {
+    error.value = null
+    await store.saveSection(editing.value, 'details', editBody.value)
+    editing.value = null
+  } catch (e) {
+    console.error('saveEdit error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to save'
+  }
 }
 
 function startRename(nodeId: string, currentName: string) {
@@ -70,28 +90,40 @@ async function saveRename() {
     renaming.value = null
     return
   }
-  await store.patchNode(renaming.value, { name: renameValue.value.trim() })
-  renaming.value = null
+  try {
+    error.value = null
+    await store.patchNode(renaming.value, { name: renameValue.value.trim() })
+    renaming.value = null
+  } catch (e) {
+    console.error('saveRename error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to rename'
+  }
 }
 
 async function addEntry() {
   if (!newSubject.value.trim()) return
-  const parts = newSubject.value.trim().split('/')
-  if (parts.length === 1) {
-    // Root node
-    await store.createNode(null, parts[0])
-  } else {
-    // Nested: find or create parent, then create child
-    const parentName = parts[0]
-    let parent = store.nodeByName(parentName, null)
-    if (!parent) {
-      parent = await store.createNode(null, parentName)
+  try {
+    error.value = null
+    const parts = newSubject.value.trim().split('/')
+    if (parts.length === 1) {
+      // Root node
+      await store.createNode(null, parts[0])
+    } else {
+      // Nested: find or create parent, then create child
+      const parentName = parts[0]
+      let parent = store.nodeByName(parentName, null)
+      if (!parent) {
+        parent = await store.createNode(null, parentName)
+      }
+      const childName = parts.slice(1).join('/')
+      await store.createNode(parent.id, childName)
     }
-    const childName = parts.slice(1).join('/')
-    await store.createNode(parent.id, childName)
+    await store.fetchRootNodes()
+    newSubject.value = ''
+  } catch (e) {
+    console.error('addEntry error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to add entry'
   }
-  await store.fetchRootNodes()
-  newSubject.value = ''
 }
 
 function prefillSubEntry(parentName: string) {
@@ -104,7 +136,14 @@ async function deleteWithConfirm(node: ContextNode) {
   const msg = childCount > 0
     ? `Delete "${node.name}" and ${childCount} sub-entr${childCount === 1 ? 'y' : 'ies'}?`
     : `Delete "${node.name}"?`
-  if (confirm(msg)) await store.deleteNode(node.id)
+  if (!confirm(msg)) return
+  try {
+    error.value = null
+    await store.deleteNode(node.id)
+  } catch (e) {
+    console.error('deleteWithConfirm error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to delete'
+  }
 }
 
 /** Get the cached details body for display (without fetching) */
@@ -119,14 +158,20 @@ async function loadRootSections() {
 }
 
 onMounted(async () => {
-  await store.fetchRootNodes()
-  await loadRootSections()
-  milestoneStore.fetchAll()
+  try {
+    await store.fetchRootNodes()
+    await loadRootSections()
+    await milestoneStore.fetchAll()
+  } catch (e) {
+    console.error('ContextEditor mount error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to load context data'
+  }
 })
 </script>
 
 <template>
   <div class="min-h-screen bg-gray-900 text-white p-6">
+  <p v-if="error" class="text-red-400 text-sm">{{ error }}</p>
   <div class="space-y-3">
     <template v-for="node in store.rootContextNodes" :key="node.id">
       <!-- Top-level entry -->

--- a/frontend/src/components/KanbanColumn.vue
+++ b/frontend/src/components/KanbanColumn.vue
@@ -32,23 +32,25 @@ async function onTaskUpdate(task: Task) {
 
 const milestoneStore = useMilestoneStore()
 
-/** Group tasks by context_subject, then by milestone within each context */
+/** Group tasks by context (node_id for uniqueness, subject for label), then by milestone */
 const grouped = computed(() => {
-  const byContext: Record<string, Task[]> = {}
+  const byContext: Record<string, { label: string; tasks: Task[] }> = {}
   for (const task of props.tasks) {
-    const ctx = task.context_subject ?? '__uncategorized__'
-    if (!byContext[ctx]) byContext[ctx] = []
-    byContext[ctx].push(task)
+    const key = task.context_node_id ?? task.context_subject ?? '__uncategorized__'
+    if (!byContext[key]) {
+      const label = task.context_subject ?? (key === '__uncategorized__' ? 'Uncategorized' : key)
+      byContext[key] = { label, tasks: [] }
+    }
+    byContext[key].tasks.push(task)
   }
   // Sort: Uncategorized last
-  const sorted = Object.entries(byContext).sort(([a], [b]) => {
-    if (a === '__uncategorized__') return 1
-    if (b === '__uncategorized__') return -1
-    return a.localeCompare(b)
+  const sorted = Object.entries(byContext).sort(([, a], [, b]) => {
+    if (a.label === 'Uncategorized') return 1
+    if (b.label === 'Uncategorized') return -1
+    return a.label.localeCompare(b.label)
   })
 
-  return sorted.map(([ctx, tasks]) => {
-    const label = ctx === '__uncategorized__' ? 'Uncategorized' : ctx
+  return sorted.map(([, { label, tasks }]) => {
     // Sub-group by milestone
     const byMilestone: Record<string, { id: string; name: string; color: string | null; tasks: Task[] }> = {}
     const ungrouped: Task[] = []

--- a/frontend/src/components/TaskList.vue
+++ b/frontend/src/components/TaskList.vue
@@ -12,7 +12,7 @@ function add() {
   emit('update', [
     ...props.tasks,
     { id: '', text: '', description: null, status: 'pending', position: props.tasks.length,
-      followup_config: null, blocks: [], blocked_by: [], context_subject: null },
+      followup_config: null, blocks: [], blocked_by: [], context_subject: null, context_node_id: null },
   ])
 }
 function remove(i: number) {

--- a/frontend/src/components/__tests__/TaskCard.test.ts
+++ b/frontend/src/components/__tests__/TaskCard.test.ts
@@ -20,6 +20,7 @@ const baseTask: Task = {
   blocks: [],
   blocked_by: [],
   context_subject: null,
+  context_node_id: null,
 }
 
 describe('TaskCard drag behavior', () => {

--- a/frontend/src/stores/context.ts
+++ b/frontend/src/stores/context.ts
@@ -1,39 +1,241 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { api } from '../lib/api'
 
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ContextNode {
+  id: string
+  parent_id: string | null
+  name: string
+  node_type: 'context' | 'milestone'
+  archived: boolean
+  target_date: string | null
+  status: string | null
+  status_override: boolean
+  color: string | null
+  created_at: string
+  updated_at: string
+  // Only present when fetched via GET /api/nodes/{id} (single-node fetch)
+  section_types?: string[]
+  children_count?: number
+}
+
+export interface NodeSection {
+  section_type: string
+  body: string
+  updated_at: string
+}
+
+// Backward-compat alias so existing imports still work
 export interface ContextEntry { subject: string; body: string; updated_at: string }
 
-export const useContextStore = defineStore('context', () => {
-  const entries = ref<ContextEntry[]>([])
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
 
-  async function fetchEntries() {
-    const resp = await api('/api/context')
-    entries.value = await resp.json()
+export const useContextStore = defineStore('context', () => {
+  /** Flat cache of all fetched nodes, keyed by id */
+  const nodes = ref<Record<string, ContextNode>>({})
+
+  /** Sections cache keyed by `${nodeId}::${sectionType}` */
+  const sectionCache = ref<Record<string, NodeSection>>({})
+
+  // -- Computed helpers ------------------------------------------------------
+
+  const rootNodes = computed<ContextNode[]>(() =>
+    Object.values(nodes.value)
+      .filter(n => n.parent_id === null && !n.archived)
+      .sort((a, b) => a.name.localeCompare(b.name))
+  )
+
+  const rootContextNodes = computed<ContextNode[]>(() =>
+    rootNodes.value.filter(n => n.node_type === 'context')
+  )
+
+  /** Backward-compat: expose entries shaped like old ContextEntry[] */
+  const entries = computed<ContextEntry[]>(() =>
+    rootContextNodes.value.map(n => ({
+      subject: n.name,
+      body: sectionCache.value[`${n.id}::details`]?.body ?? '',
+      updated_at: n.updated_at,
+    }))
+  )
+
+  function childrenOf(parentId: string): ContextNode[] {
+    return Object.values(nodes.value)
+      .filter(n => n.parent_id === parentId && !n.archived)
+      .sort((a, b) => a.name.localeCompare(b.name))
   }
 
-  async function saveEntry(subject: string, body: string) {
-    await api(`/api/context/${encodeURIComponent(subject)}`, {
+  function nodeByName(name: string, parentId: string | null = null): ContextNode | undefined {
+    return Object.values(nodes.value).find(
+      n => n.name === name && n.parent_id === parentId
+    )
+  }
+
+  // -- API methods -----------------------------------------------------------
+
+  async function fetchRootNodes(): Promise<ContextNode[]> {
+    const resp = await api('/api/nodes')
+    if (!resp.ok) throw new Error(`fetchRootNodes: ${resp.status}`)
+    const data: ContextNode[] = await resp.json()
+    for (const node of data) {
+      nodes.value[node.id] = node
+    }
+    return data
+  }
+
+  async function fetchChildren(parentId: string): Promise<ContextNode[]> {
+    const resp = await api(`/api/nodes/${parentId}/children`)
+    if (!resp.ok) throw new Error(`fetchChildren: ${resp.status}`)
+    const data: ContextNode[] = await resp.json()
+    for (const node of data) {
+      nodes.value[node.id] = node
+    }
+    return data
+  }
+
+  async function fetchNode(nodeId: string): Promise<ContextNode> {
+    const resp = await api(`/api/nodes/${nodeId}`)
+    if (!resp.ok) throw new Error(`fetchNode: ${resp.status}`)
+    const data: ContextNode = await resp.json()
+    nodes.value[data.id] = data
+    return data
+  }
+
+  async function createNode(
+    parentId: string | null,
+    name: string,
+    nodeType: 'context' | 'milestone' = 'context',
+    opts: { target_date?: string; status?: string; color?: string } = {},
+  ): Promise<ContextNode> {
+    const resp = await api('/api/nodes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ parent_id: parentId, name, node_type: nodeType, ...opts }),
+    })
+    if (!resp.ok) throw new Error(`createNode: ${resp.status}`)
+    const data: ContextNode = await resp.json()
+    nodes.value[data.id] = data
+    return data
+  }
+
+  async function patchNode(
+    nodeId: string,
+    fields: Partial<Pick<ContextNode, 'name' | 'archived' | 'target_date' | 'status' | 'color'>>,
+  ): Promise<ContextNode> {
+    const resp = await api(`/api/nodes/${nodeId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(fields),
+    })
+    if (!resp.ok) throw new Error(`patchNode: ${resp.status}`)
+    const data: ContextNode = await resp.json()
+    nodes.value[data.id] = data
+    return data
+  }
+
+  async function deleteNode(nodeId: string): Promise<void> {
+    const resp = await api(`/api/nodes/${nodeId}`, { method: 'DELETE' })
+    if (!resp.ok) throw new Error(`deleteNode: ${resp.status}`)
+    // Remove from cache (and any children)
+    const toRemove = [nodeId, ...Object.keys(nodes.value).filter(id => nodes.value[id].parent_id === nodeId)]
+    for (const id of toRemove) {
+      delete nodes.value[id]
+    }
+  }
+
+  async function fetchSections(nodeId: string): Promise<NodeSection[]> {
+    const resp = await api(`/api/nodes/${nodeId}/sections`)
+    if (!resp.ok) throw new Error(`fetchSections: ${resp.status}`)
+    const data: NodeSection[] = await resp.json()
+    for (const s of data) {
+      sectionCache.value[`${nodeId}::${s.section_type}`] = s
+    }
+    return data
+  }
+
+  async function fetchSection(nodeId: string, sectionType: string): Promise<NodeSection | null> {
+    const resp = await api(`/api/nodes/${nodeId}/sections/${encodeURIComponent(sectionType)}`)
+    if (resp.status === 404) return null
+    if (!resp.ok) throw new Error(`fetchSection: ${resp.status}`)
+    const data: NodeSection = await resp.json()
+    sectionCache.value[`${nodeId}::${sectionType}`] = data
+    return data
+  }
+
+  async function saveSection(nodeId: string, sectionType: string, body: string): Promise<NodeSection> {
+    const resp = await api(`/api/nodes/${nodeId}/sections/${encodeURIComponent(sectionType)}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ body }),
     })
-    await fetchEntries()
+    if (!resp.ok) throw new Error(`saveSection: ${resp.status}`)
+    const data: NodeSection = await resp.json()
+    sectionCache.value[`${nodeId}::${sectionType}`] = data
+    return data
   }
 
-  async function deleteEntry(subject: string) {
-    await api(`/api/context/${encodeURIComponent(subject)}`, { method: 'DELETE' })
-    await fetchEntries()
+  // -- Backward-compat shims for old API ------------------------------------
+  // These allow existing code that calls fetchEntries / saveEntry / etc.
+  // to keep working during transition.
+
+  async function fetchEntries(): Promise<void> {
+    await fetchRootNodes()
   }
 
-  async function renameEntry(oldSubject: string, newSubject: string) {
-    await api(`/api/context/${encodeURIComponent(oldSubject)}/rename`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ new_subject: newSubject }),
-    })
-    await fetchEntries()
+  async function saveEntry(subject: string, body: string): Promise<void> {
+    let node = nodeByName(subject, null)
+    if (!node) {
+      node = await createNode(null, subject)
+    }
+    await saveSection(node.id, 'details', body)
   }
 
-  return { entries, fetchEntries, saveEntry, deleteEntry, renameEntry }
+  async function deleteEntry(subject: string): Promise<void> {
+    const node = nodeByName(subject, null)
+    if (node) await deleteNode(node.id)
+  }
+
+  async function renameEntry(oldSubject: string, newSubject: string): Promise<void> {
+    const node = nodeByName(oldSubject, null)
+    if (node) await patchNode(node.id, { name: newSubject })
+  }
+
+  return {
+    // State
+    nodes,
+    sectionCache,
+
+    // Computed
+    rootNodes,
+    rootContextNodes,
+    entries,
+
+    // Helpers
+    childrenOf,
+    nodeByName,
+
+    // Node CRUD
+    fetchRootNodes,
+    fetchChildren,
+    fetchNode,
+    createNode,
+    patchNode,
+    deleteNode,
+
+    // Sections
+    fetchSections,
+    fetchSection,
+    saveSection,
+
+    // Backward-compat
+    fetchEntries,
+    saveEntry,
+    deleteEntry,
+    renameEntry,
+  }
 })

--- a/frontend/src/stores/context.ts
+++ b/frontend/src/stores/context.ts
@@ -29,9 +29,6 @@ export interface NodeSection {
   updated_at: string
 }
 
-// Backward-compat alias so existing imports still work
-export interface ContextEntry { subject: string; body: string; updated_at: string }
-
 // ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
@@ -55,15 +52,6 @@ export const useContextStore = defineStore('context', () => {
     rootNodes.value.filter(n => n.node_type === 'context')
   )
 
-  /** Backward-compat: expose entries shaped like old ContextEntry[] */
-  const entries = computed<ContextEntry[]>(() =>
-    rootContextNodes.value.map(n => ({
-      subject: n.name,
-      body: sectionCache.value[`${n.id}::details`]?.body ?? '',
-      updated_at: n.updated_at,
-    }))
-  )
-
   function childrenOf(parentId: string): ContextNode[] {
     return Object.values(nodes.value)
       .filter(n => n.parent_id === parentId && !n.archived)
@@ -80,7 +68,10 @@ export const useContextStore = defineStore('context', () => {
 
   async function fetchRootNodes(): Promise<ContextNode[]> {
     const resp = await api('/api/nodes')
-    if (!resp.ok) throw new Error(`fetchRootNodes: ${resp.status}`)
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`fetchRootNodes: ${resp.status} ${detail}`)
+    }
     const data: ContextNode[] = await resp.json()
     for (const node of data) {
       nodes.value[node.id] = node
@@ -90,7 +81,10 @@ export const useContextStore = defineStore('context', () => {
 
   async function fetchChildren(parentId: string): Promise<ContextNode[]> {
     const resp = await api(`/api/nodes/${parentId}/children`)
-    if (!resp.ok) throw new Error(`fetchChildren: ${resp.status}`)
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`fetchChildren: ${resp.status} ${detail}`)
+    }
     const data: ContextNode[] = await resp.json()
     for (const node of data) {
       nodes.value[node.id] = node
@@ -100,7 +94,10 @@ export const useContextStore = defineStore('context', () => {
 
   async function fetchNode(nodeId: string): Promise<ContextNode> {
     const resp = await api(`/api/nodes/${nodeId}`)
-    if (!resp.ok) throw new Error(`fetchNode: ${resp.status}`)
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`fetchNode: ${resp.status} ${detail}`)
+    }
     const data: ContextNode = await resp.json()
     nodes.value[data.id] = data
     return data
@@ -117,7 +114,10 @@ export const useContextStore = defineStore('context', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ parent_id: parentId, name, node_type: nodeType, ...opts }),
     })
-    if (!resp.ok) throw new Error(`createNode: ${resp.status}`)
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`createNode: ${resp.status} ${detail}`)
+    }
     const data: ContextNode = await resp.json()
     nodes.value[data.id] = data
     return data
@@ -132,7 +132,10 @@ export const useContextStore = defineStore('context', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(fields),
     })
-    if (!resp.ok) throw new Error(`patchNode: ${resp.status}`)
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`patchNode: ${resp.status} ${detail}`)
+    }
     const data: ContextNode = await resp.json()
     nodes.value[data.id] = data
     return data
@@ -140,9 +143,16 @@ export const useContextStore = defineStore('context', () => {
 
   async function deleteNode(nodeId: string): Promise<void> {
     const resp = await api(`/api/nodes/${nodeId}`, { method: 'DELETE' })
-    if (!resp.ok) throw new Error(`deleteNode: ${resp.status}`)
-    // Remove from cache (and any children)
-    const toRemove = [nodeId, ...Object.keys(nodes.value).filter(id => nodes.value[id].parent_id === nodeId)]
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`deleteNode: ${resp.status} ${detail}`)
+    }
+    // Remove from cache recursively (node and all descendants)
+    function collectDescendants(id: string): string[] {
+      const children = Object.keys(nodes.value).filter(k => nodes.value[k].parent_id === id)
+      return [id, ...children.flatMap(collectDescendants)]
+    }
+    const toRemove = collectDescendants(nodeId)
     for (const id of toRemove) {
       delete nodes.value[id]
     }
@@ -150,7 +160,10 @@ export const useContextStore = defineStore('context', () => {
 
   async function fetchSections(nodeId: string): Promise<NodeSection[]> {
     const resp = await api(`/api/nodes/${nodeId}/sections`)
-    if (!resp.ok) throw new Error(`fetchSections: ${resp.status}`)
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`fetchSections: ${resp.status} ${detail}`)
+    }
     const data: NodeSection[] = await resp.json()
     for (const s of data) {
       sectionCache.value[`${nodeId}::${s.section_type}`] = s
@@ -161,7 +174,10 @@ export const useContextStore = defineStore('context', () => {
   async function fetchSection(nodeId: string, sectionType: string): Promise<NodeSection | null> {
     const resp = await api(`/api/nodes/${nodeId}/sections/${encodeURIComponent(sectionType)}`)
     if (resp.status === 404) return null
-    if (!resp.ok) throw new Error(`fetchSection: ${resp.status}`)
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`fetchSection: ${resp.status} ${detail}`)
+    }
     const data: NodeSection = await resp.json()
     sectionCache.value[`${nodeId}::${sectionType}`] = data
     return data
@@ -173,36 +189,13 @@ export const useContextStore = defineStore('context', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ body }),
     })
-    if (!resp.ok) throw new Error(`saveSection: ${resp.status}`)
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`saveSection: ${resp.status} ${detail}`)
+    }
     const data: NodeSection = await resp.json()
     sectionCache.value[`${nodeId}::${sectionType}`] = data
     return data
-  }
-
-  // -- Backward-compat shims for old API ------------------------------------
-  // These allow existing code that calls fetchEntries / saveEntry / etc.
-  // to keep working during transition.
-
-  async function fetchEntries(): Promise<void> {
-    await fetchRootNodes()
-  }
-
-  async function saveEntry(subject: string, body: string): Promise<void> {
-    let node = nodeByName(subject, null)
-    if (!node) {
-      node = await createNode(null, subject)
-    }
-    await saveSection(node.id, 'details', body)
-  }
-
-  async function deleteEntry(subject: string): Promise<void> {
-    const node = nodeByName(subject, null)
-    if (node) await deleteNode(node.id)
-  }
-
-  async function renameEntry(oldSubject: string, newSubject: string): Promise<void> {
-    const node = nodeByName(oldSubject, null)
-    if (node) await patchNode(node.id, { name: newSubject })
   }
 
   return {
@@ -213,7 +206,6 @@ export const useContextStore = defineStore('context', () => {
     // Computed
     rootNodes,
     rootContextNodes,
-    entries,
 
     // Helpers
     childrenOf,
@@ -231,11 +223,5 @@ export const useContextStore = defineStore('context', () => {
     fetchSections,
     fetchSection,
     saveSection,
-
-    // Backward-compat
-    fetchEntries,
-    saveEntry,
-    deleteEntry,
-    renameEntry,
   }
 })

--- a/frontend/src/stores/milestones.ts
+++ b/frontend/src/stores/milestones.ts
@@ -71,6 +71,10 @@ export const useMilestoneStore = defineStore('milestones', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, description: description ?? null, target_date: targetDate ?? null }),
     })
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`createMilestone: ${resp.status} ${detail}`)
+    }
     const m: Milestone = await resp.json()
     all.value = [...all.value, m]
     return m
@@ -82,27 +86,43 @@ export const useMilestoneStore = defineStore('milestones', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(fields),
     })
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`patchMilestone: ${resp.status} ${detail}`)
+    }
     const updated: Milestone = await resp.json()
     all.value = all.value.map(m => m.id === id ? updated : m)
     return updated
   }
 
   async function deleteMilestone(id: string) {
-    await api(`/api/milestones/${id}`, { method: 'DELETE' })
+    const resp = await api(`/api/milestones/${id}`, { method: 'DELETE' })
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`deleteMilestone: ${resp.status} ${detail}`)
+    }
     all.value = all.value.filter(m => m.id !== id)
   }
 
   async function linkTask(milestoneId: string, taskId: string) {
-    await api(`/api/milestones/${milestoneId}/tasks`, {
+    const resp = await api(`/api/milestones/${milestoneId}/tasks`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ task_id: taskId }),
     })
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`linkTask: ${resp.status} ${detail}`)
+    }
     await fetchAll()
   }
 
   async function unlinkTask(milestoneId: string, taskId: string) {
-    await api(`/api/milestones/${milestoneId}/tasks/${taskId}`, { method: 'DELETE' })
+    const resp = await api(`/api/milestones/${milestoneId}/tasks/${taskId}`, { method: 'DELETE' })
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`unlinkTask: ${resp.status} ${detail}`)
+    }
     await fetchAll()
   }
 

--- a/frontend/src/stores/milestones.ts
+++ b/frontend/src/stores/milestones.ts
@@ -15,6 +15,8 @@ export interface MilestoneTask {
 export interface Milestone {
   id: string
   context_subject: string
+  /** The context_nodes id for this milestone (same as id in the new system) */
+  node_id?: string
   name: string
   description: string | null
   target_date: string | null

--- a/frontend/src/stores/plan.ts
+++ b/frontend/src/stores/plan.ts
@@ -17,6 +17,7 @@ export interface Task {
   blocks: string[]
   blocked_by: string[]
   context_subject: string | null
+  context_node_id: string | null
 }
 
 export interface AnchorPlan { tasks: Task[]; notes: string }

--- a/tests/db/test_context_nodes.py
+++ b/tests/db/test_context_nodes.py
@@ -1,0 +1,467 @@
+"""Tests for context tree query functions (context_nodes, node_sections, node_tasks)."""
+import sqlite3
+import pytest
+from pathlib import Path
+from db.schema import init_db
+from db import queries as q
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "tether.db"
+    init_db(path)
+    return path
+
+
+def _insert_task(db_path, uuid, text, status="pending"):
+    """Helper: insert a bare task directly for linking tests."""
+    from db.schema import get_db
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO tasks (uuid, text, status) VALUES (?, ?, ?)",
+            (uuid, text, status),
+        )
+
+
+# ---------------------------------------------------------------------------
+# create_node
+# ---------------------------------------------------------------------------
+
+class TestCreateNode:
+    def test_create_context_node(self, db_path):
+        node = q.create_node(db_path, None, "School")
+        assert node["name"] == "School"
+        assert node["node_type"] == "context"
+        assert node["parent_id"] is None
+        assert node["archived"] == 0
+        assert node["id"]
+
+    def test_create_milestone_node(self, db_path):
+        parent = q.create_node(db_path, None, "Project")
+        ms = q.create_node(
+            db_path, parent["id"], "MVP",
+            node_type="milestone", target_date="2026-06-01", color="#ff0000",
+        )
+        assert ms["node_type"] == "milestone"
+        assert ms["parent_id"] == parent["id"]
+        assert ms["target_date"] == "2026-06-01"
+        assert ms["color"] == "#ff0000"
+
+    def test_create_nested_node(self, db_path):
+        root = q.create_node(db_path, None, "School")
+        child = q.create_node(db_path, root["id"], "ML")
+        assert child["parent_id"] == root["id"]
+
+    def test_duplicate_sibling_name_raises(self, db_path):
+        q.create_node(db_path, None, "School")
+        with pytest.raises(sqlite3.IntegrityError):
+            q.create_node(db_path, None, "School")
+
+
+# ---------------------------------------------------------------------------
+# get_node
+# ---------------------------------------------------------------------------
+
+class TestGetNode:
+    def test_get_existing(self, db_path):
+        created = q.create_node(db_path, None, "Work")
+        fetched = q.get_node(db_path, created["id"])
+        assert fetched["name"] == "Work"
+        assert fetched["section_types"] == []
+        assert fetched["children_count"] == 0
+
+    def test_get_with_sections_and_children(self, db_path):
+        parent = q.create_node(db_path, None, "Work")
+        q.create_node(db_path, parent["id"], "Sub1")
+        q.create_node(db_path, parent["id"], "Sub2")
+        q.upsert_section(db_path, parent["id"], "details", "some info")
+        q.upsert_section(db_path, parent["id"], "notes", "extra notes")
+
+        fetched = q.get_node(db_path, parent["id"])
+        assert fetched["children_count"] == 2
+        assert fetched["section_types"] == ["details", "notes"]
+
+    def test_get_nonexistent(self, db_path):
+        assert q.get_node(db_path, "nope") is None
+
+
+# ---------------------------------------------------------------------------
+# get_node_by_path
+# ---------------------------------------------------------------------------
+
+class TestGetNodeByPath:
+    def test_single_segment(self, db_path):
+        q.create_node(db_path, None, "School")
+        node = q.get_node_by_path(db_path, "School")
+        assert node is not None
+        assert node["name"] == "School"
+
+    def test_multi_segment(self, db_path):
+        root = q.create_node(db_path, None, "School")
+        mid = q.create_node(db_path, root["id"], "ML")
+        leaf = q.create_node(db_path, mid["id"], "Project")
+        node = q.get_node_by_path(db_path, "School/ML/Project")
+        assert node is not None
+        assert node["id"] == leaf["id"]
+
+    def test_nonexistent_path(self, db_path):
+        q.create_node(db_path, None, "School")
+        assert q.get_node_by_path(db_path, "School/Physics") is None
+
+    def test_nonexistent_root(self, db_path):
+        assert q.get_node_by_path(db_path, "Nope") is None
+
+
+# ---------------------------------------------------------------------------
+# get_node_path
+# ---------------------------------------------------------------------------
+
+class TestGetNodePath:
+    def test_root_node(self, db_path):
+        root = q.create_node(db_path, None, "School")
+        assert q.get_node_path(db_path, root["id"]) == "School"
+
+    def test_nested_path(self, db_path):
+        root = q.create_node(db_path, None, "School")
+        mid = q.create_node(db_path, root["id"], "ML")
+        leaf = q.create_node(db_path, mid["id"], "Project")
+        assert q.get_node_path(db_path, leaf["id"]) == "School/ML/Project"
+
+
+# ---------------------------------------------------------------------------
+# get_children
+# ---------------------------------------------------------------------------
+
+class TestGetChildren:
+    def test_root_children(self, db_path):
+        q.create_node(db_path, None, "A")
+        q.create_node(db_path, None, "B")
+        children = q.get_children(db_path)
+        assert len(children) == 2
+        assert [c["name"] for c in children] == ["A", "B"]
+
+    def test_nested_children(self, db_path):
+        root = q.create_node(db_path, None, "Root")
+        q.create_node(db_path, root["id"], "C1")
+        q.create_node(db_path, root["id"], "C2")
+        children = q.get_children(db_path, root["id"])
+        assert len(children) == 2
+
+    def test_excludes_archived_by_default(self, db_path):
+        root = q.create_node(db_path, None, "Root")
+        q.create_node(db_path, root["id"], "Active")
+        archived = q.create_node(db_path, root["id"], "Old")
+        q.archive_node(db_path, archived["id"])
+
+        children = q.get_children(db_path, root["id"])
+        assert len(children) == 1
+        assert children[0]["name"] == "Active"
+
+    def test_include_archived(self, db_path):
+        root = q.create_node(db_path, None, "Root")
+        q.create_node(db_path, root["id"], "Active")
+        archived = q.create_node(db_path, root["id"], "Old")
+        q.archive_node(db_path, archived["id"])
+
+        children = q.get_children(db_path, root["id"], include_archived=True)
+        assert len(children) == 2
+
+
+# ---------------------------------------------------------------------------
+# get_subtree
+# ---------------------------------------------------------------------------
+
+class TestGetSubtree:
+    def test_subtree(self, db_path):
+        root = q.create_node(db_path, None, "Root")
+        c1 = q.create_node(db_path, root["id"], "C1")
+        q.create_node(db_path, c1["id"], "GC1")
+        q.create_node(db_path, root["id"], "C2")
+
+        subtree = q.get_subtree(db_path, root["id"])
+        names = {n["name"] for n in subtree}
+        assert names == {"C1", "C2", "GC1"}
+        # Root itself should NOT be in subtree
+        assert all(n["id"] != root["id"] for n in subtree)
+
+    def test_subtree_excludes_archived(self, db_path):
+        root = q.create_node(db_path, None, "Root")
+        active = q.create_node(db_path, root["id"], "Active")
+        archived = q.create_node(db_path, root["id"], "Archived")
+        q.archive_node(db_path, archived["id"])
+
+        subtree = q.get_subtree(db_path, root["id"])
+        names = {n["name"] for n in subtree}
+        assert "Active" in names
+        assert "Archived" not in names
+
+    def test_subtree_include_archived(self, db_path):
+        root = q.create_node(db_path, None, "Root")
+        q.create_node(db_path, root["id"], "Active")
+        archived = q.create_node(db_path, root["id"], "Archived")
+        q.archive_node(db_path, archived["id"])
+
+        subtree = q.get_subtree(db_path, root["id"], include_archived=True)
+        names = {n["name"] for n in subtree}
+        assert names == {"Active", "Archived"}
+
+
+# ---------------------------------------------------------------------------
+# move_node, rename_node
+# ---------------------------------------------------------------------------
+
+class TestMoveRename:
+    def test_move_node(self, db_path):
+        a = q.create_node(db_path, None, "A")
+        b = q.create_node(db_path, None, "B")
+        child = q.create_node(db_path, a["id"], "Child")
+
+        q.move_node(db_path, child["id"], b["id"])
+        moved = q.get_node(db_path, child["id"])
+        assert moved["parent_id"] == b["id"]
+
+    def test_rename_node(self, db_path):
+        node = q.create_node(db_path, None, "OldName")
+        q.rename_node(db_path, node["id"], "NewName")
+        renamed = q.get_node(db_path, node["id"])
+        assert renamed["name"] == "NewName"
+
+
+# ---------------------------------------------------------------------------
+# delete_node (cascade)
+# ---------------------------------------------------------------------------
+
+class TestDeleteNode:
+    def test_delete_cascades_children(self, db_path):
+        root = q.create_node(db_path, None, "Root")
+        child = q.create_node(db_path, root["id"], "Child")
+        q.create_node(db_path, child["id"], "Grandchild")
+
+        q.delete_node(db_path, root["id"])
+        assert q.get_node(db_path, root["id"]) is None
+        assert q.get_node(db_path, child["id"]) is None
+
+    def test_delete_cascades_sections(self, db_path):
+        node = q.create_node(db_path, None, "X")
+        q.upsert_section(db_path, node["id"], "details", "stuff")
+
+        q.delete_node(db_path, node["id"])
+        assert q.get_sections(db_path, node["id"]) == []
+
+    def test_delete_cascades_task_links(self, db_path):
+        node = q.create_node(db_path, None, "X")
+        _insert_task(db_path, "t-1", "Task 1")
+        q.link_task_to_node(db_path, node["id"], "t-1")
+
+        q.delete_node(db_path, node["id"])
+        assert q.get_task_nodes(db_path, "t-1") == []
+
+
+# ---------------------------------------------------------------------------
+# archive / unarchive
+# ---------------------------------------------------------------------------
+
+class TestArchive:
+    def test_archive_and_unarchive(self, db_path):
+        node = q.create_node(db_path, None, "X")
+        assert q.get_node(db_path, node["id"])["archived"] == 0
+
+        q.archive_node(db_path, node["id"])
+        assert q.get_node(db_path, node["id"])["archived"] == 1
+
+        q.unarchive_node(db_path, node["id"])
+        assert q.get_node(db_path, node["id"])["archived"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Section CRUD
+# ---------------------------------------------------------------------------
+
+class TestSections:
+    def test_upsert_and_get(self, db_path):
+        node = q.create_node(db_path, None, "Node")
+        result = q.upsert_section(db_path, node["id"], "details", "Hello world")
+        assert result["body"] == "Hello world"
+        assert result["section_type"] == "details"
+
+        fetched = q.get_section(db_path, node["id"], "details")
+        assert fetched["body"] == "Hello world"
+
+    def test_upsert_overwrites(self, db_path):
+        node = q.create_node(db_path, None, "Node")
+        q.upsert_section(db_path, node["id"], "details", "First")
+        q.upsert_section(db_path, node["id"], "details", "Second")
+        fetched = q.get_section(db_path, node["id"], "details")
+        assert fetched["body"] == "Second"
+
+    def test_get_all_sections(self, db_path):
+        node = q.create_node(db_path, None, "Node")
+        q.upsert_section(db_path, node["id"], "details", "D")
+        q.upsert_section(db_path, node["id"], "notes", "N")
+        sections = q.get_sections(db_path, node["id"])
+        assert len(sections) == 2
+        types = [s["section_type"] for s in sections]
+        assert "details" in types
+        assert "notes" in types
+
+    def test_append_section_creates(self, db_path):
+        node = q.create_node(db_path, None, "Node")
+        result = q.append_section(db_path, node["id"], "log", "Entry 1")
+        assert result["body"] == "Entry 1"
+
+    def test_append_section_appends(self, db_path):
+        node = q.create_node(db_path, None, "Node")
+        q.upsert_section(db_path, node["id"], "log", "Entry 1")
+        result = q.append_section(db_path, node["id"], "log", "Entry 2")
+        assert result["body"] == "Entry 1\n\nEntry 2"
+
+    def test_delete_section(self, db_path):
+        node = q.create_node(db_path, None, "Node")
+        q.upsert_section(db_path, node["id"], "details", "stuff")
+        q.delete_section(db_path, node["id"], "details")
+        assert q.get_section(db_path, node["id"], "details") is None
+
+    def test_get_nonexistent_section(self, db_path):
+        node = q.create_node(db_path, None, "Node")
+        assert q.get_section(db_path, node["id"], "nope") is None
+
+
+# ---------------------------------------------------------------------------
+# search_sections (FTS5)
+# ---------------------------------------------------------------------------
+
+class TestSearchSections:
+    def test_basic_search(self, db_path):
+        n1 = q.create_node(db_path, None, "Alpha")
+        n2 = q.create_node(db_path, None, "Beta")
+        q.upsert_section(db_path, n1["id"], "details", "Machine learning project")
+        q.upsert_section(db_path, n2["id"], "details", "Web development tasks")
+
+        results = q.search_sections(db_path, "machine learning")
+        assert len(results) == 1
+        assert results[0]["node_id"] == n1["id"]
+        assert "snippet" in results[0]
+
+    def test_search_within_subtree(self, db_path):
+        root = q.create_node(db_path, None, "Root")
+        c1 = q.create_node(db_path, root["id"], "C1")
+        c2 = q.create_node(db_path, root["id"], "C2")
+        other = q.create_node(db_path, None, "Other")
+
+        q.upsert_section(db_path, c1["id"], "details", "Important data here")
+        q.upsert_section(db_path, c2["id"], "details", "More data there")
+        q.upsert_section(db_path, other["id"], "details", "Unrelated data elsewhere")
+
+        results = q.search_sections(db_path, "data", node_id=root["id"])
+        node_ids = {r["node_id"] for r in results}
+        assert c1["id"] in node_ids
+        assert c2["id"] in node_ids
+        assert other["id"] not in node_ids
+
+    def test_search_no_results(self, db_path):
+        node = q.create_node(db_path, None, "X")
+        q.upsert_section(db_path, node["id"], "details", "Hello world")
+        results = q.search_sections(db_path, "zzzznotfound")
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# link / unlink tasks
+# ---------------------------------------------------------------------------
+
+class TestNodeTasks:
+    def test_link_and_get(self, db_path):
+        node = q.create_node(db_path, None, "Proj")
+        _insert_task(db_path, "t-1", "Build API")
+        _insert_task(db_path, "t-2", "Write tests")
+
+        q.link_task_to_node(db_path, node["id"], "t-1")
+        q.link_task_to_node(db_path, node["id"], "t-2")
+
+        tasks = q.get_node_tasks(db_path, node["id"])
+        assert len(tasks) == 2
+        ids = {t["id"] for t in tasks}
+        assert ids == {"t-1", "t-2"}
+
+    def test_unlink(self, db_path):
+        node = q.create_node(db_path, None, "Proj")
+        _insert_task(db_path, "t-1", "Build API")
+        q.link_task_to_node(db_path, node["id"], "t-1")
+        q.unlink_task_from_node(db_path, node["id"], "t-1")
+        assert q.get_node_tasks(db_path, node["id"]) == []
+
+    def test_link_idempotent(self, db_path):
+        node = q.create_node(db_path, None, "Proj")
+        _insert_task(db_path, "t-1", "Build API")
+        q.link_task_to_node(db_path, node["id"], "t-1")
+        q.link_task_to_node(db_path, node["id"], "t-1")  # no error
+        assert len(q.get_node_tasks(db_path, node["id"])) == 1
+
+    def test_get_task_nodes(self, db_path):
+        n1 = q.create_node(db_path, None, "A")
+        n2 = q.create_node(db_path, None, "B")
+        _insert_task(db_path, "t-1", "Shared task")
+        q.link_task_to_node(db_path, n1["id"], "t-1")
+        q.link_task_to_node(db_path, n2["id"], "t-1")
+
+        nodes = q.get_task_nodes(db_path, "t-1")
+        assert len(nodes) == 2
+        names = {n["name"] for n in nodes}
+        assert names == {"A", "B"}
+
+
+# ---------------------------------------------------------------------------
+# get_milestone_nodes
+# ---------------------------------------------------------------------------
+
+class TestMilestoneNodes:
+    def test_milestone_with_counts(self, db_path):
+        parent = q.create_node(db_path, None, "Project")
+        ms = q.create_node(
+            db_path, parent["id"], "Beta Release",
+            node_type="milestone", target_date="2026-07-01",
+        )
+
+        _insert_task(db_path, "t-1", "Task A", status="done")
+        _insert_task(db_path, "t-2", "Task B", status="pending")
+        _insert_task(db_path, "t-3", "Task C", status="done")
+
+        q.link_task_to_node(db_path, ms["id"], "t-1")
+        q.link_task_to_node(db_path, ms["id"], "t-2")
+        q.link_task_to_node(db_path, ms["id"], "t-3")
+
+        milestones = q.get_milestone_nodes(db_path, parent_id=parent["id"])
+        assert len(milestones) == 1
+        m = milestones[0]
+        assert m["name"] == "Beta Release"
+        assert m["task_count"] == 3
+        assert m["done_count"] == 2
+
+    def test_milestone_no_tasks(self, db_path):
+        parent = q.create_node(db_path, None, "Project")
+        q.create_node(
+            db_path, parent["id"], "Empty MS", node_type="milestone",
+        )
+        milestones = q.get_milestone_nodes(db_path)
+        assert len(milestones) == 1
+        assert milestones[0]["task_count"] == 0
+        assert milestones[0]["done_count"] == 0
+
+    def test_excludes_context_nodes(self, db_path):
+        parent = q.create_node(db_path, None, "Root")
+        q.create_node(db_path, parent["id"], "Child", node_type="context")
+        q.create_node(db_path, parent["id"], "MS", node_type="milestone")
+
+        milestones = q.get_milestone_nodes(db_path, parent_id=parent["id"])
+        assert len(milestones) == 1
+        assert milestones[0]["name"] == "MS"
+
+    def test_excludes_archived_by_default(self, db_path):
+        parent = q.create_node(db_path, None, "Root")
+        ms = q.create_node(db_path, parent["id"], "Old MS", node_type="milestone")
+        q.archive_node(db_path, ms["id"])
+
+        assert q.get_milestone_nodes(db_path, parent_id=parent["id"]) == []
+        assert len(q.get_milestone_nodes(
+            db_path, parent_id=parent["id"], include_archived=True
+        )) == 1

--- a/tests/db/test_migrate_context_tree.py
+++ b/tests/db/test_migrate_context_tree.py
@@ -1,0 +1,317 @@
+"""Tests for context_entries + milestones → context_nodes tree migration."""
+import sqlite3
+import pytest
+from pathlib import Path
+from db.schema import init_db
+from db.migrate_context_tree import migrate_context_tree
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "tether.db"
+    init_db(path)
+    return path
+
+
+def _insert_context(conn, subject, body, updated_at="2026-01-01 00:00:00"):
+    conn.execute(
+        "INSERT INTO context_entries (subject, body, updated_at) VALUES (?, ?, ?)",
+        (subject, body, updated_at),
+    )
+
+
+def _insert_milestone(conn, id, context_subject, name, **kwargs):
+    defaults = dict(
+        description=None, target_date=None, status="pending",
+        status_override=0, color=None,
+    )
+    defaults.update(kwargs)
+    conn.execute(
+        """INSERT INTO milestones
+           (id, context_subject, name, description, target_date, status,
+            status_override, color)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (id, context_subject, name, defaults["description"],
+         defaults["target_date"], defaults["status"],
+         defaults["status_override"], defaults["color"]),
+    )
+
+
+def _insert_task(conn, uuid, text, context_subject=None):
+    conn.execute(
+        "INSERT INTO tasks (uuid, text, context_subject) VALUES (?, ?, ?)",
+        (uuid, text, context_subject),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic flat subject (no slashes)
+# ---------------------------------------------------------------------------
+
+def test_flat_subject_creates_single_node(db_path):
+    conn = sqlite3.connect(db_path)
+    _insert_context(conn, "Tether", "Main project notes")
+    conn.commit()
+    conn.close()
+
+    migrate_context_tree(db_path)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    nodes = conn.execute("SELECT * FROM context_nodes").fetchall()
+    assert len(nodes) == 1
+    assert nodes[0]["name"] == "Tether"
+    assert nodes[0]["parent_id"] is None
+    assert nodes[0]["node_type"] == "context"
+
+    sections = conn.execute("SELECT * FROM node_sections").fetchall()
+    assert len(sections) == 1
+    assert sections[0]["body"] == "Main project notes"
+    assert sections[0]["section_type"] == "details"
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Nested slash-separated subject
+# ---------------------------------------------------------------------------
+
+def test_nested_subject_creates_tree(db_path):
+    conn = sqlite3.connect(db_path)
+    _insert_context(conn, "School/ML/Project", "ML project details")
+    conn.commit()
+    conn.close()
+
+    migrate_context_tree(db_path)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    nodes = conn.execute(
+        "SELECT * FROM context_nodes ORDER BY name"
+    ).fetchall()
+    by_name = {n["name"]: n for n in nodes}
+
+    assert len(nodes) == 3
+    # Root node
+    assert by_name["School"]["parent_id"] is None
+    # Middle node
+    assert by_name["ML"]["parent_id"] == by_name["School"]["id"]
+    # Leaf node
+    assert by_name["Project"]["parent_id"] == by_name["ML"]["id"]
+
+    # Only the leaf (full subject) gets a body
+    sections = conn.execute("SELECT * FROM node_sections").fetchall()
+    assert len(sections) == 1
+    assert sections[0]["node_id"] == by_name["Project"]["id"]
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Shared prefix — both entries get their bodies
+# ---------------------------------------------------------------------------
+
+def test_shared_prefix_both_get_bodies(db_path):
+    conn = sqlite3.connect(db_path)
+    _insert_context(conn, "School", "School overview", updated_at="2026-02-01 00:00:00")
+    _insert_context(conn, "School/ML", "ML class notes", updated_at="2026-03-01 00:00:00")
+    conn.commit()
+    conn.close()
+
+    migrate_context_tree(db_path)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    nodes = conn.execute("SELECT * FROM context_nodes ORDER BY name").fetchall()
+    by_name = {n["name"]: n for n in nodes}
+
+    assert len(nodes) == 2
+    assert by_name["School"]["parent_id"] is None
+    assert by_name["ML"]["parent_id"] == by_name["School"]["id"]
+
+    # Both should have node_sections entries
+    sections = conn.execute(
+        "SELECT ns.body, cn.name FROM node_sections ns "
+        "JOIN context_nodes cn ON cn.id = ns.node_id ORDER BY cn.name"
+    ).fetchall()
+    assert len(sections) == 2
+    sec_map = {s["name"]: s["body"] for s in sections}
+    assert sec_map["ML"] == "ML class notes"
+    assert sec_map["School"] == "School overview"
+
+    # Verify updated_at is preserved
+    assert by_name["School"]["updated_at"] == "2026-02-01 00:00:00"
+    assert by_name["ML"]["updated_at"] == "2026-03-01 00:00:00"
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Milestone migration
+# ---------------------------------------------------------------------------
+
+def test_milestone_becomes_child_node(db_path):
+    conn = sqlite3.connect(db_path)
+    _insert_context(conn, "Tether", "Project notes")
+    _insert_milestone(
+        conn, "ms-1", "Tether", "MVP Launch",
+        description="Ship the first version",
+        target_date="2026-06-01", status="in_progress",
+        color="#ff0000",
+    )
+    conn.commit()
+    conn.close()
+
+    migrate_context_tree(db_path)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    nodes = conn.execute("SELECT * FROM context_nodes ORDER BY node_type").fetchall()
+    by_type = {}
+    for n in nodes:
+        by_type.setdefault(n["node_type"], []).append(n)
+
+    assert len(by_type["context"]) == 1
+    assert len(by_type["milestone"]) == 1
+
+    ms_node = by_type["milestone"][0]
+    assert ms_node["id"] == "ms-1"
+    assert ms_node["name"] == "MVP Launch"
+    assert ms_node["parent_id"] == by_type["context"][0]["id"]
+    assert ms_node["target_date"] == "2026-06-01"
+    assert ms_node["status"] == "in_progress"
+    assert ms_node["color"] == "#ff0000"
+
+    # Milestone description → node_sections
+    sections = conn.execute(
+        "SELECT * FROM node_sections WHERE node_id = ?", (ms_node["id"],)
+    ).fetchall()
+    assert len(sections) == 1
+    assert sections[0]["body"] == "Ship the first version"
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# milestone_tasks → node_tasks
+# ---------------------------------------------------------------------------
+
+def test_milestone_tasks_become_node_tasks(db_path):
+    conn = sqlite3.connect(db_path)
+    _insert_context(conn, "Proj", "notes")
+    _insert_milestone(conn, "ms-2", "Proj", "Beta")
+    _insert_task(conn, "t-1", "Build API")
+    conn.execute(
+        "INSERT INTO milestone_tasks (milestone_id, task_id) VALUES (?, ?)",
+        ("ms-2", "t-1"),
+    )
+    conn.commit()
+    conn.close()
+
+    migrate_context_tree(db_path)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    nt = conn.execute("SELECT * FROM node_tasks").fetchall()
+    assert len(nt) == 1
+    assert nt[0]["node_id"] == "ms-2"
+    assert nt[0]["task_id"] == "t-1"
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# tasks.context_subject → tasks.context_node_id
+# ---------------------------------------------------------------------------
+
+def test_task_context_node_id_set(db_path):
+    conn = sqlite3.connect(db_path)
+    _insert_context(conn, "Backend", "API work")
+    _insert_task(conn, "t-10", "Fix auth bug", context_subject="Backend")
+    _insert_task(conn, "t-11", "Misc task")
+    conn.commit()
+    conn.close()
+
+    migrate_context_tree(db_path)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    t10 = conn.execute(
+        "SELECT context_node_id FROM tasks WHERE uuid = ?", ("t-10",)
+    ).fetchone()
+    t11 = conn.execute(
+        "SELECT context_node_id FROM tasks WHERE uuid = ?", ("t-11",)
+    ).fetchone()
+
+    assert t10["context_node_id"] is not None
+    # Verify it points to the right node
+    node = conn.execute(
+        "SELECT name FROM context_nodes WHERE id = ?", (t10["context_node_id"],)
+    ).fetchone()
+    assert node["name"] == "Backend"
+
+    assert t11["context_node_id"] is None
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — running twice is safe
+# ---------------------------------------------------------------------------
+
+def test_idempotent_second_run(db_path):
+    conn = sqlite3.connect(db_path)
+    _insert_context(conn, "X", "x body")
+    conn.commit()
+    conn.close()
+
+    migrate_context_tree(db_path)
+    migrate_context_tree(db_path)  # should not raise or duplicate
+
+    conn = sqlite3.connect(db_path)
+    count = conn.execute("SELECT COUNT(*) FROM context_nodes").fetchone()[0]
+    assert count == 1
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Milestone with unknown context_subject is skipped
+# ---------------------------------------------------------------------------
+
+def test_orphan_milestone_skipped(db_path, capsys):
+    conn = sqlite3.connect(db_path)
+    _insert_context(conn, "Real", "exists")
+    # Insert milestone referencing a subject not in context_entries
+    conn.execute("PRAGMA foreign_keys = OFF")
+    conn.execute(
+        """INSERT INTO milestones (id, context_subject, name, status, status_override)
+           VALUES (?, ?, ?, 'pending', 0)""",
+        ("ms-orphan", "DoesNotExist", "Ghost milestone"),
+    )
+    conn.commit()
+    conn.close()
+
+    migrate_context_tree(db_path)
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.out
+    assert "DoesNotExist" in captured.out
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    nodes = conn.execute("SELECT * FROM context_nodes").fetchall()
+    # Only the "Real" context node, no milestone node
+    assert len(nodes) == 1
+    assert nodes[0]["name"] == "Real"
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Empty body is not inserted into node_sections
+# ---------------------------------------------------------------------------
+
+def test_empty_body_no_section(db_path):
+    conn = sqlite3.connect(db_path)
+    _insert_context(conn, "EmptyProject", "")
+    conn.commit()
+    conn.close()
+
+    migrate_context_tree(db_path)
+
+    conn = sqlite3.connect(db_path)
+    sections = conn.execute("SELECT * FROM node_sections").fetchall()
+    assert len(sections) == 0
+    conn.close()

--- a/tether_mcp/server.py
+++ b/tether_mcp/server.py
@@ -500,6 +500,125 @@ async def session_done(summary: str = "") -> str:
     return f"Session done acknowledged. Summary: {summary or '(none provided)'}"
 
 
+# --- Context tree tools ---
+
+# Tree browsing
+@mcp.tool()
+def list_context_nodes(parent_id: str = "") -> list[dict]:
+    """List context nodes. If parent_id is empty, returns root nodes. Otherwise returns children of the given node."""
+    from db.queries import get_children
+    pid = parent_id if parent_id else None
+    return get_children(_db(), pid)
+
+
+@mcp.tool()
+def get_context_node(node_id: str) -> dict:
+    """Get a single context node by ID, including section types and children count."""
+    from db.queries import get_node
+    result = get_node(_db(), node_id)
+    if result is None:
+        return {"error": f"Node {node_id} not found"}
+    return result
+
+
+@mcp.tool()
+def get_node_by_path(path: str) -> dict:
+    """Resolve a slash-separated path like 'School/ML/Project' to a node."""
+    from db.queries import get_node_by_path as _get
+    result = _get(_db(), path)
+    if result is None:
+        return {"error": f"Path '{path}' not found"}
+    return result
+
+
+# Section-level read/write (token-efficient)
+@mcp.tool()
+def list_node_sections(node_id: str) -> list[dict]:
+    """List section types and their sizes for a node, WITHOUT returning full body content. Use read_section to get specific content."""
+    from db.queries import get_sections
+    sections = get_sections(_db(), node_id)
+    return [{"section_type": s["section_type"], "size": len(s["body"]), "updated_at": s["updated_at"]} for s in sections]
+
+
+@mcp.tool()
+def read_section(node_id: str, section_type: str) -> dict:
+    """Read the full body of a specific section of a node."""
+    from db.queries import get_section
+    result = get_section(_db(), node_id, section_type)
+    if result is None:
+        return {"error": f"Section '{section_type}' not found on node {node_id}"}
+    return result
+
+
+@mcp.tool()
+def write_section(node_id: str, section_type: str, body: str) -> dict:
+    """Write (create or replace) a section on a node."""
+    from db.queries import upsert_section
+    return upsert_section(_db(), node_id, section_type, body)
+
+
+@mcp.tool()
+def append_to_section(node_id: str, section_type: str, content: str) -> dict:
+    """Append text to a section with a double-newline separator. Creates the section if it doesn't exist."""
+    from db.queries import append_section
+    return append_section(_db(), node_id, section_type, content)
+
+
+@mcp.tool()
+def search_sections(query: str, node_id: str = "") -> list[dict]:
+    """Full-text search across all node sections. Returns matching snippets. Optionally scope to a node's subtree."""
+    from db.queries import search_sections as _search
+    nid = node_id if node_id else None
+    return _search(_db(), query, nid)
+
+
+# Node management
+@mcp.tool()
+def create_context_node(parent_id: str = "", name: str = "", node_type: str = "context",
+                        target_date: str = "", color: str = "") -> dict:
+    """Create a new context node or milestone. parent_id empty = root node."""
+    from db.queries import create_node
+    pid = parent_id if parent_id else None
+    kwargs = {}
+    if target_date: kwargs["target_date"] = target_date
+    if color: kwargs["color"] = color
+    return create_node(_db(), pid, name, node_type, **kwargs)
+
+
+@mcp.tool()
+def archive_context_node(node_id: str) -> dict:
+    """Archive a node (hides from default views, saves tokens)."""
+    from db.queries import archive_node
+    archive_node(_db(), node_id)
+    return {"ok": True}
+
+
+@mcp.tool()
+def move_context_node(node_id: str, new_parent_id: str = "") -> dict:
+    """Move a node to a new parent. Empty new_parent_id = move to root."""
+    from db.queries import move_node
+    pid = new_parent_id if new_parent_id else None
+    move_node(_db(), node_id, pid)
+    return {"ok": True}
+
+
+# Task linking (new system)
+@mcp.tool()
+def link_task_to_node(task_id: str, node_id: str) -> dict:
+    """Link a task to a context node or milestone."""
+    from db.queries import link_task_to_node as _link
+    _link(_db(), node_id, task_id)
+    return {"ok": True}
+
+
+@mcp.tool()
+def unlink_task_from_node(task_id: str, node_id: str) -> dict:
+    """Unlink a task from a context node or milestone."""
+    from db.queries import unlink_task_from_node as _unlink
+    _unlink(_db(), node_id, task_id)
+    return {"ok": True}
+
+
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
## Summary
Replaces the flat text-blob context system with a tree-structured hierarchy.

- **Unified `context_nodes` table** — context entries and milestones in one tree with `node_type` column. Adjacency list (parent_id FK) for hierarchy. Milestone-specific fields nullable for context nodes.
- **`node_sections` table** — typed sections (details, plans, notes, etc.) per node. FTS5 full-text search with sync triggers. Enables targeted bot reads instead of reading entire blobs.
- **Migration script** — converts existing `context_entries` (slash-separated paths) and `milestones` into the tree. Transaction-safe with rollback, path normalization, orphan warnings.
- **21 new DB query functions** — tree operations (create, move, rename, archive), section CRUD, FTS5 search, node-task linking. Cycle detection on move, input validation, consistent return shapes.
- **19 REST API endpoints** at `/api/nodes/*` — full CRUD for nodes, sections, tasks. Global error handlers for ValueError/IntegrityError.
- **15 new MCP tools** — tree browsing, section-level read/write (token-efficient), search, node management. Old tools kept as backward compat.
- **Frontend stores rewritten** — context store uses node API, milestones store has resp.ok checks, Task interface includes `context_node_id`. KanbanColumn/AnchorBlock grouping updated.
- **175 DB tests passing**, frontend builds clean.

## Migration
After deploy, run on each user DB:
```bash
cd ~/tether && source .venv/bin/activate
for f in ~/.tether-config/users/*.db; do python3 -m db.migrate_context_tree "$f"; done
```

## Test plan
- [ ] Migration script converts existing data correctly
- [ ] Context editor loads and saves via new API
- [ ] Kanban/plan views group tasks correctly
- [ ] MCP tools work: list_context_nodes, read_section, search_sections
- [ ] Creating new nodes, sections, linking tasks works
- [ ] Deleting a node cascades children + sections + task links