### PR TITLE
Skill injection: unified slash pre-processor + retire legacy slash path

### DIFF
--- a/bot/message_handler.py
+++ b/bot/message_handler.py
@@ -790,32 +790,8 @@ def _classify_message(text: str, current_anchor: dict, today: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Slash-command path (deterministic, single Claude call)
+# Slash-command path (deterministic DB writes; pipeline continues below)
 # ---------------------------------------------------------------------------
-
-def _build_slash_prompt(user_message: str, db_path: Path) -> str:
-    today = str(date_type.today())
-    anchors = get_anchors(db_path)
-    current_anchor = get_current_anchor(anchors)
-    plan = get_plan(db_path, today)
-    root_nodes = get_children(db_path, parent_id=None)
-    context_parts = []
-    for node in root_nodes:
-        sec = get_section(db_path, node["id"], "details")
-        body = sec["body"] if sec else ""
-        context_parts.append(f"## {node['name']}\n{body}")
-    context_text = "\n\n".join(context_parts)
-    template = _jinja.get_template("message_handler.md")
-    return template.render(
-        date=today,
-        current_anchor=current_anchor,
-        plan=plan,
-        context=context_text,
-        check_in_log=plan.get("check_in_log", []),
-        user_message=user_message,
-        ack=None,
-        dispatch_focus=None,
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -929,7 +905,8 @@ def _is_v2_fallback_enabled() -> bool:
 
 
 def _handle_v3(text: str, db_path: Path, anchors: list[dict],
-               current_anchor: dict) -> str:
+               current_anchor: dict,
+               skill_commands: list[str] | None = None) -> str:
     """Run a basic v3 single-shot LLM call. Returns the response text.
 
     Uses AnthropicBackend directly (no LLMRouter, no conversation loop,
@@ -961,6 +938,17 @@ def _handle_v3(text: str, db_path: Path, anchors: list[dict],
         session_notes=None,
         mode=mode,
     )
+
+    # Skill injection (v3-basic fallback): append skill content to system prompt
+    if skill_commands:
+        try:
+            from tether_premium.bot.skill_loader import load_skill_content
+            skill_blocks = [load_skill_content(cmd) for cmd in skill_commands]
+            skill_text = "\n\n".join(b for b in skill_blocks if b)
+            if skill_text:
+                system = system + "\n\n" + skill_text
+        except ImportError:
+            pass
 
     conv_history = [
         {"role": "user" if h["role"] == "user" else "assistant", "content": h["body"]}
@@ -1002,14 +990,25 @@ def handle_message(text: str, send_fn: Callable[[str], None], db_path: Path = DB
     logger.info("msg received: len=%d preview=%r", len(text or ""), _log_preview(text))
     logger.debug("msg received full: %r", text)
 
-    # Slash commands: deterministic DB writes then single Claude reply
-    if text.startswith("/check-in"):
+    # Unified slash pre-processor: DB writes + skill command extraction
+    from bot.slash_preprocessor import scan_slash_commands
+
+    _skill_registry = None
+    try:
+        from tether_premium.bot.skill_registry import REGISTRY as _skill_registry
+    except ImportError:
+        pass
+
+    _parsed = scan_slash_commands(text, skill_registry=_skill_registry)
+    _skill_commands = _parsed.skill_commands or None
+
+    if "check-in" in _parsed.db_commands_applied:
         accomplished, status = parse_check_in(text)
         insert_check_in(db_path, today, current_anchor["id"], accomplished, status)
         from datetime import datetime as _dt
         acknowledge_followup(db_path, today, current_anchor["id"], _dt.now())
 
-    elif text.startswith("/tether-update-context"):
+    if "tether-update-context" in _parsed.db_commands_applied:
         try:
             subject, body = parse_update_context(text)
             node = ensure_node_path(db_path, subject)
@@ -1017,20 +1016,13 @@ def handle_message(text: str, send_fn: Callable[[str], None], db_path: Path = DB
         except ValueError:
             pass
 
-    elif text.startswith("/update-plan"):
+    if "update-plan" in _parsed.db_commands_applied:
         anchor_id, tasks = parse_update_plan(text)
         upsert_plan(db_path, today)
         upsert_tasks(db_path, today, anchor_id, tasks, notes="")
 
-    if text.startswith("/"):
-        try:
-            raw = call_claude(_build_slash_prompt(text, db_path))
-            message, mutations = parse_claude_response(raw)
-            apply_mutations(mutations, db_path, today)
-            send_fn(message)
-        except RuntimeError as e:
-            send_fn(str(e))
-        return
+    # All messages (including slash commands) now continue into the pipeline below.
+    # The old `if text.startswith("/")` early-return path is retired.
 
     # --- v3 SDK path (if enabled) ---
     if _is_v3_enabled():
@@ -1040,7 +1032,9 @@ def handle_message(text: str, send_fn: Callable[[str], None], db_path: Path = DB
             logger.info("dispatch: premium handler")
             # Premium handler uses send_fn for Beacon notifications;
             # it returns the main response text without sending it.
-            final = get_premium_handler()(text, db_path, anchors, current_anchor, send_fn=send_fn)
+            final = get_premium_handler()(text, db_path, anchors, current_anchor,
+                                           send_fn=send_fn,
+                                           skill_commands=_skill_commands)
             insert_conversation_turn(db_path, "user", text)
             if final:
                 logger.info("reply sent: len=%d preview=%r", len(final), _log_preview(final))
@@ -1057,7 +1051,8 @@ def handle_message(text: str, send_fn: Callable[[str], None], db_path: Path = DB
 
         # Basic v3 single-shot (community edition — no tools, no sessions)
         try:
-            final = _handle_v3(text, db_path, anchors, current_anchor)
+            final = _handle_v3(text, db_path, anchors, current_anchor,
+                               skill_commands=_skill_commands)
             send_fn(final)
             insert_conversation_turn(db_path, "user", text)
             insert_conversation_turn(db_path, "assistant", final)

--- a/bot/message_handler.py
+++ b/bot/message_handler.py
@@ -942,8 +942,8 @@ def _handle_v3(text: str, db_path: Path, anchors: list[dict],
     # Skill injection (v3-basic fallback): append skill content to system prompt
     if skill_commands:
         try:
-            from tether_premium.bot.skill_loader import load_skill_content
-            skill_blocks = [load_skill_content(cmd) for cmd in skill_commands]
+            from tether_premium.bot.skill_registry import load_skill
+            skill_blocks = [load_skill(f"/{cmd}") for cmd in skill_commands]
             skill_text = "\n\n".join(b for b in skill_blocks if b)
             if skill_text:
                 system = system + "\n\n" + skill_text

--- a/bot/slash_preprocessor.py
+++ b/bot/slash_preprocessor.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+import re
+from dataclasses import dataclass, field
+
+_DB_COMMANDS: frozenset[str] = frozenset({"check-in", "tether-update-context", "update-plan"})
+_SKIP_COMMANDS: frozenset[str] = frozenset({"start", "link"})
+
+_DB_PATTERN = re.compile(
+    r"^/(check-in|tether-update-context|update-plan)",
+    re.MULTILINE,
+)
+_SLASH_PATTERN = re.compile(r"/([a-z][a-z0-9-]+)")
+
+
+@dataclass
+class SlashParseResult:
+    db_commands_applied: list[str] = field(default_factory=list)
+    skill_commands: list[str] = field(default_factory=list)
+    clean_text: str = ""
+
+
+def scan_slash_commands(text: str, skill_registry: dict | None = None) -> SlashParseResult:
+    """Parse slash commands from a message.
+
+    DB commands are only recognised at the start of a line.
+    Skill commands are found anywhere in the text.
+    """
+    db_commands = [m.group(1) for m in _DB_PATTERN.finditer(text)]
+
+    all_slash = [m.group(1) for m in _SLASH_PATTERN.finditer(text)]
+    skill_candidates = [
+        cmd for cmd in all_slash
+        if cmd not in _DB_COMMANDS and cmd not in _SKIP_COMMANDS
+    ]
+
+    if skill_registry is not None:
+        skill_candidates = [cmd for cmd in skill_candidates if f"/{cmd}" in skill_registry]
+
+    return SlashParseResult(
+        db_commands_applied=db_commands,
+        skill_commands=skill_candidates,
+        clean_text=text,
+    )

--- a/tests/bot/test_message_handler.py
+++ b/tests/bot/test_message_handler.py
@@ -185,7 +185,9 @@ def test_apply_mutations_update_plan_tasks_string_list_backward_compat(db_path):
 def test_handle_check_in_inserts_db_row(db_path):
     from bot.message_handler import handle_message
     from db.queries import get_plan
-    with patch("bot.message_handler.call_claude", return_value="Great progress!"):
+    orch_conv = [{"role": "orchestrator", "body": "Check-in noted.", "round": 0}]
+    with patch("bot.message_handler._classify_message", return_value="quick"), \
+         patch("bot.message_handler.call_response_builder", return_value="Got it."):
         handle_message("/check-in applied to 2 jobs :: about to start third", [].append, db_path=db_path)
     plan = get_plan(db_path, TODAY)
     assert len(plan["check_in_log"]) == 1
@@ -194,7 +196,8 @@ def test_handle_check_in_inserts_db_row(db_path):
 
 def test_handle_update_context_saves_to_db(db_path):
     from bot.message_handler import handle_message
-    with patch("bot.message_handler.call_claude", return_value="Got it."):
+    with patch("bot.message_handler._classify_message", return_value="quick"), \
+         patch("bot.message_handler.call_response_builder", return_value="Got it."):
         handle_message("/tether-update-context Thesis :: Working on chapter 3", [].append, db_path=db_path)
     node = get_node_by_path(db_path, "Thesis")
     assert node is not None
@@ -206,7 +209,8 @@ def test_handle_update_context_saves_to_db(db_path):
 def test_handle_update_plan_saves_tasks(db_path):
     from bot.message_handler import handle_message
     from db.queries import get_plan
-    with patch("bot.message_handler.call_claude", return_value="Updated!"):
+    with patch("bot.message_handler._classify_message", return_value="quick"), \
+         patch("bot.message_handler.call_response_builder", return_value="Updated!"):
         handle_message("/update-plan grind_am :: New task 1; New task 2", [].append, db_path=db_path)
     plan = get_plan(db_path, TODAY)
     texts = [t["text"] for t in plan["anchors"]["grind_am"]["tasks"]]
@@ -693,3 +697,63 @@ def test_handle_message_accepts_db_path(db_path):
         handle_message("hello", sent.append, db_path=db_path)
     # As long as no exception is raised and send_fn was called, routing worked.
     assert len(sent) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Unified slash pre-processor integration tests
+# ---------------------------------------------------------------------------
+
+class TestUnifiedSlashPreprocessor:
+    def test_check_in_message_applies_db_write_and_continues_to_pipeline(self, db_path):
+        """A /check-in message should write to DB AND continue into the pipeline (no early return)."""
+        from bot.message_handler import handle_message
+        from db.queries import get_plan
+
+        sent = []
+        with patch("bot.message_handler._classify_message", return_value="quick"), \
+             patch("bot.message_handler.call_response_builder", return_value="Check-in noted!") as mock_builder:
+            handle_message(
+                "/check-in applied to 2 jobs :: about to start third",
+                sent.append,
+                db_path=db_path,
+            )
+
+        # DB side-effect happened
+        plan = get_plan(db_path, TODAY)
+        assert len(plan["check_in_log"]) == 1
+        assert plan["check_in_log"][0]["accomplished"] == "applied to 2 jobs"
+
+        # Pipeline continued (response builder was called — no early return)
+        mock_builder.assert_called_once()
+        assert "Check-in noted!" in sent
+
+    def test_skill_command_forwarded_to_premium_handler(self, db_path):
+        """A skill command should be extracted and forwarded to the premium handler."""
+        import sys
+        import types
+        from bot.message_handler import handle_message
+
+        sent = []
+
+        def fake_premium(text, db_path, anchors, current_anchor, send_fn=None, skill_commands=None):
+            # Record what skill_commands were passed
+            fake_premium.received_skill_commands = skill_commands
+            return "Premium response."
+
+        fake_premium.received_skill_commands = None
+
+        # Inject a fake tether_premium.register module so the local import succeeds
+        fake_register = types.ModuleType("tether_premium.register")
+        fake_register.get_premium_handler = lambda: fake_premium
+        fake_tether_premium = types.ModuleType("tether_premium")
+
+        with patch("bot.message_handler._is_v3_enabled", return_value=True), \
+             patch.dict(sys.modules, {
+                 "tether_premium": fake_tether_premium,
+                 "tether_premium.register": fake_register,
+                 "tether_premium.bot": types.ModuleType("tether_premium.bot"),
+                 "tether_premium.bot.skill_registry": types.ModuleType("tether_premium.bot.skill_registry"),
+             }):
+            handle_message("/explain-beacon what does it do?", sent.append, db_path=db_path)
+
+        assert fake_premium.received_skill_commands == ["explain-beacon"]

--- a/tests/bot/test_slash_preprocessor.py
+++ b/tests/bot/test_slash_preprocessor.py
@@ -1,0 +1,91 @@
+from bot.slash_preprocessor import scan_slash_commands, SlashParseResult
+
+
+def test_check_in_at_start_detected_as_db_command():
+    result = scan_slash_commands("/check-in I finished the report")
+    assert "check-in" in result.db_commands_applied
+    assert result.skill_commands == []
+
+
+def test_update_context_at_start_detected_as_db_command():
+    result = scan_slash_commands("/tether-update-context Project :: notes here")
+    assert "tether-update-context" in result.db_commands_applied
+
+
+def test_update_plan_at_start_detected_as_db_command():
+    result = scan_slash_commands("/update-plan morning :: task1; task2")
+    assert "update-plan" in result.db_commands_applied
+
+
+def test_db_command_mid_sentence_not_detected():
+    # DB commands must be at line start
+    result = scan_slash_commands("I used /check-in earlier")
+    assert "check-in" not in result.db_commands_applied
+
+
+def test_skill_command_anywhere_in_sentence():
+    result = scan_slash_commands("how does /explain-beacon work?")
+    assert "explain-beacon" in result.skill_commands
+
+
+def test_skill_command_at_start():
+    result = scan_slash_commands("/explain-anchors")
+    assert "explain-anchors" in result.skill_commands
+
+
+def test_multiple_skill_commands_in_message():
+    result = scan_slash_commands("tell me about /explain-beacon and /explain-anchors")
+    assert "explain-beacon" in result.skill_commands
+    assert "explain-anchors" in result.skill_commands
+
+
+def test_plain_text_returns_empty():
+    result = scan_slash_commands("what are my tasks for today?")
+    assert result.db_commands_applied == []
+    assert result.skill_commands == []
+
+
+def test_start_excluded_from_skill_commands():
+    result = scan_slash_commands("/start")
+    assert "start" not in result.skill_commands
+    assert result.skill_commands == []
+
+
+def test_link_excluded_from_skill_commands():
+    result = scan_slash_commands("use /link to connect")
+    assert "link" not in result.skill_commands
+
+
+def test_unknown_command_no_registry_returned_as_skill():
+    result = scan_slash_commands("how does /mystery-feature work?")
+    assert "mystery-feature" in result.skill_commands
+
+
+def test_unknown_command_filtered_when_registry_provided():
+    registry = {"/explain-beacon": ("beacon.md", "what beacon does")}
+    result = scan_slash_commands("how does /mystery-feature work?", skill_registry=registry)
+    assert "mystery-feature" not in result.skill_commands
+
+
+def test_known_command_passes_registry_filter():
+    registry = {"/explain-beacon": ("beacon.md", "what beacon does")}
+    result = scan_slash_commands("how does /explain-beacon work?", skill_registry=registry)
+    assert "explain-beacon" in result.skill_commands
+
+
+def test_mixed_db_and_skill_command():
+    result = scan_slash_commands("/check-in done with tasks /explain-beacon")
+    assert "check-in" in result.db_commands_applied
+    assert "explain-beacon" in result.skill_commands
+
+
+def test_clean_text_is_original_unchanged():
+    text = "how does /explain-beacon work?"
+    result = scan_slash_commands(text)
+    assert result.clean_text == text
+
+
+def test_db_command_at_start_of_second_line():
+    text = "some preamble\n/check-in done with tasks"
+    result = scan_slash_commands(text)
+    assert "check-in" in result.db_commands_applied


### PR DESCRIPTION
## Summary

- New `bot/slash_preprocessor.py`: scans full message for `/command` tokens anywhere; classifies DB-write commands (require line-start) vs skill commands (anywhere); returns `SlashParseResult` with no side effects
- `bot/message_handler.py`: replaces hardcoded `startswith` checks and the `if text.startswith("/")` early-return block with the unified pre-processor; all messages (including slash commands) now continue into the v3/premium pipeline; `skill_commands` forwarded to premium handler
- Removes `_build_slash_prompt` entirely (Approach B from design)
- v3-basic fallback path gets skill injection via `tether_premium.bot.skill_registry.load_skill` (no-op if premium not installed)

## Test Plan
- [ ] 212 tests passing (bot suite, pg tests require live DB)
- [ ] `test_slash_preprocessor.py` — 16 tests covering DB/skill classification, filtering, mixed messages
- [ ] `test_message_handler.py` — DB writes still fire, pipeline continues, skill_commands forwarded
- [ ] Smoke: `/check-in done :: on track` → DB row inserted, response from pipeline not legacy slash path