### PR TITLE
fix: auto-run backlog column migration on kanban fetch

### DIFF
--- a/api/routes/kanban.py
+++ b/api/routes/kanban.py
@@ -2,7 +2,7 @@ import sqlite3
 from fastapi import APIRouter, Depends, HTTPException, Request
 from db.queries import (
     get_kanban_columns, create_kanban_column, update_kanban_column,
-    delete_kanban_column, seed_kanban_columns,
+    delete_kanban_column, seed_kanban_columns, migrate_backlog_column,
 )
 from api.auth import auth_dependency
 
@@ -13,6 +13,7 @@ router = APIRouter()
 async def list_columns(request: Request, _auth=Depends(auth_dependency)):
     try:
         seed_kanban_columns(request.state.db_path)
+        migrate_backlog_column(request.state.db_path)
     except sqlite3.OperationalError as e:
         if "no such table" not in str(e).lower():
             raise


### PR DESCRIPTION
## Summary
- Drag-drop to Backlog silently failed on existing DBs because `col_backlog.entry_rules={}` — frontend `onTaskDrop` early-returns without a valid `set_status`.
- `migrate_backlog_column` already existed in `db/queries.py` but was never wired to run.
- Call it idempotently alongside `seed_kanban_columns` on `GET /api/kanban/columns` so stale DBs get `{set_status: "pending", unschedule: true}` on next load.

## Test plan
- [ ] Deploy, open kanban, drag a scheduled task to Backlog → task unschedules and appears in Backlog column
- [ ] Verify fresh DB still seeds correctly (no double-migration issues)