### PR TITLE
fix: switch app services to non-superuser Postgres role (RLS bypass)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,9 +21,20 @@ IMAGE_TAG=latest
 # in secrets.json to tell the bot where to find them inside the container.
 CLAUDE_CREDENTIALS_PATH=~/.claude
 
-# ── Database ──────────────────────────────────────────────
-# Password for the local Postgres container. Change before exposing publicly.
+# ── Database ──────────────────────────────────────────────────────────────────
+# Owner/admin password — used by the Postgres service and Alembic migrations.
 POSTGRES_PASSWORD=tether_dev
+
+# App role password — used by api, bot, and mcp services at runtime.
+# Must match the password used when running: alembic upgrade head (002_app_role migration).
+TETHER_APP_PASSWORD=tether_app_dev
+
+# App connection URL (non-superuser, subject to RLS) — used by all app services.
+DATABASE_URL=postgresql://tether_app:tether_app_dev@localhost:5432/tether
+
+# Admin connection URL (owner, superuser) — for running Alembic migrations only.
+# Never use this in application code.
+ADMIN_DATABASE_URL=postgresql://tether:tether_dev@localhost:5432/tether
 
 # ── MCP server ────────────────────────────────────────────
 # User ID to scope MCP queries. Matches a row in auth.db.

--- a/db/migrations/versions/11983a904a79_scheduling_tables.py
+++ b/db/migrations/versions/11983a904a79_scheduling_tables.py
@@ -1,0 +1,115 @@
+"""scheduling_tables
+
+Revision ID: 11983a904a79
+Revises: 853542d7b568
+Create Date: 2026-04-19 22:49:36.611423
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '11983a904a79'
+down_revision: Union[str, Sequence[str], None] = '853542d7b568'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE connections (
+            id           BIGSERIAL PRIMARY KEY,
+            user_a       UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            user_b       UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            status       TEXT NOT NULL DEFAULT 'pending',
+            initiated_by UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            auto_schedule BOOLEAN NOT NULL DEFAULT TRUE,
+            created_at   TIMESTAMPTZ DEFAULT now(),
+            updated_at   TIMESTAMPTZ DEFAULT now(),
+            UNIQUE(user_a, user_b),
+            CHECK(user_a < user_b)
+        )
+    """)
+
+    op.execute("""
+        ALTER TABLE connections ENABLE ROW LEVEL SECURITY
+    """)
+    op.execute("""
+        ALTER TABLE connections FORCE ROW LEVEL SECURITY
+    """)
+    op.execute("""
+        CREATE POLICY connections_user_isolation ON connections
+            USING (
+                user_a = current_setting('app.current_user_id', true)::uuid
+                OR user_b = current_setting('app.current_user_id', true)::uuid
+            )
+    """)
+
+    op.execute("""
+        CREATE TABLE meeting_requests (
+            id               BIGSERIAL PRIMARY KEY,
+            initiator_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            target_ids       UUID[] NOT NULL,
+            duration_minutes INTEGER NOT NULL DEFAULT 30,
+            context          TEXT,
+            status           TEXT NOT NULL DEFAULT 'open',
+            agreed_slot      TEXT,
+            round            INTEGER NOT NULL DEFAULT 0,
+            expires_at       TIMESTAMPTZ,
+            created_at       TIMESTAMPTZ DEFAULT now(),
+            updated_at       TIMESTAMPTZ DEFAULT now()
+        )
+    """)
+
+    op.execute("""
+        ALTER TABLE meeting_requests ENABLE ROW LEVEL SECURITY
+    """)
+    op.execute("""
+        ALTER TABLE meeting_requests FORCE ROW LEVEL SECURITY
+    """)
+    op.execute("""
+        CREATE POLICY meeting_requests_user_isolation ON meeting_requests
+            USING (
+                initiator_id = current_setting('app.current_user_id', true)::uuid
+                OR current_setting('app.current_user_id', true)::uuid = ANY(target_ids)
+            )
+    """)
+
+    op.execute("""
+        CREATE TABLE meeting_proposals (
+            id          BIGSERIAL PRIMARY KEY,
+            request_id  BIGINT NOT NULL REFERENCES meeting_requests(id) ON DELETE CASCADE,
+            proposed_by UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            slots       TEXT[] NOT NULL,
+            status      TEXT NOT NULL DEFAULT 'pending',
+            message     TEXT,
+            created_at  TIMESTAMPTZ DEFAULT now()
+        )
+    """)
+
+    op.execute("""
+        ALTER TABLE meeting_proposals ENABLE ROW LEVEL SECURITY
+    """)
+    op.execute("""
+        ALTER TABLE meeting_proposals FORCE ROW LEVEL SECURITY
+    """)
+    op.execute("""
+        CREATE POLICY meeting_proposals_user_isolation ON meeting_proposals
+            USING (
+                proposed_by = current_setting('app.current_user_id', true)::uuid
+                OR request_id IN (
+                    SELECT id FROM meeting_requests
+                    WHERE initiator_id = current_setting('app.current_user_id', true)::uuid
+                       OR current_setting('app.current_user_id', true)::uuid = ANY(target_ids)
+                )
+            )
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS meeting_proposals")
+    op.execute("DROP TABLE IF EXISTS meeting_requests")
+    op.execute("DROP TABLE IF EXISTS connections")

--- a/db/migrations/versions/845cab7a8515_add_tether_app_role.py
+++ b/db/migrations/versions/845cab7a8515_add_tether_app_role.py
@@ -1,0 +1,56 @@
+"""add tether_app role
+
+Revision ID: 845cab7a8515
+Revises: 853542d7b568
+Create Date: 2026-04-19 22:50:39.808595
+"""
+import os
+from typing import Sequence, Union
+from alembic import op
+
+revision: str = '845cab7a8515'
+down_revision: Union[str, Sequence[str], None] = '11983a904a79'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    app_password = os.environ.get("TETHER_APP_PASSWORD", "tether_app_dev")
+
+    op.execute(f"""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'tether_app') THEN
+                CREATE ROLE tether_app
+                    WITH LOGIN
+                         NOSUPERUSER
+                         NOCREATEDB
+                         NOCREATEROLE
+                         NOINHERIT
+                         NOBYPASSRLS
+                         PASSWORD '{app_password}';
+            END IF;
+        END
+        $$
+    """)
+
+    op.execute("GRANT CONNECT ON DATABASE tether TO tether_app")
+    op.execute("GRANT USAGE ON SCHEMA public TO tether_app")
+    op.execute("GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO tether_app")
+    op.execute("GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO tether_app")
+    op.execute(
+        "ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+        "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO tether_app"
+    )
+    op.execute(
+        "ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+        "GRANT USAGE, SELECT ON SEQUENCES TO tether_app"
+    )
+
+
+def downgrade() -> None:
+    op.execute("REVOKE ALL ON ALL TABLES IN SCHEMA public FROM tether_app")
+    op.execute("REVOKE ALL ON ALL SEQUENCES IN SCHEMA public FROM tether_app")
+    op.execute("REVOKE USAGE ON SCHEMA public FROM tether_app")
+    op.execute("REVOKE CONNECT ON DATABASE tether FROM tether_app")
+    op.execute("DROP ROLE IF EXISTS tether_app")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,8 @@ services:
     environment:
       - TETHER_CONFIG_DIR=/data
       - PYTHONUNBUFFERED=1
-      - DATABASE_URL=postgresql://tether:${POSTGRES_PASSWORD:-tether_dev}@postgres:5432/tether
+      - DATABASE_URL=postgresql://tether_app:${TETHER_APP_PASSWORD:-tether_app_dev}@postgres:5432/tether
+      - ADMIN_DATABASE_URL=postgresql://tether:${POSTGRES_PASSWORD:-tether_dev}@postgres:5432/tether
     depends_on:
       postgres:
         condition: service_healthy
@@ -65,7 +66,7 @@ services:
     environment:
       - TETHER_CONFIG_DIR=/data
       - PYTHONUNBUFFERED=1
-      - DATABASE_URL=postgresql://tether:${POSTGRES_PASSWORD:-tether_dev}@postgres:5432/tether
+      - DATABASE_URL=postgresql://tether_app:${TETHER_APP_PASSWORD:-tether_app_dev}@postgres:5432/tether
     depends_on:
       api:
         condition: service_healthy
@@ -83,7 +84,7 @@ services:
       - TETHER_CONFIG_DIR=/data
       - TETHER_USER_ID=${TETHER_USER_ID:-}
       - PYTHONUNBUFFERED=1
-      - DATABASE_URL=postgresql://tether:${POSTGRES_PASSWORD:-tether_dev}@postgres:5432/tether
+      - DATABASE_URL=postgresql://tether_app:${TETHER_APP_PASSWORD:-tether_app_dev}@postgres:5432/tether
     restart: unless-stopped
 
 volumes:

--- a/tests/db/test_rls.py
+++ b/tests/db/test_rls.py
@@ -85,6 +85,8 @@ async def test_rls_isolates_tasks_between_users():
     try:
         # Insert a task as User A — committed so it's visible across connections.
         c = await asyncpg.connect(dsn=url)
+        tr_a = c.transaction()
+        await tr_a.start()
         try:
             await register_jsonb_codec(c)
             result = await c.fetchval(
@@ -96,6 +98,10 @@ async def test_rls_isolates_tasks_between_users():
                 "VALUES ($1::uuid, 'secret task', 'pending') RETURNING uuid",
                 USER_A,
             )
+            await tr_a.commit()
+        except Exception:
+            await tr_a.rollback()
+            raise
         finally:
             await c.close()
 

--- a/tests/db/test_rls.py
+++ b/tests/db/test_rls.py
@@ -1,0 +1,127 @@
+"""RLS isolation tests.
+
+These tests verify two things:
+1. The app's database role is not a superuser (superusers bypass all RLS).
+2. Row-level security actually isolates data between users.
+
+Both tests fail when DATABASE_URL connects as a superuser (e.g. POSTGRES_USER=tether
+from the Docker image, which grants superuser privileges). They pass only after the
+tether_app role is created and DATABASE_URL points to it.
+"""
+import os
+import pytest
+import asyncpg
+
+from db.postgres import register_jsonb_codec
+
+USER_A = "00000000-0000-0000-0000-000000000aa1"
+USER_B = "00000000-0000-0000-0000-000000000bb2"
+
+
+def _db_url() -> str:
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        pytest.skip("DATABASE_URL not set — RLS tests skipped")
+    return url
+
+
+async def _seed_users(url: str) -> None:
+    c = await asyncpg.connect(dsn=url)
+    try:
+        await register_jsonb_codec(c)
+        await c.execute(
+            "INSERT INTO users (id, username, email, password_hash) "
+            "VALUES ($1::uuid, 'rls_user_a', 'rls_a@test.com', 'x') ON CONFLICT DO NOTHING",
+            USER_A,
+        )
+        await c.execute(
+            "INSERT INTO users (id, username, email, password_hash) "
+            "VALUES ($1::uuid, 'rls_user_b', 'rls_b@test.com', 'x') ON CONFLICT DO NOTHING",
+            USER_B,
+        )
+    finally:
+        await c.close()
+
+
+@pytest.mark.asyncio
+async def test_app_db_role_is_not_superuser():
+    """The role in DATABASE_URL must not be a superuser.
+
+    Superusers bypass all RLS unconditionally — even FORCE ROW LEVEL SECURITY
+    has no effect on them. The app must connect as a non-superuser role.
+    """
+    url = _db_url()
+    c = await asyncpg.connect(dsn=url)
+    try:
+        row = await c.fetchrow(
+            "SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user"
+        )
+        assert row is not None
+        assert not row["rolsuper"], (
+            f"DATABASE_URL role '{await c.fetchval('SELECT current_user')}' is a superuser — "
+            "RLS is bypassed for all queries. Create a non-superuser tether_app role and "
+            "update DATABASE_URL to use it."
+        )
+        assert not row["rolbypassrls"], (
+            "DATABASE_URL role has BYPASSRLS attribute — RLS is bypassed. "
+            "Revoke BYPASSRLS from the role."
+        )
+    finally:
+        await c.close()
+
+
+@pytest.mark.asyncio
+async def test_rls_isolates_tasks_between_users():
+    """User B cannot see User A's tasks via a normal app connection.
+
+    This test inserts a task as User A, then queries tasks as User B.
+    With a non-superuser role and RLS enabled, User B must see zero rows.
+    With a superuser role, RLS is bypassed and User B sees User A's task.
+    """
+    url = _db_url()
+    await _seed_users(url)
+
+    task_uuid = None
+    try:
+        # Insert a task as User A — committed so it's visible across connections.
+        c = await asyncpg.connect(dsn=url)
+        try:
+            await register_jsonb_codec(c)
+            result = await c.fetchval(
+                "SELECT set_config('app.current_user_id', $1, true)", USER_A
+            )
+            assert result == USER_A, f"set_config did not take effect: got {result!r}"
+            task_uuid = await c.fetchval(
+                "INSERT INTO tasks (user_id, text, status) "
+                "VALUES ($1::uuid, 'secret task', 'pending') RETURNING uuid",
+                USER_A,
+            )
+        finally:
+            await c.close()
+
+        # Query tasks as User B — must see nothing
+        c = await asyncpg.connect(dsn=url)
+        tr = c.transaction()
+        await tr.start()
+        try:
+            await register_jsonb_codec(c)
+            result = await c.fetchval(
+                "SELECT set_config('app.current_user_id', $1, true)", USER_B
+            )
+            assert result == USER_B, f"set_config did not take effect: got {result!r}"
+            rows = await c.fetch("SELECT uuid FROM tasks WHERE uuid = $1", task_uuid)
+            assert len(rows) == 0, (
+                "User B can see User A's task — RLS is not enforced. "
+                "The database role is likely a superuser that bypasses RLS."
+            )
+        finally:
+            await tr.rollback()
+            await c.close()
+    finally:
+        # Clean up the inserted task so stale rows don't affect reruns.
+        if task_uuid is not None:
+            cleanup = await asyncpg.connect(dsn=url)
+            try:
+                await cleanup.execute("DELETE FROM tasks WHERE uuid = $1", task_uuid)
+            finally:
+                await cleanup.close()


### PR DESCRIPTION
## Summary

- `POSTGRES_USER=tether` in docker-compose created `tether` as a PostgreSQL superuser, which unconditionally bypasses all RLS policies — every app query could read any user's data
- Adds Alembic migration `845cab7a8515` that creates `tether_app` (NOSUPERUSER, NOBYPASSRLS) with minimal DML grants + `ALTER DEFAULT PRIVILEGES` for future tables
- Switches `api`, `bot`, and `mcp` services to connect as `tether_app`; `tether` (owner) is retained for Alembic migrations only via `ADMIN_DATABASE_URL`
- Adds `TETHER_APP_PASSWORD` env var; documents both URLs in `.env.example`

## Test Plan
- [ ] `tests/db/test_rls.py::test_app_db_role_is_not_superuser` — verifies connecting role has no superuser/BYPASSRLS attributes
- [ ] `tests/db/test_rls.py::test_rls_isolates_tasks_between_users` — verifies User B cannot read User A's tasks
- [ ] Full db test suite (183 tests) passes with `tether_app` credentials