### PR TITLE
feat: contextual "+ Add task" per group — inherit context/milestone/schedule on create

### DIFF
--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -3,7 +3,9 @@ from db.queries import patch_task_fields, move_task_atomic, \
     add_task_dependency, remove_task_dependency, \
     get_subtasks, create_subtask, update_subtask, delete_subtask, reorder_subtasks, \
     search_entities, \
-    get_unscheduled_tasks, create_unscheduled_task, get_task_by_uuid, get_all_tasks
+    get_unscheduled_tasks, create_unscheduled_task, get_task_by_uuid, get_all_tasks, \
+    link_milestone_task, upsert_plan
+from db.schema import transaction
 from api.auth import auth_dependency
 import api.config as cfg
 
@@ -33,12 +35,23 @@ async def list_unscheduled(request: Request, _auth=Depends(auth_dependency)):
 async def create_unscheduled(body: dict, request: Request, _auth=Depends(auth_dependency)):
     if "text" not in body:
         raise HTTPException(status_code=422, detail="'text' is required")
-    return create_unscheduled_task(
-        request.state.db_path, body["text"],
-        description=body.get("description"),
-        status=body.get("status", "pending"),
-        context_subject=body.get("context_subject"),
-    )
+    db_path = request.state.db_path
+    milestone_id = body.get("milestone_id")
+    date = body.get("date")
+    anchor_id = body.get("anchor_id")
+    with transaction(db_path):
+        task = create_unscheduled_task(
+            db_path, body["text"],
+            description=body.get("description"),
+            status=body.get("status", "pending"),
+            context_subject=body.get("context_subject"),
+        )
+        if milestone_id:
+            link_milestone_task(db_path, milestone_id, task["id"])
+        if date and anchor_id:
+            upsert_plan(db_path, date)
+            move_task_atomic(db_path, task["id"], date, anchor_id)
+    return get_task_by_uuid(db_path, task["id"])
 
 
 # --- Parameterized routes below ---

--- a/frontend/src/components/AnchorBlock.vue
+++ b/frontend/src/components/AnchorBlock.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import TaskCard from './TaskCard.vue'
 import GroupContainer from './GroupContainer.vue'
@@ -7,6 +7,7 @@ import { usePlanStore } from '../stores/plan'
 import type { Task } from '../stores/plan'
 import { useMilestoneStore } from '../stores/milestones'
 import type { Milestone } from '../stores/milestones'
+import { api } from '../lib/api'
 
 const router = useRouter()
 
