### PR TITLE
feat: Makefile, PREMIUM_REF cache-busting, cross-repo deploy trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,19 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+  # Triggered by tether-premium when it merges to main.
+  # Payload: { premium_ref: "<7-char SHA>" }
+  repository_dispatch:
+    types: [premium-updated]
+  # Manual trigger — optionally force a no-cache build.
+  workflow_dispatch:
+    inputs:
+      no_cache:
+        description: "Force --no-cache build (clears all Docker layer cache)"
+        required: false
+        default: "false"
+        type: choice
+        options: ["false", "true"]
 
 permissions:
   contents: read
@@ -11,8 +24,6 @@ permissions:
 
 jobs:
   # ── Premium deployment ────────────────────────────────────────────────────
-  # Builds with tether-premium installed. Image stays on the Pi — never pushed
-  # to any registry. When a private registry is available, push step goes here.
   deploy-premium:
     name: Deploy premium to Pi
     runs-on: self-hosted
@@ -34,26 +45,44 @@ jobs:
             echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
             echo "extra_tag=" >> $GITHUB_OUTPUT
           fi
-          echo "sha_tag=${SHA_TAG}" >> $GITHUB_OUTPUT
+
+      # Resolve PREMIUM_REF for cache-busting.
+      # - repository_dispatch: use the SHA sent in the payload (premium just changed)
+      # - push / workflow_dispatch: fetch current premium HEAD SHA
+      #
+      # Future (private PyPI): replace the git ls-remote call with:
+      #   pip index versions tether-premium 2>/dev/null | awk '{print $NF}'
+      # and update the Dockerfile install command accordingly.
+      - name: Resolve premium ref
+        id: premium
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            REF="${{ github.event.client_payload.premium_ref }}"
+          else
+            REF=$(git ls-remote \
+              "https://${{ secrets.TETHER_PREMIUM_TOKEN }}@github.com/jlunder00/tether-premium.git" \
+              HEAD 2>/dev/null | cut -f1 | cut -c1-7 || echo unknown)
+          fi
+          echo "ref=${REF}" >> $GITHUB_OUTPUT
+          echo "Premium ref: ${REF}"
 
       - name: Build premium image
         run: |
           cd /home/toast/tether
-          IMAGE=tether-premium
           TAG=${{ steps.version.outputs.tag }}
-          IMAGE_TAG=$TAG TETHER_IMAGE=$IMAGE PREMIUM_GIT_TOKEN=$TETHER_PREMIUM_TOKEN \
-            docker compose build
-          # Also tag as latest
-          docker tag $IMAGE:$TAG $IMAGE:latest
-          # If this is a semver release, tag that too
+          BUILD_TARGET=$( [ "${{ github.event.inputs.no_cache }}" = "true" ] && \
+            echo build-premium-no-cache || echo build-premium )
+          make ${BUILD_TARGET} \
+            IMAGE=tether-premium \
+            TAG=${TAG} \
+            PREMIUM_GIT_TOKEN=${{ secrets.TETHER_PREMIUM_TOKEN }} \
+            PREMIUM_REF=${{ steps.premium.outputs.ref }}
+          docker tag tether-premium:${TAG} tether-premium:latest
           if [ -n "${{ steps.version.outputs.extra_tag }}" ]; then
-            docker tag $IMAGE:$TAG $IMAGE:${{ steps.version.outputs.extra_tag }}
+            docker tag tether-premium:${TAG} tether-premium:${{ steps.version.outputs.extra_tag }}
           fi
-          # Write IMAGE_TAG to .env so compose uses the new image on restart
-          sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$TAG/" /home/toast/tether/.env || \
-            echo "IMAGE_TAG=$TAG" >> /home/toast/tether/.env
-        env:
-          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
+          sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${TAG}/" /home/toast/tether/.env || \
+            echo "IMAGE_TAG=${TAG}" >> /home/toast/tether/.env
 
       - name: Run DB migrations
         run: |
@@ -69,9 +98,6 @@ jobs:
       - name: Pre-pull external images
         run: |
           cd /home/toast/tether
