### PR TITLE
fix: mount Claude credentials at /home/tether/.claude so CLI finds th…

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -21,11 +21,6 @@ def _get(key: str, default: str = "") -> str:
 
 JWT_SECRET = _get("TETHER_JWT_SECRET", "dev-secret-change-in-production")
 
-# Claude Code credentials directory. Set "claude_config_dir" in secrets.json
-# to the container-internal mount path (e.g. "/claude-config").
-# Leave unset to use Claude Code's default (~/.claude).
-CLAUDE_CONFIG_DIR = _get("claude_config_dir") or None
-
 # OAuth — GitHub
 GITHUB_CLIENT_ID = _get("GITHUB_CLIENT_ID")
 GITHUB_CLIENT_SECRET = _get("GITHUB_CLIENT_SECRET")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,9 @@ services:
     entrypoint: ["/app/scripts/bot-entrypoint.sh"]
     volumes:
       - ${TETHER_DATA_DIR:-~/.tether-config}:/data
-      - ${CLAUDE_CREDENTIALS_PATH:-~/.claude}:/claude-config
+      # Mount your Claude Code credentials so the bot can authenticate.
+      # Self-hosters: change the left side if your credentials aren't at ~/.claude.
+      - ${CLAUDE_CREDENTIALS_PATH:-~/.claude}:/home/tether/.claude
     environment:
       - TETHER_CONFIG_DIR=/data
       - PYTHONUNBUFFERED=1


### PR DESCRIPTION
…em automatically

Claude Code looks for credentials at ~/.claude relative to the running user. The tether user's home is /home/tether, so mount there directly — no CLAUDE_HOME env var needed. Self-hosters change the left side of the mount in docker-compose.yml.