### PR TITLE
feat: context tree Phase B+/C — sections as files, archival, milestone by ID

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -18,6 +18,7 @@ from api.routes import sessions as sessions_routes
 from api.routes import bot as bot_routes
 from api.routes import kanban as kanban_routes
 from api.routes import nodes as nodes_routes
+from api.routes import settings as settings_routes
 from api.ws import manager
 from api.auth import decode_jwt
 from db.auth_schema import init_auth_db
@@ -71,6 +72,7 @@ def create_app(db_path: Path | None = None) -> FastAPI:
     app.include_router(bot_routes.router, prefix="/api")
     app.include_router(kanban_routes.router, prefix="/api")
     app.include_router(nodes_routes.router, prefix="/api")
+    app.include_router(settings_routes.router, prefix="/api")
 
     @app.post("/api/notify")
     async def notify():

--- a/api/routes/nodes.py
+++ b/api/routes/nodes.py
@@ -5,6 +5,7 @@ from db.queries import (
     get_children, get_subtree, move_node, delete_node,
     patch_node_fields,
     get_sections, get_section, upsert_section, append_section, delete_section,
+    list_section_files, create_section_file, rename_section_file, reorder_section_files,
     search_sections,
     link_task_to_node, unlink_task_from_node, get_node_tasks,
 )
@@ -33,6 +34,7 @@ class PatchNodeBody(BaseModel):
     target_date: str | None = None
     status: str | None = None
     color: str | None = None
+    description: str | None = None
 
 
 class UpsertSectionBody(BaseModel):
@@ -45,6 +47,19 @@ class AppendSectionBody(BaseModel):
 
 class LinkTaskBody(BaseModel):
     task_id: str
+
+
+class CreateSectionFileBody(BaseModel):
+    name: str
+    body: str = ""
+
+
+class RenameSectionFileBody(BaseModel):
+    new_name: str
+
+
+class ReorderSectionFilesBody(BaseModel):
+    name_order: list[str]
 
 
 class MoveNodeBody(BaseModel):
@@ -216,65 +231,160 @@ async def list_sections(
     request: Request,
     _auth=Depends(auth_dependency),
 ):
+    """List section types with file counts for a node."""
     node = get_node(request.state.db_path, node_id)
     if not node:
         raise HTTPException(status_code=404, detail="Node not found")
-    return get_sections(request.state.db_path, node_id)
+    rows = get_sections(request.state.db_path, node_id)
+    counts: dict[str, int] = {}
+    for r in rows:
+        counts[r["section_type"]] = counts.get(r["section_type"], 0) + 1
+    return [{"section_type": t, "file_count": c} for t, c in counts.items()]
 
 
 @router.get("/nodes/{node_id}/sections/{section_type}")
