### PR TITLE
fix: retry external image pulls on deploy to handle Pi TLS timeouts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,22 @@ jobs:
               && echo "Migrated $db" || true
           done
 
+      - name: Pre-pull external images
+        run: |
+          cd /home/toast/tether
+          # Pull any non-tether images declared in compose (e.g. postgres).
+          # Retries handle transient TLS/network timeouts on the Pi.
+          # Falls back to cached image if all retries fail.
+          EXTERNAL_IMAGES=$(TETHER_IMAGE=tether-premium docker compose config --images 2>/dev/null \
+            | grep -v '^tether' | grep -v '^ghcr.io/jlunder00' | sort -u)
+          for IMAGE in $EXTERNAL_IMAGES; do
+            for i in 1 2 3; do
+              docker pull "$IMAGE" && break
+              echo "Attempt $i for $IMAGE failed — retrying in 15s..."
+              sleep 15
+            done || echo "Warning: could not refresh $IMAGE, using cached version"
+          done
+
       - name: Restart services
         run: |
           cd /home/toast/tether


### PR DESCRIPTION
## Summary

- Adds a **Pre-pull external images** step in `deploy-premium` before the restart step
- Detects non-tether images declared in compose (e.g. `postgres:16`) and pulls them with 3 retries, sleeping 15s between attempts
- If all retries fail, falls back silently to the cached local image — preventing the TLS handshake timeout from killing the entire deploy

## Root cause

`docker compose up -d` tries to pull `postgres:16` from Docker Hub even when a cached image exists. The Pi occasionally hits TLS handshake timeouts connecting to `registry-1.docker.io`. Since there's no retry or fallback, the whole restart step fails.

## Test plan

- [ ] Merge and verify next deploy succeeds — postgres image pulled (or cache hit) cleanly
- [ ] To simulate: run the pre-pull step with a bad network and confirm it falls back without failing