-          # Pull any non-tether images declared in compose (e.g. postgres).
-          # Retries handle transient TLS/network timeouts on the Pi.
-          # Falls back to cached image if all retries fail.
           EXTERNAL_IMAGES=$(TETHER_IMAGE=tether-premium docker compose config --images 2>/dev/null \
             | grep -v '^tether' | grep -v '^ghcr.io/jlunder00' | sort -u)
           for IMAGE in $EXTERNAL_IMAGES; do
@@ -85,8 +111,7 @@ jobs:
       - name: Restart services
         run: |
           cd /home/toast/tether
-          TETHER_IMAGE=tether-premium docker compose down || true
-          TETHER_IMAGE=tether-premium docker compose up -d
+          make restart IMAGE=tether-premium TAG=${{ steps.version.outputs.tag }}
 
       - name: Prune old premium images (keep 3)
         run: |
@@ -97,11 +122,11 @@ jobs:
           docker image prune -f
 
   # ── Community edition publish ─────────────────────────────────────────────
-  # Builds without premium. Pushes to ghcr.io — publicly visible, no premium
-  # code included. Community self-hosters pull from here.
   publish-community:
     name: Publish community edition to ghcr.io
     runs-on: ubuntu-latest
+    # Only publish on direct push/tag — not on premium-triggered deploys.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
 
@@ -123,10 +148,7 @@ jobs:
 
       - name: Build community image
         run: |
-          IMAGE=ghcr.io/jlunder00/tether
-          TAG=${{ steps.version.outputs.tag }}
-          # No GITHUB_TOKEN build arg — community edition, no premium
-          docker build -t $IMAGE:$TAG .
+          make build-community TAG=${{ steps.version.outputs.tag }}
 
       - name: Push to ghcr.io
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,10 +50,15 @@ RUN pip install --no-cache-dir --no-deps .
 COPY --from=frontend-build /build/dist/ frontend/dist/
 
 # ── Optional premium layer ────────────────────────────────
-# Pass --build-arg GITHUB_TOKEN=<token> to install premium from the private
-# repo. If omitted or empty, this produces the community edition image.
+# Pass PREMIUM_GIT_TOKEN to install premium from the private repo.
+# PREMIUM_REF is a cache-buster: change it to force a fresh install.
+#   Now:    set to the premium repo HEAD SHA (7 chars)
+#   Future: set to the pip version tag when a private PyPI server is ready;
+#           swap the install command to: pip install tether-premium==${PREMIUM_REF}
 ARG PREMIUM_GIT_TOKEN=
+ARG PREMIUM_REF=unknown
 RUN if [ -n "$PREMIUM_GIT_TOKEN" ]; then \
+      echo "Installing tether-premium @ ${PREMIUM_REF}" && \
       pip install --no-cache-dir \
         "git+https://${PREMIUM_GIT_TOKEN}@github.com/jlunder00/tether-premium.git" && \
       python -c "from tether_premium.register import get_premium_handler; print('[ok] premium loaded')" ; \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,76 @@