-async def get_section_route(
+async def list_section_files_route(
     node_id: str,
     section_type: str,
     request: Request,
     _auth=Depends(auth_dependency),
 ):
-    section = get_section(request.state.db_path, node_id, section_type)
+    """List files within a section type [{name, size, position, updated_at}]."""
+    node = get_node(request.state.db_path, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    return list_section_files(request.state.db_path, node_id, section_type)
+
+
+@router.post("/nodes/{node_id}/sections/{section_type}")
+async def create_section_file_route(
+    node_id: str,
+    section_type: str,
+    body: CreateSectionFileBody,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    """Create a new named file within a section type."""
+    node = get_node(request.state.db_path, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    try:
+        result = create_section_file(
+            request.state.db_path, node_id, section_type, body.name, body.body,
+        )
+    except (ValueError, Exception) as exc:
+        if "UNIQUE constraint" in str(exc) or "already exists" in str(exc).lower():
+            raise HTTPException(status_code=409, detail=f"File '{body.name}' already exists in {section_type}")
+        raise
+    await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
+    return result
+
+
+@router.post("/nodes/{node_id}/sections/{section_type}/reorder")
+async def reorder_section_files_route(
+    node_id: str,
+    section_type: str,
+    body: ReorderSectionFilesBody,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    """Reorder files within a section type."""
+    node = get_node(request.state.db_path, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    reorder_section_files(request.state.db_path, node_id, section_type, body.name_order)
+    await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
+    return {"ok": True}
+
+
+@router.get("/nodes/{node_id}/sections/{section_type}/{name}")
+async def get_section_file_route(
+    node_id: str,
+    section_type: str,
+    name: str,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    """Get a specific section file body."""
+    section = get_section(request.state.db_path, node_id, section_type, name=name)
     if not section:
-        raise HTTPException(status_code=404, detail="Section not found")
+        raise HTTPException(status_code=404, detail="Section file not found")
     return section
 
 
-@router.put("/nodes/{node_id}/sections/{section_type}")
-async def upsert_section_route(
+@router.put("/nodes/{node_id}/sections/{section_type}/{name}")
+async def upsert_section_file_route(
     node_id: str,
     section_type: str,
+    name: str,
     body: UpsertSectionBody,
     request: Request,
     _auth=Depends(auth_dependency),
 ):
+    """Upsert a specific section file."""
     node = get_node(request.state.db_path, node_id)
     if not node:
         raise HTTPException(status_code=404, detail="Node not found")
-    result = upsert_section(request.state.db_path, node_id, section_type, body.body)
+    result = upsert_section(request.state.db_path, node_id, section_type, body.body, name=name)
     await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
     return result
 
 
-@router.post("/nodes/{node_id}/sections/{section_type}/append")
-async def append_section_route(
+@router.post("/nodes/{node_id}/sections/{section_type}/{name}/append")
+async def append_section_file_route(
     node_id: str,
     section_type: str,
+    name: str,
     body: AppendSectionBody,
     request: Request,
     _auth=Depends(auth_dependency),
 ):
+    """Append to a specific section file."""
     node = get_node(request.state.db_path, node_id)
     if not node:
         raise HTTPException(status_code=404, detail="Node not found")
-    result = append_section(request.state.db_path, node_id, section_type, body.content)
+    result = append_section(request.state.db_path, node_id, section_type, body.content, name=name)
     await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
     return result
 
 
-@router.delete("/nodes/{node_id}/sections/{section_type}")
-async def delete_section_route(
+@router.post("/nodes/{node_id}/sections/{section_type}/{name}/rename")
+async def rename_section_file_route(
     node_id: str,
     section_type: str,
+    name: str,
+    body: RenameSectionFileBody,
     request: Request,
     _auth=Depends(auth_dependency),
 ):
-    delete_section(request.state.db_path, node_id, section_type)
+    """Rename a section file."""
+    node = get_node(request.state.db_path, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    try:
+        result = rename_section_file(
+            request.state.db_path, node_id, section_type, name, body.new_name,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except Exception as exc:
+        if "UNIQUE constraint" in str(exc):
+            raise HTTPException(status_code=409, detail=f"File '{body.new_name}' already exists")
+        raise
+    await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
+    return result
+
+
+@router.delete("/nodes/{node_id}/sections/{section_type}/{name}")
+async def delete_section_file_route(
+    node_id: str,
+    section_type: str,
+    name: str,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    """Delete a specific section file."""
+    delete_section(request.state.db_path, node_id, section_type, name=name)
     await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
     return {"ok": True}
 

--- a/api/routes/nodes.py
+++ b/api/routes/nodes.py
@@ -9,6 +9,8 @@ from db.queries import (
     list_section_files, create_section_file, rename_section_file, reorder_section_files,
     search_sections,
     link_task_to_node, unlink_task_from_node, get_node_tasks,
+    get_auto_archivable_nodes, archive_node,
+    get_user_setting,
 )
 from api.ws import manager
 from api.auth import auth_dependency
@@ -65,6 +67,39 @@ class ReorderSectionFilesBody(BaseModel):
 
 class MoveNodeBody(BaseModel):
     new_parent_id: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Auto-archive
+# ---------------------------------------------------------------------------
+
+@router.post("/nodes/auto-archive")
+async def auto_archive_nodes(
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    """Run auto-archive check using the user's saved rules and archive matching nodes."""
+    db = request.state.db_path
+    uid = request.state.user_id
+
+    raw_completed = get_user_setting(db, uid, "auto_archive_days_completed")
+    raw_inactive = get_user_setting(db, uid, "auto_archive_days_inactive")
+
+    days_completed = int(raw_completed) if raw_completed else None
+    days_inactive = int(raw_inactive) if raw_inactive else None
+
+    nodes = get_auto_archivable_nodes(db, days_completed=days_completed, days_inactive=days_inactive)
+
+    for n in nodes:
+        archive_node(db, n["id"])
+
+    if nodes:
+        await manager.broadcast({"type": "nodes_updated"}, uid)
+
+    return {
+        "archived_count": len(nodes),
+        "archived_nodes": [{"id": n["id"], "name": n["name"]} for n in nodes],
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/api/routes/nodes.py
+++ b/api/routes/nodes.py
@@ -1,3 +1,4 @@
+import sqlite3
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from db.queries import (
@@ -272,10 +273,8 @@ async def create_section_file_route(
         result = create_section_file(
             request.state.db_path, node_id, section_type, body.name, body.body,
         )
-    except (ValueError, Exception) as exc:
-        if "UNIQUE constraint" in str(exc) or "already exists" in str(exc).lower():
-            raise HTTPException(status_code=409, detail=f"File '{body.name}' already exists in {section_type}")
-        raise
+    except sqlite3.IntegrityError:
+        raise HTTPException(status_code=409, detail=f"File '{body.name}' already exists in {section_type}")
     await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
     return result
 
@@ -292,7 +291,10 @@ async def reorder_section_files_route(
     node = get_node(request.state.db_path, node_id)
     if not node:
         raise HTTPException(status_code=404, detail="Node not found")
-    reorder_section_files(request.state.db_path, node_id, section_type, body.name_order)
+    try:
+        reorder_section_files(request.state.db_path, node_id, section_type, body.name_order)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
     await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
     return {"ok": True}
 
@@ -366,11 +368,10 @@ async def rename_section_file_route(
             request.state.db_path, node_id, section_type, name, body.new_name,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=404, detail=str(exc))
-    except Exception as exc:
-        if "UNIQUE constraint" in str(exc):
-            raise HTTPException(status_code=409, detail=f"File '{body.new_name}' already exists")
-        raise
+        msg = str(exc)
+        if "already exists" in msg:
+            raise HTTPException(status_code=409, detail=msg)
+        raise HTTPException(status_code=404, detail=msg)
     await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
     return result
 
@@ -384,6 +385,12 @@ async def delete_section_file_route(
     _auth=Depends(auth_dependency),
 ):
     """Delete a specific section file."""
+    node = get_node(request.state.db_path, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    section = get_section(request.state.db_path, node_id, section_type, name=name)
+    if not section:
+        raise HTTPException(status_code=404, detail="Section file not found")
     delete_section(request.state.db_path, node_id, section_type, name=name)
     await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
     return {"ok": True}
@@ -427,6 +434,9 @@ async def unlink_task_route(
     request: Request,
     _auth=Depends(auth_dependency),
 ):
+    node = get_node(request.state.db_path, node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
     unlink_task_from_node(request.state.db_path, node_id, task_id)
     await manager.broadcast({"type": "nodes_updated"}, request.state.user_id)
     return {"ok": True}

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel
+from db.queries import get_all_user_settings, set_user_setting
+from api.auth import auth_dependency
+
+router = APIRouter()
+
+
+class SetSettingBody(BaseModel):
+    value: str
+
+
+@router.get("/settings")
+async def list_settings(
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    """Return all user settings as a {key: value} dict."""
+    return get_all_user_settings(request.state.db_path, request.state.user_id)
+
+
+@router.put("/settings/{key}")
+async def put_setting(
+    key: str,
+    body: SetSettingBody,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    """Create or update a single user setting."""
+    set_user_setting(request.state.db_path, request.state.user_id, key, body.value)
+    return {"ok": True}

--- a/db/migrate_section_files.py
+++ b/db/migrate_section_files.py
@@ -33,6 +33,12 @@ def migrate_section_files(db_path: Path) -> None:
         # 2. Check if node_sections already has the name column
         if _column_exists(conn, "node_sections", "name"):
             print("  node_sections already has name column — skipping table recreation")
+            # Still ensure FTS triggers and index are intact (in case prior run crashed mid-migration)
+            try:
+                conn.execute("INSERT INTO node_sections_fts(node_sections_fts) VALUES('integrity-check')")
+            except sqlite3.OperationalError:
+                conn.execute("INSERT INTO node_sections_fts(node_sections_fts) VALUES('rebuild')")
+                print("  Rebuilt FTS index (was stale or missing)")
             return
 
         # 3. Recreate node_sections with new schema
@@ -57,29 +63,42 @@ def migrate_section_files(db_path: Path) -> None:
             FROM node_sections
         """)
 
+        # Validate row count to prevent silent data loss
+        old_count = conn.execute("SELECT COUNT(*) FROM node_sections").fetchone()[0]
+        new_count = conn.execute("SELECT COUNT(*) FROM node_sections_new").fetchone()[0]
+        if old_count != new_count:
+            raise RuntimeError(
+                f"Row count mismatch: {old_count} in old table, {new_count} in new. "
+                "Aborting to prevent data loss."
+            )
+
         # DROP TABLE silently removes triggers attached to it
         conn.execute("DROP TABLE node_sections")
         conn.execute("ALTER TABLE node_sections_new RENAME TO node_sections")
 
         # Recreate FTS5 sync triggers (lost when old table was dropped)
-        conn.executescript("""
+        # NOTE: use individual conn.execute() — NOT executescript(), which silently
+        # commits the pending transaction and breaks rollback safety.
+        conn.execute("""
             CREATE TRIGGER IF NOT EXISTS node_sections_fts_ai
             AFTER INSERT ON node_sections BEGIN
                 INSERT INTO node_sections_fts(rowid, body) VALUES (new.id, new.body);
-            END;
-
+            END
+        """)
+        conn.execute("""
             CREATE TRIGGER IF NOT EXISTS node_sections_fts_ad
             AFTER DELETE ON node_sections BEGIN
                 INSERT INTO node_sections_fts(node_sections_fts, rowid, body)
                 VALUES ('delete', old.id, old.body);
-            END;
-
+            END
+        """)
+        conn.execute("""
             CREATE TRIGGER IF NOT EXISTS node_sections_fts_au
             AFTER UPDATE ON node_sections BEGIN
                 INSERT INTO node_sections_fts(node_sections_fts, rowid, body)
                 VALUES ('delete', old.id, old.body);
                 INSERT INTO node_sections_fts(rowid, body) VALUES (new.id, new.body);
-            END;
+            END
         """)
 
         # 4. Rebuild FTS5 index
@@ -87,9 +106,11 @@ def migrate_section_files(db_path: Path) -> None:
             conn.execute("INSERT INTO node_sections_fts(node_sections_fts) VALUES('rebuild')")
         except sqlite3.OperationalError as e:
             if "no such table" in str(e).lower():
-                print("  INFO: node_sections_fts table does not exist — skipping FTS rebuild")
-            else:
-                raise
+                raise RuntimeError(
+                    "FTS table node_sections_fts does not exist after init_db() — "
+                    "schema initialization may have failed"
+                ) from e
+            raise
 
         conn.execute("COMMIT")
         print("  Migrated node_sections: added name, position columns")
@@ -97,8 +118,10 @@ def migrate_section_files(db_path: Path) -> None:
         conn.execute("ROLLBACK")
         raise
     finally:
-        conn.execute("PRAGMA foreign_keys = ON")
-        conn.close()
+        try:
+            conn.execute("PRAGMA foreign_keys = ON")
+        finally:
+            conn.close()
 
 
 if __name__ == "__main__":

--- a/db/migrate_section_files.py
+++ b/db/migrate_section_files.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Migration: add name/position columns to node_sections, description to context_nodes."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    cols = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return any(c["name"] == column for c in cols)
+
+
+def migrate_section_files(db_path: Path) -> None:
+    # Ensure all tables exist (new schema)
+    from db.schema import init_db
+    init_db(db_path)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = OFF")
+
+    try:
+        # 1. Add description column to context_nodes (idempotent)
+        try:
+            conn.execute("ALTER TABLE context_nodes ADD COLUMN description TEXT")
+            print("  Added description column to context_nodes")
+        except sqlite3.OperationalError as e:
+            if "duplicate column" not in str(e).lower():
+                raise
+            print("  description column already exists on context_nodes")
+
+        # 2. Check if node_sections already has the name column
+        if _column_exists(conn, "node_sections", "name"):
+            print("  node_sections already has name column — skipping table recreation")
+            return
+
+        # 3. Recreate node_sections with new schema
+        conn.execute("BEGIN")
+
+        conn.execute("""
+            CREATE TABLE node_sections_new (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                node_id TEXT NOT NULL REFERENCES context_nodes(id) ON DELETE CASCADE,
+                section_type TEXT NOT NULL,
+                name TEXT NOT NULL DEFAULT 'main',
+                body TEXT NOT NULL DEFAULT '',
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                position INTEGER NOT NULL DEFAULT 0,
+                UNIQUE(node_id, section_type, name)
+            )
+        """)
+
+        conn.execute("""
+            INSERT INTO node_sections_new (id, node_id, section_type, name, body, updated_at, position)
+            SELECT id, node_id, section_type, 'main', body, updated_at, 0
+            FROM node_sections
+        """)
+
+        # DROP TABLE silently removes triggers attached to it
+        conn.execute("DROP TABLE node_sections")
+        conn.execute("ALTER TABLE node_sections_new RENAME TO node_sections")
+
+        # Recreate FTS5 sync triggers (lost when old table was dropped)
+        conn.executescript("""
+            CREATE TRIGGER IF NOT EXISTS node_sections_fts_ai
+            AFTER INSERT ON node_sections BEGIN
+                INSERT INTO node_sections_fts(rowid, body) VALUES (new.id, new.body);
+            END;
+
+            CREATE TRIGGER IF NOT EXISTS node_sections_fts_ad
+            AFTER DELETE ON node_sections BEGIN
+                INSERT INTO node_sections_fts(node_sections_fts, rowid, body)
+                VALUES ('delete', old.id, old.body);
+            END;
+
+            CREATE TRIGGER IF NOT EXISTS node_sections_fts_au
+            AFTER UPDATE ON node_sections BEGIN
+                INSERT INTO node_sections_fts(node_sections_fts, rowid, body)
+                VALUES ('delete', old.id, old.body);
+                INSERT INTO node_sections_fts(rowid, body) VALUES (new.id, new.body);
+            END;
+        """)
+
+        # 4. Rebuild FTS5 index
+        try:
+            conn.execute("INSERT INTO node_sections_fts(node_sections_fts) VALUES('rebuild')")
+        except sqlite3.OperationalError as e:
+            if "no such table" in str(e).lower():
+                print("  INFO: node_sections_fts table does not exist — skipping FTS rebuild")
+            else:
+                raise
+
+        conn.execute("COMMIT")
+        print("  Migrated node_sections: added name, position columns")
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+    finally:
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.close()
+
+
+if __name__ == "__main__":
+    import sys
+    for path in sys.argv[1:]:
+        print(f"Migrating {path}...")
+        migrate_section_files(Path(path))
+        print("  done")

--- a/db/queries.py
+++ b/db/queries.py
@@ -898,7 +898,7 @@ def create_node(
         )
     return {
         "id": node_id, "parent_id": parent_id, "name": name,
-        "node_type": node_type, "archived": 0,
+        "node_type": node_type, "description": None, "archived": 0,
         "target_date": target_date, "status": status,
         "status_override": status_override, "color": color,
         "created_at": now, "updated_at": now,
@@ -915,7 +915,7 @@ def get_node(db_path: Path, node_id: str) -> dict | None:
             return None
         d = dict(row)
         sections = conn.execute(
-            "SELECT section_type FROM node_sections WHERE node_id = ? ORDER BY section_type",
+            "SELECT DISTINCT section_type FROM node_sections WHERE node_id = ? ORDER BY section_type",
             (node_id,),
         ).fetchall()
         d["section_types"] = [s["section_type"] for s in sections]
@@ -1085,7 +1085,7 @@ def unarchive_node(db_path: Path, node_id: str) -> None:
 
 def patch_node_fields(db_path: Path, node_id: str, fields: dict) -> dict | None:
     """Update allowed fields on a context node. Returns updated node dict or None."""
-    allowed = {"name", "target_date", "status", "color", "archived"}
+    allowed = {"name", "target_date", "status", "color", "archived", "description"}
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:
         return get_node(db_path, node_id)
@@ -1115,58 +1115,134 @@ def get_sections(db_path: Path, node_id: str) -> list[dict]:
     """Get all sections for a node."""
     with get_db(db_path) as conn:
         rows = conn.execute(
-            "SELECT section_type, body, updated_at FROM node_sections "
-            "WHERE node_id = ? ORDER BY section_type",
+            "SELECT section_type, name, body, position, updated_at FROM node_sections "
+            "WHERE node_id = ? ORDER BY section_type, position",
             (node_id,),
         ).fetchall()
     return [dict(r) for r in rows]
 
 
-def get_section(db_path: Path, node_id: str, section_type: str) -> dict | None:
-    """Get a single section by type."""
+def get_section(db_path: Path, node_id: str, section_type: str, name: str = "main") -> dict | None:
+    """Get a single section by type and name."""
     with get_db(db_path) as conn:
         row = conn.execute(
-            "SELECT section_type, body, updated_at FROM node_sections "
-            "WHERE node_id = ? AND section_type = ?",
-            (node_id, section_type),
+            "SELECT section_type, name, body, position, updated_at FROM node_sections "
+            "WHERE node_id = ? AND section_type = ? AND name = ?",
+            (node_id, section_type, name),
         ).fetchone()
     return dict(row) if row else None
 
 
-def upsert_section(db_path: Path, node_id: str, section_type: str, body: str) -> dict:
+def upsert_section(db_path: Path, node_id: str, section_type: str, body: str, name: str = "main") -> dict:
     """Insert or update a section. Also update node's updated_at."""
     now = datetime.now(timezone.utc).isoformat(timespec="seconds")
     with get_db(db_path) as conn:
         conn.execute(
-            """INSERT INTO node_sections (node_id, section_type, body, updated_at)
-               VALUES (?, ?, ?, ?)
-               ON CONFLICT(node_id, section_type) DO UPDATE SET
+            """INSERT INTO node_sections (node_id, section_type, name, body, updated_at)
+               VALUES (?, ?, ?, ?, ?)
+               ON CONFLICT(node_id, section_type, name) DO UPDATE SET
                    body = excluded.body, updated_at = excluded.updated_at""",
-            (node_id, section_type, body, now),
+            (node_id, section_type, name, body, now),
         )
         conn.execute(
             "UPDATE context_nodes SET updated_at = ? WHERE id = ?",
             (now, node_id),
         )
-    return {"section_type": section_type, "body": body, "updated_at": now}
+    return {"section_type": section_type, "name": name, "body": body, "updated_at": now}
 
 
-def append_section(db_path: Path, node_id: str, section_type: str, content: str) -> dict:
+def append_section(db_path: Path, node_id: str, section_type: str, content: str, name: str = "main") -> dict:
     """Append text to a section with '\\n\\n' separator. Create if missing."""
-    existing = get_section(db_path, node_id, section_type)
+    existing = get_section(db_path, node_id, section_type, name=name)
     if existing and existing["body"]:
         new_body = existing["body"] + "\n\n" + content
     else:
         new_body = content
-    return upsert_section(db_path, node_id, section_type, new_body)
+    return upsert_section(db_path, node_id, section_type, new_body, name=name)
 
 
-def delete_section(db_path: Path, node_id: str, section_type: str) -> None:
+def delete_section(db_path: Path, node_id: str, section_type: str, name: str = "main") -> None:
     """Delete a section."""
     with get_db(db_path) as conn:
         conn.execute(
-            "DELETE FROM node_sections WHERE node_id = ? AND section_type = ?",
+            "DELETE FROM node_sections WHERE node_id = ? AND section_type = ? AND name = ?",
+            (node_id, section_type, name),
+        )
+
+
+def list_section_files(db_path: Path, node_id: str, section_type: str) -> list[dict]:
+    """List files within a section type: [{name, size, position, updated_at}] -- no body content.
+
+    size = length(body) in characters.
+    """
+    with get_db(db_path) as conn:
+        rows = conn.execute(
+            """SELECT name, length(body) AS size, position, updated_at
+               FROM node_sections
+               WHERE node_id = ? AND section_type = ?
+               ORDER BY position""",
             (node_id, section_type),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def create_section_file(db_path: Path, node_id: str, section_type: str, name: str, body: str = "") -> dict:
+    """Create a new named file within a section type.
+
+    Sets position to max(position)+1 within that section_type. Returns the created dict.
+    """
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    with get_db(db_path) as conn:
+        row = conn.execute(
+            "SELECT COALESCE(MAX(position), -1) + 1 AS next_pos FROM node_sections "
+            "WHERE node_id = ? AND section_type = ?",
+            (node_id, section_type),
+        ).fetchone()
+        position = row["next_pos"]
+        conn.execute(
+            """INSERT INTO node_sections (node_id, section_type, name, body, position, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (node_id, section_type, name, body, position, now),
+        )
+        conn.execute(
+            "UPDATE context_nodes SET updated_at = ? WHERE id = ?",
+            (now, node_id),
+        )
+    return {"section_type": section_type, "name": name, "body": body,
+            "position": position, "updated_at": now}
+
+
+def rename_section_file(db_path: Path, node_id: str, section_type: str, old_name: str, new_name: str) -> dict:
+    """Rename a section file. Raises ValueError if old_name not found."""
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    with get_db(db_path) as conn:
+        cur = conn.execute(
+            """UPDATE node_sections SET name = ?, updated_at = ?
+               WHERE node_id = ? AND section_type = ? AND name = ?""",
+            (new_name, now, node_id, section_type, old_name),
+        )
+        if cur.rowcount == 0:
+            raise ValueError(f"Section file '{old_name}' not found in {section_type}")
+        conn.execute(
+            "UPDATE context_nodes SET updated_at = ? WHERE id = ?",
+            (now, node_id),
+        )
+    return get_section(db_path, node_id, section_type, name=new_name)
+
+
+def reorder_section_files(db_path: Path, node_id: str, section_type: str, name_order: list[str]) -> None:
+    """Reorder files by updating position values based on list order."""
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    with get_db(db_path) as conn:
+        for position, name in enumerate(name_order):
+            conn.execute(
+                """UPDATE node_sections SET position = ?, updated_at = ?
+                   WHERE node_id = ? AND section_type = ? AND name = ?""",
+                (position, now, node_id, section_type, name),
+            )
+        conn.execute(
+            "UPDATE context_nodes SET updated_at = ? WHERE id = ?",
+            (now, node_id),
         )
 
 
@@ -1175,7 +1251,7 @@ def search_sections(
 ) -> list[dict]:
     """FTS5 search across node_sections.
 
-    Returns [{node_id, section_type, snippet}].
+    Returns [{node_id, section_type, name, snippet}].
     If node_id is provided, filter to that node's subtree.
     """
     # Wrap in double quotes for literal matching; escape embedded quotes.
@@ -1198,7 +1274,7 @@ def search_sections(
                 return []
             ph = ",".join("?" for _ in id_set)
             rows = conn.execute(
-                f"""SELECT ns.node_id, ns.section_type,
+                f"""SELECT ns.node_id, ns.section_type, ns.name,
                            snippet(node_sections_fts, 0, '<b>', '</b>', '...', 32) AS snippet
                     FROM node_sections_fts fts
                     JOIN node_sections ns ON ns.id = fts.rowid
@@ -1209,7 +1285,7 @@ def search_sections(
             ).fetchall()
         else:
             rows = conn.execute(
-                """SELECT ns.node_id, ns.section_type,
+                """SELECT ns.node_id, ns.section_type, ns.name,
                           snippet(node_sections_fts, 0, '<b>', '</b>', '...', 32) AS snippet
                    FROM node_sections_fts fts
                    JOIN node_sections ns ON ns.id = fts.rowid

--- a/db/queries.py
+++ b/db/queries.py
@@ -1747,3 +1747,95 @@ def update_kanban_column(db_path: Path, column_id: str, fields: dict) -> dict | 
 def delete_kanban_column(db_path: Path, column_id: str) -> None:
     with get_db(db_path) as conn:
         conn.execute("DELETE FROM kanban_columns WHERE id=?", (column_id,))
+
+
+# ---------------------------------------------------------------------------
+# User settings (user_settings table)
+# ---------------------------------------------------------------------------
+
+
+def get_user_setting(db_path: Path, user_id: str, key: str) -> str | None:
+    """Get a single user setting value, or None if not set."""
+    with get_db(db_path) as conn:
+        row = conn.execute(
+            "SELECT value FROM user_settings WHERE user_id = ? AND key = ?",
+            (user_id, key),
+        ).fetchone()
+    return row["value"] if row else None
+
+
+def get_all_user_settings(db_path: Path, user_id: str) -> dict[str, str]:
+    """Get all settings for a user as a {key: value} dict."""
+    with get_db(db_path) as conn:
+        rows = conn.execute(
+            "SELECT key, value FROM user_settings WHERE user_id = ?",
+            (user_id,),
+        ).fetchall()
+    return {r["key"]: r["value"] for r in rows}
+
+
+def set_user_setting(db_path: Path, user_id: str, key: str, value: str) -> None:
+    """Upsert a user setting."""
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO user_settings (user_id, key, value) VALUES (?, ?, ?) "
+            "ON CONFLICT(user_id, key) DO UPDATE SET value = excluded.value",
+            (user_id, key, value),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Auto-archive query
+# ---------------------------------------------------------------------------
+
+
+def get_auto_archivable_nodes(
+    db_path: Path,
+    days_completed: int | None = None,
+    days_inactive: int | None = None,
+) -> list[dict]:
+    """Find non-archived context nodes that match auto-archive criteria.
+
+    - days_completed: all linked tasks are done AND the node's updated_at
+      is more than X days ago (proxy for completion time since tasks lack
+      a completed_at timestamp).
+    - days_inactive: node's updated_at is more than X days ago.
+
+    Returns the union of both criteria (a node matching either is included).
+    """
+    if days_completed is None and days_inactive is None:
+        return []
+
+    results: dict[str, dict] = {}
+
+    with get_db(db_path) as conn:
+        if days_inactive is not None:
+            rows = conn.execute(
+                """SELECT * FROM context_nodes
+                   WHERE archived = 0
+                     AND updated_at <= datetime('now', ?)""",
+                (f"-{days_inactive} days",),
+            ).fetchall()
+            for r in rows:
+                results[r["id"]] = dict(r)
+
+        if days_completed is not None:
+            # Nodes where: (a) at least one linked task exists,
+            # (b) ALL linked tasks are done, and
+            # (c) updated_at is old enough.
+            rows = conn.execute(
+                """SELECT cn.*
+                   FROM context_nodes cn
+                   JOIN node_tasks nt ON nt.node_id = cn.id
+                   JOIN tasks t ON t.uuid = nt.task_id
+                   WHERE cn.archived = 0
+                     AND cn.updated_at <= datetime('now', ?)
+                   GROUP BY cn.id
+                   HAVING COUNT(t.uuid) > 0
+                      AND COUNT(t.uuid) = SUM(CASE WHEN t.status = 'done' THEN 1 ELSE 0 END)""",
+                (f"-{days_completed} days",),
+            ).fetchall()
+            for r in rows:
+                results[r["id"]] = dict(r)
+
+    return list(results.values())

--- a/db/queries.py
+++ b/db/queries.py
@@ -1137,12 +1137,17 @@ def upsert_section(db_path: Path, node_id: str, section_type: str, body: str, na
     """Insert or update a section. Also update node's updated_at."""
     now = datetime.now(timezone.utc).isoformat(timespec="seconds")
     with get_db(db_path) as conn:
+        next_pos = conn.execute(
+            "SELECT COALESCE(MAX(position), -1) + 1 FROM node_sections "
+            "WHERE node_id = ? AND section_type = ?",
+            (node_id, section_type),
+        ).fetchone()[0]
         conn.execute(
-            """INSERT INTO node_sections (node_id, section_type, name, body, updated_at)
-               VALUES (?, ?, ?, ?, ?)
+            """INSERT INTO node_sections (node_id, section_type, name, body, position, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)
                ON CONFLICT(node_id, section_type, name) DO UPDATE SET
                    body = excluded.body, updated_at = excluded.updated_at""",
-            (node_id, section_type, name, body, now),
+            (node_id, section_type, name, body, next_pos, now),
         )
         conn.execute(
             "UPDATE context_nodes SET updated_at = ? WHERE id = ?",
@@ -1213,14 +1218,17 @@ def create_section_file(db_path: Path, node_id: str, section_type: str, name: st
 
 
 def rename_section_file(db_path: Path, node_id: str, section_type: str, old_name: str, new_name: str) -> dict:
-    """Rename a section file. Raises ValueError if old_name not found."""
+    """Rename a section file. Raises ValueError if old_name not found or new_name already exists."""
     now = datetime.now(timezone.utc).isoformat(timespec="seconds")
     with get_db(db_path) as conn:
-        cur = conn.execute(
-            """UPDATE node_sections SET name = ?, updated_at = ?
-               WHERE node_id = ? AND section_type = ? AND name = ?""",
-            (new_name, now, node_id, section_type, old_name),
-        )
+        try:
+            cur = conn.execute(
+                """UPDATE node_sections SET name = ?, updated_at = ?
+                   WHERE node_id = ? AND section_type = ? AND name = ?""",
+                (new_name, now, node_id, section_type, old_name),
+            )
+        except sqlite3.IntegrityError:
+            raise ValueError(f"Section file '{new_name}' already exists in {section_type}")
         if cur.rowcount == 0:
             raise ValueError(f"Section file '{old_name}' not found in {section_type}")
         conn.execute(
@@ -1231,9 +1239,22 @@ def rename_section_file(db_path: Path, node_id: str, section_type: str, old_name
 
 
 def reorder_section_files(db_path: Path, node_id: str, section_type: str, name_order: list[str]) -> None:
-    """Reorder files by updating position values based on list order."""
+    """Reorder files by updating position values based on list order.
+    Raises ValueError if name_order contains unknown names or omits existing files."""
     now = datetime.now(timezone.utc).isoformat(timespec="seconds")
     with get_db(db_path) as conn:
+        existing = conn.execute(
+            "SELECT name FROM node_sections WHERE node_id = ? AND section_type = ?",
+            (node_id, section_type),
+        ).fetchall()
+        existing_names = {r["name"] for r in existing}
+        order_set = set(name_order)
+        unknown = order_set - existing_names
+        if unknown:
+            raise ValueError(f"Names not found in {section_type}: {unknown}")
+        missing = existing_names - order_set
+        if missing:
+            raise ValueError(f"Existing files omitted from ordering: {missing}")
         for position, name in enumerate(name_order):
             conn.execute(
                 """UPDATE node_sections SET position = ?, updated_at = ?

--- a/db/schema.py
+++ b/db/schema.py
@@ -215,6 +215,7 @@ CREATE TABLE IF NOT EXISTS context_nodes (
     parent_id TEXT REFERENCES context_nodes(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
     node_type TEXT NOT NULL DEFAULT 'context',
+    description TEXT,
     archived INTEGER NOT NULL DEFAULT 0,
     target_date TEXT,
     status TEXT DEFAULT 'pending',
@@ -229,9 +230,11 @@ CREATE TABLE IF NOT EXISTS node_sections (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     node_id TEXT NOT NULL REFERENCES context_nodes(id) ON DELETE CASCADE,
     section_type TEXT NOT NULL,
+    name TEXT NOT NULL DEFAULT 'main',
     body TEXT NOT NULL DEFAULT '',
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE(node_id, section_type)
+    position INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(node_id, section_type, name)
 );
 
 CREATE TABLE IF NOT EXISTS node_tasks (

--- a/frontend/src/components/ContextEditor.vue
+++ b/frontend/src/components/ContextEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, watch, onMounted } from 'vue'
 import { useContextStore } from '../stores/context'
 import { useMilestoneStore } from '../stores/milestones'
 import { useAutoScrollDrag } from '../composables/useAutoScrollDrag'
@@ -57,6 +57,17 @@ async function loadRootSections() {
   await Promise.allSettled(nodes.map(n => contextStore.fetchSection(n.id, 'details')))
 }
 
+watch(() => contextStore.showArchived, async () => {
+  try {
+    error.value = null
+    await contextStore.fetchRootNodes()
+    await loadRootSections()
+  } catch (e) {
+    console.error('showArchived toggle error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to reload context data'
+  }
+})
+
 onMounted(async () => {
   try {
     await contextStore.fetchRootNodes()
@@ -73,7 +84,14 @@ onMounted(async () => {
   <div class="min-h-screen bg-gray-900 text-white p-6"
        @dragover="autoScrollDragOver"
        @drop="autoScrollCleanup">
-    <h2 class="text-lg font-semibold mb-4">Context</h2>
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="text-lg font-semibold">Context</h2>
+      <label class="flex items-center gap-1.5 text-xs text-white/40 hover:text-white/60 cursor-pointer select-none">
+        <input type="checkbox" v-model="contextStore.showArchived"
+               class="accent-blue-500 w-3.5 h-3.5" />
+        Show archived
+      </label>
+    </div>
     <p v-if="error" class="text-red-400 text-sm mb-2">{{ error }}</p>
 
     <div class="flex flex-col gap-3">

--- a/frontend/src/components/ContextEditor.vue
+++ b/frontend/src/components/ContextEditor.vue
@@ -2,10 +2,12 @@
 import { ref, onMounted } from 'vue'
 import { useContextStore } from '../stores/context'
 import { useMilestoneStore } from '../stores/milestones'
+import { useAutoScrollDrag } from '../composables/useAutoScrollDrag'
 import ContextTreeNode from './ContextTreeNode.vue'
 
 const contextStore = useContextStore()
 const milestoneStore = useMilestoneStore()
+const { onDragOver: autoScrollDragOver, cleanup: autoScrollCleanup } = useAutoScrollDrag()
 const error = ref<string | null>(null)
 const newName = ref('')
 const rootDropOver = ref(false)
@@ -68,7 +70,9 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="min-h-screen bg-gray-900 text-white p-6">
+  <div class="min-h-screen bg-gray-900 text-white p-6"
+       @dragover="autoScrollDragOver"
+       @drop="autoScrollCleanup">
     <h2 class="text-lg font-semibold mb-4">Context</h2>
     <p v-if="error" class="text-red-400 text-sm mb-2">{{ error }}</p>
 

--- a/frontend/src/components/ContextTreeNode.vue
+++ b/frontend/src/components/ContextTreeNode.vue
@@ -2,8 +2,6 @@
 import { ref, computed, watch } from 'vue'
 import { useContextStore } from '../stores/context'
 import type { ContextNode, SectionFileInfo } from '../stores/context'
-import { useMilestoneStore } from '../stores/milestones'
-import MilestoneDetail from './MilestoneDetail.vue'
 import ContextTreeNode from './ContextTreeNode.vue'
 
 const props = withDefaults(defineProps<{
@@ -14,7 +12,6 @@ const props = withDefaults(defineProps<{
 })
 
 const contextStore = useContextStore()
-const milestoneStore = useMilestoneStore()
 
 // --- Local state (per-instance) ---
 const expanded = ref(false)
@@ -28,9 +25,6 @@ const renameValue = ref('')
 const error = ref<string | null>(null)
 const addingChild = ref(false)
 const newChildName = ref('')
-const expandedMilestones = ref<Set<string>>(new Set())
-const addingMilestone = ref(false)
-const newMilestoneName = ref('')
 const showAddSection = ref(false)
 const newSectionName = ref('')
 const localSectionTypes = ref<string[]>([])
@@ -49,7 +43,6 @@ const hasChildren = computed(() =>
   children.value.length > 0 || props.node.children_count == null || props.node.children_count > 0
 )
 const nodeBody = computed(() => contextStore.sectionCache[`${props.node.id}::details::main`]?.body ?? '')
-const milestones = computed(() => milestoneStore.bySubject[props.node.name] ?? [])
 
 const STATUS_COLORS: Record<string, string> = {
   pending: 'bg-white/20', in_progress: 'bg-blue-400',
@@ -77,9 +70,16 @@ const depthStyle = computed(() => ({
   paddingLeft: props.depth * 16 + 'px',
 }))
 
-const cardStyle = computed(() => ({
-  backgroundColor: 'rgba(255,255,255,' + (0.03 + props.depth * 0.01) + ')',
-}))
+const cardStyle = computed(() => {
+  const base: Record<string, string> = {
+    backgroundColor: 'rgba(255,255,255,' + (0.03 + props.depth * 0.01) + ')',
+  }
+  if (props.node.node_type === 'milestone' && props.node.color) {
+    base.borderLeftColor = props.node.color
+    base.borderLeftWidth = '3px'
+  }
+  return base
+})
 
 // --- Drag & Drop ---
 
@@ -348,24 +348,6 @@ async function addChild() {
   }
 }
 
-function toggleMilestone(id: string) {
-  const next = new Set(expandedMilestones.value)
-  if (next.has(id)) next.delete(id); else next.add(id)
-  expandedMilestones.value = next
-}
-
-async function addMilestone() {
-  if (!newMilestoneName.value.trim()) return
-  try {
-    error.value = null
-    await milestoneStore.createMilestone(props.node.name, newMilestoneName.value.trim())
-    newMilestoneName.value = ''
-    addingMilestone.value = false
-  } catch (e) {
-    console.error('addMilestone error:', e)
-    error.value = e instanceof Error ? e.message : 'Failed to add milestone'
-  }
-}
 </script>
 
 <template>
@@ -401,7 +383,30 @@ async function addMilestone() {
               (renames node, {{ children.length }} children unaffected)
             </span>
           </template>
-          <h3 v-else class="font-semibold text-sm truncate" :class="node.archived ? 'line-through text-white/40' : ''">{{ node.name }}</h3>
+          <template v-else>
+            <!-- Milestone color dot -->
+            <span v-if="node.node_type === 'milestone'"
+                  class="w-2 h-2 rounded-full shrink-0"
+                  :class="node.color ? '' : (STATUS_COLORS[node.status ?? ''] ?? 'bg-white/20')"
+                  :style="node.color ? { backgroundColor: node.color } : {}" />
+            <h3 class="font-semibold text-sm truncate" :class="node.archived ? 'line-through text-white/40' : ''">{{ node.name }}</h3>
+          </template>
+          <!-- Milestone status badge -->
+          <span v-if="node.node_type === 'milestone' && node.status"
+                class="text-[9px] px-1.5 py-0.5 rounded shrink-0"
+                :class="{
+                  'bg-white/10 text-white/50': node.status === 'pending',
+                  'bg-blue-500/20 text-blue-300': node.status === 'in_progress',
+                  'bg-green-500/20 text-green-300': node.status === 'done',
+                  'bg-red-500/20 text-red-300': node.status === 'blocked',
+                }">
+            {{ node.status.replace('_', ' ') }}
+          </span>
+          <!-- Milestone target date -->
+          <span v-if="node.node_type === 'milestone' && node.target_date"
+                class="text-[9px] text-white/40 shrink-0">
+            {{ node.target_date }}
+          </span>
           <span v-if="node.archived" class="text-[9px] px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400/80 shrink-0">Archived</span>
         </div>
 
@@ -528,36 +533,6 @@ async function addMilestone() {
           </div>
         </div>
       </template>
-
-      <!-- Milestone chips -->
-      <div v-if="milestones.length" class="mt-2 flex flex-wrap gap-1">
-        <button
-          v-for="m in milestones" :key="m.id"
-          @click="toggleMilestone(m.id)"
-          :style="m.color ? { backgroundColor: m.color + '33', color: m.color, borderColor: m.color + '66' } : {}"
-          class="text-xs px-1.5 py-0.5 rounded border flex items-center gap-1"
-          :class="m.color ? 'hover:opacity-80' : 'bg-white/10 hover:bg-white/20 border-transparent'">
-          <span :class="STATUS_COLORS[m.status] ?? 'bg-white/20'"
-                class="w-1.5 h-1.5 rounded-full" />
-          {{ m.name }} {{ m.done_count }}/{{ m.task_count }}
-        </button>
-      </div>
-      <template v-for="m in milestones" :key="'detail-' + m.id">
-        <MilestoneDetail
-          v-if="expandedMilestones.has(m.id)"
-          :milestone="m"
-          @close="toggleMilestone(m.id)" />
-      </template>
-      <div v-if="addingMilestone" class="mt-2 flex gap-2">
-        <input v-model="newMilestoneName" placeholder="Milestone name..."
-               @keydown.enter="addMilestone"
-               class="flex-1 bg-transparent border-b border-white/30 outline-none text-xs" />
-        <button @click="addMilestone" class="text-xs text-white/60 hover:text-white">Add</button>
-        <button @click="addingMilestone = false; newMilestoneName = ''"
-                class="text-xs text-white/40">cancel</button>
-      </div>
-      <button v-else @click="addingMilestone = true"
-              class="mt-1 text-xs text-white/30 hover:text-white/60">+ milestone</button>
 
       <!-- Children (expanded) -->
       <template v-if="expanded">

--- a/frontend/src/components/ContextTreeNode.vue
+++ b/frontend/src/components/ContextTreeNode.vue
@@ -361,7 +361,7 @@ async function addMilestone() {
 <template>
   <div :style="depthStyle">
     <div class="border border-white/10 rounded-xl p-4 transition-shadow"
-         :class="dragOver ? 'ring-2 ring-blue-400/50' : ''"
+         :class="[dragOver ? 'ring-2 ring-blue-400/50' : '', node.archived ? 'opacity-50' : '']"
          :style="cardStyle"
          :draggable="true"
          @dragstart.stop="onDragStart"
@@ -391,7 +391,8 @@ async function addMilestone() {
               (renames node, {{ children.length }} children unaffected)
             </span>
           </template>
-          <h3 v-else class="font-semibold text-sm truncate">{{ node.name }}</h3>
+          <h3 v-else class="font-semibold text-sm truncate" :class="node.archived ? 'line-through text-white/40' : ''">{{ node.name }}</h3>
+          <span v-if="node.archived" class="text-[9px] px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400/80 shrink-0">Archived</span>
         </div>
 
         <div class="flex gap-2 shrink-0">
@@ -401,6 +402,12 @@ async function addMilestone() {
           </template>
           <button v-else @click="startRename"
                   class="text-xs text-white/50 hover:text-white">Rename</button>
+          <button v-if="node.archived"
+                  @click="contextStore.patchNode(node.id, { archived: false })"
+                  class="text-xs text-yellow-400/60 hover:text-yellow-400">Unarchive</button>
+          <button v-else
+                  @click="contextStore.patchNode(node.id, { archived: true })"
+                  class="text-xs text-white/40 hover:text-white/70">Archive</button>
           <button @click="deleteWithConfirm"
                   class="text-xs text-red-400/60 hover:text-red-400">Delete</button>
         </div>

--- a/frontend/src/components/ContextTreeNode.vue
+++ b/frontend/src/components/ContextTreeNode.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useContextStore } from '../stores/context'
 import type { ContextNode, SectionFileInfo } from '../stores/context'
 import { useMilestoneStore } from '../stores/milestones'
@@ -115,6 +115,16 @@ async function onDrop(evt: DragEvent) {
 }
 
 // --- Actions ---
+
+// Re-fetch children when "Show archived" toggles while this node is expanded
+watch(() => contextStore.showArchived, async () => {
+  if (!expanded.value) return
+  try {
+    await contextStore.fetchChildren(props.node.id)
+  } catch (e) {
+    console.error('showArchived re-fetch error:', e)
+  }
+})
 
 async function toggleExpand() {
   if (expanded.value) {

--- a/frontend/src/components/ContextTreeNode.vue
+++ b/frontend/src/components/ContextTreeNode.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { useContextStore } from '../stores/context'
-import type { ContextNode } from '../stores/context'
+import type { ContextNode, SectionFileInfo } from '../stores/context'
 import { useMilestoneStore } from '../stores/milestones'
 import MilestoneDetail from './MilestoneDetail.vue'
 import ContextTreeNode from './ContextTreeNode.vue'
@@ -19,6 +19,8 @@ const milestoneStore = useMilestoneStore()
 // --- Local state (per-instance) ---
 const expanded = ref(false)
 const activeTab = ref<string>('details')
+const activeFileName = ref<string>('main')
+const sectionFiles = ref<SectionFileInfo[]>([])
 const editingSection = ref<string | null>(null)
 const editBody = ref('')
 const renaming = ref(false)
@@ -36,13 +38,17 @@ const dragOver = ref(false)
 const newChildType = ref<'context' | 'milestone'>('context')
 const newChildTargetDate = ref('')
 const newChildColor = ref('#3b82f6')
+const editingDescription = ref(false)
+const descriptionDraft = ref('')
+const addingFile = ref(false)
+const newFileName = ref('')
 
 // --- Computed ---
 const children = computed(() => contextStore.childrenOf(props.node.id))
 const hasChildren = computed(() =>
   children.value.length > 0 || props.node.children_count == null || props.node.children_count > 0
 )
-const nodeBody = computed(() => contextStore.sectionCache[`${props.node.id}::details`]?.body ?? '')
+const nodeBody = computed(() => contextStore.sectionCache[`${props.node.id}::details::main`]?.body ?? '')
 const milestones = computed(() => milestoneStore.bySubject[props.node.name] ?? [])
 
 const STATUS_COLORS: Record<string, string> = {
@@ -58,8 +64,13 @@ const allSectionTypes = computed(() => {
 })
 
 const activeBody = computed(() => {
-  const key = `${props.node.id}::${activeTab.value}`
+  const key = `${props.node.id}::${activeTab.value}::${activeFileName.value}`
   return contextStore.sectionCache[key]?.body ?? ''
+})
+
+const collapsedPreview = computed(() => {
+  if (props.node.description) return props.node.description
+  return nodeBody.value || '(empty)'
 })
 
 const depthStyle = computed(() => ({
@@ -114,9 +125,9 @@ async function toggleExpand() {
   try {
     error.value = null
     const fetched = await contextStore.fetchChildren(props.node.id)
-    await Promise.allSettled(fetched.map(c => contextStore.fetchSection(c.id, 'details')))
-    // Fetch the active tab's section for this node
-    await contextStore.fetchSection(props.node.id, activeTab.value)
+    await Promise.allSettled(fetched.map(c => contextStore.fetchSection(c.id, 'details', 'main')))
+    // Fetch file list for the active tab and load the active file
+    await loadTabFiles(activeTab.value)
   } catch (e) {
     expanded.value = false
     console.error('toggleExpand error:', e)
@@ -124,16 +135,48 @@ async function toggleExpand() {
   }
 }
 
+async function loadTabFiles(sectionType: string) {
+  try {
+    const files = await contextStore.fetchSectionFiles(props.node.id, sectionType)
+    sectionFiles.value = files
+    // Pick active file: prefer current activeFileName if it exists, else first file, else 'main'
+    const match = files.find(f => f.name === activeFileName.value)
+    if (!match && files.length > 0) {
+      activeFileName.value = files[0].name
+    } else if (!match) {
+      activeFileName.value = 'main'
+    }
+    // Fetch the body for the active file
+    const key = `${props.node.id}::${sectionType}::${activeFileName.value}`
+    if (!contextStore.sectionCache[key]) {
+      await contextStore.fetchSection(props.node.id, sectionType, activeFileName.value)
+    }
+  } catch (e) {
+    // If the section type has no files yet, that's OK
+    sectionFiles.value = []
+    activeFileName.value = 'main'
+    console.error('loadTabFiles error:', e)
+  }
+}
+
 async function switchTab(sectionType: string) {
   activeTab.value = sectionType
   editingSection.value = null
-  const key = `${props.node.id}::${sectionType}`
+  activeFileName.value = 'main'
+  addingFile.value = false
+  await loadTabFiles(sectionType)
+}
+
+async function selectFile(fileName: string) {
+  activeFileName.value = fileName
+  editingSection.value = null
+  const key = `${props.node.id}::${activeTab.value}::${fileName}`
   if (!contextStore.sectionCache[key]) {
     try {
-      await contextStore.fetchSection(props.node.id, sectionType)
+      await contextStore.fetchSection(props.node.id, activeTab.value, fileName)
     } catch (e) {
-      console.error('switchTab fetch error:', e)
-      error.value = e instanceof Error ? e.message : 'Failed to load section'
+      console.error('selectFile fetch error:', e)
+      error.value = e instanceof Error ? e.message : 'Failed to load file'
     }
   }
 }
@@ -141,7 +184,7 @@ async function switchTab(sectionType: string) {
 async function startEdit() {
   editingSection.value = activeTab.value
   try {
-    const section = await contextStore.fetchSection(props.node.id, activeTab.value)
+    const section = await contextStore.fetchSection(props.node.id, activeTab.value, activeFileName.value)
     editBody.value = section?.body ?? ''
   } catch (e) {
     editingSection.value = null
@@ -154,8 +197,10 @@ async function saveEdit() {
   if (!editingSection.value) return
   try {
     error.value = null
-    await contextStore.saveSection(props.node.id, editingSection.value, editBody.value)
+    await contextStore.saveSection(props.node.id, editingSection.value, editBody.value, activeFileName.value)
     editingSection.value = null
+    // Refresh file list to get updated size
+    await loadTabFiles(activeTab.value)
   } catch (e) {
     console.error('saveEdit error:', e)
     error.value = e instanceof Error ? e.message : 'Failed to save'
@@ -174,14 +219,65 @@ async function addSection() {
   }
   try {
     error.value = null
-    await contextStore.saveSection(props.node.id, name, '')
+    await contextStore.createSectionFile(props.node.id, name, 'main', '')
     localSectionTypes.value.push(name)
     showAddSection.value = false
     newSectionName.value = ''
     activeTab.value = name
+    activeFileName.value = 'main'
+    await loadTabFiles(name)
   } catch (e) {
     console.error('addSection error:', e)
     error.value = e instanceof Error ? e.message : 'Failed to add section'
+  }
+}
+
+async function addFile() {
+  const name = newFileName.value.trim()
+  if (!name) return
+  // Check if file already exists in current tab
+  if (sectionFiles.value.some(f => f.name === name)) {
+    error.value = `File "${name}" already exists in ${activeTab.value}`
+    return
+  }
+  try {
+    error.value = null
+    await contextStore.createSectionFile(props.node.id, activeTab.value, name, '')
+    addingFile.value = false
+    newFileName.value = ''
+    activeFileName.value = name
+    await loadTabFiles(activeTab.value)
+  } catch (e) {
+    console.error('addFile error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to add file'
+  }
+}
+
+async function deleteFile(fileName: string) {
+  if (!confirm(`Delete file "${fileName}" from ${activeTab.value}?`)) return
+  try {
+    error.value = null
+    await contextStore.deleteSectionFile(props.node.id, activeTab.value, fileName)
+    await loadTabFiles(activeTab.value)
+  } catch (e) {
+    console.error('deleteFile error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to delete file'
+  }
+}
+
+function startDescriptionEdit() {
+  editingDescription.value = true
+  descriptionDraft.value = props.node.description ?? ''
+}
+
+async function saveDescription() {
+  try {
+    error.value = null
+    await contextStore.patchNode(props.node.id, { description: descriptionDraft.value || null })
+    editingDescription.value = false
+  } catch (e) {
+    console.error('saveDescription error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to save description'
   }
 }
 
@@ -310,11 +406,29 @@ async function addMilestone() {
         </div>
       </div>
 
-      <!-- Collapsed: show details preview -->
-      <p v-if="!expanded" class="text-xs text-white/50 line-clamp-2">{{ nodeBody || '(empty)' }}</p>
+      <!-- Collapsed: show description or details preview -->
+      <p v-if="!expanded" class="text-xs text-white/50 line-clamp-2">{{ collapsedPreview }}</p>
 
-      <!-- Expanded: section tabs + content -->
+      <!-- Expanded: description + section tabs + content -->
       <template v-if="expanded">
+        <!-- Description area -->
+        <div class="mb-2">
+          <div v-if="editingDescription" class="flex flex-col gap-1">
+            <textarea v-model="descriptionDraft" rows="2" placeholder="Node description..."
+                      class="w-full bg-transparent border border-white/20 rounded p-2 text-xs outline-none focus:border-white/50 resize-none" />
+            <div class="flex gap-2">
+              <button @click="saveDescription" class="text-[10px] text-green-400/70 hover:text-green-400">Save</button>
+              <button @click="editingDescription = false" class="text-[10px] text-white/40 hover:text-white/70">Cancel</button>
+            </div>
+          </div>
+          <div v-else class="flex items-start gap-1">
+            <p v-if="node.description" class="text-xs text-white/60 italic flex-1">{{ node.description }}</p>
+            <p v-else class="text-xs text-white/30 italic flex-1">(no description)</p>
+            <button @click="startDescriptionEdit"
+                    class="text-[10px] text-white/30 hover:text-white/60 shrink-0">edit</button>
+          </div>
+        </div>
+
         <!-- Tab bar -->
         <div class="flex gap-1 mt-1 flex-wrap items-center">
           <button v-for="st in allSectionTypes" :key="st"
@@ -338,6 +452,48 @@ async function addMilestone() {
           </button>
         </div>
 
+        <!-- File list within active tab -->
+        <div v-if="sectionFiles.length > 1 || addingFile" class="mt-1 flex gap-1 flex-wrap items-center">
+          <button v-for="f in sectionFiles" :key="f.name"
+                  @click.stop="selectFile(f.name)"
+                  class="text-[10px] px-1.5 py-0.5 rounded border flex items-center gap-1 group"
+                  :class="activeFileName === f.name
+                    ? 'border-blue-400/40 bg-blue-500/15 text-blue-200'
+                    : 'border-white/10 bg-white/5 text-white/40 hover:bg-white/10 hover:text-white/60'">
+            {{ f.name }}
+            <span class="text-white/20 text-[8px]">{{ f.size }}c</span>
+            <span v-if="sectionFiles.length > 1"
+                  @click.stop="deleteFile(f.name)"
+                  class="text-red-400/0 group-hover:text-red-400/50 hover:!text-red-400 cursor-pointer ml-0.5"
+                  title="Delete file">&times;</span>
+          </button>
+          <div v-if="addingFile" class="flex items-center gap-1">
+            <input v-model="newFileName" placeholder="file name..."
+                   @keydown.enter="addFile"
+                   @keydown.escape="addingFile = false; newFileName = ''"
+                   class="bg-transparent border-b border-white/30 outline-none text-[10px] w-20" />
+            <button @click="addFile" class="text-[10px] text-white/60 hover:text-white">add</button>
+            <button @click="addingFile = false; newFileName = ''"
+                    class="text-[10px] text-white/40">cancel</button>
+          </div>
+          <button v-else @click.stop="addingFile = true"
+                  class="text-[10px] px-1 py-0.5 text-white/25 hover:text-white/50">+ file</button>
+        </div>
+        <!-- If only one file (or none), just show a small add-file button -->
+        <div v-else class="mt-1">
+          <div v-if="addingFile" class="flex items-center gap-1">
+            <input v-model="newFileName" placeholder="file name..."
+                   @keydown.enter="addFile"
+                   @keydown.escape="addingFile = false; newFileName = ''"
+                   class="bg-transparent border-b border-white/30 outline-none text-[10px] w-20" />
+            <button @click="addFile" class="text-[10px] text-white/60 hover:text-white">add</button>
+            <button @click="addingFile = false; newFileName = ''"
+                    class="text-[10px] text-white/40">cancel</button>
+          </div>
+          <button v-else @click.stop="addingFile = true"
+                  class="text-[10px] text-white/25 hover:text-white/50">+ file</button>
+        </div>
+
         <!-- Active tab content -->
         <div class="mt-2">
           <div v-if="editingSection === activeTab">
@@ -351,7 +507,7 @@ async function addMilestone() {
           <div v-else>
             <p class="text-xs text-white/50 whitespace-pre-wrap">{{ activeBody || '(empty)' }}</p>
             <button @click="startEdit"
-                    class="mt-1 text-xs text-white/40 hover:text-white/70">Edit {{ activeTab }}</button>
+                    class="mt-1 text-xs text-white/40 hover:text-white/70">Edit {{ activeTab }}/{{ activeFileName }}</button>
           </div>
         </div>
       </template>

--- a/frontend/src/composables/useAutoScrollDrag.ts
+++ b/frontend/src/composables/useAutoScrollDrag.ts
@@ -1,0 +1,57 @@
+/**
+ * Auto-scroll when dragging near viewport edges.
+ * Returns a dragover handler to attach to the scroll container
+ * and a cleanup function to call on drop.
+ *
+ * Also usable for kanban columns — attach onDragOver to the column's
+ * scroll container and call cleanup() when the drag ends.
+ */
+export function useAutoScrollDrag(options?: {
+  edgeDistance?: number // px from edge to trigger scroll (default: 60)
+  scrollSpeed?: number // px per frame (default: 10)
+}) {
+  const edgeDistance = options?.edgeDistance ?? 60
+  const scrollSpeed = options?.scrollSpeed ?? 10
+
+  let rafId: number | null = null
+  let currentDirection: -1 | 1 | 0 = 0
+
+  function scrollLoop(direction: -1 | 1) {
+    window.scrollBy(0, direction * scrollSpeed)
+    rafId = requestAnimationFrame(() => scrollLoop(direction))
+  }
+
+  function startScroll(direction: -1 | 1) {
+    if (currentDirection === direction) return // already scrolling this way
+    stopScroll()
+    currentDirection = direction
+    scrollLoop(direction)
+  }
+
+  function stopScroll() {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId)
+      rafId = null
+    }
+    currentDirection = 0
+  }
+
+  function onDragOver(evt: DragEvent) {
+    const y = evt.clientY
+    const viewportHeight = window.innerHeight
+
+    if (y < edgeDistance) {
+      startScroll(-1)
+    } else if (y > viewportHeight - edgeDistance) {
+      startScroll(1)
+    } else {
+      stopScroll()
+    }
+  }
+
+  function cleanup() {
+    stopScroll()
+  }
+
+  return { onDragOver, cleanup }
+}

--- a/frontend/src/stores/context.ts
+++ b/frontend/src/stores/context.ts
@@ -55,11 +55,14 @@ export const useContextStore = defineStore('context', () => {
   /** Sections cache keyed by `${nodeId}::${sectionType}::${name}` */
   const sectionCache = ref<Record<string, NodeSection>>({})
 
+  /** Whether to include archived nodes in tree views */
+  const showArchived = ref(false)
+
   // -- Computed helpers ------------------------------------------------------
 
   const rootNodes = computed<ContextNode[]>(() =>
     Object.values(nodes.value)
-      .filter(n => n.parent_id === null && !n.archived)
+      .filter(n => n.parent_id === null && (showArchived.value || !n.archived))
       .sort((a, b) => a.name.localeCompare(b.name))
   )
 
@@ -69,7 +72,7 @@ export const useContextStore = defineStore('context', () => {
 
   function childrenOf(parentId: string): ContextNode[] {
     return Object.values(nodes.value)
-      .filter(n => n.parent_id === parentId && !n.archived)
+      .filter(n => n.parent_id === parentId && (showArchived.value || !n.archived))
       .sort((a, b) => a.name.localeCompare(b.name))
   }
 
@@ -82,7 +85,8 @@ export const useContextStore = defineStore('context', () => {
   // -- API methods -----------------------------------------------------------
 
   async function fetchRootNodes(): Promise<ContextNode[]> {
-    const resp = await api('/api/nodes')
+    const qs = showArchived.value ? '?include_archived=1' : ''
+    const resp = await api(`/api/nodes${qs}`)
     if (!resp.ok) {
       const detail = await resp.text().catch(() => '')
       throw new Error(`fetchRootNodes: ${resp.status} ${detail}`)
@@ -95,7 +99,8 @@ export const useContextStore = defineStore('context', () => {
   }
 
   async function fetchChildren(parentId: string): Promise<ContextNode[]> {
-    const resp = await api(`/api/nodes/${parentId}/children`)
+    const qs = showArchived.value ? '?include_archived=1' : ''
+    const resp = await api(`/api/nodes/${parentId}/children${qs}`)
     if (!resp.ok) {
       const detail = await resp.text().catch(() => '')
       throw new Error(`fetchChildren: ${resp.status} ${detail}`)
@@ -264,6 +269,7 @@ export const useContextStore = defineStore('context', () => {
     // State
     nodes,
     sectionCache,
+    showArchived,
 
     // Computed
     rootNodes,

--- a/frontend/src/stores/context.ts
+++ b/frontend/src/stores/context.ts
@@ -10,6 +10,7 @@ export interface ContextNode {
   id: string
   parent_id: string | null
   name: string
+  description: string | null
   node_type: 'context' | 'milestone'
   archived: boolean
   target_date: string | null
@@ -25,8 +26,22 @@ export interface ContextNode {
 
 export interface NodeSection {
   section_type: string
+  name: string
   body: string
+  position: number
   updated_at: string
+}
+
+export interface SectionFileInfo {
+  name: string
+  size: number
+  position: number
+  updated_at: string
+}
+
+export interface SectionTypeSummary {
+  section_type: string
+  file_count: number
 }
 
 // ---------------------------------------------------------------------------
@@ -37,7 +52,7 @@ export const useContextStore = defineStore('context', () => {
   /** Flat cache of all fetched nodes, keyed by id */
   const nodes = ref<Record<string, ContextNode>>({})
 
-  /** Sections cache keyed by `${nodeId}::${sectionType}` */
+  /** Sections cache keyed by `${nodeId}::${sectionType}::${name}` */
   const sectionCache = ref<Record<string, NodeSection>>({})
 
   // -- Computed helpers ------------------------------------------------------
@@ -125,7 +140,7 @@ export const useContextStore = defineStore('context', () => {
 
   async function patchNode(
     nodeId: string,
-    fields: Partial<Pick<ContextNode, 'name' | 'archived' | 'target_date' | 'status' | 'color'>>,
+    fields: Partial<Pick<ContextNode, 'name' | 'archived' | 'target_date' | 'status' | 'color' | 'description'>>,
   ): Promise<ContextNode> {
     const resp = await api(`/api/nodes/${nodeId}`, {
       method: 'PATCH',
@@ -174,33 +189,38 @@ export const useContextStore = defineStore('context', () => {
     }
   }
 
-  async function fetchSections(nodeId: string): Promise<NodeSection[]> {
+  async function fetchSections(nodeId: string): Promise<SectionTypeSummary[]> {
     const resp = await api(`/api/nodes/${nodeId}/sections`)
     if (!resp.ok) {
       const detail = await resp.text().catch(() => '')
       throw new Error(`fetchSections: ${resp.status} ${detail}`)
     }
-    const data: NodeSection[] = await resp.json()
-    for (const s of data) {
-      sectionCache.value[`${nodeId}::${s.section_type}`] = s
-    }
-    return data
+    return await resp.json()
   }
 
-  async function fetchSection(nodeId: string, sectionType: string): Promise<NodeSection | null> {
+  async function fetchSectionFiles(nodeId: string, sectionType: string): Promise<SectionFileInfo[]> {
     const resp = await api(`/api/nodes/${nodeId}/sections/${encodeURIComponent(sectionType)}`)
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`fetchSectionFiles: ${resp.status} ${detail}`)
+    }
+    return await resp.json()
+  }
+
+  async function fetchSection(nodeId: string, sectionType: string, name: string = 'main'): Promise<NodeSection | null> {
+    const resp = await api(`/api/nodes/${nodeId}/sections/${encodeURIComponent(sectionType)}/${encodeURIComponent(name)}`)
     if (resp.status === 404) return null
     if (!resp.ok) {
       const detail = await resp.text().catch(() => '')
       throw new Error(`fetchSection: ${resp.status} ${detail}`)
     }
     const data: NodeSection = await resp.json()
-    sectionCache.value[`${nodeId}::${sectionType}`] = data
+    sectionCache.value[`${nodeId}::${sectionType}::${name}`] = data
     return data
   }
 
-  async function saveSection(nodeId: string, sectionType: string, body: string): Promise<NodeSection> {
-    const resp = await api(`/api/nodes/${nodeId}/sections/${encodeURIComponent(sectionType)}`, {
+  async function saveSection(nodeId: string, sectionType: string, body: string, name: string = 'main'): Promise<NodeSection> {
+    const resp = await api(`/api/nodes/${nodeId}/sections/${encodeURIComponent(sectionType)}/${encodeURIComponent(name)}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ body }),
@@ -210,8 +230,34 @@ export const useContextStore = defineStore('context', () => {
       throw new Error(`saveSection: ${resp.status} ${detail}`)
     }
     const data: NodeSection = await resp.json()
-    sectionCache.value[`${nodeId}::${sectionType}`] = data
+    sectionCache.value[`${nodeId}::${sectionType}::${name}`] = data
     return data
+  }
+
+  async function createSectionFile(nodeId: string, sectionType: string, name: string, body: string = ''): Promise<NodeSection> {
+    const resp = await api(`/api/nodes/${nodeId}/sections/${encodeURIComponent(sectionType)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, body }),
+    })
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`createSectionFile: ${resp.status} ${detail}`)
+    }
+    const data: NodeSection = await resp.json()
+    sectionCache.value[`${nodeId}::${sectionType}::${name}`] = data
+    return data
+  }
+
+  async function deleteSectionFile(nodeId: string, sectionType: string, name: string): Promise<void> {
+    const resp = await api(`/api/nodes/${nodeId}/sections/${encodeURIComponent(sectionType)}/${encodeURIComponent(name)}`, {
+      method: 'DELETE',
+    })
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '')
+      throw new Error(`deleteSectionFile: ${resp.status} ${detail}`)
+    }
+    delete sectionCache.value[`${nodeId}::${sectionType}::${name}`]
   }
 
   return {
@@ -238,7 +284,10 @@ export const useContextStore = defineStore('context', () => {
 
     // Sections
     fetchSections,
+    fetchSectionFiles,
     fetchSection,
     saveSection,
+    createSectionFile,
+    deleteSectionFile,
   }
 })

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -69,6 +69,62 @@ function resetLLMDefaults() {
   llmConfig.value.llm = { ...llmConfig.value.defaults.llm } as LLMConfig['llm']
 }
 
+// ---------------------------------------------------------------------------
+// Auto-archive rules
+// ---------------------------------------------------------------------------
+
+const archiveDaysCompleted = ref<number | null>(null)
+const archiveDaysInactive = ref<number | null>(null)
+const archiveStatus = ref<'idle' | 'saving' | 'saved' | 'error'>('idle')
+const archiveMessage = ref('')
+
+async function loadArchiveSettings() {
+  try {
+    const resp = await api('/api/settings')
+    if (resp.ok) {
+      const data = await resp.json()
+      if (data.auto_archive_days_completed)
+        archiveDaysCompleted.value = parseInt(data.auto_archive_days_completed, 10)
+      if (data.auto_archive_days_inactive)
+        archiveDaysInactive.value = parseInt(data.auto_archive_days_inactive, 10)
+    }
+  } catch { /* ignore */ }
+}
+
+async function saveArchiveSettings() {
+  archiveStatus.value = 'saving'
+  archiveMessage.value = ''
+  try {
+    const puts: Promise<Response>[] = []
+    if (archiveDaysCompleted.value != null) {
+      puts.push(api('/api/settings/auto_archive_days_completed', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value: String(archiveDaysCompleted.value) }),
+      }))
+    }
+    if (archiveDaysInactive.value != null) {
+      puts.push(api('/api/settings/auto_archive_days_inactive', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value: String(archiveDaysInactive.value) }),
+      }))
+    }
+    const results = await Promise.all(puts)
+    if (results.every(r => r.ok)) {
+      archiveStatus.value = 'saved'
+      archiveMessage.value = 'Auto-archive rules saved.'
+      setTimeout(() => { archiveStatus.value = 'idle'; archiveMessage.value = '' }, 2000)
+    } else {
+      archiveStatus.value = 'error'
+      archiveMessage.value = 'Failed to save.'
+    }
+  } catch {
+    archiveStatus.value = 'error'
+    archiveMessage.value = 'Network error.'
+  }
+}
+
 // Telegram link
 const telegramCode = ref('')
 const telegramStatus = ref<'idle' | 'loading' | 'success' | 'error'>('idle')
@@ -77,6 +133,7 @@ const telegramLinked = ref(false)
 
 onMounted(async () => {
   loadLLMConfig()
+  loadArchiveSettings()
   try {
     const resp = await fetch('/auth/me', { credentials: 'include' })
     if (resp.ok) {
@@ -232,6 +289,52 @@ function connectGoogle() {
             </svg>
             Connect Google
           </button>
+        </div>
+      </section>
+
+      <!-- Auto-Archive Rules -->
+      <section class="mb-8">
+        <h2 class="text-sm font-semibold text-white/50 uppercase tracking-wider mb-3">Auto-Archive Rules</h2>
+        <div class="bg-gray-800 rounded-xl p-4 space-y-4">
+          <p class="text-sm text-white/60">
+            Automatically archive context nodes when they become stale. Leave blank to disable a rule.
+          </p>
+          <div class="grid grid-cols-2 gap-3">
+            <div>
+              <label class="text-xs text-gray-400 mb-1 block">Archive after completion (days)</label>
+              <input
+                type="number"
+                v-model.number="archiveDaysCompleted"
+                min="1"
+                placeholder="e.g. 7"
+                class="w-full bg-gray-700 text-white rounded-lg px-3 py-2 text-sm border border-gray-600 focus:outline-none focus:border-indigo-500 placeholder-gray-500"
+              />
+              <p class="text-xs text-gray-500 mt-1">Archive nodes whose tasks are all done for X days</p>
+            </div>
+            <div>
+              <label class="text-xs text-gray-400 mb-1 block">Archive after inactivity (days)</label>
+              <input
+                type="number"
+                v-model.number="archiveDaysInactive"
+                min="1"
+                placeholder="e.g. 30"
+                class="w-full bg-gray-700 text-white rounded-lg px-3 py-2 text-sm border border-gray-600 focus:outline-none focus:border-indigo-500 placeholder-gray-500"
+              />
+              <p class="text-xs text-gray-500 mt-1">Archive nodes with no updates for X days</p>
+            </div>
+          </div>
+          <div class="flex gap-2 pt-1">
+            <button
+              @click="saveArchiveSettings"
+              :disabled="archiveStatus === 'saving'"
+              class="flex-1 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg px-4 py-2 transition-colors"
+            >
+              {{ archiveStatus === 'saving' ? 'Saving...' : 'Save' }}
+            </button>
+          </div>
+          <p v-if="archiveMessage" :class="archiveStatus === 'saved' ? 'text-green-400' : 'text-red-400'" class="text-sm">
+            {{ archiveMessage }}
+          </p>
         </div>
       </section>
 

--- a/tests/db/test_auto_archive.py
+++ b/tests/db/test_auto_archive.py
@@ -1,0 +1,159 @@
+"""Tests for auto-archive query and user settings functions."""
+import pytest
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from db.schema import init_db, get_db
+from db import queries as q
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "tether.db"
+    init_db(path)
+    return path
+
+
+def _insert_task(db_path, uuid, text, status="pending"):
+    """Helper: insert a bare task directly."""
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO tasks (uuid, text, status) VALUES (?, ?, ?)",
+            (uuid, text, status),
+        )
+
+
+def _set_node_updated_at(db_path, node_id, days_ago):
+    """Helper: set a node's updated_at to N days in the past."""
+    ts = (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat(timespec="seconds")
+    with get_db(db_path) as conn:
+        conn.execute(
+            "UPDATE context_nodes SET updated_at = ? WHERE id = ?",
+            (ts, node_id),
+        )
+
+
+# ---------------------------------------------------------------------------
+# User settings
+# ---------------------------------------------------------------------------
+
+class TestUserSettings:
+    def test_get_missing_setting_returns_none(self, db_path):
+        assert q.get_user_setting(db_path, "u1", "nonexistent") is None
+
+    def test_set_and_get_setting(self, db_path):
+        q.set_user_setting(db_path, "u1", "theme", "dark")
+        assert q.get_user_setting(db_path, "u1", "theme") == "dark"
+
+    def test_upsert_overwrites(self, db_path):
+        q.set_user_setting(db_path, "u1", "theme", "dark")
+        q.set_user_setting(db_path, "u1", "theme", "light")
+        assert q.get_user_setting(db_path, "u1", "theme") == "light"
+
+    def test_get_all_settings(self, db_path):
+        q.set_user_setting(db_path, "u1", "a", "1")
+        q.set_user_setting(db_path, "u1", "b", "2")
+        result = q.get_all_user_settings(db_path, "u1")
+        assert result == {"a": "1", "b": "2"}
+
+    def test_settings_isolated_per_user(self, db_path):
+        q.set_user_setting(db_path, "u1", "k", "v1")
+        q.set_user_setting(db_path, "u2", "k", "v2")
+        assert q.get_user_setting(db_path, "u1", "k") == "v1"
+        assert q.get_user_setting(db_path, "u2", "k") == "v2"
+
+
+# ---------------------------------------------------------------------------
+# get_auto_archivable_nodes
+# ---------------------------------------------------------------------------
+
+class TestAutoArchivableNodes:
+    def test_no_criteria_returns_empty(self, db_path):
+        q.create_node(db_path, None, "Project")
+        assert q.get_auto_archivable_nodes(db_path) == []
+
+    def test_inactive_node_found(self, db_path):
+        node = q.create_node(db_path, None, "Old Project")
+        _set_node_updated_at(db_path, node["id"], days_ago=15)
+
+        result = q.get_auto_archivable_nodes(db_path, days_inactive=10)
+        assert len(result) == 1
+        assert result[0]["id"] == node["id"]
+
+    def test_recently_updated_node_not_found(self, db_path):
+        node = q.create_node(db_path, None, "Active")
+        _set_node_updated_at(db_path, node["id"], days_ago=3)
+
+        result = q.get_auto_archivable_nodes(db_path, days_inactive=10)
+        assert len(result) == 0
+
+    def test_already_archived_excluded(self, db_path):
+        node = q.create_node(db_path, None, "Archived Already")
+        _set_node_updated_at(db_path, node["id"], days_ago=60)
+        q.archive_node(db_path, node["id"])
+        # Reset updated_at after archiving (archive_node updates it)
+        _set_node_updated_at(db_path, node["id"], days_ago=60)
+
+        result = q.get_auto_archivable_nodes(db_path, days_inactive=10)
+        assert len(result) == 0
+
+    def test_completed_tasks_node_found(self, db_path):
+        node = q.create_node(db_path, None, "Done Project")
+        _insert_task(db_path, "t1", "Task 1", status="done")
+        _insert_task(db_path, "t2", "Task 2", status="done")
+        q.link_task_to_node(db_path, node["id"], "t1")
+        q.link_task_to_node(db_path, node["id"], "t2")
+        _set_node_updated_at(db_path, node["id"], days_ago=10)
+
+        result = q.get_auto_archivable_nodes(db_path, days_completed=7)
+        assert len(result) == 1
+        assert result[0]["id"] == node["id"]
+
+    def test_partially_done_tasks_not_found(self, db_path):
+        node = q.create_node(db_path, None, "Partial")
+        _insert_task(db_path, "t1", "Done", status="done")
+        _insert_task(db_path, "t2", "Pending", status="pending")
+        q.link_task_to_node(db_path, node["id"], "t1")
+        q.link_task_to_node(db_path, node["id"], "t2")
+        _set_node_updated_at(db_path, node["id"], days_ago=10)
+
+        result = q.get_auto_archivable_nodes(db_path, days_completed=7)
+        assert len(result) == 0
+
+    def test_completed_but_recent_not_found(self, db_path):
+        node = q.create_node(db_path, None, "Recently Done")
+        _insert_task(db_path, "t1", "Task", status="done")
+        q.link_task_to_node(db_path, node["id"], "t1")
+        _set_node_updated_at(db_path, node["id"], days_ago=2)
+
+        result = q.get_auto_archivable_nodes(db_path, days_completed=7)
+        assert len(result) == 0
+
+    def test_no_tasks_excluded_from_completed_check(self, db_path):
+        """A node with no linked tasks should NOT match days_completed."""
+        node = q.create_node(db_path, None, "No Tasks")
+        _set_node_updated_at(db_path, node["id"], days_ago=30)
+
+        result = q.get_auto_archivable_nodes(db_path, days_completed=7)
+        assert len(result) == 0
+
+    def test_both_criteria_union(self, db_path):
+        """When both criteria are given, nodes matching either are returned."""
+        # Node 1: inactive only (no tasks)
+        n1 = q.create_node(db_path, None, "Inactive")
+        _set_node_updated_at(db_path, n1["id"], days_ago=20)
+
+        # Node 2: completed tasks only (also old enough for inactive, but test union)
+        n2 = q.create_node(db_path, None, "Completed")
+        _insert_task(db_path, "t1", "Task", status="done")
+        q.link_task_to_node(db_path, n2["id"], "t1")
+        _set_node_updated_at(db_path, n2["id"], days_ago=10)
+
+        # Node 3: active, not done — should NOT appear
+        n3 = q.create_node(db_path, None, "Active")
+        _set_node_updated_at(db_path, n3["id"], days_ago=1)
+
+        result = q.get_auto_archivable_nodes(db_path, days_completed=7, days_inactive=15)
+        ids = {n["id"] for n in result}
+        assert n1["id"] in ids
+        assert n2["id"] in ids
+        assert n3["id"] not in ids

--- a/tests/db/test_context_nodes.py
+++ b/tests/db/test_context_nodes.py
@@ -465,3 +465,164 @@ class TestMilestoneNodes:
         assert len(q.get_milestone_nodes(
             db_path, parent_id=parent["id"], include_archived=True
         )) == 1
+
+
+# ---------------------------------------------------------------------------
+# Named section files
+# ---------------------------------------------------------------------------
+
+class TestNamedSectionFiles:
+    def test_upsert_section_with_name(self, db_path):
+        node = q.create_node(db_path, None, "Node")
+        result = q.upsert_section(db_path, node["id"], "notes", "Main notes")
+        assert result["name"] == "main"
+        assert result["body"] == "Main notes"
+
+        result2 = q.upsert_section(db_path, node["id"], "notes", "Ideas", name="ideas")
+        assert result2["name"] == "ideas"
+        assert result2["body"] == "Ideas"
+
+        # Both should coexist
+        sections = q.get_sections(db_path, node["id"])
+        assert len(sections) == 2
+        names = {s["name"] for s in sections}
+        assert names == {"main", "ideas"}
+
+        # get_section with default name still returns the 'main' one
+        main = q.get_section(db_path, node["id"], "notes")
+        assert main["body"] == "Main notes"
+
+        # get_section with explicit name
+        ideas = q.get_section(db_path, node["id"], "notes", name="ideas")
+        assert ideas["body"] == "Ideas"
+
+    def test_list_section_files(self, db_path):
+        node = q.create_node(db_path, None, "Node")
+        q.upsert_section(db_path, node["id"], "notes", "File A content", name="a")
+        q.upsert_section(db_path, node["id"], "notes", "File B longer content", name="b")
+
+        files = q.list_section_files(db_path, node["id"], "notes")
+        assert len(files) == 2
+        # Check returned fields
+        for f in files:
+            assert "name" in f
+            assert "size" in f
+            assert "updated_at" in f
+            assert "position" in f
+            # body should NOT be in the result
+            assert "body" not in f
+
+        names = [f["name"] for f in files]
+        assert "a" in names
+        assert "b" in names
+
+        # size should be character count of body
+        a_file = next(f for f in files if f["name"] == "a")
+        assert a_file["size"] == len("File A content")
+
+    def test_create_section_file(self, db_path):
+        node = q.create_node(db_path, None, "Node")
+        result = q.create_section_file(db_path, node["id"], "notes", "readme")
+        assert result["name"] == "readme"
+        assert result["body"] == ""
+        assert result["position"] == 0
+
+        result2 = q.create_section_file(db_path, node["id"], "notes", "changelog", body="v1.0")
+        assert result2["name"] == "changelog"
+        assert result2["body"] == "v1.0"
+        assert result2["position"] == 1
+
+        # Verify we can read them back
+        fetched = q.get_section(db_path, node["id"], "notes", name="readme")
+        assert fetched is not None
+        assert fetched["body"] == ""
+
+        fetched2 = q.get_section(db_path, node["id"], "notes", name="changelog")
+        assert fetched2["body"] == "v1.0"
+
+    def test_create_section_file_duplicate_raises(self, db_path):
+        node = q.create_node(db_path, None, "Node")
+        q.create_section_file(db_path, node["id"], "notes", "readme")
+        with pytest.raises(sqlite3.IntegrityError):
+            q.create_section_file(db_path, node["id"], "notes", "readme")
+
+    def test_rename_section_file(self, db_path):
+        node = q.create_node(db_path, None, "Node")
+        q.create_section_file(db_path, node["id"], "notes", "old_name", body="content")
+
+        result = q.rename_section_file(db_path, node["id"], "notes", "old_name", "new_name")
+        assert result["name"] == "new_name"
+        assert result["body"] == "content"
+
+        # Old name should be gone
+        assert q.get_section(db_path, node["id"], "notes", name="old_name") is None
+
+    def test_rename_section_file_missing_raises(self, db_path):
+        node = q.create_node(db_path, None, "Node")
+        with pytest.raises(ValueError, match="not found"):
+            q.rename_section_file(db_path, node["id"], "notes", "nonexistent", "new")
+
+    def test_reorder_section_files(self, db_path):
+        node = q.create_node(db_path, None, "Node")
+        q.create_section_file(db_path, node["id"], "notes", "a")
+        q.create_section_file(db_path, node["id"], "notes", "b")
+        q.create_section_file(db_path, node["id"], "notes", "c")
+
+        # Reorder: c, a, b
+        q.reorder_section_files(db_path, node["id"], "notes", ["c", "a", "b"])
+
+        files = q.list_section_files(db_path, node["id"], "notes")
+        names_in_order = [f["name"] for f in files]
+        assert names_in_order == ["c", "a", "b"]
+
+    def test_search_includes_name(self, db_path):
+        node = q.create_node(db_path, None, "Node")
+        q.upsert_section(db_path, node["id"], "notes", "important search text", name="ideas")
+
+        results = q.search_sections(db_path, "important search")
+        assert len(results) == 1
+        assert results[0]["name"] == "ideas"
+        assert results[0]["section_type"] == "notes"
+
+    def test_append_section_with_name(self, db_path):
+        node = q.create_node(db_path, None, "Node")
+        q.upsert_section(db_path, node["id"], "log", "Entry 1", name="daily")
+        result = q.append_section(db_path, node["id"], "log", "Entry 2", name="daily")
+        assert result["body"] == "Entry 1\n\nEntry 2"
+        assert result["name"] == "daily"
+
+    def test_delete_section_with_name(self, db_path):
+        node = q.create_node(db_path, None, "Node")
+        q.upsert_section(db_path, node["id"], "notes", "Main", name="main")
+        q.upsert_section(db_path, node["id"], "notes", "Extra", name="extra")
+
+        q.delete_section(db_path, node["id"], "notes", name="extra")
+        # main should still exist
+        assert q.get_section(db_path, node["id"], "notes", name="main") is not None
+        # extra should be gone
+        assert q.get_section(db_path, node["id"], "notes", name="extra") is None
+
+
+# ---------------------------------------------------------------------------
+# Node description
+# ---------------------------------------------------------------------------
+
+class TestNodeDescription:
+    def test_patch_node_fields_with_description(self, db_path):
+        node = q.create_node(db_path, None, "MyNode")
+        assert node["description"] is None
+
+        updated = q.patch_node_fields(db_path, node["id"], {"description": "A useful desc"})
+        assert updated["description"] == "A useful desc"
+
+    def test_get_node_returns_description(self, db_path):
+        node = q.create_node(db_path, None, "MyNode")
+        q.patch_node_fields(db_path, node["id"], {"description": "Hello there"})
+
+        fetched = q.get_node(db_path, node["id"])
+        assert fetched["description"] == "Hello there"
+
+    def test_create_node_has_null_description(self, db_path):
+        node = q.create_node(db_path, None, "MyNode")
+        fetched = q.get_node(db_path, node["id"])
+        assert fetched["description"] is None

--- a/tests/db/test_section_files.py
+++ b/tests/db/test_section_files.py
@@ -1,0 +1,280 @@
+"""Tests for node_sections name/position migration and context_nodes description."""
+import sqlite3
+import pytest
+from pathlib import Path
+from db.schema import init_db
+from db.migrate_section_files import migrate_section_files
+
+
+OLD_NODE_SECTIONS_DDL = """
+CREATE TABLE node_sections (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    node_id TEXT NOT NULL REFERENCES context_nodes(id) ON DELETE CASCADE,
+    section_type TEXT NOT NULL,
+    body TEXT NOT NULL DEFAULT '',
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(node_id, section_type)
+);
+"""
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "test.db"
+    init_db(path)
+    return path
+
+
+@pytest.fixture
+def old_schema_db(tmp_path):
+    """Create a database with the OLD node_sections schema (no name/position)."""
+    path = tmp_path / "old.db"
+    init_db(path)
+
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA foreign_keys = OFF")
+    # Drop triggers first (they reference node_sections)
+    conn.execute("DROP TRIGGER IF EXISTS node_sections_fts_ai")
+    conn.execute("DROP TRIGGER IF EXISTS node_sections_fts_ad")
+    conn.execute("DROP TRIGGER IF EXISTS node_sections_fts_au")
+    # Drop the new-schema table and recreate with old schema
+    conn.execute("DROP TABLE node_sections")
+    conn.executescript(OLD_NODE_SECTIONS_DDL)
+    # Recreate triggers for old schema
+    conn.executescript("""
+        CREATE TRIGGER IF NOT EXISTS node_sections_fts_ai
+        AFTER INSERT ON node_sections BEGIN
+            INSERT INTO node_sections_fts(rowid, body) VALUES (new.id, new.body);
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS node_sections_fts_ad
+        AFTER DELETE ON node_sections BEGIN
+            INSERT INTO node_sections_fts(node_sections_fts, rowid, body)
+            VALUES ('delete', old.id, old.body);
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS node_sections_fts_au
+        AFTER UPDATE ON node_sections BEGIN
+            INSERT INTO node_sections_fts(node_sections_fts, rowid, body)
+            VALUES ('delete', old.id, old.body);
+            INSERT INTO node_sections_fts(rowid, body) VALUES (new.id, new.body);
+        END;
+    """)
+    # Also remove description column from context_nodes by recreating it
+    # (SQLite can't drop columns in older versions)
+    # For simplicity, we just test the migration handles both cases
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _col_names(conn, table):
+    return [c["name"] for c in conn.execute(f"PRAGMA table_info({table})").fetchall()]
+
+
+def _insert_node(conn, node_id, name, parent_id=None):
+    conn.execute(
+        "INSERT INTO context_nodes (id, parent_id, name) VALUES (?, ?, ?)",
+        (node_id, parent_id, name),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Migration adds name and position columns
+# ---------------------------------------------------------------------------
+
+def test_migration_adds_name_and_position(old_schema_db):
+    conn = sqlite3.connect(old_schema_db)
+    conn.row_factory = sqlite3.Row
+    cols_before = _col_names(conn, "node_sections")
+    assert "name" not in cols_before
+    assert "position" not in cols_before
+    conn.close()
+
+    migrate_section_files(old_schema_db)
+
+    conn = sqlite3.connect(old_schema_db)
+    conn.row_factory = sqlite3.Row
+    cols_after = _col_names(conn, "node_sections")
+    assert "name" in cols_after
+    assert "position" in cols_after
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Existing sections get name='main' and position=0
+# ---------------------------------------------------------------------------
+
+def test_existing_sections_get_main_name(old_schema_db):
+    conn = sqlite3.connect(old_schema_db)
+    conn.row_factory = sqlite3.Row
+    _insert_node(conn, "n1", "Project")
+    conn.execute(
+        "INSERT INTO node_sections (node_id, section_type, body) VALUES (?, ?, ?)",
+        ("n1", "details", "some notes"),
+    )
+    conn.execute(
+        "INSERT INTO node_sections (node_id, section_type, body) VALUES (?, ?, ?)",
+        ("n1", "plan", "the plan"),
+    )
+    conn.commit()
+    conn.close()
+
+    migrate_section_files(old_schema_db)
+
+    conn = sqlite3.connect(old_schema_db)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT section_type, name, position, body FROM node_sections ORDER BY section_type"
+    ).fetchall()
+    assert len(rows) == 2
+    for row in rows:
+        assert row["name"] == "main"
+        assert row["position"] == 0
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# New UNIQUE constraint allows multiple names per (node_id, section_type)
+# ---------------------------------------------------------------------------
+
+def test_unique_constraint_allows_multiple_names(db_path):
+    """After migration, (node_id, section_type, name) is unique — not just (node_id, section_type)."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    _insert_node(conn, "n1", "Project")
+    conn.execute(
+        "INSERT INTO node_sections (node_id, section_type, name, body) VALUES (?, ?, ?, ?)",
+        ("n1", "notes", "main", "primary notes"),
+    )
+    conn.execute(
+        "INSERT INTO node_sections (node_id, section_type, name, body) VALUES (?, ?, ?, ?)",
+        ("n1", "notes", "api-design", "API design notes"),
+    )
+    conn.commit()
+
+    rows = conn.execute(
+        "SELECT name, body FROM node_sections WHERE node_id = ? AND section_type = ? ORDER BY name",
+        ("n1", "notes"),
+    ).fetchall()
+    assert len(rows) == 2
+    assert rows[0]["name"] == "api-design"
+    assert rows[1]["name"] == "main"
+    conn.close()
+
+
+def test_unique_constraint_rejects_duplicate_name(db_path):
+    """Duplicate (node_id, section_type, name) is still rejected."""
+    conn = sqlite3.connect(db_path)
+    _insert_node(conn, "n1", "Project")
+    conn.execute(
+        "INSERT INTO node_sections (node_id, section_type, name, body) VALUES (?, ?, ?, ?)",
+        ("n1", "notes", "main", "first"),
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO node_sections (node_id, section_type, name, body) VALUES (?, ?, ?, ?)",
+            ("n1", "notes", "main", "duplicate"),
+        )
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# description column exists on context_nodes
+# ---------------------------------------------------------------------------
+
+def test_description_column_on_context_nodes(db_path):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cols = _col_names(conn, "context_nodes")
+    assert "description" in cols
+
+    # Verify it's usable
+    _insert_node(conn, "n1", "Project")
+    conn.execute(
+        "UPDATE context_nodes SET description = ? WHERE id = ?",
+        ("A short description", "n1"),
+    )
+    conn.commit()
+    row = conn.execute("SELECT description FROM context_nodes WHERE id = ?", ("n1",)).fetchone()
+    assert row["description"] == "A short description"
+    conn.close()
+
+
+def test_description_added_by_migration(old_schema_db):
+    """Migration adds description to context_nodes even on old-schema DBs."""
+    # The old_schema_db fixture was created by init_db which already has the new schema,
+    # but the ALTER TABLE in migration is idempotent. Verify column exists after migration.
+    migrate_section_files(old_schema_db)
+
+    conn = sqlite3.connect(old_schema_db)
+    conn.row_factory = sqlite3.Row
+    cols = _col_names(conn, "context_nodes")
+    assert "description" in cols
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# FTS still works after migration
+# ---------------------------------------------------------------------------
+
+def test_fts_works_after_migration(old_schema_db):
+    conn = sqlite3.connect(old_schema_db)
+    conn.row_factory = sqlite3.Row
+    _insert_node(conn, "n1", "Project")
+    conn.execute(
+        "INSERT INTO node_sections (node_id, section_type, body) VALUES (?, ?, ?)",
+        ("n1", "details", "quantum entanglement research"),
+    )
+    conn.commit()
+    conn.close()
+
+    migrate_section_files(old_schema_db)
+
+    conn = sqlite3.connect(old_schema_db)
+    conn.row_factory = sqlite3.Row
+    # FTS search should find the migrated content
+    results = conn.execute(
+        "SELECT rowid FROM node_sections_fts WHERE body MATCH ?",
+        ("quantum",),
+    ).fetchall()
+    assert len(results) == 1
+
+    # Insert a new section and verify FTS trigger works
+    conn.execute(
+        "INSERT INTO node_sections (node_id, section_type, name, body) VALUES (?, ?, ?, ?)",
+        ("n1", "notes", "extra", "photosynthesis details"),
+    )
+    conn.commit()
+    results = conn.execute(
+        "SELECT rowid FROM node_sections_fts WHERE body MATCH ?",
+        ("photosynthesis",),
+    ).fetchall()
+    assert len(results) == 1
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — running migration twice is safe
+# ---------------------------------------------------------------------------
+
+def test_migration_idempotent(old_schema_db):
+    conn = sqlite3.connect(old_schema_db)
+    _insert_node(conn, "n1", "Project")
+    conn.execute(
+        "INSERT INTO node_sections (node_id, section_type, body) VALUES (?, ?, ?)",
+        ("n1", "details", "content"),
+    )
+    conn.commit()
+    conn.close()
+
+    migrate_section_files(old_schema_db)
+    migrate_section_files(old_schema_db)  # second run should not raise or duplicate
+
+    conn = sqlite3.connect(old_schema_db)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute("SELECT * FROM node_sections").fetchall()
+    assert len(rows) == 1
+    assert rows[0]["name"] == "main"
+    conn.close()

--- a/tether_mcp/server.py
+++ b/tether_mcp/server.py
@@ -562,15 +562,23 @@ def read_section(node_id: str, section_type: str, name: str = "main") -> dict:
 @mcp.tool()
 def write_section(node_id: str, section_type: str, body: str, name: str = "main") -> dict:
     """Write (create or replace) a section file on a node. Use name='main' (default) for the primary file, or pass a specific name for named files."""
+    import sqlite3
     from db.queries import upsert_section
-    return upsert_section(_db(), node_id, section_type, body, name=name)
+    try:
+        return upsert_section(_db(), node_id, section_type, body, name=name)
+    except sqlite3.IntegrityError as e:
+        return {"error": f"Write failed: {e}. Check that node_id '{node_id}' exists."}
 
 
 @mcp.tool()
 def append_to_section(node_id: str, section_type: str, content: str, name: str = "main") -> dict:
     """Append text to a section file with a double-newline separator. Creates the section if it doesn't exist. Use name='main' (default) for the primary file, or pass a specific name for named files."""
+    import sqlite3
     from db.queries import append_section
-    return append_section(_db(), node_id, section_type, content, name=name)
+    try:
+        return append_section(_db(), node_id, section_type, content, name=name)
+    except sqlite3.IntegrityError as e:
+        return {"error": f"Append failed: {e}. Check that node_id '{node_id}' exists."}
 
 
 @mcp.tool()
@@ -583,8 +591,12 @@ def list_section_files(node_id: str, section_type: str) -> list[dict]:
 @mcp.tool()
 def create_section_file(node_id: str, section_type: str, name: str, body: str = "") -> dict:
     """Create a new named file within a section type. Position is auto-assigned. Use write_section with name param to update an existing file."""
+    import sqlite3
     from db.queries import create_section_file as _create_section_file
-    return _create_section_file(_db(), node_id, section_type, name, body=body)
+    try:
+        return _create_section_file(_db(), node_id, section_type, name, body=body)
+    except sqlite3.IntegrityError:
+        return {"error": f"Section file '{name}' already exists in '{section_type}'. Use write_section to update it."}
 
 
 @mcp.tool()

--- a/tether_mcp/server.py
+++ b/tether_mcp/server.py
@@ -534,39 +534,62 @@ def get_node_by_path(path: str) -> dict:
 # Section-level read/write (token-efficient)
 @mcp.tool()
 def list_node_sections(node_id: str) -> list[dict]:
-    """List section types and their sizes for a node, WITHOUT returning full body content. Use read_section to get specific content."""
+    """List section types for a node with file counts per type. Does NOT return body content. Use list_section_files to see individual files, then read_section to get content."""
     from db.queries import get_sections
     sections = get_sections(_db(), node_id)
-    return [{"section_type": s["section_type"], "size": len(s["body"]), "updated_at": s["updated_at"]} for s in sections]
+    grouped: dict[str, dict] = {}
+    for s in sections:
+        st = s["section_type"]
+        if st not in grouped:
+            grouped[st] = {"section_type": st, "file_count": 0, "total_size": 0, "updated_at": s["updated_at"]}
+        grouped[st]["file_count"] += 1
+        grouped[st]["total_size"] += len(s["body"])
+        if s["updated_at"] > grouped[st]["updated_at"]:
+            grouped[st]["updated_at"] = s["updated_at"]
+    return list(grouped.values())
 
 
 @mcp.tool()
-def read_section(node_id: str, section_type: str) -> dict:
-    """Read the full body of a specific section of a node."""
+def read_section(node_id: str, section_type: str, name: str = "main") -> dict:
+    """Read the full body of a specific section file. Use name='main' (default) for the primary file, or pass a specific name for named files."""
     from db.queries import get_section
-    result = get_section(_db(), node_id, section_type)
+    result = get_section(_db(), node_id, section_type, name=name)
     if result is None:
-        return {"error": f"Section '{section_type}' not found on node {node_id}"}
+        return {"error": f"Section '{section_type}' file '{name}' not found on node {node_id}"}
     return result
 
 
 @mcp.tool()
-def write_section(node_id: str, section_type: str, body: str) -> dict:
-    """Write (create or replace) a section on a node."""
+def write_section(node_id: str, section_type: str, body: str, name: str = "main") -> dict:
+    """Write (create or replace) a section file on a node. Use name='main' (default) for the primary file, or pass a specific name for named files."""
     from db.queries import upsert_section
-    return upsert_section(_db(), node_id, section_type, body)
+    return upsert_section(_db(), node_id, section_type, body, name=name)
 
 
 @mcp.tool()
-def append_to_section(node_id: str, section_type: str, content: str) -> dict:
-    """Append text to a section with a double-newline separator. Creates the section if it doesn't exist."""
+def append_to_section(node_id: str, section_type: str, content: str, name: str = "main") -> dict:
+    """Append text to a section file with a double-newline separator. Creates the section if it doesn't exist. Use name='main' (default) for the primary file, or pass a specific name for named files."""
     from db.queries import append_section
-    return append_section(_db(), node_id, section_type, content)
+    return append_section(_db(), node_id, section_type, content, name=name)
+
+
+@mcp.tool()
+def list_section_files(node_id: str, section_type: str) -> list[dict]:
+    """List individual files within a section type. Returns [{name, size, position, updated_at}] without body content — token-efficient for browsing. Use read_section with name param to get a specific file's content."""
+    from db.queries import list_section_files as _list_section_files
+    return _list_section_files(_db(), node_id, section_type)
+
+
+@mcp.tool()
+def create_section_file(node_id: str, section_type: str, name: str, body: str = "") -> dict:
+    """Create a new named file within a section type. Position is auto-assigned. Use write_section with name param to update an existing file."""
+    from db.queries import create_section_file as _create_section_file
+    return _create_section_file(_db(), node_id, section_type, name, body=body)
 
 
 @mcp.tool()
 def search_sections(query: str, node_id: str = "") -> list[dict]:
-    """Full-text search across all node sections. Returns matching snippets. Optionally scope to a node's subtree."""
+    """Full-text search across all node sections. Returns matching snippets with name field. Optionally scope to a node's subtree."""
     from db.queries import search_sections as _search
     nid = node_id if node_id else None
     return _search(_db(), query, nid)


### PR DESCRIPTION
## Summary
- **Sections as named files** — `node_sections` now supports multiple named files per section type (e.g. `details/overview.md`, `details/requirements.md`). Default file name is `main` for backward compat.
- **Node description field** — `context_nodes.description` for collapsed previews without reading section bodies
- **Archive system** — archive/unarchive buttons in tree UI, "Show archived" toggle, auto-archive rules (days after completion, days inactive) with settings UI and trigger endpoint
- **Milestone lookup by node ID** — removed fragile name-based lookups, milestones render as tree children with color/status/date badges
- **Auto-scroll during drag** — `useAutoScrollDrag` composable scrolls viewport when dragging near edges
- **Full API** — file listing, CRUD, rename, reorder endpoints; MCP tools with name param; settings API

## Stack
- Schema: `name`, `position` on node_sections; `description` on context_nodes; migration script
- DB: 21 updated/new query functions, 210 tests passing
- API: 9 new/updated section file routes, settings routes, auto-archive endpoint
- MCP: 7 updated/new tools with IntegrityError handling
- Frontend: store + ContextTreeNode file list UI, description editor, archive UI, auto-scroll


## Test plan
- [ ] Migration: existing sections get `name='main'`, new UNIQUE constraint works
- [ ] API: create/read/update/delete named files within section types
- [ ] Tree UI: section tabs show file list, click to view/edit, + Add file
- [ ] Description: inline editing, shows when collapsed
- [ ] Archive: toggle visibility, archive/unarchive buttons, dimmed styling
- [ ] Auto-archive: settings persist, trigger endpoint archives matching nodes
- [ ] Milestones: render as tree children with color dot, status badge, target date
- [ ] Drag: auto-scroll near viewport edges