### PR TITLE
Phase 0: Migrate public bot from context_entries to context_nodes

### DIFF
--- a/bot/message_handler.py
+++ b/bot/message_handler.py
@@ -23,7 +23,6 @@ from bot.handler_utils import (
 )
 from db.queries import (
     get_anchors,
-    get_context_entries,
     get_plan,
     get_recent_history,
     insert_check_in,
@@ -31,7 +30,6 @@ from db.queries import (
     list_plan_dates,
     log_stage,
     patch_anchor,
-    upsert_context_entry,
     upsert_plan,
     upsert_tasks,
     clear_session_state,
@@ -40,7 +38,6 @@ from db.queries import (
     upsert_staging_mutation,
     get_staging_mutations,
     link_milestone_task,
-    create_milestone,
     patch_milestone,
     init_followup_state,
     get_active_followup_states,
@@ -48,6 +45,15 @@ from db.queries import (
     record_ping,
     mark_followup_completed,
     resolve_followup_config,
+    # context_nodes model
+    ensure_node_path,
+    get_node_by_path,
+    get_section,
+    upsert_section,
+    append_section,
+    get_children,
+    get_all_node_paths,
+    create_node,
 )
 from db.schema import init_db
 
@@ -151,10 +157,11 @@ def _fetch_requested_context(requests: list[dict], db_path: Path, round_num: int
         kind = req.get("kind")
         if kind == "context_entry":
             subject = req.get("subject", "")
-            entries = get_context_entries(db_path, prefix=subject)
-            if entries:
-                for e in entries:
-                    sections.append(f"### Context: {e['subject']}\n{e['body']}")
+            node = get_node_by_path(db_path, subject)
+            if node:
+                sec = get_section(db_path, node["id"], "details")
+                body = sec["body"] if sec else "(no details section)"
+                sections.append(f"### Context: {subject}\n{body}")
             else:
                 sections.append(f"### Context: {subject}\n(not found)")
         elif kind == "plan":
@@ -268,19 +275,18 @@ def apply_mutations(mutations: list[dict], db_path: Path, today: str) -> None:
                 upsert_plan(db_path, date)
                 upsert_tasks(db_path, date, m["anchor_id"], m["tasks"], notes="")
             elif op == "update_context":
-                upsert_context_entry(db_path, m["subject"], m["body"])
+                node = ensure_node_path(db_path, m["subject"])
+                upsert_section(db_path, node["id"], "details", m["body"])
             elif op == "append_context":
-                entries = get_context_entries(db_path)
-                entry = next((e for e in entries if e["subject"] == m["subject"]), None)
-                current = entry["body"] if entry else ""
-                upsert_context_entry(db_path, m["subject"],
-                                     current.rstrip() + "\n\n" + m["content"])
+                node = ensure_node_path(db_path, m["subject"])
+                append_section(db_path, node["id"], "details", m["content"])
             elif op == "patch_context":
-                entries = get_context_entries(db_path)
-                entry = next((e for e in entries if e["subject"] == m["subject"]), None)
-                if entry:
-                    new_body = entry["body"].replace(m["old"], m["new"], 1)
-                    upsert_context_entry(db_path, m["subject"], new_body)
+                node = get_node_by_path(db_path, m["subject"])
+                if node:
+                    sec = get_section(db_path, node["id"], "details")
+                    if sec and m["old"] in sec["body"]:
+                        new_body = sec["body"].replace(m["old"], m["new"], 1)
+                        upsert_section(db_path, node["id"], "details", new_body)
                 else:
                     logger.warning("patch_context: subject %r not found", m["subject"])
             elif op == "insert_check_in":
@@ -291,11 +297,11 @@ def apply_mutations(mutations: list[dict], db_path: Path, today: str) -> None:
                 for task_id in m.get("task_ids", []):
                     link_milestone_task(db_path, milestone_id, task_id)
             elif op == "create_milestone":
-                create_milestone(
-                    db_path,
-                    m["context_subject"],
-                    m["name"],
-                    description=m.get("description"),
+                parent = get_node_by_path(db_path, m.get("context_subject", ""))
+                parent_id = parent["id"] if parent else None
+                create_node(
+                    db_path, parent_id, m["name"],
+                    node_type="milestone",
                     target_date=m.get("target_date"),
                 )
             elif op == "patch_milestone":
@@ -627,8 +633,12 @@ def _dispatch_single_subagent(
         )
     elif op_type in ("patch_context", "append_context"):
         subject = mutation.get("subject", "")
-        entries = get_context_entries(db_path, prefix=subject)
-        current_body = next((e["body"] for e in entries if e["subject"] == subject), "(not found)")
+        node = get_node_by_path(db_path, subject)
+        if node:
+            sec = get_section(db_path, node["id"], "details")
+            current_body = sec["body"] if sec else "(not found)"
+        else:
+            current_body = "(not found)"
         template = _jinja.get_template("subagent_patch.md")
         prompt = template.render(
             op=op_type,
@@ -775,8 +785,13 @@ def _build_slash_prompt(user_message: str, db_path: Path) -> str:
     anchors = get_anchors(db_path)
     current_anchor = get_current_anchor(anchors)
     plan = get_plan(db_path, today)
-    context_entries = get_context_entries(db_path, top_level_only=True)
-    context_text = "\n\n".join(f"## {e['subject']}\n{e['body']}" for e in context_entries)
+    root_nodes = get_children(db_path, parent_id=None)
+    context_parts = []
+    for node in root_nodes:
+        sec = get_section(db_path, node["id"], "details")
+        body = sec["body"] if sec else ""
+        context_parts.append(f"## {node['name']}\n{body}")
+    context_text = "\n\n".join(context_parts)
     template = _jinja.get_template("message_handler.md")
     return template.render(
         date=today,
@@ -807,7 +822,7 @@ def _run_v2_planning_loop(
     Returns (mutation_plan, reports, chat_messages, orchestrator_conv).
     Raises RuntimeError if parse errors exceed threshold.
     """
-    all_subjects = [e["subject"] for e in get_context_entries(db_path)]
+    all_subjects = get_all_node_paths(db_path)
     available_dates = list(dict.fromkeys([today] + list_plan_dates(db_path)))
     session_id = str(uuid.uuid4())
     clear_session_state(db_path, session_id)
@@ -912,7 +927,7 @@ def _handle_v3(text: str, db_path: Path, anchors: list[dict],
 
     today = str(date_type.today())
     plan = get_plan(db_path, today)
-    subjects = [e["subject"] for e in get_context_entries(db_path)]
+    subjects = get_all_node_paths(db_path)
     history = get_recent_history(db_path, HISTORY_EXCHANGES)
 
     plan_lines = []
@@ -973,7 +988,8 @@ def handle_message(text: str, send_fn: Callable[[str], None], db_path: Path = DB
     elif text.startswith("/tether-update-context"):
         try:
             subject, body = parse_update_context(text)
-            upsert_context_entry(db_path, subject, body)
+            node = ensure_node_path(db_path, subject)
+            upsert_section(db_path, node["id"], "details", body)
         except ValueError:
             pass
 

--- a/bot/plan_reader.py
+++ b/bot/plan_reader.py
@@ -69,8 +69,14 @@ def _load_plan_from_yaml(config_dir: Path) -> DayPlan:
 
 
 def _load_context_from_db(db_path: Path) -> str:
-    from db.queries import get_context_entries
-    entries = get_context_entries(db_path)
-    if not entries:
+    from db.queries import get_children, get_section, get_node_path
+    root_nodes = get_children(db_path, parent_id=None)
+    if not root_nodes:
         return ""
-    return "\n\n".join(f"## {e['subject']}\n{e['body']}" for e in entries)
+    parts = []
+    for node in root_nodes:
+        path = get_node_path(db_path, node["id"]) or node["name"]
+        sec = get_section(db_path, node["id"], "details")
+        body = sec["body"] if sec else ""
+        parts.append(f"## {path}\n{body}")
+    return "\n\n".join(parts)

--- a/bot/prompt_sections.py
+++ b/bot/prompt_sections.py
@@ -53,10 +53,13 @@ TOOL_GUIDANCE = (
     "making changes — don't assume the plan hasn't changed since the last message.\n\n"
     "Key tools:\n"
     "  - get_today_plan / update_plan_tasks — read and modify daily schedules\n"
-    "  - get_milestones / get_context_entry — understand project state\n"
-    "  - patch_task — update individual task status, descriptions, scheduling\n"
-    "  - search — find tasks across dates and projects\n"
-    "  - list_context_entries — see all tracked projects and areas\n\n"
+    "  - list_context_nodes / get_context_node — navigate the project context tree\n"
+    "  - read_section / write_section / append_to_section — read/write node content\n"
+    "  - get_node_by_path — resolve a path like 'Intellipat/GPU Offload' to a node\n"
+    "  - search_sections — full-text search across all context content\n"
+    "  - upsert_task — create or update tasks with node linking\n"
+    "  - patch_task — update individual task status, descriptions\n"
+    "  - search — find tasks and milestones by text\n\n"
     "Always fetch before modifying. Batch related reads in parallel when possible. "
     "Keep tool calls focused — don't fetch everything if you only need one anchor's tasks."
 )
@@ -136,12 +139,21 @@ def plan_summary(ctx: dict) -> str | None:
 
 
 def context_index(ctx: dict) -> str | None:
-    """List of available context entries (subjects only)."""
+    """List of available context nodes as a tree or flat subject list."""
+    nodes = ctx.get("context_nodes")
+    if nodes:
+        lines = []
+        for node in nodes:
+            indent = "  " * node.get("depth", 0)
+            suffix = f" ({node['children_count']} children)" if node.get("children_count", 0) > 0 else ""
+            lines.append(f"  {indent}- {node['name']}{suffix}")
+        return f"Available context (use read_section to fetch details):\n" + "\n".join(lines)
+    # Fallback: flat subject list
     subjects = ctx.get("context_subjects", [])
     if not subjects:
         return None
     subjects_list = "\n".join(f"  - {s}" for s in subjects)
-    return f"Available context entries (fetch bodies with get_context_entry tool):\n{subjects_list}"
+    return f"Available context (use read_section to fetch details):\n{subjects_list}"
 
 
 def session_notes(ctx: dict) -> str | None:

--- a/bot/tools/append_context_entry.py
+++ b/bot/tools/append_context_entry.py
@@ -1,6 +1,6 @@
-"""Tool: append_context_entry — add content to an existing context entry."""
+"""Tool: append_context_entry — append content to a context node's details section."""
 from bot.tools.base import Tool, ToolResult
-from db.queries import get_context_entries, upsert_context_entry
+from db.queries import ensure_node_path, append_section
 
 
 async def _execute(inp: dict, ctx) -> ToolResult:
@@ -9,19 +9,16 @@ async def _execute(inp: dict, ctx) -> ToolResult:
     if not subject:
         return ToolResult.error("subject is required")
     try:
-        entries = get_context_entries(ctx.db_path, prefix=subject)
-        exact = [e for e in entries if e["subject"] == subject]
-        existing_body = exact[0]["body"] if exact else ""
-        new_body = existing_body + content
-        upsert_context_entry(ctx.db_path, subject, new_body)
-        return ToolResult.ok(f"Appended to context entry {subject!r}.")
+        node = ensure_node_path(ctx.db_path, subject)
+        append_section(ctx.db_path, node["id"], "details", content)
+        return ToolResult.ok(f"Appended to context node {subject!r}.")
     except Exception as e:
-        return ToolResult.error(f"Failed to append context entry: {e}")
+        return ToolResult.error(f"Failed to append to context: {e}")
 
 
 TOOL = Tool(
     name="append_context_entry",
-    description="Append content to an existing context entry. Creates it if it doesn't exist.",
+    description="Append content to a context node's details. Creates the node if it doesn't exist.",
     input_schema={
         "type": "object",
         "properties": {

--- a/bot/tools/get_context_entry.py
+++ b/bot/tools/get_context_entry.py
@@ -1,6 +1,6 @@
-"""Tool: get_context_entry — fetch the body of a context entry by subject."""
+"""Tool: get_context_entry — fetch context node details by path."""
 from bot.tools.base import Tool, ToolResult
-from db.queries import get_context_entries
+from db.queries import get_node_by_path, get_section
 
 
 async def _execute(inp: dict, ctx) -> ToolResult:
@@ -8,22 +8,23 @@ async def _execute(inp: dict, ctx) -> ToolResult:
     if not subject:
         return ToolResult.error("subject is required")
     try:
-        entries = get_context_entries(ctx.db_path, prefix=subject)
-        exact = [e for e in entries if e["subject"] == subject]
-        if not exact:
-            return ToolResult.error(f"No context entry found for subject: {subject!r}")
-        return ToolResult.ok(exact[0]["body"])
+        node = get_node_by_path(ctx.db_path, subject)
+        if not node:
+            return ToolResult.error(f"No context node found for path: {subject!r}")
+        sec = get_section(ctx.db_path, node["id"], "details")
+        body = sec["body"] if sec else "(no details section)"
+        return ToolResult.ok(body)
     except Exception as e:
-        return ToolResult.error(f"Could not fetch context entry: {e}")
+        return ToolResult.error(f"Could not fetch context: {e}")
 
 
 TOOL = Tool(
     name="get_context_entry",
-    description="Fetch the full body of a context entry by its exact subject path.",
+    description="Fetch the details section of a context node by its path (e.g. 'Work/Alpha').",
     input_schema={
         "type": "object",
         "properties": {
-            "subject": {"type": "string", "description": "Exact subject path, e.g. 'Work/Alpha'"},
+            "subject": {"type": "string", "description": "Node path, e.g. 'Work/Alpha'"},
         },
         "required": ["subject"],
     },

--- a/bot/tools/patch_context_entry.py
+++ b/bot/tools/patch_context_entry.py
@@ -1,6 +1,6 @@
-"""Tool: patch_context_entry — targeted find-and-replace in a context entry."""
+"""Tool: patch_context_entry — targeted find-and-replace in a context node's details."""
 from bot.tools.base import Tool, ToolResult
-from db.queries import get_context_entries, upsert_context_entry
+from db.queries import get_node_by_path, get_section, upsert_section
 
 
 async def _execute(inp: dict, ctx) -> ToolResult:
@@ -10,25 +10,27 @@ async def _execute(inp: dict, ctx) -> ToolResult:
     if not subject or not old_string:
         return ToolResult.error("subject and old_string are required")
     try:
-        entries = get_context_entries(ctx.db_path, prefix=subject)
-        exact = [e for e in entries if e["subject"] == subject]
-        if not exact:
-            return ToolResult.error(f"No context entry found for subject: {subject!r}")
-        body = exact[0]["body"]
+        node = get_node_by_path(ctx.db_path, subject)
+        if not node:
+            return ToolResult.error(f"No context node found for path: {subject!r}")
+        sec = get_section(ctx.db_path, node["id"], "details")
+        if not sec:
+            return ToolResult.error(f"No details section found for {subject!r}")
+        body = sec["body"]
         if old_string not in body:
             return ToolResult.error(
                 f"old_string not found in {subject!r}. No changes made."
             )
         new_body = body.replace(old_string, new_string, 1)
-        upsert_context_entry(ctx.db_path, subject, new_body)
-        return ToolResult.ok(f"Patched context entry {subject!r}.")
+        upsert_section(ctx.db_path, node["id"], "details", new_body)
+        return ToolResult.ok(f"Patched context node {subject!r}.")
     except Exception as e:
-        return ToolResult.error(f"Failed to patch context entry: {e}")
+        return ToolResult.error(f"Failed to patch context: {e}")
 
 
 TOOL = Tool(
     name="patch_context_entry",
-    description="Find and replace an exact string in a context entry. Fails if old_string is not found.",
+    description="Find and replace an exact string in a context node's details. Fails if old_string is not found.",
     input_schema={
         "type": "object",
         "properties": {

--- a/bot/tools/search_context.py
+++ b/bot/tools/search_context.py
@@ -1,27 +1,28 @@
-"""Tool: search_context — list context entry subjects matching a prefix."""
+"""Tool: search_context — list context node paths."""
 from bot.tools.base import Tool, ToolResult
-from db.queries import get_context_entries
+from db.queries import get_all_node_paths
 
 
 async def _execute(inp: dict, ctx) -> ToolResult:
-    prefix = inp.get("prefix", "")
     try:
-        entries = get_context_entries(ctx.db_path, prefix=prefix if prefix else None)
-        subjects = [e["subject"] for e in entries]
-        if not subjects:
-            return ToolResult.ok("No context entries found.")
-        return ToolResult.ok("\n".join(subjects))
+        paths = get_all_node_paths(ctx.db_path)
+        prefix = inp.get("prefix", "")
+        if prefix:
+            paths = [p for p in paths if p.startswith(prefix)]
+        if not paths:
+            return ToolResult.ok("No context nodes found.")
+        return ToolResult.ok("\n".join(paths))
     except Exception as e:
-        return ToolResult.error(f"Could not search context: {e}")
+        return ToolResult.error(f"Could not list context nodes: {e}")
 
 
 TOOL = Tool(
     name="search_context",
-    description="List context entry subject paths, optionally filtered by prefix.",
+    description="List context node paths, optionally filtered by path prefix.",
     input_schema={
         "type": "object",
         "properties": {
-            "prefix": {"type": "string", "description": "Subject prefix to filter by, e.g. 'Work'"},
+            "prefix": {"type": "string", "description": "Path prefix to filter by, e.g. 'Work'"},
         },
     },
     execute=_execute,

--- a/bot/tools/upsert_context_entry.py
+++ b/bot/tools/upsert_context_entry.py
@@ -1,6 +1,6 @@
-"""Tool: upsert_context_entry — full rewrite of a context entry."""
+"""Tool: upsert_context_entry — create/overwrite a context node's details section."""
 from bot.tools.base import Tool, ToolResult
-from db.queries import upsert_context_entry
+from db.queries import ensure_node_path, upsert_section
 
 
 async def _execute(inp: dict, ctx) -> ToolResult:
@@ -9,19 +9,20 @@ async def _execute(inp: dict, ctx) -> ToolResult:
     if not subject:
         return ToolResult.error("subject is required")
     try:
-        upsert_context_entry(ctx.db_path, subject, body)
-        return ToolResult.ok(f"Context entry {subject!r} updated.")
+        node = ensure_node_path(ctx.db_path, subject)
+        upsert_section(ctx.db_path, node["id"], "details", body)
+        return ToolResult.ok(f"Context node {subject!r} updated.")
     except Exception as e:
-        return ToolResult.error(f"Failed to upsert context entry: {e}")
+        return ToolResult.error(f"Failed to upsert context: {e}")
 
 
 TOOL = Tool(
     name="upsert_context_entry",
-    description="Create or fully overwrite a context entry. Use append_context_entry to add without overwriting.",
+    description="Create or fully overwrite a context node's details. Use append_context_entry to add without overwriting.",
     input_schema={
         "type": "object",
         "properties": {
-            "subject": {"type": "string", "description": "Subject path, e.g. 'Work/Alpha'"},
+            "subject": {"type": "string", "description": "Node path, e.g. 'Work/Alpha'"},
             "body": {"type": "string", "description": "Full markdown body"},
         },
         "required": ["subject", "body"],

--- a/db/queries.py
+++ b/db/queries.py
@@ -1006,6 +1006,50 @@ def get_node_path(db_path: Path, node_id: str) -> str | None:
     return "/".join(r["name"] for r in rows)
 
 
+def ensure_node_path(db_path: Path, path: str) -> dict:
+    """Resolve a slash-separated path to a node, creating intermediate nodes as needed.
+
+    Example: ensure_node_path(db, "School/ML/Project") creates School, then ML
+    under School, then Project under ML (if they don't already exist).
+    Returns the leaf node dict (via get_node).
+    """
+    parts = [p.strip() for p in path.split("/") if p.strip()]
+    if not parts:
+        raise ValueError("ensure_node_path: empty path")
+    parent_id = None
+    node_id = None
+    for part in parts:
+        existing = find_child_by_name(db_path, parent_id, part)
+        if existing:
+            node_id = existing["id"]
+        else:
+            created = create_node(db_path, parent_id, part)
+            node_id = created["id"]
+        parent_id = node_id
+    return get_node(db_path, node_id)
+
+
+def get_all_node_paths(db_path: Path) -> list[str]:
+    """Return all non-archived node paths as slash-separated strings.
+
+    Uses a single recursive CTE for efficiency.
+    """
+    with get_db(db_path) as conn:
+        rows = conn.execute(
+            """WITH RECURSIVE tree(id, path) AS (
+                   SELECT id, name FROM context_nodes
+                   WHERE parent_id IS NULL AND archived = 0
+                   UNION ALL
+                   SELECT cn.id, tree.path || '/' || cn.name
+                   FROM context_nodes cn
+                   JOIN tree ON cn.parent_id = tree.id
+                   WHERE cn.archived = 0
+               )
+               SELECT path FROM tree ORDER BY path"""
+        ).fetchall()
+    return [r["path"] for r in rows]
+
+
 def get_children(
     db_path: Path, parent_id: str | None = None, include_archived: bool = False,
 ) -> list[dict]:

--- a/tests/bot/test_message_handler.py
+++ b/tests/bot/test_message_handler.py
@@ -4,7 +4,12 @@ import subprocess
 from datetime import date
 from unittest.mock import patch, call as mock_call
 from db.schema import init_db
-from db.queries import get_anchors, get_plan, upsert_anchor, upsert_plan, upsert_tasks, upsert_context_entry, get_context_entries
+from db.queries import (
+    get_anchors, get_plan, upsert_anchor, upsert_plan, upsert_tasks,
+    upsert_context_entry, get_context_entries,
+    ensure_node_path, upsert_section, get_section, get_node_by_path,
+    get_children, get_milestones,
+)
 
 TODAY = str(date.today())
 
@@ -20,7 +25,8 @@ def db_path(tmp_path):
     upsert_anchor(path, ANCHOR)
     upsert_plan(path, TODAY)
     upsert_tasks(path, TODAY, "grind_am", tasks=["Apply to 3 jobs"], notes="ML roles")
-    upsert_context_entry(path, "Job Applications", "Priority 1.")
+    node = ensure_node_path(path, "Job Applications")
+    upsert_section(path, node["id"], "details", "Priority 1.")
     return path
 
 
@@ -109,29 +115,29 @@ def test_get_model_falls_back_when_config_missing():
 def test_apply_mutations_append_context(db_path):
     from bot.message_handler import apply_mutations
     apply_mutations([{"op": "append_context", "subject": "Job Applications", "content": "New line."}], db_path, TODAY)
-    entries = get_context_entries(db_path)
-    body = next(e["body"] for e in entries if e["subject"] == "Job Applications")
-    assert "Priority 1." in body
-    assert "New line." in body
+    node = get_node_by_path(db_path, "Job Applications")
+    sec = get_section(db_path, node["id"], "details")
+    assert "Priority 1." in sec["body"]
+    assert "New line." in sec["body"]
 
 
 def test_apply_mutations_patch_context(db_path):
     from bot.message_handler import apply_mutations
     apply_mutations([{"op": "patch_context", "subject": "Job Applications",
                       "old": "Priority 1.", "new": "Priority updated."}], db_path, TODAY)
-    entries = get_context_entries(db_path)
-    body = next(e["body"] for e in entries if e["subject"] == "Job Applications")
-    assert "Priority updated." in body
-    assert "Priority 1." not in body
+    node = get_node_by_path(db_path, "Job Applications")
+    sec = get_section(db_path, node["id"], "details")
+    assert "Priority updated." in sec["body"]
+    assert "Priority 1." not in sec["body"]
 
 
 def test_apply_mutations_patch_context_remove(db_path):
     from bot.message_handler import apply_mutations
     apply_mutations([{"op": "patch_context", "subject": "Job Applications",
                       "old": "Priority 1.", "new": ""}], db_path, TODAY)
-    entries = get_context_entries(db_path)
-    body = next(e["body"] for e in entries if e["subject"] == "Job Applications")
-    assert "Priority 1." not in body
+    node = get_node_by_path(db_path, "Job Applications")
+    sec = get_section(db_path, node["id"], "details")
+    assert "Priority 1." not in sec["body"]
 
 
 def test_apply_mutations_patch_context_missing_subject(db_path, caplog):
@@ -190,8 +196,11 @@ def test_handle_update_context_saves_to_db(db_path):
     from bot.message_handler import handle_message
     with patch("bot.message_handler.call_claude", return_value="Got it."):
         handle_message("/tether-update-context Thesis :: Working on chapter 3", [].append, db_path=db_path)
-    entries = get_context_entries(db_path)
-    assert any(e["subject"] == "Thesis" for e in entries)
+    node = get_node_by_path(db_path, "Thesis")
+    assert node is not None
+    sec = get_section(db_path, node["id"], "details")
+    assert sec is not None
+    assert "Working on chapter 3" in sec["body"]
 
 
 def test_handle_update_plan_saves_tasks(db_path):
@@ -250,14 +259,15 @@ def test_handle_message_persists_conversation_turn(db_path):
 # ---------------------------------------------------------------------------
 
 def test_fetch_context_entry(db_path):
-    upsert_context_entry(db_path, "Intellipat", "Main entry.")
-    upsert_context_entry(db_path, "Intellipat/Backend", "Backend details.")
+    node = ensure_node_path(db_path, "Intellipat")
+    upsert_section(db_path, node["id"], "details", "Main entry.")
+    child = ensure_node_path(db_path, "Intellipat/Backend")
+    upsert_section(db_path, child["id"], "details", "Backend details.")
     from bot.message_handler import _fetch_requested_context
     result = _fetch_requested_context(
         [{"kind": "context_entry", "subject": "Intellipat"}], db_path, round_num=1
     )
     assert "Main entry." in result
-    assert "Backend details." in result
     assert "Fetched context (round 1)" in result
 
 
@@ -302,7 +312,8 @@ def test_fetch_check_in_log(db_path):
 
 def test_fetch_multiple_kinds(db_path):
     from bot.message_handler import _fetch_requested_context
-    upsert_context_entry(db_path, "General", "General notes.")
+    node = ensure_node_path(db_path, "General")
+    upsert_section(db_path, node["id"], "details", "General notes.")
     result = _fetch_requested_context([
         {"kind": "context_entry", "subject": "General"},
         {"kind": "anchor_detail", "anchor_id": "grind_am"},
@@ -318,7 +329,7 @@ def test_fetch_multiple_kinds(db_path):
 def test_handle_message_loops_on_request_context(db_path):
     """Planning loop makes one context fetch then commits."""
     from bot.message_handler import _run_v2_planning_loop, MAX_PLANNING_ROUNDS
-    upsert_context_entry(db_path, "Job Applications", "Priority 1.")
+    # "Job Applications" node already seeded by db_path fixture
 
     # Round 0: orchestrator reasons; meta_eval fetches context, not done
     # Round 1: orchestrator reasons; meta_eval stages chat mutation, done
@@ -570,7 +581,8 @@ def test_call_satisfaction_eval_fails_gracefully(db_path):
 
 def test_apply_mutations_create_milestone(db_path):
     from bot.message_handler import apply_mutations
-    upsert_context_entry(db_path, "Proj", "body")
+    node = ensure_node_path(db_path, "Proj")
+    upsert_section(db_path, node["id"], "details", "body")
     apply_mutations([{
         "op": "create_milestone",
         "context_subject": "Proj",
@@ -578,16 +590,16 @@ def test_apply_mutations_create_milestone(db_path):
         "description": "All tasks for v2 launch",
         "target_date": "2026-04-30",
     }], db_path, TODAY)
-    from db.queries import get_milestones
-    ms = get_milestones(db_path, "Proj")
-    assert len(ms) == 1
-    assert ms[0]["name"] == "Ship v2"
-    assert ms[0]["target_date"] == "2026-04-30"
+    milestone = get_node_by_path(db_path, "Proj/Ship v2")
+    assert milestone is not None
+    assert milestone["node_type"] == "milestone"
+    assert milestone["target_date"] == "2026-04-30"
 
 
 def test_apply_mutations_patch_milestone(db_path):
     from bot.message_handler import apply_mutations
     from db.queries import create_milestone
+    # Old create_milestone still needs context_entries FK
     upsert_context_entry(db_path, "Proj", "body")
     m = create_milestone(db_path, "Proj", "Old Name")
     apply_mutations([{

--- a/tests/bot/test_plan_reader.py
+++ b/tests/bot/test_plan_reader.py
@@ -69,7 +69,7 @@ def test_load_context_returns_empty_string_if_missing(tmp_path):
 
 from datetime import date as date_type
 from db.schema import init_db
-from db.queries import upsert_anchor, upsert_plan, upsert_tasks, upsert_context_entry
+from db.queries import upsert_anchor, upsert_plan, upsert_tasks, ensure_node_path, upsert_section
 
 
 @pytest.fixture
@@ -83,7 +83,8 @@ def db_config_dir(tmp_path):
     upsert_plan(db_path, today)
     upsert_tasks(db_path, today, "grind_am",
                  tasks=["Apply to 3 jobs", "Follow up"], notes="ML roles")
-    upsert_context_entry(db_path, "Job Applications", "Priority 1.")
+    node = ensure_node_path(db_path, "Job Applications")
+    upsert_section(db_path, node["id"], "details", "Priority 1.")
     return tmp_path
 
 

--- a/tests/bot/test_tools.py
+++ b/tests/bot/test_tools.py
@@ -15,8 +15,8 @@ def db_path(tmp_path):
 
 @pytest.fixture
 def seeded_db(db_path):
-    """DB with one anchor, a plan for today, and a context entry."""
-    from db.queries import upsert_anchor, upsert_plan, upsert_tasks, upsert_context_entry
+    """DB with one anchor, a plan for today, and a context node."""
+    from db.queries import upsert_anchor, upsert_plan, upsert_tasks, ensure_node_path, upsert_section
     from datetime import date
     today = date.today().isoformat()
     upsert_anchor(db_path, {
@@ -28,7 +28,8 @@ def seeded_db(db_path):
     upsert_tasks(db_path, today, "morning", [
         {"text": "Do the thing", "status": "pending", "position": 0},
     ])
-    upsert_context_entry(db_path, "Work/Alpha", "Working on project alpha.")
+    node = ensure_node_path(db_path, "Work/Alpha")
+    upsert_section(db_path, node["id"], "details", "Working on project alpha.")
     return db_path
 
 
@@ -239,67 +240,71 @@ class TestUpdateTaskStatusTool:
 class TestUpsertContextEntryTool:
     def test_creates_new_entry(self, seeded_db):
         from bot.tools.upsert_context_entry import TOOL
-        from db.queries import get_context_entries
+        from db.queries import get_node_by_path, get_section
         result = asyncio.run(TOOL.execute({
             "subject": "Health/Sleep",
             "body": "Sleep at 10pm.",
         }, ctx_db(seeded_db)))
         assert result.ok is True
 
-        entries = get_context_entries(seeded_db)
-        subjects = [e["subject"] for e in entries]
-        assert "Health/Sleep" in subjects
+        node = get_node_by_path(seeded_db, "Health/Sleep")
+        assert node is not None
+        sec = get_section(seeded_db, node["id"], "details")
+        assert sec["body"] == "Sleep at 10pm."
 
     def test_overwrites_existing_entry(self, seeded_db):
         from bot.tools.upsert_context_entry import TOOL
-        from db.queries import get_context_entries
+        from db.queries import get_node_by_path, get_section
         asyncio.run(TOOL.execute({
             "subject": "Work/Alpha",
             "body": "Updated content.",
         }, ctx_db(seeded_db)))
 
-        entries = {e["subject"]: e for e in get_context_entries(seeded_db)}
-        assert entries["Work/Alpha"]["body"] == "Updated content."
+        node = get_node_by_path(seeded_db, "Work/Alpha")
+        sec = get_section(seeded_db, node["id"], "details")
+        assert sec["body"] == "Updated content."
 
 
 class TestAppendContextEntryTool:
     def test_appends_to_existing_entry(self, seeded_db):
         from bot.tools.append_context_entry import TOOL
-        from db.queries import get_context_entries
+        from db.queries import get_node_by_path, get_section
         result = asyncio.run(TOOL.execute({
             "subject": "Work/Alpha",
             "content": "\nNew note added.",
         }, ctx_db(seeded_db)))
         assert result.ok is True
 
-        entries = {e["subject"]: e for e in get_context_entries(seeded_db)}
-        assert "New note added." in entries["Work/Alpha"]["body"]
-        assert "project alpha" in entries["Work/Alpha"]["body"].lower()
+        node = get_node_by_path(seeded_db, "Work/Alpha")
+        sec = get_section(seeded_db, node["id"], "details")
+        assert "New note added." in sec["body"]
+        assert "project alpha" in sec["body"].lower()
 
     def test_creates_entry_if_missing(self, seeded_db):
         from bot.tools.append_context_entry import TOOL
-        from db.queries import get_context_entries
+        from db.queries import get_node_by_path
         result = asyncio.run(TOOL.execute({
             "subject": "New/Topic",
             "content": "First note.",
         }, ctx_db(seeded_db)))
         assert result.ok is True
-        entries = {e["subject"]: e for e in get_context_entries(seeded_db)}
-        assert "New/Topic" in entries
+        node = get_node_by_path(seeded_db, "New/Topic")
+        assert node is not None
 
 
 class TestPatchContextEntryTool:
     def test_replaces_exact_string(self, seeded_db):
         from bot.tools.patch_context_entry import TOOL
-        from db.queries import get_context_entries
+        from db.queries import get_node_by_path, get_section
         result = asyncio.run(TOOL.execute({
             "subject": "Work/Alpha",
             "old_string": "project alpha",
             "new_string": "project beta",
         }, ctx_db(seeded_db)))
         assert result.ok is True
-        entries = {e["subject"]: e for e in get_context_entries(seeded_db)}
-        assert "project beta" in entries["Work/Alpha"]["body"]
+        node = get_node_by_path(seeded_db, "Work/Alpha")
+        sec = get_section(seeded_db, node["id"], "details")
+        assert "project beta" in sec["body"]
 
     def test_returns_error_when_old_string_not_found(self, seeded_db):
         from bot.tools.patch_context_entry import TOOL

--- a/tests/db/test_queries.py
+++ b/tests/db/test_queries.py
@@ -7,6 +7,7 @@ from db.queries import (
     upsert_tasks,
     upsert_context_entry, get_context_entries, delete_context_entry,
     rename_context_subject,
+    ensure_node_path, get_all_node_paths, get_node_by_path, create_node,
     insert_conversation_turn, get_recent_history,
     clear_session_state,
     insert_orchestrator_turn, get_orchestrator_conversation,
@@ -909,3 +910,67 @@ def test_get_full_task_dependencies_cross_day(db_path):
     assert len(deps_day2["blocked_by"]) == 1
     assert deps_day2["blocked_by"][0]["type"] == "task"
     assert deps_day2["blocked_by"][0]["id"] == uid_day1
+
+
+# ---------------------------------------------------------------------------
+# ensure_node_path + get_all_node_paths
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_node_path_creates_intermediates(db_path):
+    node = ensure_node_path(db_path, "School/ML/Project")
+    assert node["name"] == "Project"
+    # Intermediates should exist
+    school = get_node_by_path(db_path, "School")
+    assert school is not None
+    ml = get_node_by_path(db_path, "School/ML")
+    assert ml is not None
+    assert ml["parent_id"] == school["id"]
+    assert node["parent_id"] == ml["id"]
+
+
+def test_ensure_node_path_idempotent(db_path):
+    node1 = ensure_node_path(db_path, "School/ML/Project")
+    node2 = ensure_node_path(db_path, "School/ML/Project")
+    assert node1["id"] == node2["id"]
+
+
+def test_ensure_node_path_single_segment(db_path):
+    node = ensure_node_path(db_path, "Thesis")
+    assert node["name"] == "Thesis"
+    assert node["parent_id"] is None
+
+
+def test_ensure_node_path_empty_raises(db_path):
+    with pytest.raises(ValueError):
+        ensure_node_path(db_path, "")
+
+
+def test_ensure_node_path_reuses_existing_parents(db_path):
+    create_node(db_path, None, "Existing")
+    node = ensure_node_path(db_path, "Existing/Child")
+    existing = get_node_by_path(db_path, "Existing")
+    assert node["parent_id"] == existing["id"]
+
+
+def test_get_all_node_paths_empty(db_path):
+    assert get_all_node_paths(db_path) == []
+
+
+def test_get_all_node_paths_tree(db_path):
+    ensure_node_path(db_path, "School/ML")
+    ensure_node_path(db_path, "School/Thesis")
+    ensure_node_path(db_path, "Work")
+    paths = get_all_node_paths(db_path)
+    assert "School" in paths
+    assert "School/ML" in paths
+    assert "School/Thesis" in paths
+    assert "Work" in paths
+
+
+def test_get_all_node_paths_excludes_archived(db_path):
+    from db.queries import archive_node
+    node = ensure_node_path(db_path, "Old")
+    archive_node(db_path, node["id"])
+    paths = get_all_node_paths(db_path)
+    assert "Old" not in paths


### PR DESCRIPTION
## Summary
- Add `ensure_node_path()` and `get_all_node_paths()` helpers to `db/queries.py`
- Rewrite all `get_context_entries` / `upsert_context_entry` calls in `bot/message_handler.py` (10+ sites) to use context_nodes APIs
- Update `bot/plan_reader.py`, `bot/prompt_sections.py`, all 5 `bot/tools/` files
- Update tool guidance to reference new MCP tool names (list_context_nodes, read_section, etc.)
- Add context_nodes tree rendering to `context_index()` prompt section (matches premium)
- 8 new tests for helpers, all existing tests updated

## What doesn't change
- Prompt template mutation op names (update_context, append_context, patch_context)
- DB schema (context_entries table stays, context_nodes already existed)
- MCP server (already uses context_nodes)
- Old query functions in db/queries.py (remain as utility)

## Test plan
- [x] 504 public tests passing (was 496, +8 new)
- [x] 201 premium tests passing
- [x] Zero `get_context_entries`/`upsert_context_entry` imports in bot/
- [ ] Manual smoke test: send message via Telegram, verify context loads from nodes