### PR TITLE
Containerize Tether stack (SQLite, Pi)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# .dockerignore
+.git
+.github
+.worktrees
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.mypy_cache
+*.egg-info
+.venv
+venv
+node_modules
+frontend/node_modules
+*.db
+*.sqlite
+.tether-config
+systemd
+tests
+docs
+*.md
+!pyproject.toml
+!requirements*.txt

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# .env.example — Copy to .env and fill in values.
+# DO NOT commit .env to git.
+
+# ── Data directory (bind mount) ───────────────────────────
+# Path to your existing ~/.tether-config directory.
+# Contains SQLite databases, config.yaml, secrets.json.
+TETHER_DATA_DIR=~/.tether-config
+
+# ── Auth ──────────────────────────────────────────────────
+TETHER_JWT_SECRET=dev-secret-change-in-production
+
+# ── Telegram bot ──────────────────────────────────────────
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+
+# ── OAuth (optional — for web dashboard login) ───────────
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+GITHUB_CALLBACK_URL=http://localhost:8000/auth/github/callback
+
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_CALLBACK_URL=http://localhost:8000/auth/google/callback
+
+# ── MCP server ────────────────────────────────────────────
+# User ID for MCP server (scopes queries to this user's DB).
+# Will be replaced by per-session auth in cloud deployment.
+TETHER_USER_ID=
+
+# ── LLM API keys (for bot) ───────────────────────────────
+ANTHROPIC_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,31 +1,16 @@
 # .env.example — Copy to .env and fill in values.
 # DO NOT commit .env to git.
+#
+# Most configuration (secrets, API keys, OAuth credentials, Telegram token)
+# lives in ~/.tether-config/secrets.json and config.yaml — mounted at /data.
+# Only Docker-level settings belong here.
 
 # ── Data directory (bind mount) ───────────────────────────
-# Path to your existing ~/.tether-config directory.
-# Contains SQLite databases, config.yaml, secrets.json.
-TETHER_DATA_DIR=~/.tether-config
-
-# ── Auth ──────────────────────────────────────────────────
-TETHER_JWT_SECRET=dev-secret-change-in-production
-
-# ── Telegram bot ──────────────────────────────────────────
-TELEGRAM_BOT_TOKEN=
-TELEGRAM_CHAT_ID=
-
-# ── OAuth (optional — for web dashboard login) ───────────
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
-GITHUB_CALLBACK_URL=http://localhost:8000/auth/github/callback
-
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
-GOOGLE_CALLBACK_URL=http://localhost:8000/auth/google/callback
+# Absolute path to your ~/.tether-config directory.
+# Contains config.yaml, secrets.json, SQLite databases.
+TETHER_DATA_DIR=/home/toast/.tether-config
 
 # ── MCP server ────────────────────────────────────────────
-# User ID for MCP server (scopes queries to this user's DB).
-# Will be replaced by per-session auth in cloud deployment.
+# User ID to scope MCP queries. Matches a row in auth.db.
+# Will be replaced by per-session API key auth in cloud deployment.
 TETHER_USER_ID=
-
-# ── LLM API keys (for bot) ───────────────────────────────
-ANTHROPIC_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,12 @@
 # Contains config.yaml, secrets.json, SQLite databases.
 TETHER_DATA_DIR=/home/toast/.tether-config
 
+# ── Premium (optional) ────────────────────────────────────
+# GitHub personal access token with read access to jlunder00/tether-premium.
+# If set, docker compose build installs premium — cloud/company release.
+# If unset, builds community edition.
+GITHUB_TOKEN=
+
 # ── MCP server ────────────────────────────────────────────
 # User ID to scope MCP queries. Matches a row in auth.db.
 # Will be replaced by per-session API key auth in cloud deployment.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,87 +13,30 @@ jobs:
           cd /home/toast/tether
           git pull origin main
 
-      - name: Install Python dependencies
-        run: |
-          cd /home/toast/tether
-          source .venv/bin/activate
-          pip install -q -e .
-
-      - name: Pull and install tether-premium (if available)
+      - name: Pull tether-premium (if available)
         run: |
           if [ -d /home/toast/tether-premium ]; then
             cd /home/toast/tether-premium
             git pull origin main
