### PR TITLE
fix: archive error handling, navigable TaskCard prop, stale tasks

### DIFF
--- a/frontend/src/components/ContextTreeNode.vue
+++ b/frontend/src/components/ContextTreeNode.vue
@@ -221,7 +221,7 @@ async function fetchNodeTasks() {
   } catch (e) {
     console.error('fetchNodeTasks error:', e)
     error.value = e instanceof Error ? e.message : 'Failed to fetch tasks'
-    nodeTasks.value = []
+    // Don't clear nodeTasks — stale data is better than showing "(no linked tasks)" after a fetch failure
   } finally {
     loadingTasks.value = false
   }
@@ -373,6 +373,16 @@ async function saveRename() {
   }
 }
 
+async function setArchived(archived: boolean) {
+  try {
+    error.value = null
+    await contextStore.patchNode(props.node.id, { archived })
+  } catch (e) {
+    console.error('setArchived error:', e)
+    error.value = e instanceof Error ? e.message : 'Failed to update archive status'
+  }
+}
+
 async function deleteWithConfirm() {
   const childCount = children.value.length
   const msg = childCount > 0
@@ -483,10 +493,10 @@ async function addChild() {
           <button v-else @click="startRename"
                   class="text-xs text-white/50 hover:text-white">Rename</button>
           <button v-if="node.archived"
-                  @click="contextStore.patchNode(node.id, { archived: false })"
+                  @click="setArchived(false)"
                   class="text-xs text-yellow-400/60 hover:text-yellow-400">Unarchive</button>
           <button v-else
-                  @click="contextStore.patchNode(node.id, { archived: true })"
+                  @click="setArchived(true)"
                   class="text-xs text-white/40 hover:text-white/70">Archive</button>
           <button @click="deleteWithConfirm"
                   class="text-xs text-red-400/60 hover:text-red-400">Delete</button>
@@ -638,7 +648,8 @@ async function addChild() {
                   :compact="true"
                   :editable="false"
                   :showRemove="false"
-                  :hideTags="false" />
+                  :hideTags="false"
+                  :navigable="false" />
               </div>
             </GroupContainer>
           </div>

--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -24,12 +24,14 @@ const props = withDefaults(defineProps<{
   showDetailLink?: boolean
   compact?: boolean
   hideTags?: boolean  // hide milestone/context tags (when inside a GroupContainer that already shows them)
+  navigable?: boolean  // whether clicking the card navigates to detail panel
 }>(), {
   editable: true,
   showRemove: true,
   showDetailLink: true,
   compact: false,
   hideTags: false,
+  navigable: true,
 })
 const emit = defineEmits<{
   (e: 'update', task: Task): void
@@ -119,7 +121,7 @@ function toggleFollowup(enabled: boolean) {
       :style="STATUS_CARD_STYLE[task.status]"
       :draggable="!editable && !!task.id"
       @dragstart="onDragStart"
-      @click="task.id && router.push(`${routeBase}/task/${task.id}`)">
+      @click="navigable && task.id && router.push(`${routeBase}/task/${task.id}`)">
     <div class="flex flex-col gap-1 p-2">
     <!-- Status pill (top-right) — dropdown only in editable mode (plan view) -->
     <div class="absolute top-1.5 right-1.5">


### PR DESCRIPTION
## Summary
Review fixes from PR #122 that were committed after merge:

- **Archive/Unarchive error handling** — buttons were fire-and-forget, now wrapped in `setArchived()` with try-catch + error display
- **TaskCard `navigable` prop** — prevents clicking task cards in the context tree from navigating away to `/plan/day/...` (routeBase doesn't handle `/context`)
- **Stale tasks on fetch error** — don't clear `nodeTasks` array on failure; stale data is better than misleading "(no linked tasks)"

## Test plan
- [ ] Click Archive on a node — should work, show error if network fails
- [ ] Click a task card in the tasks tab — should NOT navigate away
- [ ] Disconnect network, switch to tasks tab — should show error, not "(no linked tasks)"