### PR TITLE
Overdue indicator + auto-block status resolver

### DIFF
--- a/db/queries.py
+++ b/db/queries.py
@@ -427,16 +427,19 @@ def resolve_blocked_status(
 
         db.execute("UPDATE tasks SET status=? WHERE uuid=?", (new_status, task_uuid))
 
-        dependents = db.execute(
-            """
-            SELECT d.blocked_id FROM dependencies d
-            WHERE d.blocker_type = 'task' AND d.blocker_id = ?
-              AND d.blocked_type = 'task'
-            """,
-            (task_uuid,),
-        ).fetchall()
-        for (dep_uuid,) in dependents:
-            resolve_blocked_status(db_path, dep_uuid, _visited)
+        dependents_to_cascade = [
+            row[0] for row in db.execute(
+                """
+                SELECT d.blocked_id FROM dependencies d
+                WHERE d.blocker_type = 'task' AND d.blocker_id = ?
+                  AND d.blocked_type = 'task'
+                """,
+                (task_uuid,),
+            ).fetchall()
+        ]
+
+    for dep_uuid in dependents_to_cascade:
+        resolve_blocked_status(db_path, dep_uuid, _visited)
 
 
 def get_full_task_dependencies(db_path: Path, task_uuid: str) -> dict:

--- a/db/queries.py
+++ b/db/queries.py
@@ -262,6 +262,14 @@ def patch_task_fields(db_path: Path, task_uuid: str, fields: dict) -> dict | Non
         for (dep_uuid,) in dependents:
             resolve_blocked_status(db_path, dep_uuid)
         resolve_blocked_status(db_path, task_uuid)
+        # Re-read to reflect any resolver changes
+        with get_db(db_path) as conn:
+            row = conn.execute(
+                "SELECT uuid, text, status, position, followup_config, description, context_subject FROM tasks WHERE uuid=?",
+                (task_uuid,),
+            ).fetchone()
+        if row:
+            result = _row_to_task(row)
     return result
 
 
@@ -279,6 +287,14 @@ def get_task_by_uuid(db_path: Path, task_uuid: str) -> dict | None:
 
 def delete_task_by_uuid(db_path: Path, task_uuid: str) -> None:
     """Delete a task and its related data."""
+    # Collect downstream tasks that were blocked by this task before deleting
+    with get_db(db_path) as conn:
+        downstream = [
+            r[0] for r in conn.execute(
+                "SELECT blocked_id FROM dependencies WHERE blocker_type='task' AND blocker_id=? AND blocked_type='task'",
+                (task_uuid,),
+            ).fetchall()
+        ]
     with get_db(db_path) as conn:
         conn.execute("DELETE FROM subtasks WHERE task_id=?", (task_uuid,))
         conn.execute("DELETE FROM links WHERE parent_type='tasks' AND parent_id=?", (task_uuid,))
@@ -286,6 +302,9 @@ def delete_task_by_uuid(db_path: Path, task_uuid: str) -> None:
         conn.execute("DELETE FROM milestone_tasks WHERE task_id=?", (task_uuid,))
         conn.execute("DELETE FROM followup_state WHERE task_id=?", (task_uuid,))
         conn.execute("DELETE FROM tasks WHERE uuid=?", (task_uuid,))
+    # Resolve blocked status on any tasks that were waiting on the deleted task
+    for dep_uuid in downstream:
+        resolve_blocked_status(db_path, dep_uuid)
 
 
 def move_task_atomic(

--- a/db/queries.py
+++ b/db/queries.py
@@ -396,16 +396,16 @@ def resolve_blocked_status(
         return
     _visited.add(task_uuid)
 
-    with transaction(db_path):
-        db = get_db(db_path)
-        row = db.execute("SELECT status FROM tasks WHERE uuid=?", (task_uuid,)).fetchone()
+    dependents_to_cascade: list[str] = []
+    with get_db(db_path) as conn:
+        row = conn.execute("SELECT status FROM tasks WHERE uuid=?", (task_uuid,)).fetchone()
         if row is None:
             return
         current = row[0]
         if current in ("done", "skipped"):
             return
 
-        blocker_rows = db.execute(
+        blocker_rows = conn.execute(
             """
             SELECT t.status FROM dependencies d
             JOIN tasks t ON t.uuid = d.blocker_id
@@ -425,10 +425,10 @@ def resolve_blocked_status(
         if new_status is None:
             return
 
-        db.execute("UPDATE tasks SET status=? WHERE uuid=?", (new_status, task_uuid))
+        conn.execute("UPDATE tasks SET status=? WHERE uuid=?", (new_status, task_uuid))
 
         dependents_to_cascade = [
-            row[0] for row in db.execute(
+            r[0] for r in conn.execute(
                 """
                 SELECT d.blocked_id FROM dependencies d
                 WHERE d.blocker_type = 'task' AND d.blocker_id = ?

--- a/db/queries.py
+++ b/db/queries.py
@@ -6,7 +6,7 @@ import uuid
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
-from db.schema import get_db
+from db.schema import get_db, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -252,7 +252,17 @@ def patch_task_fields(db_path: Path, task_uuid: str, fields: dict) -> dict | Non
         ).fetchone()
     if not row:
         return None
-    return _row_to_task(row)
+    result = _row_to_task(row)
+    if "status" in fields:
+        with get_db(db_path) as conn:
+            dependents = conn.execute(
+                "SELECT blocked_id FROM dependencies WHERE blocker_type='task' AND blocker_id=? AND blocked_type='task'",
+                (task_uuid,),
+            ).fetchall()
+        for (dep_uuid,) in dependents:
+            resolve_blocked_status(db_path, dep_uuid)
+        resolve_blocked_status(db_path, task_uuid)
+    return result
 
 
 def get_task_by_uuid(db_path: Path, task_uuid: str) -> dict | None:
@@ -319,18 +329,27 @@ def add_dependency(db_path: Path, blocker_type: str, blocker_id: str,
             (blocker_type, blocker_id, blocked_type, blocked_id),
         )
         if cur.lastrowid:
-            return cur.lastrowid
-        row = conn.execute(
-            "SELECT id FROM dependencies WHERE blocker_type=? AND blocker_id=? AND blocked_type=? AND blocked_id=?",
-            (blocker_type, blocker_id, blocked_type, blocked_id),
-        ).fetchone()
-        return row["id"]
+            dep_id = cur.lastrowid
+        else:
+            row = conn.execute(
+                "SELECT id FROM dependencies WHERE blocker_type=? AND blocker_id=? AND blocked_type=? AND blocked_id=?",
+                (blocker_type, blocker_id, blocked_type, blocked_id),
+            ).fetchone()
+            dep_id = row["id"]
+    if blocked_type == "task":
+        resolve_blocked_status(db_path, blocked_id)
+    return dep_id
 
 
 def remove_dependency(db_path: Path, dep_id: int) -> None:
     """Remove a dependency by id."""
     with get_db(db_path) as conn:
+        row = conn.execute(
+            "SELECT blocked_type, blocked_id FROM dependencies WHERE id=?", (dep_id,)
+        ).fetchone()
         conn.execute("DELETE FROM dependencies WHERE id=?", (dep_id,))
+    if row and row[0] == "task":
+        resolve_blocked_status(db_path, row[1])
 
 
 def get_dependencies_for(db_path: Path, entity_type: str, entity_id: str) -> dict:
@@ -364,6 +383,60 @@ def get_dependencies_for(db_path: Path, entity_type: str, entity_id: str) -> dic
                        "name": _resolve_name(conn, r["blocker_type"], r["blocker_id"])}
                       for r in blocked_rows]
     return {"blocks": blocks, "blocked_by": blocked_by}
+
+
+def resolve_blocked_status(
+    db_path: Path,
+    task_uuid: str,
+    _visited: set[str] | None = None,
+) -> None:
+    if _visited is None:
+        _visited = set()
+    if task_uuid in _visited:
+        return
+    _visited.add(task_uuid)
+
+    with transaction(db_path):
+        db = get_db(db_path)
+        row = db.execute("SELECT status FROM tasks WHERE uuid=?", (task_uuid,)).fetchone()
+        if row is None:
+            return
+        current = row[0]
+        if current in ("done", "skipped"):
+            return
+
+        blocker_rows = db.execute(
+            """
+            SELECT t.status FROM dependencies d
+            JOIN tasks t ON t.uuid = d.blocker_id
+            WHERE d.blocked_type = 'task' AND d.blocked_id = ?
+              AND d.blocker_type = 'task'
+            """,
+            (task_uuid,),
+        ).fetchall()
+        has_open = any(r[0] not in ("done", "skipped") for r in blocker_rows)
+
+        new_status: str | None = None
+        if has_open and current != "blocked":
+            new_status = "blocked"
+        elif not has_open and current == "blocked":
+            new_status = "pending"
+
+        if new_status is None:
+            return
+
+        db.execute("UPDATE tasks SET status=? WHERE uuid=?", (new_status, task_uuid))
+
+        dependents = db.execute(
+            """
+            SELECT d.blocked_id FROM dependencies d
+            WHERE d.blocker_type = 'task' AND d.blocker_id = ?
+              AND d.blocked_type = 'task'
+            """,
+            (task_uuid,),
+        ).fetchall()
+        for (dep_uuid,) in dependents:
+            resolve_blocked_status(db_path, dep_uuid, _visited)
 
 
 def get_full_task_dependencies(db_path: Path, task_uuid: str) -> dict:
@@ -1564,7 +1637,9 @@ def create_unscheduled_task(
             "SELECT uuid, text, status, position, followup_config, description, context_subject, context_node_id "
             "FROM tasks WHERE uuid=?", (task_uuid,)
         ).fetchone()
-    return _row_to_task(row)
+    new_task = _row_to_task(row)
+    resolve_blocked_status(db_path, new_task["id"])
+    return new_task
 
 
 def get_unscheduled_tasks(db_path: Path) -> list[dict]:

--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -60,7 +60,8 @@ const isOverdue = computed(() => {
   const pd = (props.task as any).plan_date as string | null | undefined
   if (!pd) return false
   if (props.task.status === 'done' || props.task.status === 'skipped') return false
-  const today = new Date().toISOString().slice(0, 10)
+  const d = new Date()
+  const today = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
   return pd < today
 })
 

--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -56,6 +56,14 @@ const STATUS_CARD_STYLE: Record<TaskStatus, Record<string, string>> = {
   blocked:     { backgroundColor: 'rgb(30,22,37)' },           // red tint
 }
 
+const isOverdue = computed(() => {
+  const pd = (props.task as any).plan_date as string | null | undefined
+  if (!pd) return false
+  if (props.task.status === 'done' || props.task.status === 'skipped') return false
+  const today = new Date().toISOString().slice(0, 10)
+  return pd < today
+})
+
 const showFollowup = ref(false)
 const showStatusDropdown = ref(false)
 const popoverStyle = ref({ top: '0px', right: '0px' })
@@ -169,6 +177,10 @@ function toggleFollowup(enabled: boolean) {
         @click.stop
         class="text-[10px] px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-300">
         {{ (task as any).plan_date }}{{ (task as any).anchor_id ? ' · ' + (task as any).anchor_id : '' }}
+      </span>
+      <span v-if="isOverdue" @click.stop
+            class="text-[10px] px-1.5 py-0.5 rounded bg-red-500/20 text-red-300 font-medium">
+        overdue
       </span>
       <template v-if="!hideTags">
         <span

--- a/tests/db/test_queries.py
+++ b/tests/db/test_queries.py
@@ -17,6 +17,7 @@ from db.queries import (
     link_milestone_task, unlink_milestone_task,
     add_dependency, remove_dependency, get_dependencies_for,
     get_full_task_dependencies,
+    get_task_by_uuid,
     get_subtasks, create_subtask, update_subtask, delete_subtask, reorder_subtasks,
     get_links, create_link, delete_link,
     patch_task_fields,
@@ -974,3 +975,78 @@ def test_get_all_node_paths_excludes_archived(db_path):
     archive_node(db_path, node["id"])
     paths = get_all_node_paths(db_path)
     assert "Old" not in paths
+
+
+# ---------------------------------------------------------------------------
+# resolve_blocked_status (triggered implicitly via add_dependency / patch_task_fields / remove_dependency)
+# ---------------------------------------------------------------------------
+
+def test_resolver_flips_pending_to_blocked(db_path):
+    tasks = _make_tasks(db_path, 2)
+    uid_a, uid_b = tasks[0]["id"], tasks[1]["id"]
+    add_dependency(db_path, "task", uid_a, "task", uid_b)
+    task_b = get_task_by_uuid(db_path, uid_b)
+    assert task_b["status"] == "blocked"
+
+
+def test_resolver_restores_to_pending_when_blocker_done(db_path):
+    tasks = _make_tasks(db_path, 2)
+    uid_a, uid_b = tasks[0]["id"], tasks[1]["id"]
+    add_dependency(db_path, "task", uid_a, "task", uid_b)
+    assert get_task_by_uuid(db_path, uid_b)["status"] == "blocked"
+
+    patch_task_fields(db_path, uid_a, {"status": "done"})
+    assert get_task_by_uuid(db_path, uid_b)["status"] == "pending"
+
+
+def test_resolver_preserves_user_set_done(db_path):
+    tasks = _make_tasks(db_path, 2)
+    uid_a, uid_b = tasks[0]["id"], tasks[1]["id"]
+    add_dependency(db_path, "task", uid_a, "task", uid_b)
+    assert get_task_by_uuid(db_path, uid_b)["status"] == "blocked"
+
+    # User manually marks B as done
+    patch_task_fields(db_path, uid_b, {"status": "done"})
+    # Now A finishes — resolver should not downgrade B
+    patch_task_fields(db_path, uid_a, {"status": "done"})
+    assert get_task_by_uuid(db_path, uid_b)["status"] == "done"
+
+
+def test_resolver_cascades_through_chain(db_path):
+    tasks = _make_tasks(db_path, 3)
+    uid_a, uid_b, uid_c = tasks[0]["id"], tasks[1]["id"], tasks[2]["id"]
+    add_dependency(db_path, "task", uid_a, "task", uid_b)  # A blocks B
+    add_dependency(db_path, "task", uid_b, "task", uid_c)  # B blocks C
+
+    assert get_task_by_uuid(db_path, uid_b)["status"] == "blocked"
+    assert get_task_by_uuid(db_path, uid_c)["status"] == "blocked"
+
+    # A done → B unblocked, but B still blocks C
+    patch_task_fields(db_path, uid_a, {"status": "done"})
+    assert get_task_by_uuid(db_path, uid_b)["status"] == "pending"
+    assert get_task_by_uuid(db_path, uid_c)["status"] == "blocked"
+
+    # B done → C unblocked
+    patch_task_fields(db_path, uid_b, {"status": "done"})
+    assert get_task_by_uuid(db_path, uid_c)["status"] == "pending"
+
+
+def test_resolver_cycle_safe(db_path):
+    tasks = _make_tasks(db_path, 2)
+    uid_a, uid_b = tasks[0]["id"], tasks[1]["id"]
+    # Create a cycle: A blocks B and B blocks A
+    add_dependency(db_path, "task", uid_a, "task", uid_b)
+    add_dependency(db_path, "task", uid_b, "task", uid_a)  # must not infinite-loop
+    # Both should end up blocked
+    assert get_task_by_uuid(db_path, uid_a)["status"] == "blocked"
+    assert get_task_by_uuid(db_path, uid_b)["status"] == "blocked"
+
+
+def test_remove_dependency_unblocks(db_path):
+    tasks = _make_tasks(db_path, 2)
+    uid_a, uid_b = tasks[0]["id"], tasks[1]["id"]
+    dep_id = add_dependency(db_path, "task", uid_a, "task", uid_b)
+    assert get_task_by_uuid(db_path, uid_b)["status"] == "blocked"
+
+    remove_dependency(db_path, dep_id)
+    assert get_task_by_uuid(db_path, uid_b)["status"] == "pending"


### PR DESCRIPTION
## Summary
- **Overdue pill** — tasks with `plan_date < today` and non-terminal status now show a red `overdue` badge in `TaskCard.vue` (frontend-derived, no backend changes)
- **Auto-block resolver** — new `resolve_blocked_status()` in `db/queries.py` keeps task `status` in sync with its dependency state: auto-flips `pending↔blocked` when blockers are added/removed/completed; `done`/`skipped` statuses are never auto-downgraded
- **Call-site hooks** wired into `patch_task_fields`, `add_dependency`, `remove_dependency`, `create_unscheduled_task`, and `delete_task_by_uuid`

## Test Plan
- [ ] `python3 -m pytest tests/db/test_queries.py -k "resolver or blocked or dependency" -v` — 11 tests pass (6 new resolver cases)
- [ ] `python3 -m pytest tests/db/test_queries.py tests/api/ -q` — 169 pass, no regressions
- [ ] `cd frontend && npm run build` — TS clean
- [ ] Manual: add task B with task A as dependency → B pill shows `blocked`; mark A done → B returns to `pending`
- [ ] Manual: backdate a task's `plan_date` → card shows red `overdue` pill; mark done → pill disappears
- [ ] Manual: mark B `done` while auto-blocked, then mark A `done` → B stays `done` (no auto-downgrade)