-            cd /home/toast/tether
-            source .venv/bin/activate
-            pip install -q -e /home/toast/tether-premium
-            python -c "from tether_premium.register import get_premium_handler; print('[ok] premium loaded')"
+            echo "tether-premium updated"
           else
             echo "tether-premium not cloned — running community edition"
           fi
 
-      - name: Write Telegram secrets to config
+      - name: Build Docker image
         run: |
           cd /home/toast/tether
-          source .venv/bin/activate
-          python3 - <<'EOF'
-          import yaml, os
-          from pathlib import Path
+          docker compose build
 
-          config_path = Path.home() / ".tether-config" / "config.yaml"
-          if config_path.exists():
-              with open(config_path) as f:
-                  config = yaml.safe_load(f) or {}
-          else:
-              config = {}
-
-          bot_token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
-          chat_id = os.environ.get("TELEGRAM_CHAT_ID", "")
-
-          if not bot_token or not chat_id:
-              print("TELEGRAM secrets not set — skipping config update, existing values preserved.")
-          else:
-              config.setdefault("telegram", {})
-              config["telegram"]["bot_token"] = bot_token
-              config["telegram"]["chat_id"] = chat_id
-              with open(config_path, "w") as f:
-                  yaml.dump(config, f)
-              print("Config updated.")
-          EOF
-        env:
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-
-      - name: Verify bot can run
+      - name: Run DB migrations
         run: |
           cd /home/toast/tether
