### PR TITLE
fix: dependency names instead of UUIDs + segmented milestone progress bar

### DIFF
--- a/db/queries.py
+++ b/db/queries.py
@@ -335,7 +335,19 @@ def remove_dependency(db_path: Path, dep_id: int) -> None:
 
 def get_dependencies_for(db_path: Path, entity_type: str, entity_id: str) -> dict:
     """Return {"blocks": [...], "blocked_by": [...]} for an entity.
-    Each item: {"id": dep_id, "type": blocker/blocked type, "entity_id": the other entity's id}"""
+    Each item: {"id": dep_id, "type": blocker/blocked type, "entity_id": the other entity's id, "name": resolved name}"""
+
+    def _resolve_name(conn, etype, eid):
+        if etype == 'task':
+            row = conn.execute("SELECT text FROM tasks WHERE uuid=?", (eid,)).fetchone()
+            return row["text"] if row else None
+        elif etype == 'milestone':
+            row = conn.execute("SELECT name FROM context_nodes WHERE id=?", (eid,)).fetchone()
+            if not row:
+                row = conn.execute("SELECT name FROM milestones WHERE id=?", (eid,)).fetchone()
+            return row["name"] if row else None
+        return None
+
     with get_db(db_path) as conn:
         blocker_rows = conn.execute(
             "SELECT id, blocked_type, blocked_id FROM dependencies WHERE blocker_type=? AND blocker_id=?",
@@ -345,10 +357,12 @@ def get_dependencies_for(db_path: Path, entity_type: str, entity_id: str) -> dic
             "SELECT id, blocker_type, blocker_id FROM dependencies WHERE blocked_type=? AND blocked_id=?",
             (entity_type, entity_id),
         ).fetchall()
-    blocks = [{"id": r["id"], "type": r["blocked_type"], "entity_id": r["blocked_id"]}
-              for r in blocker_rows]
-    blocked_by = [{"id": r["id"], "type": r["blocker_type"], "entity_id": r["blocker_id"]}
-                  for r in blocked_rows]
+        blocks = [{"id": r["id"], "type": r["blocked_type"], "entity_id": r["blocked_id"],
+                    "name": _resolve_name(conn, r["blocked_type"], r["blocked_id"])}
+                  for r in blocker_rows]
+        blocked_by = [{"id": r["id"], "type": r["blocker_type"], "entity_id": r["blocker_id"],
+                       "name": _resolve_name(conn, r["blocker_type"], r["blocker_id"])}
+                      for r in blocked_rows]
     return {"blocks": blocks, "blocked_by": blocked_by}
 
 

--- a/frontend/src/components/ContextTreeNode.vue
+++ b/frontend/src/components/ContextTreeNode.vue
@@ -95,6 +95,22 @@ const taskGroups = computed(() => {
     .filter(g => g.tasks.length > 0)
 })
 
+const PROGRESS_BAR_SEGMENTS = [
+  { status: 'done', color: '#22c55e' },
+  { status: 'in_progress', color: '#3b82f6' },
+  { status: 'pending', color: 'rgba(255,255,255,0.15)' },
+  { status: 'blocked', color: '#ef4444' },
+  { status: 'skipped', color: '#94a3b8' },
+]
+
+const taskStatusCounts = computed(() => {
+  const counts: Record<string, number> = {}
+  for (const t of nodeTasks.value) {
+    counts[t.status] = (counts[t.status] || 0) + 1
+  }
+  return counts
+})
+
 const tasksDoneCount = computed(() => nodeTasks.value.filter(t => t.status === 'done').length)
 const tasksTotalCount = computed(() => nodeTasks.value.length)
 const tasksProgressPct = computed(() =>
@@ -176,6 +192,9 @@ async function toggleExpand() {
       await fetchNodeTasks()
     } else {
       await loadTabFiles(activeTab.value)
+      if (props.node.node_type === 'milestone') {
+        fetchNodeTasks()  // fire-and-forget for header progress bar
+      }
     }
   } catch (e) {
     expanded.value = false
@@ -501,6 +520,15 @@ async function addChild() {
           <button @click="deleteWithConfirm"
                   class="text-xs text-red-400/60 hover:text-red-400">Delete</button>
         </div>
+      </div>
+
+      <!-- Segmented progress bar for milestones -->
+      <div v-if="node.node_type === 'milestone' && tasksTotalCount > 0"
+           class="flex h-1.5 rounded-full overflow-hidden mt-1">
+        <div v-for="seg in PROGRESS_BAR_SEGMENTS"
+             :key="seg.status"
+             v-show="taskStatusCounts[seg.status]"
+             :style="{ width: ((taskStatusCounts[seg.status] || 0) / tasksTotalCount * 100) + '%', backgroundColor: seg.color }" />
       </div>
 
       <!-- Collapsed: show description or details preview -->

--- a/frontend/src/components/MilestoneDetailPanel.vue
+++ b/frontend/src/components/MilestoneDetailPanel.vue
@@ -272,7 +272,7 @@ onMounted(async () => {
               @click="openDep(d.type, d.entity_id)"
               class="flex items-center gap-2 text-left group">
               <span class="w-2 h-2 rounded-full bg-white/20 flex-shrink-0" />
-              <span class="text-sm text-white/70 hover:text-white flex-1 truncate">{{ d.entity_id }}</span>
+              <span class="text-sm text-white/70 hover:text-white flex-1 truncate">{{ d.name || d.entity_id }}</span>
               <span class="text-xs px-1 py-0.5 rounded bg-white/10 text-white/40">{{ d.type }}</span>
               <button @click.stop="removeDep(d.id)" class="text-white/20 hover:text-red-400 text-xs opacity-0 group-hover:opacity-100">✕</button>
             </button>
@@ -286,7 +286,7 @@ onMounted(async () => {
               @click="openDep(d.type, d.entity_id)"
               class="flex items-center gap-2 text-left group">
               <span class="w-2 h-2 rounded-full bg-white/20 flex-shrink-0" />
-              <span class="text-sm text-white/70 hover:text-white flex-1 truncate">{{ d.entity_id }}</span>
+              <span class="text-sm text-white/70 hover:text-white flex-1 truncate">{{ d.name || d.entity_id }}</span>
               <span class="text-xs px-1 py-0.5 rounded bg-white/10 text-white/40">{{ d.type }}</span>
               <button @click.stop="removeDep(d.id)" class="text-white/20 hover:text-red-400 text-xs opacity-0 group-hover:opacity-100">✕</button>
             </button>

--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -462,7 +462,7 @@ onMounted(async () => {
               @click="openDep(d.type, d.entity_id)"
               class="flex items-center gap-2 text-left group">
               <span :class="STATUS_COLORS['pending']" class="w-2 h-2 rounded-full flex-shrink-0" />
-              <span class="text-sm text-white/70 hover:text-white flex-1 truncate">{{ depLabel(d.type, d.entity_id) }}</span>
+              <span class="text-sm text-white/70 hover:text-white flex-1 truncate">{{ d.name || depLabel(d.type, d.entity_id) }}</span>
               <span class="text-xs px-1 py-0.5 rounded bg-white/10 text-white/40">{{ d.type }}</span>
               <button @click.stop="removeDep(d.id)" class="text-white/20 hover:text-red-400 text-xs opacity-0 group-hover:opacity-100">✕</button>
             </button>
@@ -477,7 +477,7 @@ onMounted(async () => {
               @click="openDep(d.type, d.entity_id)"
               class="flex items-center gap-2 text-left group">
               <span :class="STATUS_COLORS['pending']" class="w-2 h-2 rounded-full flex-shrink-0" />
-              <span class="text-sm text-white/70 hover:text-white flex-1 truncate">{{ depLabel(d.type, d.entity_id) }}</span>
+              <span class="text-sm text-white/70 hover:text-white flex-1 truncate">{{ d.name || depLabel(d.type, d.entity_id) }}</span>
               <span class="text-xs px-1 py-0.5 rounded bg-white/10 text-white/40">{{ d.type }}</span>
               <button @click.stop="removeDep(d.id)" class="text-white/20 hover:text-red-400 text-xs opacity-0 group-hover:opacity-100">✕</button>
             </button>

--- a/frontend/src/composables/useDependencies.ts
+++ b/frontend/src/composables/useDependencies.ts
@@ -5,6 +5,7 @@ export interface Dependency {
   id: number
   type: string      // the OTHER entity's type
   entity_id: string  // the OTHER entity's id
+  name?: string     // resolved human-readable name
 }
 
 export interface Dependencies {


### PR DESCRIPTION
## Summary
- **Dependencies show names** — `get_dependencies_for()` now resolves entity names (task text, milestone/node name) instead of showing raw UUIDs. Frontend falls back to ID if name resolution fails.
- **Segmented progress bar** on milestone node headers — thin bar proportional to task status distribution (green done, blue in_progress, dark pending, red blocked, gray skipped). Auto-fetches tasks on milestone expand.

## Files changed
- `db/queries.py` — `_resolve_name()` helper + enriched dependency dicts
- `MilestoneDetailPanel.vue` + `TaskDetailPanel.vue` — display `d.name || d.entity_id`
- `useDependencies.ts` — `name?: string` on Dependency interface
- `ContextTreeNode.vue` — segmented progress bar + auto-fetch tasks for milestones

## Test plan
- [ ] Open milestone detail panel — dependencies show names, not UUIDs
- [ ] Open task detail panel — dependencies show names
- [ ] Expand a milestone in context tree — segmented progress bar appears
- [ ] Progress bar segments are proportional to task statuses