+# Tether build & deployment helpers
+#
+# Variables (all overridable):
+#   PREMIUM_GIT_TOKEN  GitHub PAT for cloning tether-premium (required for premium builds)
+#   PREMIUM_REF        Cache-buster: SHA (now) or version tag (when private PyPI is ready).
+#                      Auto-fetched from remote HEAD if unset and TOKEN is set.
+#   IMAGE              Docker image name  (default: tether-premium)
+#   TAG                Image tag          (default: dev)
+#
+# Swapping to private PyPI (future):
+#   Replace the PREMIUM_REF auto-fetch below with:
+#     PREMIUM_REF ?= $(shell pip index versions tether-premium 2>/dev/null | awk '{print $$NF}')
+#   And update the Dockerfile install command from git+https://... to
+#     pip install tether-premium==$(PREMIUM_REF)
+
+IMAGE             ?= tether-premium
+TAG               ?= dev
+PREMIUM_GIT_TOKEN ?=
+# Resolve PREMIUM_REF: caller can pass it explicitly; otherwise fetch remote HEAD SHA.
+PREMIUM_REF       ?= $(shell \
+  [ -n "$(PREMIUM_GIT_TOKEN)" ] && \
+  git ls-remote "https://$(PREMIUM_GIT_TOKEN)@github.com/jlunder00/tether-premium.git" HEAD \
+    2>/dev/null | cut -f1 | cut -c1-7 || echo unknown)
+
+COMPOSE_ENV = PREMIUM_GIT_TOKEN=$(PREMIUM_GIT_TOKEN) \
+              PREMIUM_REF=$(PREMIUM_REF) \
+              IMAGE_TAG=$(TAG) \
+              TETHER_IMAGE=$(IMAGE)
+
+.PHONY: build build-premium build-community \
+        build-no-cache build-premium-no-cache build-community-no-cache \
+        up down restart \
+        deploy deploy-no-cache deploy-community \
+        tag-latest
+
+# ── Build targets ─────────────────────────────────────────
+
+build: build-premium
+
+build-premium:
+	$(COMPOSE_ENV) docker compose build
+
+build-community:
+	IMAGE_TAG=$(TAG) TETHER_IMAGE=ghcr.io/jlunder00/tether docker compose build
+
+build-no-cache: build-premium-no-cache
+
+build-premium-no-cache:
+	$(COMPOSE_ENV) docker compose build --no-cache
+
+build-community-no-cache:
+	IMAGE_TAG=$(TAG) TETHER_IMAGE=ghcr.io/jlunder00/tether docker compose build --no-cache
+
+# ── Service targets ───────────────────────────────────────
+
+up:
+	TETHER_IMAGE=$(IMAGE) IMAGE_TAG=$(TAG) docker compose up -d
+
+down:
+	TETHER_IMAGE=$(IMAGE) docker compose down || true
+
+restart: down up
+
+# ── Combined deploy targets ───────────────────────────────
+
+deploy: build up
+
+deploy-no-cache: build-premium-no-cache up
+
+deploy-community: build-community
+	IMAGE_TAG=$(TAG) TETHER_IMAGE=ghcr.io/jlunder00/tether docker compose up -d
+
+# ── Tagging ───────────────────────────────────────────────
+
+tag-latest:
+	docker tag $(IMAGE):$(TAG) $(IMAGE):latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ x-build: &build
   context: .
   args:
     PREMIUM_GIT_TOKEN: ${PREMIUM_GIT_TOKEN:-}
+    PREMIUM_REF: ${PREMIUM_REF:-unknown}
   # TETHER_IMAGE selects the image name:
   #   Premium (Pi):      tether-premium   — local only, never pushed to any registry
   #   Community (ghcr):  ghcr.io/jlunder00/tether   — public, no premium code


### PR DESCRIPTION
## Summary

- **Makefile**: wraps all build/deploy commands (`build-premium`, `build-community`, `build-premium-no-cache`, `up`, `down`, `restart`, `deploy`, `deploy-no-cache`). Easier to use manually on the Pi and cleaner to read in CI.
- **PREMIUM_REF cache-buster**: new `ARG PREMIUM_REF=unknown` in Dockerfile and docker-compose.yml. Changing this arg invalidates only the `pip install tether-premium` layer. Without it, Docker reuses the cached layer even when premium has new commits.
- **Cross-repo deploy trigger**: `deploy.yml` now listens on `repository_dispatch: [premium-updated]`. When tether-premium merges to main, it sends this event with the HEAD SHA as `premium_ref`, which flows through as `PREMIUM_REF` — busting the cache automatically.
- **workflow_dispatch** with `no_cache` boolean for manual force-rebuild.
- **Private PyPI ready**: swap points are commented throughout. When private PyPI is ready, change `PREMIUM_REF` resolution from `git ls-remote` to `pip index versions` and swap the Dockerfile install command — nothing else changes.

## Prerequisite

tether-premium needs secret `TETHER_PUBLIC_DISPATCH_TOKEN` — a PAT with `repo` scope on `jlunder00/tether`.

## Test plan
- [ ] Merge companion premium PR (trigger-deploy workflow)
- [ ] Add `TETHER_PUBLIC_DISPATCH_TOKEN` to tether-premium repo secrets
- [ ] Push trivial commit to premium main → tether deploy fires automatically
- [ ] Verify `/explain-beacon` returns actual skill content
- [ ] `make deploy-no-cache` works on Pi for emergency cache-bust