### PR TITLE
fix: restore MCP server startup block

### DIFF
--- a/tether_mcp/server.py
+++ b/tether_mcp/server.py
@@ -157,3 +157,11 @@ try:
     register_mcp_tools(mcp)
 except ImportError:
     pass
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sse", action="store_true", help="Run as SSE server (for network access)")
+    args = parser.parse_args()
+    mcp.run(transport="sse" if args.sse else "stdio")


### PR DESCRIPTION
## Summary

The MCP consolidation PR (merged recently) accidentally dropped the \`if __name__ == \"__main__\"\` block from \`tether_mcp/server.py\`. The Docker compose \`mcp\` service runs:

\`\`\`
python -m tether_mcp.server --sse
\`\`\`

Without the startup block, the module imports, registers all 9 tools + premium tools, and exits immediately — no server is started. The \`--sse\` argv is ignored. Result: the mcp container restarts every ~10s, the bot container can't reach tether tools, and the bot responds "MCP server not connected."

## Symptoms observed in prod

- \`docker compose ps\` shows mcp status \`Restarting (0) 6 seconds ago\`
- \`docker compose logs mcp\` shows repeated \"MCP tools registered\" messages, one per restart cycle
- \`docker compose exec bot python -c "import socket; socket.gethostbyname('mcp')"\` fails — service is restarting too fast for DNS
- Bot sessions complete with \"the tether MCP tools aren't reachable\"

## Fix

Restore the startup block exactly as it was before consolidation:

\`\`\`python
if __name__ == \"__main__\":
    import argparse
    parser = argparse.ArgumentParser()
    parser.add_argument(\"--sse\", action=\"store_true\", ...)
    args = parser.parse_args()
    mcp.run(transport=\"sse\" if args.sse else \"stdio\")
\`\`\`

## Test plan

- [x] \`pytest tests/tether_mcp\` — 123 passed
- [ ] After merge + redeploy: \`docker compose ps\` shows mcp as \`Up\` (not restarting); bot successfully calls \`mcp__tether__get_anchors\` and returns real data