@@ -31,6 +32,7 @@ type TaskWithIndex = { task: Task; index: number }
 const groupedByContext = computed(() => {
   const byContext: Record<string, {
     label: string
+    contextSubject: string | null
     milestoneGroups: { milestone: Milestone; tasks: TaskWithIndex[] }[]
     ungrouped: TaskWithIndex[]
   }> = {}
@@ -38,8 +40,9 @@ const groupedByContext = computed(() => {
   anchorPlan.value.tasks.forEach((task, index) => {
     const key = task.context_node_id ?? task.context_subject ?? '__uncategorized__'
     if (!byContext[key]) {
-      const label = task.context_subject ?? (key === '__uncategorized__' ? 'Uncategorized' : key)
-      byContext[key] = { label, milestoneGroups: [], ungrouped: [] }
+      const isUncat = key === '__uncategorized__'
+      const label = task.context_subject ?? (isUncat ? 'Uncategorized' : key)
+      byContext[key] = { label, contextSubject: isUncat ? null : (task.context_subject ?? null), milestoneGroups: [], ungrouped: [] }
     }
     const ctx = key
 
@@ -83,23 +86,24 @@ async function onRemove(index: number) {
   store.updateAnchorTasks(props.anchorId, updated, anchorPlan.value.notes ?? '')
 }
 
-function onAddNewTask() {
-  const effectivePlan = props.date ? store.plans[props.date] : store.plan
-  if (!effectivePlan) return
-  if (!effectivePlan.anchors[props.anchorId]) {
-    effectivePlan.anchors[props.anchorId] = { tasks: [], notes: '' }
+async function onAddNewTask(opts: { context_subject?: string; milestone_id?: string } = {}) {
+  const body: Record<string, unknown> = {
+    text: 'New task',
+    date: effectiveDate.value,
+    anchor_id: props.anchorId,
+    ...opts,
   }
-  const tasks = effectivePlan.anchors[props.anchorId].tasks
-  tasks.push({
-    id: '', text: '', description: null, status: 'pending' as const,
-    position: tasks.length, followup_config: null, blocks: [], blocked_by: [],
-    context_subject: null,
-    context_node_id: null,
-  })
-  nextTick(() => {
-    const inputs = tasksRef.value?.querySelectorAll('input')
-    if (inputs?.length) (inputs[inputs.length - 1] as HTMLInputElement).focus()
-  })
+  try {
+    const resp = await api('/api/tasks/unscheduled', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    if (!resp.ok) throw new Error(`${resp.status}`)
+    await store.fetchPlan(effectiveDate.value)
+  } catch (e) {
+    console.error('Failed to create task:', e)
+  }
 }
 
 // ── Drag and drop (native HTML5 DnD) ─────────────────────────────────────────
@@ -190,6 +194,11 @@ function onDrop(evt: DragEvent, toIndex: number) {
                 <TaskCard class="min-w-0" :task="task" :hideTags="true"
                           @update="onUpdate($event, i)" @remove="onRemove(i)" />
               </div>
+              <button type="button"
+                      @click.stop="onAddNewTask({ ...(ctx.contextSubject ? { context_subject: ctx.contextSubject } : {}), milestone_id: mg.milestone.id })"
+                      class="mt-1 text-xs text-white/40 hover:text-white/70 w-full text-left">
+                + Add task
+              </button>
             </GroupContainer>
           </template>
 
@@ -202,11 +211,17 @@ function onDrop(evt: DragEvent, toIndex: number) {
             <TaskCard class="min-w-0" :task="task" :hideTags="true"
                       @update="onUpdate($event, i)" @remove="onRemove(i)" />
           </div>
+
+          <button type="button"
+                  @click.stop="onAddNewTask(ctx.contextSubject ? { context_subject: ctx.contextSubject } : {})"
+                  class="mt-1 text-xs text-white/40 hover:text-white/70 w-full text-left">
+            + Add task
+          </button>
         </GroupContainer>
       </template>
     </div>
 
-    <button type="button" @click="onAddNewTask"
+    <button type="button" @click="onAddNewTask()"
             class="mt-2 text-xs text-white/40 hover:text-white/70">+ Add task</button>
   </GroupContainer>
 </template>

--- a/frontend/src/components/KanbanColumn.vue
+++ b/frontend/src/components/KanbanColumn.vue
@@ -16,7 +16,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  (e: 'add-task'): void
+  (e: 'add-task', opts: { context_subject?: string; milestone_id?: string }): void
   (e: 'task-drop', taskId: string, columnId: string): void
 }>()
 
@@ -34,12 +34,13 @@ const milestoneStore = useMilestoneStore()
 
 /** Group tasks by context (node_id for uniqueness, subject for label), then by milestone */
 const grouped = computed(() => {
-  const byContext: Record<string, { label: string; tasks: Task[] }> = {}
+  const byContext: Record<string, { label: string; contextSubject: string | null; tasks: Task[] }> = {}
   for (const task of props.tasks) {
     const key = task.context_node_id ?? task.context_subject ?? '__uncategorized__'
     if (!byContext[key]) {
-      const label = task.context_subject ?? (key === '__uncategorized__' ? 'Uncategorized' : key)
-      byContext[key] = { label, tasks: [] }
+      const isUncat = key === '__uncategorized__'
+      const label = task.context_subject ?? (isUncat ? 'Uncategorized' : key)
+      byContext[key] = { label, contextSubject: isUncat ? null : (task.context_subject ?? null), tasks: [] }
     }
     byContext[key].tasks.push(task)
   }
@@ -50,7 +51,7 @@ const grouped = computed(() => {
     return a.label.localeCompare(b.label)
   })
 
-  return sorted.map(([, { label, tasks }]) => {
+  return sorted.map(([, { label, contextSubject, tasks }]) => {
     // Sub-group by milestone
     const byMilestone: Record<string, { id: string; name: string; color: string | null; tasks: Task[] }> = {}
     const ungrouped: Task[] = []
@@ -68,12 +69,20 @@ const grouped = computed(() => {
 
     return {
       label,
+      contextSubject,
       tasks,
       milestoneGroups: Object.values(byMilestone),
       ungrouped,
     }
   })
 })
+
+function addOpts(contextSubject: string | null, milestoneId?: string) {
+  const opts: { context_subject?: string; milestone_id?: string } = {}
+  if (contextSubject) opts.context_subject = contextSubject
+  if (milestoneId) opts.milestone_id = milestoneId
+  return opts
+}
 
 // ── Drop target (dragenter counter avoids highlight flicker on child elements) ──
 
@@ -168,6 +177,10 @@ function onColumnDrop(evt: DragEvent) {
                 :compact="true" :hideTags="true"
                 @update="onTaskUpdate" />
             </div>
+            <button @click.stop="emit('add-task', addOpts(group.contextSubject, mg.id))"
+                    class="mt-1 text-xs text-white/40 hover:text-white/70 w-full text-left">
+              + Add task
+            </button>
           </GroupContainer>
 
           <!-- Ungrouped tasks -->
@@ -181,10 +194,15 @@ function onColumnDrop(evt: DragEvent) {
               :compact="true" :hideTags="true"
               @update="onTaskUpdate" />
           </div>
+
+          <button @click.stop="emit('add-task', addOpts(group.contextSubject))"
+                  class="mt-1 text-xs text-white/40 hover:text-white/70 w-full text-left">
+            + Add task
+          </button>
         </GroupContainer>
       </template>
 
-      <button @click="emit('add-task')" class="mt-2 text-xs text-white/40 hover:text-white/70 w-full text-left">
+      <button @click="emit('add-task', {})" class="mt-2 text-xs text-white/40 hover:text-white/70 w-full text-left">
         + Add task
       </button>
     </div>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -45,6 +45,22 @@ const currentTasks = computed(() => {
   return planStore.plan.anchors[currentAnchor.value.id]?.tasks ?? []
 })
 
+async function onAddTaskToNow() {
+  if (!currentAnchor.value) return
+  const today = new Date().toISOString().slice(0, 10)
+  try {
+    const resp = await api('/api/tasks/unscheduled', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'New task', date: today, anchor_id: currentAnchor.value.id }),
+    })
+    if (!resp.ok) throw new Error(`${resp.status}`)
+    await planStore.fetchPlan(today)
+  } catch (e) {
+    console.error('Failed to create task:', e)
+  }
+}
+
 const dayStats = computed(() => {
   if (!planStore.plan) return []
   return anchorStore.anchors.map(a => {
@@ -79,6 +95,10 @@ const dayStats = computed(() => {
             :task="task" :editable="false" :show-remove="false" :show-detail-link="false" :compact="true" />
           <li v-if="!currentTasks.length" class="text-white/30 text-sm">No tasks</li>
         </ul>
+        <button v-if="currentAnchor" type="button" @click="onAddTaskToNow"
+                class="mt-2 text-xs text-white/40 hover:text-white/70 w-full text-left">
+          + Add task
+        </button>
       </div>
 
       <!-- Today Box -->

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -38,16 +38,24 @@ onMounted(() => {
   fetchAllTasks()
 })
 
-async function onAddTask() {
+async function onAddTask(columnId: string, opts: { context_subject?: string; milestone_id?: string }) {
+  const col = kanbanStore.columns.find(c => c.id === columnId)
+  if (!col) return
+  const body: Record<string, unknown> = { text: 'New task', ...opts }
+  const rules = col.entry_rules ?? {}
+  if (typeof rules['set_status'] === 'string') body.status = rules['set_status']
+  if (rules['prompt_schedule']) {
+    body.date = new Date().toISOString().slice(0, 10)
+  }
   try {
     const resp = await api('/api/tasks/unscheduled', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text: 'New task' }),
+      body: JSON.stringify(body),
     })
     if (!resp.ok) throw new Error(`${resp.status}`)
     const task = await resp.json()
-    await fetchAllTasks() // refresh
+    await fetchAllTasks()
     router.push({ name: 'kanban-task', params: { taskId: task.id } })
   } catch (e) {
     console.error('Failed to create task:', e)
@@ -162,7 +170,7 @@ function matchesRules(task: KanbanTask, rules: Record<string, unknown>): boolean
         :key="col.id"
         :column="col"
         :tasks="columnTasks[col.id] ?? []"
-        @add-task="onAddTask"
+        @add-task="(opts) => onAddTask(col.id, opts)"
         @task-drop="onTaskDrop" />
     </div>
 

--- a/tests/api/test_task_create_routes.py
+++ b/tests/api/test_task_create_routes.py
@@ -1,0 +1,94 @@
+"""Tests for POST /tasks/unscheduled — contextual creation with metadata."""
+import pytest
+from datetime import date
+from db.schema import init_db, get_db
+from db.queries import (
+    upsert_anchor, upsert_plan, upsert_context_entry,
+    create_milestone, get_task_by_uuid,
+)
+from api.main import create_app
+from tests.api.conftest import make_authenticated_client
+
+ANCHOR = {
+    "id": "grind_am", "name": "The Grind", "time": "08:00",
+    "duration_minutes": 120, "flexibility": "locked",
+    "strictness": 4, "color": "#e05c5c", "position": 1,
+}
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "tether.db"
+    init_db(path)
+    upsert_anchor(path, ANCHOR)
+    upsert_plan(path, str(date.today()))
+    upsert_context_entry(path, "Proj", "body")
+    return path
+
+
+@pytest.fixture
+def app(db_path):
+    return create_app(db_path=db_path)
+
+
+@pytest.mark.asyncio
+async def test_create_task_minimal(app, db_path):
+    async with make_authenticated_client(app, db_path) as client:
+        resp = await client.post("/api/tasks/unscheduled", json={"text": "Hello"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["text"] == "Hello"
+    assert data["plan_date"] is None
+    assert data["anchor_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_task_with_context_and_schedule(app, db_path):
+    today = str(date.today())
+    async with make_authenticated_client(app, db_path) as client:
+        resp = await client.post("/api/tasks/unscheduled", json={
+            "text": "Scheduled task",
+            "context_subject": "Proj",
+            "date": today,
+            "anchor_id": "grind_am",
+        })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["context_subject"] == "Proj"
+    assert data["plan_date"] == today
+    assert data["anchor_id"] == "grind_am"
+
+
+@pytest.mark.asyncio
+async def test_create_task_links_milestone(app, db_path):
+    milestone = create_milestone(db_path, "Proj", "M1")
+    async with make_authenticated_client(app, db_path) as client:
+        resp = await client.post("/api/tasks/unscheduled", json={
+            "text": "With milestone",
+            "context_subject": "Proj",
+            "milestone_id": milestone["id"],
+        })
+    assert resp.status_code == 200
+    task_id = resp.json()["id"]
+    with get_db(db_path) as conn:
+        row = conn.execute(
+            "SELECT milestone_id FROM milestone_tasks WHERE task_id=?",
+            (task_id,),
+        ).fetchone()
+    assert row is not None
+    assert row["milestone_id"] == milestone["id"]
+
+
+@pytest.mark.asyncio
+async def test_create_task_bad_milestone_rolls_back(app, db_path):
+    """Invalid milestone_id should roll back the create (FK violation)."""
+    async with make_authenticated_client(app, db_path) as client:
+        resp = await client.post("/api/tasks/unscheduled", json={
+            "text": "Should not persist",
+            "milestone_id": "00000000-0000-0000-0000-deadbeef0000",
+        })
+    # The backend surfaces the FK error as a 500; the task should not be in the DB
+    assert resp.status_code >= 400
+    with get_db(db_path) as conn:
+        row = conn.execute("SELECT COUNT(*) AS n FROM tasks WHERE text='Should not persist'").fetchone()
+    assert row["n"] == 0


### PR DESCRIPTION
## Summary
- Every group header in kanban / plan / dashboard views now has its own `+ Add task` button that inherits the group's metadata, so users don't have to create then edit.
- Kanban column-root button keeps the "uncategorized" fallback and applies column `entry_rules` (`set_status`, `prompt_schedule`).
- Plan-view creation switches from local-array mutation to a real POST with metadata, so new anchor tasks arrive with context + milestone already set.
- Dashboard Now box gains a `+ Add task` shortcut scoped to the active anchor.
- Backend: `POST /api/tasks/unscheduled` now accepts `milestone_id`, `date`, `anchor_id`; follow-up linking/scheduling runs inside a `transaction()` so a bad id rolls back the create.

Spec: `docs/superpowers/specs/2026-04-12-contextual-task-creation.md`

## Test plan
- [x] `pytest tests/api/ -q` — 81 pass (77 existing + 4 new in `tests/api/test_task_create_routes.py`: minimal, scheduled, milestone-linked, rollback on invalid milestone_id)
- [x] `npm run build` in frontend — clean
- [ ] Deploy, manual smoke:
  - Kanban column root + Add task → Uncategorized with column status
  - Kanban context group → context_subject set
  - Kanban milestone group → context + milestone_id (verify in milestone_tasks)
  - Kanban Pending column → plan_date=today
  - Plan view milestone group → task with milestone under that anchor
  - Dashboard Now box → task in active anchor for today