### PR TITLE
feat: context tree editor — recursive nesting, section tabs, drag-drop (Phase B)

### DIFF
--- a/frontend/src/components/ContextEditor.vue
+++ b/frontend/src/components/ContextEditor.vue
@@ -1,165 +1,36 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useContextStore } from '../stores/context'
-import type { ContextNode } from '../stores/context'
-import MilestoneDetail from './MilestoneDetail.vue'
 import { useMilestoneStore } from '../stores/milestones'
+import ContextTreeNode from './ContextTreeNode.vue'
 
-const store = useContextStore()
-const editing = ref<string | null>(null) // node id being edited
-const editBody = ref('')
-const renaming = ref<string | null>(null) // node id being renamed
-const renameValue = ref('')
-const newSubject = ref('')
-const expandedGroups = ref<Set<string>>(new Set()) // node ids
-const error = ref<string | null>(null)
-
+const contextStore = useContextStore()
 const milestoneStore = useMilestoneStore()
-const expandedMilestones = ref<Set<string>>(new Set())
-const addingMilestoneFor = ref<string | null>(null) // node id
-const newMilestoneName = ref('')
+const error = ref<string | null>(null)
+const newName = ref('')
 
-function toggleMilestone(id: string) {
-  const next = new Set(expandedMilestones.value)
-  if (next.has(id)) next.delete(id); else next.add(id)
-  expandedMilestones.value = next
-}
-
-async function addMilestone(nodeName: string) {
-  if (!newMilestoneName.value.trim()) return
+async function addRootNode() {
+  if (!newName.value.trim()) return
   try {
     error.value = null
-    await milestoneStore.createMilestone(nodeName, newMilestoneName.value.trim())
-    newMilestoneName.value = ''
-    addingMilestoneFor.value = null
+    await contextStore.createNode(null, newName.value.trim())
+    await contextStore.fetchRootNodes()
+    newName.value = ''
   } catch (e) {
-    console.error('addMilestone error:', e)
-    error.value = e instanceof Error ? e.message : 'Failed to add milestone'
-  }
-}
-
-async function toggleExpand(node: ContextNode) {
-  if (expandedGroups.value.has(node.id)) {
-    expandedGroups.value.delete(node.id)
-  } else {
-    // Optimistic: add to expanded set before fetch
-    expandedGroups.value.add(node.id)
-    try {
-      const children = await store.fetchChildren(node.id)
-      await Promise.allSettled(children.map(c => store.fetchSection(c.id, 'details')))
-    } catch (e) {
-      // Rollback on error
-      expandedGroups.value.delete(node.id)
-      console.error('toggleExpand error:', e)
-      error.value = e instanceof Error ? e.message : 'Failed to expand node'
-    }
-  }
-}
-
-async function startEdit(nodeId: string) {
-  editing.value = nodeId
-  // Fetch the 'details' section for this node
-  const section = await store.fetchSection(nodeId, 'details')
-  editBody.value = section?.body ?? ''
-}
-
-async function saveEdit() {
-  if (!editing.value) return
-  try {
-    error.value = null
-    await store.saveSection(editing.value, 'details', editBody.value)
-    editing.value = null
-  } catch (e) {
-    console.error('saveEdit error:', e)
-    error.value = e instanceof Error ? e.message : 'Failed to save'
-  }
-}
-
-function startRename(nodeId: string, currentName: string) {
-  renaming.value = nodeId
-  renameValue.value = currentName
-}
-
-async function saveRename() {
-  if (!renaming.value || !renameValue.value.trim()) {
-    renaming.value = null
-    return
-  }
-  const node = store.nodes[renaming.value]
-  if (!node || renameValue.value.trim() === node.name) {
-    renaming.value = null
-    return
-  }
-  try {
-    error.value = null
-    await store.patchNode(renaming.value, { name: renameValue.value.trim() })
-    renaming.value = null
-  } catch (e) {
-    console.error('saveRename error:', e)
-    error.value = e instanceof Error ? e.message : 'Failed to rename'
-  }
-}
-
-async function addEntry() {
-  if (!newSubject.value.trim()) return
-  try {
-    error.value = null
-    const parts = newSubject.value.trim().split('/')
-    if (parts.length === 1) {
-      // Root node
-      await store.createNode(null, parts[0])
-    } else {
-      // Nested: find or create parent, then create child
-      const parentName = parts[0]
-      let parent = store.nodeByName(parentName, null)
-      if (!parent) {
-        parent = await store.createNode(null, parentName)
-      }
-      const childName = parts.slice(1).join('/')
-      await store.createNode(parent.id, childName)
-    }
-    await store.fetchRootNodes()
-    newSubject.value = ''
-  } catch (e) {
-    console.error('addEntry error:', e)
+    console.error('addRootNode error:', e)
     error.value = e instanceof Error ? e.message : 'Failed to add entry'
   }
 }
 
-function prefillSubEntry(parentName: string) {
-  newSubject.value = parentName + '/'
-}
-
-async function deleteWithConfirm(node: ContextNode) {
-  const children = store.childrenOf(node.id)
-  const childCount = children.length
-  const msg = childCount > 0
-    ? `Delete "${node.name}" and ${childCount} sub-entr${childCount === 1 ? 'y' : 'ies'}?`
-    : `Delete "${node.name}"?`
-  if (!confirm(msg)) return
-  try {
-    error.value = null
-    await store.deleteNode(node.id)
-  } catch (e) {
-    console.error('deleteWithConfirm error:', e)
-    error.value = e instanceof Error ? e.message : 'Failed to delete'
-  }
-}
-
-/** Get the cached details body for display (without fetching) */
-function nodeBody(nodeId: string): string {
-  return store.sectionCache[`${nodeId}::details`]?.body ?? ''
-}
-
-/** Load sections for all root context nodes (for display bodies) */
+/** Load details sections for all root context nodes (for display bodies) */
 async function loadRootSections() {
-  const nodes = store.rootContextNodes
-  await Promise.allSettled(nodes.map(n => store.fetchSection(n.id, 'details')))
+  const nodes = contextStore.rootContextNodes
+  await Promise.allSettled(nodes.map(n => contextStore.fetchSection(n.id, 'details')))
 }
 
 onMounted(async () => {
   try {
-    await store.fetchRootNodes()
+    await contextStore.fetchRootNodes()
     await loadRootSections()
     await milestoneStore.fetchAll()
   } catch (e) {
@@ -171,138 +42,27 @@ onMounted(async () => {
 
 <template>
   <div class="min-h-screen bg-gray-900 text-white p-6">
-  <p v-if="error" class="text-red-400 text-sm">{{ error }}</p>
-  <div class="space-y-3">
-    <template v-for="node in store.rootContextNodes" :key="node.id">
-      <!-- Top-level entry -->
-      <div class="bg-white/5 border border-white/10 rounded-xl p-4">
-        <div class="flex justify-between items-center mb-2">
-          <div class="flex items-center gap-2 flex-1 min-w-0">
-            <button v-if="store.childrenOf(node.id).length > 0 || (node.children_count ?? 0) > 0"
-                    @click="toggleExpand(node)"
-                    class="text-white/40 hover:text-white/80 text-xs w-4 shrink-0">
-              {{ expandedGroups.has(node.id) ? '\u25BC' : '\u25B6' }}
-            </button>
-            <span v-else class="w-4 shrink-0" />
+    <h2 class="text-lg font-semibold mb-4">Context</h2>
+    <p v-if="error" class="text-red-400 text-sm mb-2">{{ error }}</p>
 
-            <template v-if="renaming === node.id">
-              <input v-model="renameValue" @keyup.enter="saveRename" @keyup.escape="renaming = null"
-                     class="flex-1 bg-transparent border-b border-white/40 text-sm outline-none" />
-              <span v-if="store.childrenOf(node.id).length > 0"
-                    class="text-xs text-yellow-400/70 ml-1">
-                (renames node, {{ store.childrenOf(node.id).length }} children unaffected)
-              </span>
-            </template>
-            <h3 v-else class="font-semibold text-sm truncate">{{ node.name }}</h3>
-          </div>
-
-          <div class="flex gap-2 shrink-0">
-            <button @click="startEdit(node.id)"
-                    class="text-xs text-white/50 hover:text-white">Edit</button>
-            <template v-if="renaming === node.id">
-              <button @click="saveRename" class="text-xs text-green-400/70 hover:text-green-400">Save</button>
-              <button @click="renaming = null" class="text-xs text-white/40 hover:text-white/70">Cancel</button>
-            </template>
-            <button v-else @click="startRename(node.id, node.name)"
-                    class="text-xs text-white/50 hover:text-white">Rename</button>
-            <button @click="deleteWithConfirm(node)"
-                    class="text-xs text-red-400/60 hover:text-red-400">Delete</button>
-          </div>
-        </div>
-
-        <div v-if="editing === node.id">
-          <textarea v-model="editBody" rows="4"
-                    class="w-full bg-transparent border border-white/20 rounded p-2 text-sm outline-none focus:border-white/50 resize-none" />
-          <div class="flex gap-2 mt-2">
-            <button @click="saveEdit" class="text-xs bg-white/10 hover:bg-white/20 px-3 py-1 rounded">Save</button>
-            <button @click="editing = null" class="text-xs text-white/40 hover:text-white/70">Cancel</button>
-          </div>
-        </div>
-        <p v-else class="text-xs text-white/50 line-clamp-2">{{ nodeBody(node.id) || '(empty)' }}</p>
-
-        <!-- Milestone chips -->
-        <div v-if="milestoneStore.bySubject[node.name]?.length" class="mt-2 flex flex-wrap gap-1">
-          <button
-            v-for="m in milestoneStore.bySubject[node.name]" :key="m.id"
-            @click="toggleMilestone(m.id)"
-            :style="m.color ? { backgroundColor: m.color + '33', color: m.color, borderColor: m.color + '66' } : {}"
-            class="text-xs px-1.5 py-0.5 rounded border flex items-center gap-1"
-            :class="m.color ? 'hover:opacity-80' : 'bg-white/10 hover:bg-white/20 border-transparent'">
-            <span :class="m.status === 'done' ? 'bg-green-400'
-                        : m.status === 'in_progress' ? 'bg-blue-400'
-                        : m.status === 'blocked' ? 'bg-red-400' : 'bg-white/20'"
-                  class="w-1.5 h-1.5 rounded-full" />
-            {{ m.name }} {{ m.done_count }}/{{ m.task_count }}
-          </button>
-        </div>
-        <template v-for="m in milestoneStore.bySubject[node.name]" :key="'detail-' + m.id">
-          <MilestoneDetail
-            v-if="expandedMilestones.has(m.id)"
-            :milestone="m"
-            @close="toggleMilestone(m.id)" />
-        </template>
-        <div v-if="addingMilestoneFor === node.id" class="mt-2 flex gap-2">
-          <input v-model="newMilestoneName" placeholder="Milestone name..."
-                 @keydown.enter="addMilestone(node.name)"
-                 class="flex-1 bg-transparent border-b border-white/30 outline-none text-xs" />
-          <button @click="addMilestone(node.name)" class="text-xs text-white/60 hover:text-white">Add</button>
-          <button @click="addingMilestoneFor = null; newMilestoneName = ''"
-                  class="text-xs text-white/40">cancel</button>
-        </div>
-        <button v-else @click="addingMilestoneFor = node.id"
-                class="mt-1 text-xs text-white/30 hover:text-white/60">+ milestone</button>
-
-        <!-- Children (expanded) -->
-        <template v-if="expandedGroups.has(node.id)">
-          <div v-for="child in store.childrenOf(node.id)" :key="child.id"
-               class="mt-2 ml-6 bg-white/5 border border-white/10 rounded-lg p-3">
-            <div class="flex justify-between items-center mb-1">
-              <template v-if="renaming === child.id">
-                <input v-model="renameValue" @keyup.enter="saveRename" @keyup.escape="renaming = null"
-                       class="flex-1 bg-transparent border-b border-white/40 text-sm outline-none" />
-              </template>
-              <h4 v-else class="font-medium text-sm truncate">
-                {{ child.name }}
-              </h4>
-              <div class="flex gap-2 shrink-0">
-                <button @click="startEdit(child.id)"
-                        class="text-xs text-white/50 hover:text-white">Edit</button>
-                <template v-if="renaming === child.id">
-                  <button @click="saveRename" class="text-xs text-green-400/70 hover:text-green-400">Save</button>
-                  <button @click="renaming = null" class="text-xs text-white/40 hover:text-white/70">Cancel</button>
-                </template>
-                <button v-else @click="startRename(child.id, child.name)"
-                        class="text-xs text-white/50 hover:text-white">Rename</button>
-                <button @click="deleteWithConfirm(child)"
-                        class="text-xs text-red-400/60 hover:text-red-400">Delete</button>
-              </div>
-            </div>
-            <div v-if="editing === child.id">
-              <textarea v-model="editBody" rows="3"
-                        class="w-full bg-transparent border border-white/20 rounded p-2 text-sm outline-none focus:border-white/50 resize-none" />
-              <div class="flex gap-2 mt-2">
-                <button @click="saveEdit" class="text-xs bg-white/10 hover:bg-white/20 px-3 py-1 rounded">Save</button>
-                <button @click="editing = null" class="text-xs text-white/40 hover:text-white/70">Cancel</button>
-              </div>
-            </div>
-            <p v-else class="text-xs text-white/50 line-clamp-2">{{ nodeBody(child.id) || '(empty)' }}</p>
-          </div>
-
-          <!-- Add sub-entry button -->
-          <button @click="prefillSubEntry(node.name)"
-                  class="mt-2 ml-6 text-xs text-white/40 hover:text-white/70">
-            + Add sub-entry
-          </button>
-        </template>
-      </div>
-    </template>
-
-    <div class="flex gap-2 mt-4">
-      <input v-model="newSubject" placeholder="New name (or Parent/Child)..."
-             class="flex-1 bg-white/5 border border-white/20 rounded px-3 py-2 text-sm outline-none focus:border-white/50" />
-      <button @click="addEntry" class="bg-white/10 hover:bg-white/20 px-4 py-2 rounded text-sm">Add</button>
+    <div class="flex flex-col gap-3">
+      <ContextTreeNode
+        v-for="node in contextStore.rootContextNodes"
+        :key="node.id"
+        :node="node"
+        :depth="0" />
     </div>
-  </div>
-  <router-view />
+
+    <!-- Add root entry form -->
+    <div class="mt-4 flex gap-2">
+      <input v-model="newName" placeholder="New context entry name..."
+             class="flex-1 bg-white/10 text-white rounded-lg px-3 py-2 outline-none"
+             @keyup.enter="addRootNode" />
+      <button @click="addRootNode" class="px-4 py-2 bg-blue-500/20 text-blue-300 rounded-lg text-sm">
+        + Add
+      </button>
+    </div>
+
+    <router-view />
   </div>
 </template>

--- a/frontend/src/components/ContextEditor.vue
+++ b/frontend/src/components/ContextEditor.vue
@@ -8,6 +8,33 @@ const contextStore = useContextStore()
 const milestoneStore = useMilestoneStore()
 const error = ref<string | null>(null)
 const newName = ref('')
+const rootDropOver = ref(false)
+
+function onRootDragOver(evt: DragEvent) {
+  evt.preventDefault()
+  evt.dataTransfer!.dropEffect = 'move'
+  rootDropOver.value = true
+}
+
+function onRootDragLeave() {
+  rootDropOver.value = false
+}
+
+async function onRootDrop(evt: DragEvent) {
+  evt.preventDefault()
+  evt.stopPropagation()
+  rootDropOver.value = false
+  const raw = evt.dataTransfer?.getData('text/plain')
+  if (!raw) return
+  try {
+    const { nodeId } = JSON.parse(raw)
+    if (!nodeId) return
+    await contextStore.moveNode(nodeId, null)
+  } catch (e) {
+    console.error('Root drop failed:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to move node to root'
+  }
+}
 
 async function addRootNode() {
   if (!newName.value.trim()) return
@@ -51,6 +78,15 @@ onMounted(async () => {
         :key="node.id"
         :node="node"
         :depth="0" />
+    </div>
+
+    <!-- Root-level drop zone for reparenting nodes to root -->
+    <div class="mt-3 border-2 border-dashed rounded-lg px-4 py-2 text-center text-xs transition-colors"
+         :class="rootDropOver ? 'border-blue-400/60 bg-blue-400/10 text-blue-300' : 'border-white/10 text-white/30'"
+         @dragover="onRootDragOver"
+         @dragleave="onRootDragLeave"
+         @drop="onRootDrop">
+      Drop here to make root-level
     </div>
 
     <!-- Add root entry form -->

--- a/frontend/src/components/ContextTreeNode.vue
+++ b/frontend/src/components/ContextTreeNode.vue
@@ -17,7 +17,8 @@ const milestoneStore = useMilestoneStore()
 
 // --- Local state (per-instance) ---
 const expanded = ref(false)
-const editing = ref(false)
+const activeTab = ref<string>('details')
+const editingSection = ref<string | null>(null)
 const editBody = ref('')
 const renaming = ref(false)
 const renameValue = ref('')
@@ -27,12 +28,27 @@ const newChildName = ref('')
 const expandedMilestones = ref<Set<string>>(new Set())
 const addingMilestone = ref(false)
 const newMilestoneName = ref('')
+const showAddSection = ref(false)
+const newSectionName = ref('')
+const localSectionTypes = ref<string[]>([])
 
 // --- Computed ---
 const children = computed(() => contextStore.childrenOf(props.node.id))
 const hasChildren = computed(() => children.value.length > 0 || (props.node.children_count ?? 0) > 0)
 const nodeBody = computed(() => contextStore.sectionCache[`${props.node.id}::details`]?.body ?? '')
 const milestones = computed(() => milestoneStore.bySubject[props.node.name] ?? [])
+
+const allSectionTypes = computed(() => {
+  const defaults = ['details', 'plans', 'notes']
+  const fromNode = props.node.section_types ?? []
+  const local = localSectionTypes.value
+  return [...new Set([...defaults, ...fromNode, ...local])]
+})
+
+const activeBody = computed(() => {
+  const key = `${props.node.id}::${activeTab.value}`
+  return contextStore.sectionCache[key]?.body ?? ''
+})
 
 const depthStyle = computed(() => ({
   paddingLeft: props.depth * 16 + 'px',
@@ -54,6 +70,8 @@ async function toggleExpand() {
     error.value = null
     const fetched = await contextStore.fetchChildren(props.node.id)
     await Promise.allSettled(fetched.map(c => contextStore.fetchSection(c.id, 'details')))
+    // Fetch the active tab's section for this node
+    await contextStore.fetchSection(props.node.id, activeTab.value)
   } catch (e) {
     expanded.value = false
     console.error('toggleExpand error:', e)
@@ -61,10 +79,24 @@ async function toggleExpand() {
   }
 }
 
+async function switchTab(sectionType: string) {
+  activeTab.value = sectionType
+  editingSection.value = null
+  const key = `${props.node.id}::${sectionType}`
+  if (!contextStore.sectionCache[key]) {
+    try {
+      await contextStore.fetchSection(props.node.id, sectionType)
+    } catch (e) {
+      console.error('switchTab fetch error:', e)
+      error.value = e instanceof Error ? e.message : 'Failed to load section'
+    }
+  }
+}
+
 async function startEdit() {
-  editing.value = true
+  editingSection.value = activeTab.value
   try {
-    const section = await contextStore.fetchSection(props.node.id, 'details')
+    const section = await contextStore.fetchSection(props.node.id, activeTab.value)
     editBody.value = section?.body ?? ''
   } catch (e) {
     console.error('startEdit error:', e)
@@ -73,13 +105,37 @@ async function startEdit() {
 }
 
 async function saveEdit() {
+  if (!editingSection.value) return
   try {
     error.value = null
-    await contextStore.saveSection(props.node.id, 'details', editBody.value)
-    editing.value = false
+    await contextStore.saveSection(props.node.id, editingSection.value, editBody.value)
+    editingSection.value = null
   } catch (e) {
     console.error('saveEdit error:', e)
     error.value = e instanceof Error ? e.message : 'Failed to save'
+  }
+}
+
+async function addSection() {
+  const name = newSectionName.value.trim().toLowerCase()
+  if (!name) return
+  if (allSectionTypes.value.includes(name)) {
+    // Section type already exists, just switch to it
+    showAddSection.value = false
+    newSectionName.value = ''
+    await switchTab(name)
+    return
+  }
+  try {
+    error.value = null
+    await contextStore.saveSection(props.node.id, name, '')
+    localSectionTypes.value.push(name)
+    showAddSection.value = false
+    newSectionName.value = ''
+    activeTab.value = name
+  } catch (e) {
+    console.error('addSection error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to add section'
   }
 }
 
@@ -183,8 +239,6 @@ async function addMilestone() {
         </div>
 
         <div class="flex gap-2 shrink-0">
-          <button @click="startEdit"
-                  class="text-xs text-white/50 hover:text-white">Edit</button>
           <template v-if="renaming">
             <button @click="saveRename" class="text-xs text-green-400/70 hover:text-green-400">Save</button>
             <button @click="renaming = false" class="text-xs text-white/40 hover:text-white/70">Cancel</button>
@@ -196,17 +250,51 @@ async function addMilestone() {
         </div>
       </div>
 
-      <!-- Edit mode -->
-      <div v-if="editing">
-        <textarea v-model="editBody" rows="4"
-                  class="w-full bg-transparent border border-white/20 rounded p-2 text-sm outline-none focus:border-white/50 resize-none" />
-        <div class="flex gap-2 mt-2">
-          <button @click="saveEdit" class="text-xs bg-white/10 hover:bg-white/20 px-3 py-1 rounded">Save</button>
-          <button @click="editing = false" class="text-xs text-white/40 hover:text-white/70">Cancel</button>
+      <!-- Collapsed: show details preview -->
+      <p v-if="!expanded" class="text-xs text-white/50 line-clamp-2">{{ nodeBody || '(empty)' }}</p>
+
+      <!-- Expanded: section tabs + content -->
+      <template v-if="expanded">
+        <!-- Tab bar -->
+        <div class="flex gap-1 mt-1 flex-wrap items-center">
+          <button v-for="st in allSectionTypes" :key="st"
+                  @click.stop="switchTab(st)"
+                  class="text-[10px] px-2 py-0.5 rounded-full"
+                  :class="activeTab === st ? 'bg-blue-500/30 text-blue-300' : 'bg-white/10 text-white/40 hover:bg-white/20'">
+            {{ st }}
+          </button>
+          <div v-if="showAddSection" class="flex items-center gap-1">
+            <input v-model="newSectionName" placeholder="section name..."
+                   @keydown.enter="addSection"
+                   @keydown.escape="showAddSection = false; newSectionName = ''"
+                   class="bg-transparent border-b border-white/30 outline-none text-[10px] w-24" />
+            <button @click="addSection" class="text-[10px] text-white/60 hover:text-white">add</button>
+            <button @click="showAddSection = false; newSectionName = ''"
+                    class="text-[10px] text-white/40">cancel</button>
+          </div>
+          <button v-else @click.stop="showAddSection = true"
+                  class="text-[10px] px-2 py-0.5 rounded-full bg-white/5 text-white/30 hover:text-white/50">
+            +
+          </button>
         </div>
-      </div>
-      <!-- Body display -->
-      <p v-else class="text-xs text-white/50 line-clamp-2">{{ nodeBody || '(empty)' }}</p>
+
+        <!-- Active tab content -->
+        <div class="mt-2">
+          <div v-if="editingSection === activeTab">
+            <textarea v-model="editBody" rows="4"
+                      class="w-full bg-transparent border border-white/20 rounded p-2 text-sm outline-none focus:border-white/50 resize-none" />
+            <div class="flex gap-2 mt-2">
+              <button @click="saveEdit" class="text-xs bg-white/10 hover:bg-white/20 px-3 py-1 rounded">Save</button>
+              <button @click="editingSection = null" class="text-xs text-white/40 hover:text-white/70">Cancel</button>
+            </div>
+          </div>
+          <div v-else>
+            <p class="text-xs text-white/50 whitespace-pre-wrap">{{ activeBody || '(empty)' }}</p>
+            <button @click="startEdit"
+                    class="mt-1 text-xs text-white/40 hover:text-white/70">Edit {{ activeTab }}</button>
+          </div>
+        </div>
+      </template>
 
       <!-- Milestone chips -->
       <div v-if="milestones.length" class="mt-2 flex flex-wrap gap-1">

--- a/frontend/src/components/ContextTreeNode.vue
+++ b/frontend/src/components/ContextTreeNode.vue
@@ -1,0 +1,271 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useContextStore } from '../stores/context'
+import type { ContextNode } from '../stores/context'
+import { useMilestoneStore } from '../stores/milestones'
+import MilestoneDetail from './MilestoneDetail.vue'
+
+const props = withDefaults(defineProps<{
+  node: ContextNode
+  depth?: number
+}>(), {
+  depth: 0,
+})
+
+const contextStore = useContextStore()
+const milestoneStore = useMilestoneStore()
+
+// --- Local state (per-instance) ---
+const expanded = ref(false)
+const editing = ref(false)
+const editBody = ref('')
+const renaming = ref(false)
+const renameValue = ref('')
+const error = ref<string | null>(null)
+const addingChild = ref(false)
+const newChildName = ref('')
+const expandedMilestones = ref<Set<string>>(new Set())
+const addingMilestone = ref(false)
+const newMilestoneName = ref('')
+
+// --- Computed ---
+const children = computed(() => contextStore.childrenOf(props.node.id))
+const hasChildren = computed(() => children.value.length > 0 || (props.node.children_count ?? 0) > 0)
+const nodeBody = computed(() => contextStore.sectionCache[`${props.node.id}::details`]?.body ?? '')
+const milestones = computed(() => milestoneStore.bySubject[props.node.name] ?? [])
+
+const depthStyle = computed(() => ({
+  paddingLeft: props.depth * 16 + 'px',
+}))
+
+const cardStyle = computed(() => ({
+  backgroundColor: 'rgba(255,255,255,' + (0.03 + props.depth * 0.01) + ')',
+}))
+
+// --- Actions ---
+
+async function toggleExpand() {
+  if (expanded.value) {
+    expanded.value = false
+    return
+  }
+  expanded.value = true
+  try {
+    error.value = null
+    const fetched = await contextStore.fetchChildren(props.node.id)
+    await Promise.allSettled(fetched.map(c => contextStore.fetchSection(c.id, 'details')))
+  } catch (e) {
+    expanded.value = false
+    console.error('toggleExpand error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to expand node'
+  }
+}
+
+async function startEdit() {
+  editing.value = true
+  try {
+    const section = await contextStore.fetchSection(props.node.id, 'details')
+    editBody.value = section?.body ?? ''
+  } catch (e) {
+    console.error('startEdit error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to load section'
+  }
+}
+
+async function saveEdit() {
+  try {
+    error.value = null
+    await contextStore.saveSection(props.node.id, 'details', editBody.value)
+    editing.value = false
+  } catch (e) {
+    console.error('saveEdit error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to save'
+  }
+}
+
+function startRename() {
+  renaming.value = true
+  renameValue.value = props.node.name
+}
+
+async function saveRename() {
+  if (!renameValue.value.trim() || renameValue.value.trim() === props.node.name) {
+    renaming.value = false
+    return
+  }
+  try {
+    error.value = null
+    await contextStore.patchNode(props.node.id, { name: renameValue.value.trim() })
+    renaming.value = false
+  } catch (e) {
+    console.error('saveRename error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to rename'
+  }
+}
+
+async function deleteWithConfirm() {
+  const childCount = children.value.length
+  const msg = childCount > 0
+    ? `Delete "${props.node.name}" and ${childCount} sub-entr${childCount === 1 ? 'y' : 'ies'}?`
+    : `Delete "${props.node.name}"?`
+  if (!confirm(msg)) return
+  try {
+    error.value = null
+    await contextStore.deleteNode(props.node.id)
+  } catch (e) {
+    console.error('deleteWithConfirm error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to delete'
+  }
+}
+
+async function addChild() {
+  if (!newChildName.value.trim()) return
+  try {
+    error.value = null
+    await contextStore.createNode(props.node.id, newChildName.value.trim())
+    await contextStore.fetchChildren(props.node.id)
+    newChildName.value = ''
+    addingChild.value = false
+    if (!expanded.value) expanded.value = true
+  } catch (e) {
+    console.error('addChild error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to add child'
+  }
+}
+
+function toggleMilestone(id: string) {
+  const next = new Set(expandedMilestones.value)
+  if (next.has(id)) next.delete(id); else next.add(id)
+  expandedMilestones.value = next
+}
+
+async function addMilestone() {
+  if (!newMilestoneName.value.trim()) return
+  try {
+    error.value = null
+    await milestoneStore.createMilestone(props.node.name, newMilestoneName.value.trim())
+    newMilestoneName.value = ''
+    addingMilestone.value = false
+  } catch (e) {
+    console.error('addMilestone error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to add milestone'
+  }
+}
+</script>
+
+<template>
+  <div :style="depthStyle">
+    <div class="border border-white/10 rounded-xl p-4" :style="cardStyle">
+      <!-- Error -->
+      <p v-if="error" class="text-red-400 text-sm mb-2">{{ error }}</p>
+
+      <!-- Header row -->
+      <div class="flex justify-between items-center mb-2">
+        <div class="flex items-center gap-2 flex-1 min-w-0">
+          <button v-if="hasChildren"
+                  @click="toggleExpand"
+                  class="text-white/40 hover:text-white/80 text-xs w-4 shrink-0">
+            {{ expanded ? '\u25BC' : '\u25B6' }}
+          </button>
+          <span v-else class="w-4 shrink-0" />
+
+          <template v-if="renaming">
+            <input v-model="renameValue"
+                   @keyup.enter="saveRename"
+                   @keyup.escape="renaming = false"
+                   class="flex-1 bg-transparent border-b border-white/40 text-sm outline-none" />
+            <span v-if="children.length > 0"
+                  class="text-xs text-yellow-400/70 ml-1">
+              (renames node, {{ children.length }} children unaffected)
+            </span>
+          </template>
+          <h3 v-else class="font-semibold text-sm truncate">{{ node.name }}</h3>
+        </div>
+
+        <div class="flex gap-2 shrink-0">
+          <button @click="startEdit"
+                  class="text-xs text-white/50 hover:text-white">Edit</button>
+          <template v-if="renaming">
+            <button @click="saveRename" class="text-xs text-green-400/70 hover:text-green-400">Save</button>
+            <button @click="renaming = false" class="text-xs text-white/40 hover:text-white/70">Cancel</button>
+          </template>
+          <button v-else @click="startRename"
+                  class="text-xs text-white/50 hover:text-white">Rename</button>
+          <button @click="deleteWithConfirm"
+                  class="text-xs text-red-400/60 hover:text-red-400">Delete</button>
+        </div>
+      </div>
+
+      <!-- Edit mode -->
+      <div v-if="editing">
+        <textarea v-model="editBody" rows="4"
+                  class="w-full bg-transparent border border-white/20 rounded p-2 text-sm outline-none focus:border-white/50 resize-none" />
+        <div class="flex gap-2 mt-2">
+          <button @click="saveEdit" class="text-xs bg-white/10 hover:bg-white/20 px-3 py-1 rounded">Save</button>
+          <button @click="editing = false" class="text-xs text-white/40 hover:text-white/70">Cancel</button>
+        </div>
+      </div>
+      <!-- Body display -->
+      <p v-else class="text-xs text-white/50 line-clamp-2">{{ nodeBody || '(empty)' }}</p>
+
+      <!-- Milestone chips -->
+      <div v-if="milestones.length" class="mt-2 flex flex-wrap gap-1">
+        <button
+          v-for="m in milestones" :key="m.id"
+          @click="toggleMilestone(m.id)"
+          :style="m.color ? { backgroundColor: m.color + '33', color: m.color, borderColor: m.color + '66' } : {}"
+          class="text-xs px-1.5 py-0.5 rounded border flex items-center gap-1"
+          :class="m.color ? 'hover:opacity-80' : 'bg-white/10 hover:bg-white/20 border-transparent'">
+          <span :class="m.status === 'done' ? 'bg-green-400'
+                      : m.status === 'in_progress' ? 'bg-blue-400'
+                      : m.status === 'blocked' ? 'bg-red-400' : 'bg-white/20'"
+                class="w-1.5 h-1.5 rounded-full" />
+          {{ m.name }} {{ m.done_count }}/{{ m.task_count }}
+        </button>
+      </div>
+      <template v-for="m in milestones" :key="'detail-' + m.id">
+        <MilestoneDetail
+          v-if="expandedMilestones.has(m.id)"
+          :milestone="m"
+          @close="toggleMilestone(m.id)" />
+      </template>
+      <div v-if="addingMilestone" class="mt-2 flex gap-2">
+        <input v-model="newMilestoneName" placeholder="Milestone name..."
+               @keydown.enter="addMilestone"
+               class="flex-1 bg-transparent border-b border-white/30 outline-none text-xs" />
+        <button @click="addMilestone" class="text-xs text-white/60 hover:text-white">Add</button>
+        <button @click="addingMilestone = false; newMilestoneName = ''"
+                class="text-xs text-white/40">cancel</button>
+      </div>
+      <button v-else @click="addingMilestone = true"
+              class="mt-1 text-xs text-white/30 hover:text-white/60">+ milestone</button>
+
+      <!-- Children (expanded) -->
+      <template v-if="expanded">
+        <div class="mt-3 flex flex-col gap-3">
+          <ContextTreeNode
+            v-for="child in children"
+            :key="child.id"
+            :node="child"
+            :depth="depth + 1" />
+        </div>
+
+        <!-- Add child button / form -->
+        <div v-if="addingChild" class="mt-2 flex gap-2" :style="{ paddingLeft: (depth + 1) * 16 + 'px' }">
+          <input v-model="newChildName" placeholder="New child name..."
+                 @keyup.enter="addChild"
+                 @keyup.escape="addingChild = false"
+                 class="flex-1 bg-transparent border-b border-white/30 outline-none text-xs" />
+          <button @click="addChild" class="text-xs text-white/60 hover:text-white">Add</button>
+          <button @click="addingChild = false; newChildName = ''"
+                  class="text-xs text-white/40">cancel</button>
+        </div>
+        <button v-else @click="addingChild = true"
+                class="mt-2 text-xs text-white/40 hover:text-white/70"
+                :style="{ paddingLeft: (depth + 1) * 16 + 'px' }">
+          + Add child
+        </button>
+      </template>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/ContextTreeNode.vue
+++ b/frontend/src/components/ContextTreeNode.vue
@@ -4,6 +4,7 @@ import { useContextStore } from '../stores/context'
 import type { ContextNode } from '../stores/context'
 import { useMilestoneStore } from '../stores/milestones'
 import MilestoneDetail from './MilestoneDetail.vue'
+import ContextTreeNode from './ContextTreeNode.vue'
 
 const props = withDefaults(defineProps<{
   node: ContextNode
@@ -34,9 +35,16 @@ const localSectionTypes = ref<string[]>([])
 
 // --- Computed ---
 const children = computed(() => contextStore.childrenOf(props.node.id))
-const hasChildren = computed(() => children.value.length > 0 || (props.node.children_count ?? 0) > 0)
+const hasChildren = computed(() =>
+  children.value.length > 0 || props.node.children_count == null || props.node.children_count > 0
+)
 const nodeBody = computed(() => contextStore.sectionCache[`${props.node.id}::details`]?.body ?? '')
 const milestones = computed(() => milestoneStore.bySubject[props.node.name] ?? [])
+
+const STATUS_COLORS: Record<string, string> = {
+  pending: 'bg-white/20', in_progress: 'bg-blue-400',
+  done: 'bg-green-400', blocked: 'bg-red-400',
+}
 
 const allSectionTypes = computed(() => {
   const defaults = ['details', 'plans', 'notes']
@@ -99,6 +107,7 @@ async function startEdit() {
     const section = await contextStore.fetchSection(props.node.id, activeTab.value)
     editBody.value = section?.body ?? ''
   } catch (e) {
+    editingSection.value = null
     console.error('startEdit error:', e)
     error.value = e instanceof Error ? e.message : 'Failed to load section'
   }
@@ -179,7 +188,6 @@ async function addChild() {
   try {
     error.value = null
     await contextStore.createNode(props.node.id, newChildName.value.trim())
-    await contextStore.fetchChildren(props.node.id)
     newChildName.value = ''
     addingChild.value = false
     if (!expanded.value) expanded.value = true
@@ -304,9 +312,7 @@ async function addMilestone() {
           :style="m.color ? { backgroundColor: m.color + '33', color: m.color, borderColor: m.color + '66' } : {}"
           class="text-xs px-1.5 py-0.5 rounded border flex items-center gap-1"
           :class="m.color ? 'hover:opacity-80' : 'bg-white/10 hover:bg-white/20 border-transparent'">
-          <span :class="m.status === 'done' ? 'bg-green-400'
-                      : m.status === 'in_progress' ? 'bg-blue-400'
-                      : m.status === 'blocked' ? 'bg-red-400' : 'bg-white/20'"
+          <span :class="STATUS_COLORS[m.status] ?? 'bg-white/20'"
                 class="w-1.5 h-1.5 rounded-full" />
           {{ m.name }} {{ m.done_count }}/{{ m.task_count }}
         </button>

--- a/frontend/src/components/ContextTreeNode.vue
+++ b/frontend/src/components/ContextTreeNode.vue
@@ -32,6 +32,10 @@ const newMilestoneName = ref('')
 const showAddSection = ref(false)
 const newSectionName = ref('')
 const localSectionTypes = ref<string[]>([])
+const dragOver = ref(false)
+const newChildType = ref<'context' | 'milestone'>('context')
+const newChildTargetDate = ref('')
+const newChildColor = ref('#3b82f6')
 
 // --- Computed ---
 const children = computed(() => contextStore.childrenOf(props.node.id))
@@ -65,6 +69,39 @@ const depthStyle = computed(() => ({
 const cardStyle = computed(() => ({
   backgroundColor: 'rgba(255,255,255,' + (0.03 + props.depth * 0.01) + ')',
 }))
+
+// --- Drag & Drop ---
+
+function onDragStart(evt: DragEvent) {
+  evt.dataTransfer!.effectAllowed = 'move'
+  evt.dataTransfer!.setData('text/plain', JSON.stringify({ nodeId: props.node.id }))
+}
+
+function onDragOver(evt: DragEvent) {
+  evt.preventDefault()
+  evt.dataTransfer!.dropEffect = 'move'
+  dragOver.value = true
+}
+
+function onDragLeave() {
+  dragOver.value = false
+}
+
+async function onDrop(evt: DragEvent) {
+  evt.preventDefault()
+  evt.stopPropagation()
+  dragOver.value = false
+  const raw = evt.dataTransfer?.getData('text/plain')
+  if (!raw) return
+  try {
+    const { nodeId } = JSON.parse(raw)
+    if (!nodeId || nodeId === props.node.id) return
+    await contextStore.moveNode(nodeId, props.node.id)
+  } catch (e) {
+    console.error('Drop failed:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to move node'
+  }
+}
 
 // --- Actions ---
 
@@ -187,8 +224,16 @@ async function addChild() {
   if (!newChildName.value.trim()) return
   try {
     error.value = null
-    await contextStore.createNode(props.node.id, newChildName.value.trim())
+    const opts: { target_date?: string; color?: string } = {}
+    if (newChildType.value === 'milestone') {
+      if (newChildTargetDate.value) opts.target_date = newChildTargetDate.value
+      if (newChildColor.value) opts.color = newChildColor.value
+    }
+    await contextStore.createNode(props.node.id, newChildName.value.trim(), newChildType.value, opts)
     newChildName.value = ''
+    newChildType.value = 'context'
+    newChildTargetDate.value = ''
+    newChildColor.value = '#3b82f6'
     addingChild.value = false
     if (!expanded.value) expanded.value = true
   } catch (e) {
@@ -219,7 +264,14 @@ async function addMilestone() {
 
 <template>
   <div :style="depthStyle">
-    <div class="border border-white/10 rounded-xl p-4" :style="cardStyle">
+    <div class="border border-white/10 rounded-xl p-4 transition-shadow"
+         :class="dragOver ? 'ring-2 ring-blue-400/50' : ''"
+         :style="cardStyle"
+         :draggable="true"
+         @dragstart.stop="onDragStart"
+         @dragover="onDragOver"
+         @dragleave="onDragLeave"
+         @drop="onDrop">
       <!-- Error -->
       <p v-if="error" class="text-red-400 text-sm mb-2">{{ error }}</p>
 
@@ -345,13 +397,21 @@ async function addMilestone() {
         </div>
 
         <!-- Add child button / form -->
-        <div v-if="addingChild" class="mt-2 flex gap-2" :style="{ paddingLeft: (depth + 1) * 16 + 'px' }">
+        <div v-if="addingChild" class="mt-2 flex flex-wrap gap-2 items-center" :style="{ paddingLeft: (depth + 1) * 16 + 'px' }">
           <input v-model="newChildName" placeholder="New child name..."
                  @keyup.enter="addChild"
-                 @keyup.escape="addingChild = false"
-                 class="flex-1 bg-transparent border-b border-white/30 outline-none text-xs" />
+                 @keyup.escape="addingChild = false; newChildType = 'context'; newChildTargetDate = ''; newChildColor = '#3b82f6'"
+                 class="flex-1 bg-transparent border-b border-white/30 outline-none text-xs min-w-[120px]" />
+          <select v-model="newChildType" class="bg-white/10 text-white text-xs rounded px-1 py-0.5">
+            <option value="context">Context</option>
+            <option value="milestone">Milestone</option>
+          </select>
+          <template v-if="newChildType === 'milestone'">
+            <input v-model="newChildTargetDate" type="date" class="bg-white/10 text-white text-xs rounded px-2 py-0.5" />
+            <input v-model="newChildColor" type="color" class="w-6 h-6 rounded cursor-pointer" />
+          </template>
           <button @click="addChild" class="text-xs text-white/60 hover:text-white">Add</button>
-          <button @click="addingChild = false; newChildName = ''"
+          <button @click="addingChild = false; newChildName = ''; newChildType = 'context'; newChildTargetDate = ''; newChildColor = '#3b82f6'"
                   class="text-xs text-white/40">cancel</button>
         </div>
         <button v-else @click="addingChild = true"

--- a/frontend/src/components/MilestoneDetail.vue
+++ b/frontend/src/components/MilestoneDetail.vue
@@ -8,6 +8,7 @@ const emit = defineEmits<{ (e: 'close'): void }>()
 const store = useMilestoneStore()
 
 const editing = ref(false)
+const error = ref<string | null>(null)
 const editName = ref(props.milestone.name)
 const editDesc = ref(props.milestone.description ?? '')
 const editDate = ref(props.milestone.target_date ?? '')
@@ -18,24 +19,36 @@ const STATUS_COLORS: Record<string, string> = {
 }
 
 async function save() {
-  await store.patchMilestone(props.milestone.id, {
-    name: editName.value,
-    description: editDesc.value || null,
-    target_date: editDate.value || null,
-  })
-  editing.value = false
+  try {
+    error.value = null
+    await store.patchMilestone(props.milestone.id, {
+      name: editName.value,
+      description: editDesc.value || null,
+      target_date: editDate.value || null,
+    })
+    editing.value = false
+  } catch (e) {
+    console.error('save error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to save milestone'
+  }
 }
 
 async function remove() {
-  if (confirm(`Delete milestone "${props.milestone.name}"?`)) {
+  if (!confirm(`Delete milestone "${props.milestone.name}"?`)) return
+  try {
+    error.value = null
     await store.deleteMilestone(props.milestone.id)
     emit('close')
+  } catch (e) {
+    console.error('remove error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to delete milestone'
   }
 }
 </script>
 
 <template>
   <div class="bg-white/5 border border-white/10 rounded-xl p-4 space-y-3 mt-2">
+    <p v-if="error" class="text-red-400 text-sm">{{ error }}</p>
     <div class="flex items-center gap-2">
       <span :class="STATUS_COLORS[milestone.status]" class="w-2.5 h-2.5 rounded-full flex-shrink-0" />
       <span v-if="!editing" class="font-semibold text-sm flex-1">{{ milestone.name }}</span>

--- a/frontend/src/stores/context.ts
+++ b/frontend/src/stores/context.ts
@@ -158,6 +158,22 @@ export const useContextStore = defineStore('context', () => {
     }
   }
 
+  async function moveNode(nodeId: string, newParentId: string | null): Promise<void> {
+    const resp = await api(`/api/nodes/${nodeId}/move`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ new_parent_id: newParentId }),
+    })
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`moveNode: ${resp.status} ${detail}`)
+    }
+    // Update cache: change the node's parent_id
+    if (nodes.value[nodeId]) {
+      nodes.value[nodeId].parent_id = newParentId
+    }
+  }
+
   async function fetchSections(nodeId: string): Promise<NodeSection[]> {
     const resp = await api(`/api/nodes/${nodeId}/sections`)
     if (!resp.ok) {
@@ -218,6 +234,7 @@ export const useContextStore = defineStore('context', () => {
     createNode,
     patchNode,
     deleteNode,
+    moveNode,
 
     // Sections
     fetchSections,


### PR DESCRIPTION
## Summary
Replaces the 2-level hardcoded ContextEditor with a recursive tree UI.

- **ContextTreeNode.vue** — recursive component rendering unlimited depth nesting
  - Expand/collapse with lazy-loading of children and sections
  - Depth-based indentation and visual nesting
  - Inline rename, edit, delete at any level
  - "+ Add child" with type selector (context or milestone, with date/color for milestones)
- **Section tabs** — details, plans, notes, custom sections per node
  - Tab bar with pill buttons, lazy section loading
  - Edit mode per section tab with Save/Cancel
  - "+ section" to create custom section types
- **Drag-drop reorganization** — native HTML5 DnD to reparent nodes
  - Drag any node, drop on another to make it a child
  - Root drop zone to move nodes to top level
  - Blue ring highlight on valid targets
  - Cycle prevention via API (returns 400)
- **ContextEditor.vue** simplified from 308 lines to 70 lines
- **MilestoneDetail.vue** — added error handling to save/remove

## Test plan
- [ ] Root nodes render, expanding shows children at any depth
- [ ] Section tabs switch between details/plans/notes, editing saves correctly
- [ ] Custom section creation works
- [ ] Dragging a node onto another reparents it
- [ ] Dragging to root drop zone moves node to root level
- [ ] "+ Add child" creates context or milestone children
- [ ] Delete cascades children visually
- [ ] Error messages show on failures