### PR TITLE
Separate community and premium Docker build paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,11 +10,10 @@
 # Contains config.yaml, secrets.json, SQLite databases.
 TETHER_DATA_DIR=/home/toast/.tether-config
 
-# ── Premium (optional) ────────────────────────────────────
-# GitHub personal access token with read access to jlunder00/tether-premium.
-# If set, docker compose build installs premium — cloud/company release.
-# If unset, builds community edition.
-GITHUB_TOKEN=
+# ── Image selection ───────────────────────────────────────
+# IMAGE_TAG: pin to a specific release or roll back to a previous one.
+# Leave as latest to always use the most recent community image.
+IMAGE_TAG=latest
 
 # ── MCP server ────────────────────────────────────────────
 # User ID to scope MCP queries. Matches a row in auth.db.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,34 +1,123 @@
-name: Deploy to Pi
+name: Deploy
 
 on:
   push:
     branches: [main]
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  packages: write   # needed by publish-community to push to ghcr.io
 
 jobs:
-  deploy:
-    runs-on: self-hosted   # Pi registered as self-hosted runner
+  # ── Premium deployment ────────────────────────────────────────────────────
+  # Builds with tether-premium installed. Image stays on the Pi — never pushed
+  # to any registry. When a private registry is available, push step goes here.
+  deploy-premium:
+    name: Deploy premium to Pi
+    runs-on: self-hosted
     steps:
       - name: Pull latest code
         run: |
           cd /home/toast/tether
           git pull origin main
 
-      - name: Build Docker image
+      - name: Resolve version tag
+        id: version
+        run: |
+          SHA_TAG="sha-$(echo ${GITHUB_SHA} | cut -c1-7)"
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            SEMVER="${GITHUB_REF#refs/tags/}"
+            echo "tag=${SEMVER}" >> $GITHUB_OUTPUT
+            echo "extra_tag=${SEMVER}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
+            echo "extra_tag=" >> $GITHUB_OUTPUT
+          fi
+          echo "sha_tag=${SHA_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Build premium image
         run: |
           cd /home/toast/tether
-          docker compose build
+          IMAGE=tether-premium
+          TAG=${{ steps.version.outputs.tag }}
+          IMAGE_TAG=$TAG TETHER_IMAGE=$IMAGE GITHUB_TOKEN=$TETHER_PREMIUM_TOKEN \
+            docker compose build
+          # Also tag as latest
+          docker tag $IMAGE:$TAG $IMAGE:latest
+          # If this is a semver release, tag that too
+          if [ -n "${{ steps.version.outputs.extra_tag }}" ]; then
+            docker tag $IMAGE:$TAG $IMAGE:${{ steps.version.outputs.extra_tag }}
+          fi
+          # Write IMAGE_TAG to .env so compose uses the new image on restart
+          sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$TAG/" /home/toast/tether/.env || \
+            echo "IMAGE_TAG=$TAG" >> /home/toast/tether/.env
         env:
