### PR TITLE
fix: phase3a audit bug fixes

### DIFF
--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -85,7 +85,8 @@ async def patch_task(task_uuid: str, body: dict,
 @router.delete("/tasks/{task_uuid}")
 async def delete_task(task_uuid: str, _auth=Depends(auth_dependency),
                       conn: asyncpg.Connection = Depends(get_db_conn)):
-    await delete_task_by_uuid(conn, task_uuid)
+    async with conn.transaction():
+        await delete_task_by_uuid(conn, task_uuid)
     return {"ok": True}
 
 

--- a/db/pg_queries/anchors.py
+++ b/db/pg_queries/anchors.py
@@ -1,6 +1,5 @@
 """Async Postgres queries — anchors table."""
 from __future__ import annotations
-import json
 import uuid as _uuid
 
 import asyncpg
@@ -32,7 +31,7 @@ async def upsert_anchor(conn: asyncpg.Connection, anchor: dict) -> None:
         anchor.get("strictness", 3),
         anchor.get("color", "#888888"),
         anchor.get("position", 0),
-        json.dumps(anchor.get("followup_config")) if anchor.get("followup_config") is not None else None,
+        anchor.get("followup_config"),
     )
 
 

--- a/db/pg_queries/followup.py
+++ b/db/pg_queries/followup.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+import uuid as _uuid
 
 import asyncpg
 
@@ -127,15 +128,15 @@ async def resolve_followup_config(
         WHERE uuid = $1
           AND user_id = current_setting('app.current_user_id', true)::uuid
         """,
-        task_id,
+        _uuid.UUID(task_id),
     )
     anchor_row = await conn.fetchrow(
         """
         SELECT followup_config FROM anchors
-        WHERE id = $1::uuid
+        WHERE id = $1
           AND user_id = current_setting('app.current_user_id', true)::uuid
         """,
-        anchor_id,
+        _uuid.UUID(anchor_id),
     )
     task_fc = task_row["followup_config"] if task_row else None    # already dict from JSONB
     anchor_fc = anchor_row["followup_config"] if anchor_row else None

--- a/db/pg_queries/plans.py
+++ b/db/pg_queries/plans.py
@@ -85,23 +85,6 @@ async def list_plan_dates(conn: asyncpg.Connection) -> list[str]:
     return [r["date"] for r in rows]
 
 
-async def insert_check_in(
-    conn: asyncpg.Connection,
-    date: str,
-    anchor_id: str,
-    accomplished: str,
-    current_status: str,
-) -> None:
-    await conn.execute(
-        """
-        INSERT INTO check_ins
-            (plan_date, anchor_id, type, timestamp, accomplished, current_status)
-        VALUES ($1, $2, 'user_checkin', now(), $3, $4)
-        """,
-        date, anchor_id, accomplished, current_status,
-    )
-
-
 def _row_to_task(row, *, include_schedule: bool = False) -> dict:
     r = dict(row)
     d = {


### PR DESCRIPTION
## Summary

Fixes 5 production bugs found by the post-Phase-3a audit:

- **JSONB double-encode** (`anchors.py`): `upsert_anchor` was calling `json.dumps()` on `followup_config` before passing to asyncpg. With the JSONB codec registered, this double-encodes the value. Fixed by passing the dict directly.
- **UUID type mismatch** (`followup.py`): `resolve_followup_config` passed raw strings to UUID columns — `task_id` to `tasks.uuid` and `anchor_id` with a `::uuid` SQL cast. Fixed by wrapping with `_uuid.UUID()` and dropping the SQL cast.
- **Missing user_id on check_ins INSERT** (`plans.py`): Dead duplicate of `insert_check_in` had the bug. The actual exported function (in `followup.py`) is correct. Deleted the dead duplicate.
- **Non-atomic task delete** (`api/routes/tasks.py`): `delete_task_by_uuid` performs 6 DELETEs + cascading `resolve_blocked_status` UPDATEs. Route handler now wraps the call in `conn.transaction()`.

The `create_unscheduled_task` route already had a transaction wrap — audit finding #6 was already resolved.

## Test plan
- [ ] All 160 tests pass (verified locally before commit)
- [ ] No new failures introduced