-          source .venv/bin/activate
-          python -c "from bot.anchor_trigger import load_anchors; print('[ok] imports work')"
-
-      - name: Run DB migrations on user databases
-        run: |
-          cd /home/toast/tether
-          source .venv/bin/activate
           for db in /home/toast/.tether-config/users/*.db; do
-            [ -f "$db" ] && python db/migrate_data_model.py "$db" && echo "Migrated $db" || true
+            [ -f "$db" ] && docker compose run --rm --no-deps api python db/migrate_data_model.py "$db" \
+              && echo "Migrated $db" || true
           done
 
-      - name: Build Vue frontend
+      - name: Restart services
         run: |
-          cd /home/toast/tether/frontend
-          npm ci
-          npm run build
-
-      - name: Install systemd service files
-        run: |
-          sudo cp /home/toast/tether/systemd/tether-*.service /etc/systemd/system/
-          sudo systemctl daemon-reload
-
-      - name: Restart API service
-        run: sudo systemctl restart tether-api
-
-      - name: Restart bot service
-        run: sudo systemctl restart tether-bot
-
-      - name: Restart MCP service
-        run: sudo systemctl restart tether-mcp
+          cd /home/toast/tether
+          docker compose up -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,20 +13,12 @@ jobs:
           cd /home/toast/tether
           git pull origin main
 
-      - name: Pull tether-premium (if available)
-        run: |
-          if [ -d /home/toast/tether-premium ]; then
-            cd /home/toast/tether-premium
-            git pull origin main
-            echo "tether-premium updated"
-          else
-            echo "tether-premium not cloned — running community edition"
-          fi
-
       - name: Build Docker image
         run: |
           cd /home/toast/tether
           docker compose build
+        env:
+          GITHUB_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
 
       - name: Run DB migrations
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,3 +19,11 @@ jobs:
 
       - name: Run tests
         run: pytest -v
+
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build --no-cache -t tether:ci .

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,15 +24,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# External dependencies (cached layer — only reruns when pyproject.toml changes)
-# tomllib is stdlib in Python 3.11 — no extra tools needed.
-COPY pyproject.toml ./
-RUN python3 -c "
-import tomllib, subprocess, sys
-with open('pyproject.toml', 'rb') as f:
-    deps = tomllib.load(f)['project']['dependencies']
-subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--no-cache-dir'] + deps)
-"
+# External dependencies (cached layer — only reruns when requirements.txt changes)
+COPY requirements.txt pyproject.toml ./
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Application code
 COPY api/ api/
@@ -44,7 +38,7 @@ COPY prompts/ prompts/
 COPY cron/ cron/
 COPY scripts/ scripts/
 
-# Install local package (no external downloads — deps already satisfied above)
+# Install local package (deps already satisfied — no external downloads)
 RUN pip install --no-cache-dir --no-deps .
 
 # Frontend build artifacts

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# Python dependencies (cached layer — changes less often than code)
+# External dependencies (cached layer — only reruns when pyproject.toml changes)
+# tomllib is stdlib in Python 3.11 — no extra tools needed.
 COPY pyproject.toml ./
-RUN pip install --no-cache-dir -e . 2>/dev/null || pip install --no-cache-dir .
+RUN python3 -c "
+import tomllib, subprocess, sys
+with open('pyproject.toml', 'rb') as f:
+    deps = tomllib.load(f)['project']['dependencies']
+subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--no-cache-dir'] + deps)
+"
 
 # Application code
 COPY api/ api/
@@ -37,6 +43,9 @@ COPY config/ config/
 COPY prompts/ prompts/
 COPY cron/ cron/
 COPY scripts/ scripts/
+
+# Install local package (no external downloads — deps already satisfied above)
+RUN pip install --no-cache-dir --no-deps .
 
 # Frontend build artifacts
 COPY --from=frontend-build /build/dist/ frontend/dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Dockerfile
+# Shared image for all three Tether services (api, bot, mcp).
+# The service-specific CMD is set in docker-compose.yml.
+
+# ── Stage 1: Build Vue frontend ──────────────────────────
+FROM node:20-slim AS frontend-build
+
+WORKDIR /build
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci --ignore-scripts
+
+COPY frontend/ ./
+RUN npm run build
+# Output: /build/dist/
+
+# ── Stage 2: Python runtime ──────────────────────────────
+FROM python:3.11-slim
+
+# System deps for bcrypt, PyJWT, and potential native extensions.
+# cron is needed for anchor trigger scheduling in the bot container.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc libffi-dev cron \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Python dependencies (cached layer — changes less often than code)
+COPY pyproject.toml ./
+RUN pip install --no-cache-dir -e . 2>/dev/null || pip install --no-cache-dir .
+
+# Application code
+COPY api/ api/
+COPY bot/ bot/
+COPY db/ db/
+COPY tether_mcp/ tether_mcp/
+COPY config/ config/
+COPY prompts/ prompts/
+COPY cron/ cron/
+COPY scripts/ scripts/
+
+# Frontend build artifacts
+COPY --from=frontend-build /build/dist/ frontend/dist/
+
+# Default port for API
+EXPOSE 8000
+
+# Default CMD — overridden per service in docker-compose.yml
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,18 @@ COPY scripts/ scripts/
 # Frontend build artifacts
 COPY --from=frontend-build /build/dist/ frontend/dist/
 
+# ── Optional premium layer ────────────────────────────────
+# Pass --build-arg GITHUB_TOKEN=<token> to install premium from the private
+# repo. If omitted or empty, this produces the community edition image.
+ARG GITHUB_TOKEN=
+RUN if [ -n "$GITHUB_TOKEN" ]; then \
+      pip install --no-cache-dir \
+        "git+https://${GITHUB_TOKEN}@github.com/jlunder00/tether-premium.git" && \
+      python -c "from tether_premium.register import get_premium_handler; print('[ok] premium loaded')" ; \
+    else \
+      echo "[skip] no GITHUB_TOKEN — community edition" ; \
+    fi
+
 # Default port for API
 EXPOSE 8000
 

--- a/api/config.py
+++ b/api/config.py
@@ -2,7 +2,7 @@ import json
 import os
 from pathlib import Path
 
-CONFIG_DIR = Path.home() / ".tether-config"
+CONFIG_DIR = Path(os.environ.get("TETHER_CONFIG_DIR", Path.home() / ".tether-config"))
 DB_PATH = CONFIG_DIR / "tether.db"
 AUTH_DB_PATH = CONFIG_DIR / "auth.db"
 USERS_DB_DIR = CONFIG_DIR / "users"

--- a/bot/message_handler.py
+++ b/bot/message_handler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import json
 import logging
+import os
 import random
 import re
 import subprocess
@@ -62,7 +63,7 @@ def _resolve_db_path(chat_id: str) -> Path | None:
         from db.auth_queries import get_user_by_telegram_chat_id
         user = get_user_by_telegram_chat_id(AUTH_DB_PATH, chat_id)
         if user:
-            return Path.home() / ".tether-config" / "users" / f"{user['id']}.db"
+            return _CONFIG_DIR / "users" / f"{user['id']}.db"
     except Exception as e:
         logger.warning("_resolve_db_path error: %s", e)
     return None
@@ -77,10 +78,11 @@ def verify_link_code(code: str) -> str | None:
         logger.warning("verify_link_code error: %s", e)
         return None
 
-DB_PATH = Path.home() / ".tether-config" / "tether.db"
-AUTH_DB_PATH = Path.home() / ".tether-config" / "auth.db"
-_CONFIG_PATH = Path.home() / ".tether-config" / "config.yaml"
-_OFFSET_PATH = Path.home() / ".tether-config" / "telegram_offset"
+_CONFIG_DIR = Path(os.environ.get("TETHER_CONFIG_DIR", Path.home() / ".tether-config"))
+DB_PATH = _CONFIG_DIR / "tether.db"
+AUTH_DB_PATH = _CONFIG_DIR / "auth.db"
+_CONFIG_PATH = _CONFIG_DIR / "config.yaml"
+_OFFSET_PATH = _CONFIG_DIR / "telegram_offset"
 
 # pending link codes: code -> (chat_id, timestamp) — in-memory cache; authoritative copy is auth.db
 _pending_links: dict[str, tuple[str, float]] = {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,14 @@
 # Run the full Tether stack: API + Bot + MCP server.
 # Data lives at the bind-mounted TETHER_DATA_DIR (default: ~/.tether-config).
 
+x-build: &build
+  context: .
+  args:
+    GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+
 services:
   api:
-    build: .
+    build: *build
     command: ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]
     ports:
       - "8000:8000"
@@ -20,7 +25,7 @@ services:
       retries: 3
 
   bot:
-    build: .
+    build: *build
     entrypoint: ["/app/scripts/bot-entrypoint.sh"]
     volumes:
       - ${TETHER_DATA_DIR:-~/.tether-config}:/data
@@ -32,7 +37,7 @@ services:
     restart: unless-stopped
 
   mcp:
-    build: .
+    build: *build
     command: ["python", "-m", "tether_mcp.server", "--sse"]
     ports:
       - "5001:5001"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,6 @@ services:
       - ${TETHER_DATA_DIR:-~/.tether-config}:/data
     environment:
       - TETHER_CONFIG_DIR=/data
-      - TETHER_JWT_SECRET=${TETHER_JWT_SECRET:-dev-secret-change-in-production}
-    env_file:
-      - .env
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health')"]
@@ -29,8 +26,6 @@ services:
       - ${TETHER_DATA_DIR:-~/.tether-config}:/data
     environment:
       - TETHER_CONFIG_DIR=/data
-    env_file:
-      - .env
     depends_on:
       api:
         condition: service_healthy
@@ -46,6 +41,4 @@ services:
     environment:
       - TETHER_CONFIG_DIR=/data
       - TETHER_USER_ID=${TETHER_USER_ID:-}
-    env_file:
-      - .env
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+# docker-compose.yml
+# Run the full Tether stack: API + Bot + MCP server.
+# Data lives at the bind-mounted TETHER_DATA_DIR (default: ~/.tether-config).
+
+services:
+  api:
+    build: .
+    command: ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+    ports:
+      - "8000:8000"
+    volumes:
+      - ${TETHER_DATA_DIR:-~/.tether-config}:/data
+    environment:
+      - TETHER_CONFIG_DIR=/data
+      - TETHER_JWT_SECRET=${TETHER_JWT_SECRET:-dev-secret-change-in-production}
+    env_file:
+      - .env
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  bot:
+    build: .
+    entrypoint: ["/app/scripts/bot-entrypoint.sh"]
+    volumes:
+      - ${TETHER_DATA_DIR:-~/.tether-config}:/data
+    environment:
+      - TETHER_CONFIG_DIR=/data
+    env_file:
+      - .env
+    depends_on:
+      api:
+        condition: service_healthy
+    restart: unless-stopped
+
+  mcp:
+    build: .
+    command: ["python", "-m", "tether_mcp.server", "--sse"]
+    ports:
+      - "5001:5001"
+    volumes:
+      - ${TETHER_DATA_DIR:-~/.tether-config}:/data
+    environment:
+      - TETHER_CONFIG_DIR=/data
+      - TETHER_USER_ID=${TETHER_USER_ID:-}
+    env_file:
+      - .env
+    restart: unless-stopped

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+pyyaml>=6.0
+jinja2>=3.1
+requests>=2.31
+fastapi>=0.110
+uvicorn[standard]>=0.29
+python-multipart>=0.0.9
+mcp>=1.0
+bcrypt>=4.0
+pyjwt>=2.8
+authlib>=1.3
+httpx>=0.27
+anthropic>=0.40
+openai>=1.0

--- a/scripts/bot-entrypoint.sh
+++ b/scripts/bot-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start cron daemon in background (needed for anchor triggers).
+# bot/crontab.py writes cron entries for anchor transition scheduling.
+cron
+
+echo "[bot-entrypoint] cron started, launching bot..."
+
+# Run the bot (exec replaces shell so signals propagate correctly)
+exec python -m bot.message_handler "$@"

--- a/tether_mcp/server.py
+++ b/tether_mcp/server.py
@@ -31,9 +31,11 @@ from db.queries import (
 
 mcp = FastMCP("tether", host="0.0.0.0", port=5001)
 
+_CONFIG_DIR = Path(os.environ.get("TETHER_CONFIG_DIR", Path.home() / ".tether-config"))
+
 
 def _load_secrets() -> dict:
-    p = Path.home() / ".tether-config" / "secrets.json"
+    p = _CONFIG_DIR / "secrets.json"
     if p.exists():
         import json
         return json.loads(p.read_text())
@@ -47,8 +49,8 @@ def _db() -> Path:
         return Path(env)
     user_id = os.environ.get("TETHER_USER_ID") or _secrets.get("TETHER_USER_ID")
     if user_id:
-        return Path.home() / ".tether-config" / "users" / f"{user_id}.db"
-    return Path.home() / ".tether-config" / "tether.db"
+        return _CONFIG_DIR / "users" / f"{user_id}.db"
+    return _CONFIG_DIR / "tether.db"
 
 
 def _current_anchor(anchors: list[dict], now: Optional[datetime] = None) -> dict:


### PR DESCRIPTION
## Summary

- **Dockerfile** — multi-stage build (Node 20 → Python 3.11); all three services (api, bot, mcp) share one image with service-specific CMD in compose
- **docker-compose.yml** — 3 services mirroring the existing systemd setup; data bind-mounted from `~/.tether-config` so existing SQLite DBs and config files work without migration
- **Premium support** — pass `GITHUB_TOKEN` build arg to install `tether-premium` via `pip+git`; omit for community edition
- **Config dir env var** — `TETHER_CONFIG_DIR` added to `api/config.py`, `bot/message_handler.py`, and `tether_mcp/server.py` so containers resolve paths to the `/data` mount point instead of `~/.tether-config`
- **Bot entrypoint** — `scripts/bot-entrypoint.sh` starts cron daemon before the bot process (needed for anchor trigger scheduling)
- **deploy.yml** — rewritten to use `docker compose build` + `docker compose up -d`; drops venv/pip, systemd restarts, frontend build step, and secrets-writing-to-yaml (all handled by Docker or the mounted config dir)
- **test.yml** — adds parallel `docker-build` job to verify the image builds on every PR; unit tests continue on bare Python

## Test plan

- [ ] Copy `.env.example` → `.env`, set `TETHER_DATA_DIR` to absolute path of `~/.tether-config`
- [ ] `docker compose build` — verify multi-stage build completes, frontend dist copied in
- [ ] `docker compose up api` — verify uvicorn starts, `curl localhost:8000` returns SPA HTML
- [ ] `docker compose up -d` — verify all three services reach running state
- [ ] `curl -N localhost:5001/sse` — verify MCP SSE endpoint opens
- [ ] Send Telegram message — verify bot responds and logs are clean
- [ ] `docker compose exec bot pgrep cron` — verify cron daemon is alive in bot container
- [ ] `docker compose down` → `docker compose up -d` — verify data persists across restart
- [ ] Build with `GITHUB_TOKEN` set — verify `[ok] premium loaded` in build output
- [ ] Build without `GITHUB_TOKEN` — verify `[skip] no GITHUB_TOKEN — community edition`

🤖 Generated with [Claude Code](https://claude.com/claude-code)