-          GITHUB_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
+          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
 
       - name: Run DB migrations
         run: |
           cd /home/toast/tether
           for db in /home/toast/.tether-config/users/*.db; do
-            [ -f "$db" ] && docker compose run --rm --no-deps api python db/migrate_data_model.py "$db" \
+            [ -f "$db" ] && \
+              TETHER_IMAGE=tether-premium IMAGE_TAG=${{ steps.version.outputs.tag }} \
+              docker compose run --rm --no-deps api python db/migrate_data_model.py "$db" \
               && echo "Migrated $db" || true
           done
 
       - name: Restart services
         run: |
           cd /home/toast/tether
-          docker compose up -d
+          TETHER_IMAGE=tether-premium docker compose up -d
+
+      - name: Prune old premium images (keep 3)
+        run: |
+          docker images tether-premium --format "{{.CreatedAt}}\t{{.ID}}\t{{.Tag}}" \
+            | sort -r \
+            | awk 'NR>3 && $3 != "latest" {print $2}' \
+            | xargs -r docker rmi --force 2>/dev/null || true
+          docker image prune -f
+
+  # ── Community edition publish ─────────────────────────────────────────────
+  # Builds without premium. Pushes to ghcr.io — publicly visible, no premium
+  # code included. Community self-hosters pull from here.
+  publish-community:
+    name: Publish community edition to ghcr.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version tag
+        id: version
+        run: |
+          SHA_TAG="sha-$(echo ${GITHUB_SHA} | cut -c1-7)"
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            SEMVER="${GITHUB_REF#refs/tags/}"
+            echo "tag=${SEMVER}" >> $GITHUB_OUTPUT
+            echo "extra_tag=${SEMVER}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
+            echo "extra_tag=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build community image
+        run: |
+          IMAGE=ghcr.io/jlunder00/tether
+          TAG=${{ steps.version.outputs.tag }}
+          # No GITHUB_TOKEN build arg — community edition, no premium
+          docker build -t $IMAGE:$TAG .
+
+      - name: Push to ghcr.io
+        run: |
+          IMAGE=ghcr.io/jlunder00/tether
+          TAG=${{ steps.version.outputs.tag }}
+          docker push $IMAGE:$TAG
+          docker tag $IMAGE:$TAG $IMAGE:latest
+          docker push $IMAGE:latest
+          if [ -n "${{ steps.version.outputs.extra_tag }}" ]; then
+            docker tag $IMAGE:$TAG $IMAGE:${{ steps.version.outputs.extra_tag }}
+            docker push $IMAGE:${{ steps.version.outputs.extra_tag }}
+          fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,16 @@ x-build: &build
   context: .
   args:
     GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+  # TETHER_IMAGE selects the image name:
+  #   Premium (Pi):      tether-premium   — local only, never pushed to any registry
+  #   Community (ghcr):  ghcr.io/jlunder00/tether   — public, no premium code
+  # IMAGE_TAG is set by the deploy workflow (sha-<7> or semver). Defaults to latest.
+  # Rollback: IMAGE_TAG=sha-abc1234 docker compose up -d
 
 services:
   api:
     build: *build
+    image: ${TETHER_IMAGE:-ghcr.io/jlunder00/tether}:${IMAGE_TAG:-latest}
     command: ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]
     ports:
       - "8000:8000"
@@ -26,6 +32,7 @@ services:
 
   bot:
     build: *build
+    image: ${TETHER_IMAGE:-ghcr.io/jlunder00/tether}:${IMAGE_TAG:-latest}
     entrypoint: ["/app/scripts/bot-entrypoint.sh"]
     volumes:
       - ${TETHER_DATA_DIR:-~/.tether-config}:/data
@@ -38,6 +45,7 @@ services:
 
   mcp:
     build: *build
+    image: ${TETHER_IMAGE:-ghcr.io/jlunder00/tether}:${IMAGE_TAG:-latest}
     command: ["python", "-m", "tether_mcp.server", "--sse"]
     ports:
       - "5001:5001"


### PR DESCRIPTION
## Summary

- **Two distinct build jobs** in `deploy.yml`:
  - `deploy-premium` — runs on self-hosted Pi, builds with `TETHER_PREMIUM_TOKEN`, tags as `tether-premium:<version>` locally, never pushed to any registry. Private registry push goes here when cloud infra is ready.
  - `publish-community` — runs on `ubuntu-latest`, builds without premium token, pushes community edition to `ghcr.io/jlunder00/tether:<version>`
- **Version tagging** — both jobs tag with `sha-<7>` on every push to main; additionally tag with semver (e.g. `v1.2.3`) when a git tag is pushed
- **`TETHER_IMAGE` var in docker-compose.yml** — Pi `.env` sets `tether-premium`, community self-hosters default to `ghcr.io/jlunder00/tether`
- **Local image pruning** — premium deploy keeps 3 most recent images on Pi, prunes the rest to preserve SD card space
- **`.env.example`** — configured for community self-hosters (no premium internals)

## Secrets required

- `TETHER_PREMIUM_TOKEN` — fine-grained PAT with `Contents: read` on `jlunder00/tether-premium`. Already added.
- `GITHUB_TOKEN` — built-in, no setup needed. Used by community job to push to ghcr.io.

## Test plan

- [ ] Push to main — verify both jobs trigger
- [ ] `publish-community`: image appears at `ghcr.io/jlunder00/tether:sha-<7>` and `:latest`
- [ ] `deploy-premium`: `docker images tether-premium` on Pi shows new tag, services restarted
- [ ] Push a `v*` tag — verify semver tag appears on both image names
- [ ] Verify no premium code in the ghcr.io image: `docker run --rm ghcr.io/jlunder00/tether:latest python -c "import tether_premium" 2>&1` should fail with ImportError