### PR TITLE
feat: coordinated scheduling API — connections, meetings, WS events

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -19,6 +19,7 @@ from api.routes import bot as bot_routes
 from api.routes import kanban as kanban_routes
 from api.routes import nodes as nodes_routes
 from api.routes import settings as settings_routes
+from api.routes import connections as connections_routes
 from api.ws import manager
 from api.auth import decode_jwt
 from db.pool_middleware import lifespan
@@ -77,6 +78,7 @@ def create_app(lifespan_override=None) -> FastAPI:
     app.include_router(kanban_routes.router, prefix="/api")
     app.include_router(nodes_routes.router, prefix="/api")
     app.include_router(settings_routes.router, prefix="/api")
+    app.include_router(connections_routes.router, prefix="/api")
 
     # --- Premium plugin hook ---
     try:

--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,7 @@
+import asyncio
+import json
 import asyncpg
+from contextlib import asynccontextmanager
 from pathlib import Path
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
@@ -20,13 +23,44 @@ from api.routes import kanban as kanban_routes
 from api.routes import nodes as nodes_routes
 from api.routes import settings as settings_routes
 from api.routes import connections as connections_routes
+from api.routes import meetings as meetings_routes
 from api.ws import manager
 from api.auth import decode_jwt
-from db.pool_middleware import lifespan
+from db.pool_middleware import lifespan as _pool_lifespan
 from db.pg_queries.errors import StaleReadError
+import db.postgres as pg
 import api.config as cfg
 
 FRONTEND_DIST = Path(__file__).parent.parent / "frontend" / "dist"
+
+
+async def _expiry_loop(app):
+    from db.pg_queries.scheduling import expire_old_requests, get_meeting_request, get_participants
+    while True:
+        await asyncio.sleep(3600)
+        try:
+            async with pg.get_conn(app.state.pool) as conn:
+                expired_ids = await expire_old_requests(conn)
+            for req_id in expired_ids:
+                async with pg.get_conn(app.state.pool) as conn:
+                    req = await get_meeting_request(conn, req_id)
+                if req:
+                    for uid in get_participants(req):
+                        await manager.broadcast({"type": "meeting_cancelled", "request_id": req_id}, uid)
+        except Exception:
+            pass
+
+
+@asynccontextmanager
+async def lifespan(app):
+    async with _pool_lifespan(app):
+        task = asyncio.create_task(_expiry_loop(app))
+        yield
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
 
 def create_app(lifespan_override=None) -> FastAPI:
@@ -79,6 +113,7 @@ def create_app(lifespan_override=None) -> FastAPI:
     app.include_router(nodes_routes.router, prefix="/api")
     app.include_router(settings_routes.router, prefix="/api")
     app.include_router(connections_routes.router, prefix="/api")
+    app.include_router(meetings_routes.router, prefix="/api")
 
     # --- Premium plugin hook ---
     try:
@@ -96,21 +131,42 @@ def create_app(lifespan_override=None) -> FastAPI:
     @app.websocket("/ws")
     async def websocket_endpoint(websocket: WebSocket):
         token = websocket.cookies.get("tether_token")
-        if not token:
-            await websocket.close(code=1008)
-            return
-        try:
-            payload = decode_jwt(token)
-            user_id = payload["user_id"]
-        except Exception:
-            await websocket.close(code=1008)
-            return
-        await manager.connect(websocket, user_id)
-        try:
-            while True:
-                await websocket.receive_text()
-        except WebSocketDisconnect:
-            manager.disconnect(websocket, user_id)
+        if token:
+            try:
+                payload = decode_jwt(token)
+                user_id = payload["user_id"]
+            except Exception:
+                await websocket.close(code=1008)
+                return
+            await manager.connect(websocket, user_id)
+            try:
+                while True:
+                    await websocket.receive_text()
+            except WebSocketDisconnect:
+                manager.disconnect(websocket, user_id)
+        else:
+            await websocket.accept()
+            try:
+                raw = await asyncio.wait_for(websocket.receive_text(), timeout=10.0)
+                msg = json.loads(raw)
+            except Exception:
+                await websocket.close(code=1008)
+                return
+            if msg.get("type") != "auth" or not msg.get("token"):
+                await websocket.close(code=1008)
+                return
+            try:
+                payload = decode_jwt(msg["token"])
+                user_id = payload["user_id"]
+            except Exception:
+                await websocket.close(code=1008)
+                return
+            manager._connections.setdefault(user_id, []).append(websocket)
+            try:
+                while True:
+                    await websocket.receive_text()
+            except WebSocketDisconnect:
+                manager.disconnect(websocket, user_id)
 
     if FRONTEND_DIST.exists():
         # Serve static assets (JS, CSS, images) directly

--- a/api/routes/connections.py
+++ b/api/routes/connections.py
@@ -1,0 +1,110 @@
+"""Connection management endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+import asyncpg
+
+from api.auth import auth_dependency
+from db.pool_middleware import get_db_conn
+from db.pg_auth_queries import get_user_by_username
+from db.pg_queries.scheduling import (
+    create_connection,
+    get_connection,
+    accept_connection,
+    decline_connection,
+    list_connections_for_user,
+    patch_connection,
+)
+
+router = APIRouter()
+
+
+class ConnectionRequestBody(BaseModel):
+    target_username: str
+
+
+class DeclineBody(BaseModel):
+    block: bool = False
+
+
+class PatchConnectionBody(BaseModel):
+    auto_schedule: bool
+
+
+@router.post("/connections/request", status_code=201)
+async def request_connection(
+    body: ConnectionRequestBody,
+    auth=Depends(auth_dependency),
+    conn: asyncpg.Connection = Depends(get_db_conn),
+):
+    caller_id = auth["user_id"]
+    target = await get_user_by_username(conn, body.target_username)
+    if not target:
+        raise HTTPException(status_code=404, detail="User not found")
+    try:
+        result = await create_connection(conn, caller_id, target["id"], caller_id)
+    except asyncpg.UniqueViolationError:
+        raise HTTPException(status_code=409, detail="Connection already exists")
+    return result
+
+
+@router.post("/connections/{conn_id}/accept")
+async def accept_connection_route(
+    conn_id: int,
+    auth=Depends(auth_dependency),
+    conn: asyncpg.Connection = Depends(get_db_conn),
+):
+    caller_id = auth["user_id"]
+    connection = await get_connection(conn, conn_id)
+    if not connection:
+        raise HTTPException(status_code=404, detail="Connection not found")
+    if caller_id == connection["initiated_by"]:
+        raise HTTPException(status_code=403, detail="Initiator cannot accept their own request")
+    result = await accept_connection(conn, conn_id)
+    return {"id": result["id"], "status": result["status"]}
+
+
+@router.post("/connections/{conn_id}/decline")
+async def decline_connection_route(
+    conn_id: int,
+    body: DeclineBody,
+    auth=Depends(auth_dependency),
+    conn: asyncpg.Connection = Depends(get_db_conn),
+):
+    caller_id = auth["user_id"]
+    connection = await get_connection(conn, conn_id)
+    if not connection:
+        raise HTTPException(status_code=404, detail="Connection not found")
+    if caller_id == connection["initiated_by"]:
+        raise HTTPException(status_code=403, detail="Initiator cannot decline their own request")
+    result = await decline_connection(conn, conn_id, block=body.block)
+    if result is None:
+        return {"id": conn_id, "deleted": True}
+    return {"id": result["id"], "status": result["status"]}
+
+
+@router.get("/connections")
+async def list_connections(
+    auth=Depends(auth_dependency),
+    conn: asyncpg.Connection = Depends(get_db_conn),
+):
+    caller_id = auth["user_id"]
+    return await list_connections_for_user(conn, caller_id)
+
+
+@router.patch("/connections/{conn_id}")
+async def patch_connection_route(
+    conn_id: int,
+    body: PatchConnectionBody,
+    auth=Depends(auth_dependency),
+    conn: asyncpg.Connection = Depends(get_db_conn),
+):
+    caller_id = auth["user_id"]
+    connection = await get_connection(conn, conn_id)
+    if not connection:
+        raise HTTPException(status_code=404, detail="Connection not found")
+    if caller_id not in (connection["user_a"], connection["user_b"]):
+        raise HTTPException(status_code=403, detail="Not a participant")
+    result = await patch_connection(conn, conn_id, body.auto_schedule)
+    return result

--- a/api/routes/meetings.py
+++ b/api/routes/meetings.py
@@ -1,0 +1,242 @@
+"""Meeting request endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+import asyncpg
+from typing import Optional
+
+from api.auth import auth_dependency
+from db.pool_middleware import get_db_conn
+from db.pg_auth_queries import get_user_by_username, get_user_by_id
+from db.pg_queries.scheduling import (
+    create_meeting_request,
+    create_proposal,
+    accept_meeting_slot,
+    cancel_meeting,
+    get_meeting_request,
+    list_meetings_for_user,
+    list_incoming_for_user,
+    get_connection_by_users,
+    get_participants,
+)
+from api.ws import manager
+
+router = APIRouter()
+
+
+class MeetingRequestBody(BaseModel):
+    target_usernames: list[str]
+    duration_minutes: int = 30
+    slots: list[str]
+    context: Optional[str] = None
+
+
+class ProposeBody(BaseModel):
+    slots: list[str]
+    message: Optional[str] = None
+
+
+class AcceptSlotBody(BaseModel):
+    slot: str
+
+
+@router.post("/meetings/request", status_code=201)
+async def request_meeting(
+    body: MeetingRequestBody,
+    auth=Depends(auth_dependency),
+    conn: asyncpg.Connection = Depends(get_db_conn),
+):
+    caller_id = auth["user_id"]
+    caller_username = auth["username"]
+
+    if not body.slots:
+        raise HTTPException(status_code=400, detail="slots cannot be empty")
+
+    # Resolve target usernames to user IDs
+    target_ids = []
+    for username in body.target_usernames:
+        user = await get_user_by_username(conn, username)
+        if not user:
+            raise HTTPException(status_code=404, detail=f"User '{username}' not found")
+        target_ids.append(user["id"])
+
+    # Verify each target has an accepted connection with caller
+    for target_id in target_ids:
+        connection = await get_connection_by_users(conn, caller_id, target_id)
+        if not connection or connection["status"] != "accepted":
+            raise HTTPException(
+                status_code=400,
+                detail=f"No accepted connection with one or more targets",
+            )
+
+    request = await create_meeting_request(
+        conn, caller_id, target_ids, body.duration_minutes, body.context, body.slots
+    )
+
+    # Broadcast meeting_request event to each target
+    for target_id in target_ids:
+        await manager.broadcast(
+            {
+                "type": "meeting_request",
+                "request_id": request["id"],
+                "from_user": caller_username,
+                "duration": body.duration_minutes,
+                "context": body.context or "",
+            },
+            target_id,
+        )
+
+    return {"id": request["id"], "status": request["status"], "round": request["round"]}
+
+
+@router.post("/meetings/incoming")
+async def noop_incoming_post():
+    """Prevent POST to /meetings/incoming from matching /{id}."""
+    raise HTTPException(status_code=405, detail="Method not allowed")
+
+
+@router.get("/meetings/incoming")
+async def list_incoming(
+    auth=Depends(auth_dependency),
+    conn: asyncpg.Connection = Depends(get_db_conn),
+):
+    caller_id = auth["user_id"]
+    return await list_incoming_for_user(conn, caller_id)
+
+
+@router.post("/meetings/{meeting_id}/propose", status_code=201)
+async def propose_slots(
+    meeting_id: int,
+    body: ProposeBody,
+    auth=Depends(auth_dependency),
+    conn: asyncpg.Connection = Depends(get_db_conn),
+):
+    caller_id = auth["user_id"]
+    caller_username = auth["username"]
+
+    request = await get_meeting_request(conn, meeting_id)
+    if not request:
+        raise HTTPException(status_code=404, detail="Meeting request not found")
+    if request["status"] != "open":
+        raise HTTPException(status_code=404, detail="Meeting request is not open")
+    if caller_id not in request["target_ids"]:
+        raise HTTPException(status_code=403, detail="Only targets can propose slots")
+
+    proposal = await create_proposal(conn, meeting_id, caller_id, body.slots, body.message)
+
+    # Broadcast to initiator
+    req_after = await get_meeting_request(conn, meeting_id)
+    await manager.broadcast(
+        {
+            "type": "meeting_proposal",
+            "request_id": meeting_id,
+            "round": req_after["round"],
+            "proposed_by": caller_username,
+        },
+        request["initiator_id"],
+    )
+
+    return {
+        "proposal_id": proposal["id"],
+        "request_id": meeting_id,
+        "status": proposal["status"],
+    }
+
+
+@router.post("/meetings/{meeting_id}/accept")
+async def accept_slot(
+    meeting_id: int,
+    body: AcceptSlotBody,
+    auth=Depends(auth_dependency),
+    conn: asyncpg.Connection = Depends(get_db_conn),
+):
+    caller_id = auth["user_id"]
+
+    request = await get_meeting_request(conn, meeting_id)
+    if not request:
+        raise HTTPException(status_code=404, detail="Meeting request not found")
+    if caller_id != request["initiator_id"]:
+        raise HTTPException(status_code=403, detail="Only initiator can accept a slot")
+
+    try:
+        updated = await accept_meeting_slot(conn, meeting_id, body.slot)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    # Gather participant usernames for the WS event
+    participant_ids = get_participants(updated)
+    usernames = []
+    for uid in participant_ids:
+        user = await get_user_by_id(conn, uid)
+        if user:
+            usernames.append(user["username"])
+
+    event = {
+        "type": "meeting_agreed",
+        "request_id": meeting_id,
+        "agreed_slot": body.slot,
+        "duration_minutes": updated["duration_minutes"],
+        "participants": usernames,
+    }
+    for uid in participant_ids:
+        await manager.broadcast(event, uid)
+
+    return {
+        "id": updated["id"],
+        "status": updated["status"],
+        "agreed_slot": updated["agreed_slot"],
+    }
+
+
+@router.post("/meetings/{meeting_id}/cancel")
+async def cancel_meeting_route(
+    meeting_id: int,
+    auth=Depends(auth_dependency),
+    conn: asyncpg.Connection = Depends(get_db_conn),
+):
+    caller_id = auth["user_id"]
+
+    request = await get_meeting_request(conn, meeting_id)
+    if not request:
+        raise HTTPException(status_code=404, detail="Meeting request not found")
+
+    participants = get_participants(request)
+    if caller_id not in participants:
+        raise HTTPException(status_code=403, detail="Not a participant")
+
+    updated = await cancel_meeting(conn, meeting_id)
+
+    event = {"type": "meeting_cancelled", "request_id": meeting_id}
+    for uid in participants:
+        await manager.broadcast(event, uid)
+
+    return {"id": updated["id"], "status": updated["status"]}
+
+
+@router.get("/meetings")
+async def list_meetings(
+    status: Optional[str] = None,
+    auth=Depends(auth_dependency),
+    conn: asyncpg.Connection = Depends(get_db_conn),
+):
+    caller_id = auth["user_id"]
+    return await list_meetings_for_user(conn, caller_id, status_filter=status)
+
+
+@router.get("/meetings/{meeting_id}")
+async def get_meeting(
+    meeting_id: int,
+    auth=Depends(auth_dependency),
+    conn: asyncpg.Connection = Depends(get_db_conn),
+):
+    caller_id = auth["user_id"]
+    request = await get_meeting_request(conn, meeting_id)
+    if not request:
+        raise HTTPException(status_code=404, detail="Meeting request not found")
+
+    participants = get_participants(request)
+    if caller_id not in participants:
+        raise HTTPException(status_code=403, detail="Not a participant")
+
+    return request

--- a/db/migrations/versions/11983a904a79_scheduling_tables.py
+++ b/db/migrations/versions/11983a904a79_scheduling_tables.py
@@ -1,0 +1,115 @@
+"""scheduling_tables
+
+Revision ID: 11983a904a79
+Revises: 853542d7b568
+Create Date: 2026-04-19 22:49:36.611423
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '11983a904a79'
+down_revision: Union[str, Sequence[str], None] = '853542d7b568'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE connections (
+            id           BIGSERIAL PRIMARY KEY,
+            user_a       UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            user_b       UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            status       TEXT NOT NULL DEFAULT 'pending',
+            initiated_by UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            auto_schedule BOOLEAN NOT NULL DEFAULT TRUE,
+            created_at   TIMESTAMPTZ DEFAULT now(),
+            updated_at   TIMESTAMPTZ DEFAULT now(),
+            UNIQUE(user_a, user_b),
+            CHECK(user_a < user_b)
+        )
+    """)
+
+    op.execute("""
+        ALTER TABLE connections ENABLE ROW LEVEL SECURITY
+    """)
+    op.execute("""
+        ALTER TABLE connections FORCE ROW LEVEL SECURITY
+    """)
+    op.execute("""
+        CREATE POLICY connections_user_isolation ON connections
+            USING (
+                user_a = current_setting('app.current_user_id', true)::uuid
+                OR user_b = current_setting('app.current_user_id', true)::uuid
+            )
+    """)
+
+    op.execute("""
+        CREATE TABLE meeting_requests (
+            id               BIGSERIAL PRIMARY KEY,
+            initiator_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            target_ids       UUID[] NOT NULL,
+            duration_minutes INTEGER NOT NULL DEFAULT 30,
+            context          TEXT,
+            status           TEXT NOT NULL DEFAULT 'open',
+            agreed_slot      TEXT,
+            round            INTEGER NOT NULL DEFAULT 0,
+            expires_at       TIMESTAMPTZ,
+            created_at       TIMESTAMPTZ DEFAULT now(),
+            updated_at       TIMESTAMPTZ DEFAULT now()
+        )
+    """)
+
+    op.execute("""
+        ALTER TABLE meeting_requests ENABLE ROW LEVEL SECURITY
+    """)
+    op.execute("""
+        ALTER TABLE meeting_requests FORCE ROW LEVEL SECURITY
+    """)
+    op.execute("""
+        CREATE POLICY meeting_requests_user_isolation ON meeting_requests
+            USING (
+                initiator_id = current_setting('app.current_user_id', true)::uuid
+                OR current_setting('app.current_user_id', true)::uuid = ANY(target_ids)
+            )
+    """)
+
+    op.execute("""
+        CREATE TABLE meeting_proposals (
+            id          BIGSERIAL PRIMARY KEY,
+            request_id  BIGINT NOT NULL REFERENCES meeting_requests(id) ON DELETE CASCADE,
+            proposed_by UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            slots       TEXT[] NOT NULL,
+            status      TEXT NOT NULL DEFAULT 'pending',
+            message     TEXT,
+            created_at  TIMESTAMPTZ DEFAULT now()
+        )
+    """)
+
+    op.execute("""
+        ALTER TABLE meeting_proposals ENABLE ROW LEVEL SECURITY
+    """)
+    op.execute("""
+        ALTER TABLE meeting_proposals FORCE ROW LEVEL SECURITY
+    """)
+    op.execute("""
+        CREATE POLICY meeting_proposals_user_isolation ON meeting_proposals
+            USING (
+                proposed_by = current_setting('app.current_user_id', true)::uuid
+                OR request_id IN (
+                    SELECT id FROM meeting_requests
+                    WHERE initiator_id = current_setting('app.current_user_id', true)::uuid
+                       OR current_setting('app.current_user_id', true)::uuid = ANY(target_ids)
+                )
+            )
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS meeting_proposals")
+    op.execute("DROP TABLE IF EXISTS meeting_requests")
+    op.execute("DROP TABLE IF EXISTS connections")

--- a/db/pg_queries/scheduling.py
+++ b/db/pg_queries/scheduling.py
@@ -1,0 +1,377 @@
+"""Scheduling queries — connections and meeting requests.
+
+All functions take conn: asyncpg.Connection as first arg.
+No SQLite, no file paths.
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+from datetime import datetime, timezone, timedelta
+from typing import Any
+
+import asyncpg
+
+
+def _row(row: asyncpg.Record | None) -> dict | None:
+    if row is None:
+        return None
+    return _convert(dict(row))
+
+
+def _rows(rows) -> list[dict]:
+    return [_row(r) for r in rows]
+
+
+def _convert(d: dict) -> dict:
+    """Recursively convert UUIDs to strings and UUID lists to str lists."""
+    result = {}
+    for k, v in d.items():
+        if isinstance(v, _uuid.UUID):
+            result[k] = str(v)
+        elif isinstance(v, list):
+            result[k] = [str(x) if isinstance(x, _uuid.UUID) else x for x in v]
+        else:
+            result[k] = v
+    return result
+
+
+def _canonical(uid1: str, uid2: str) -> tuple[str, str]:
+    """Return (user_a, user_b) in canonical UUID order (user_a < user_b)."""
+    a = _uuid.UUID(uid1)
+    b = _uuid.UUID(uid2)
+    if a < b:
+        return str(a), str(b)
+    return str(b), str(a)
+
+
+# ─── Connection queries ────────────────────────────────────────────────────────
+
+async def create_connection(
+    conn: asyncpg.Connection,
+    user_a_id: str,
+    user_b_id: str,
+    initiated_by: str,
+) -> dict:
+    a, b = _canonical(user_a_id, user_b_id)
+    row = await conn.fetchrow(
+        """
+        INSERT INTO connections (user_a, user_b, initiated_by)
+        VALUES ($1::uuid, $2::uuid, $3::uuid)
+        RETURNING *
+        """,
+        a, b, initiated_by,
+    )
+    return _row(row)
+
+
+async def get_connection(conn: asyncpg.Connection, conn_id: int) -> dict | None:
+    row = await conn.fetchrow(
+        "SELECT * FROM connections WHERE id = $1", conn_id
+    )
+    return _row(row)
+
+
+async def get_connection_by_users(
+    conn: asyncpg.Connection, uid1: str, uid2: str
+) -> dict | None:
+    a, b = _canonical(uid1, uid2)
+    row = await conn.fetchrow(
+        "SELECT * FROM connections WHERE user_a = $1::uuid AND user_b = $2::uuid",
+        a, b,
+    )
+    return _row(row)
+
+
+async def list_connections_for_user(
+    conn: asyncpg.Connection, user_id: str
+) -> list[dict]:
+    rows = await conn.fetch(
+        """
+        SELECT *,
+               CASE WHEN user_a = $1::uuid THEN user_b ELSE user_a END AS other_user_id
+        FROM connections
+        WHERE user_a = $1::uuid OR user_b = $1::uuid
+        ORDER BY created_at DESC
+        """,
+        user_id,
+    )
+    return _rows(rows)
+
+
+async def accept_connection(conn: asyncpg.Connection, conn_id: int) -> dict:
+    row = await conn.fetchrow(
+        """
+        UPDATE connections
+        SET status = 'accepted', updated_at = now()
+        WHERE id = $1
+        RETURNING *
+        """,
+        conn_id,
+    )
+    return _row(row)
+
+
+async def decline_connection(
+    conn: asyncpg.Connection, conn_id: int, block: bool
+) -> dict | None:
+    if block:
+        row = await conn.fetchrow(
+            """
+            UPDATE connections
+            SET status = 'blocked', updated_at = now()
+            WHERE id = $1
+            RETURNING *
+            """,
+            conn_id,
+        )
+        return _row(row)
+    else:
+        await conn.execute("DELETE FROM connections WHERE id = $1", conn_id)
+        return None
+
+
+async def patch_connection(
+    conn: asyncpg.Connection, conn_id: int, auto_schedule: bool
+) -> dict:
+    row = await conn.fetchrow(
+        """
+        UPDATE connections
+        SET auto_schedule = $2, updated_at = now()
+        WHERE id = $1
+        RETURNING *
+        """,
+        conn_id, auto_schedule,
+    )
+    return _row(row)
+
+
+# ─── Meeting queries ───────────────────────────────────────────────────────────
+
+async def create_meeting_request(
+    conn: asyncpg.Connection,
+    initiator_id: str,
+    target_ids: list[str],
+    duration_minutes: int,
+    context: str | None,
+    slots: list[str],
+) -> dict:
+    expires_at = datetime.now(timezone.utc) + timedelta(hours=48)
+    target_uuids = [_uuid.UUID(t) for t in target_ids]
+
+    row = await conn.fetchrow(
+        """
+        INSERT INTO meeting_requests
+            (initiator_id, target_ids, duration_minutes, context, expires_at)
+        VALUES ($1::uuid, $2::uuid[], $3, $4, $5)
+        RETURNING *
+        """,
+        initiator_id, target_uuids, duration_minutes, context, expires_at,
+    )
+    request = _row(row)
+
+    # Store initiator's slots as first proposal
+    if slots:
+        await conn.execute(
+            """
+            INSERT INTO meeting_proposals (request_id, proposed_by, slots)
+            VALUES ($1, $2::uuid, $3::text[])
+            """,
+            request["id"], initiator_id, slots,
+        )
+
+    return request
+
+
+async def create_proposal(
+    conn: asyncpg.Connection,
+    request_id: int,
+    proposed_by: str,
+    slots: list[str],
+    message: str | None,
+) -> dict:
+    # Mark previous pending proposals from same user as superseded
+    await conn.execute(
+        """
+        UPDATE meeting_proposals
+        SET status = 'superseded'
+        WHERE request_id = $1 AND proposed_by = $2::uuid AND status = 'pending'
+        """,
+        request_id, proposed_by,
+    )
+
+    row = await conn.fetchrow(
+        """
+        INSERT INTO meeting_proposals (request_id, proposed_by, slots, message)
+        VALUES ($1, $2::uuid, $3::text[], $4)
+        RETURNING *
+        """,
+        request_id, proposed_by, slots, message,
+    )
+    proposal = _row(row)
+
+    # Check if all targets have now proposed — bump round if so
+    req_row = await conn.fetchrow(
+        "SELECT target_ids, round FROM meeting_requests WHERE id = $1", request_id
+    )
+    if req_row:
+        target_ids = [str(t) for t in req_row["target_ids"]]
+        # Count targets with at least one active (non-superseded) proposal
+        proposer_rows = await conn.fetch(
+            """
+            SELECT DISTINCT proposed_by FROM meeting_proposals
+            WHERE request_id = $1
+              AND status NOT IN ('superseded')
+              AND proposed_by != (
+                  SELECT initiator_id FROM meeting_requests WHERE id = $1
+              )
+            """,
+            request_id,
+        )
+        proposers = {str(r["proposed_by"]) for r in proposer_rows}
+        if set(target_ids) == proposers:
+            new_round = req_row["round"] + 1
+            await conn.execute(
+                "UPDATE meeting_requests SET round = $2, updated_at = now() WHERE id = $1",
+                request_id, new_round,
+            )
+            proposal["round_bumped"] = True
+
+    return proposal
+
+
+async def accept_meeting_slot(
+    conn: asyncpg.Connection, request_id: int, slot: str
+) -> dict:
+    # Validate slot exists in a non-initiator proposal
+    req_row = await conn.fetchrow(
+        "SELECT initiator_id FROM meeting_requests WHERE id = $1", request_id
+    )
+    if not req_row:
+        raise ValueError("Meeting request not found")
+
+    initiator_id = req_row["initiator_id"]
+
+    # Check slot exists in target proposals
+    slot_row = await conn.fetchrow(
+        """
+        SELECT id FROM meeting_proposals
+        WHERE request_id = $1
+          AND proposed_by != $2::uuid
+          AND status = 'pending'
+          AND $3 = ANY(slots)
+        LIMIT 1
+        """,
+        request_id, str(initiator_id), slot,
+    )
+    if not slot_row:
+        raise ValueError(f"Slot '{slot}' not found in any pending target proposal")
+
+    row = await conn.fetchrow(
+        """
+        UPDATE meeting_requests
+        SET agreed_slot = $2, status = 'agreed', updated_at = now()
+        WHERE id = $1
+        RETURNING *
+        """,
+        request_id, slot,
+    )
+    return _row(row)
+
+
+async def cancel_meeting(conn: asyncpg.Connection, request_id: int) -> dict:
+    row = await conn.fetchrow(
+        """
+        UPDATE meeting_requests
+        SET status = 'cancelled', updated_at = now()
+        WHERE id = $1
+        RETURNING *
+        """,
+        request_id,
+    )
+    return _row(row)
+
+
+async def get_meeting_request(
+    conn: asyncpg.Connection, request_id: int
+) -> dict | None:
+    row = await conn.fetchrow(
+        "SELECT * FROM meeting_requests WHERE id = $1", request_id
+    )
+    if row is None:
+        return None
+    request = _row(row)
+
+    # Fetch proposals
+    proposal_rows = await conn.fetch(
+        "SELECT * FROM meeting_proposals WHERE request_id = $1 ORDER BY created_at",
+        request_id,
+    )
+    request["proposals"] = _rows(proposal_rows)
+    return request
+
+
+async def list_meetings_for_user(
+    conn: asyncpg.Connection,
+    user_id: str,
+    status_filter: str | None = None,
+) -> list[dict]:
+    if status_filter:
+        rows = await conn.fetch(
+            """
+            SELECT * FROM meeting_requests
+            WHERE status = $2
+            ORDER BY created_at DESC
+            """,
+            user_id, status_filter,
+        )
+    else:
+        rows = await conn.fetch(
+            """
+            SELECT * FROM meeting_requests
+            ORDER BY created_at DESC
+            """,
+            user_id,
+        )
+    return _rows(rows)
+
+
+async def list_incoming_for_user(
+    conn: asyncpg.Connection, user_id: str
+) -> list[dict]:
+    """Return open meeting requests where user_id is in target_ids and has no pending proposal yet."""
+    rows = await conn.fetch(
+        """
+        SELECT mr.* FROM meeting_requests mr
+        WHERE mr.status = 'open'
+          AND $1::uuid = ANY(mr.target_ids)
+          AND NOT EXISTS (
+              SELECT 1 FROM meeting_proposals mp
+              WHERE mp.request_id = mr.id
+                AND mp.proposed_by = $1::uuid
+                AND mp.status IN ('pending', 'accepted')
+          )
+        ORDER BY mr.created_at DESC
+        """,
+        user_id,
+    )
+    return _rows(rows)
+
+
+async def expire_old_requests(conn: asyncpg.Connection) -> list[int]:
+    rows = await conn.fetch(
+        """
+        UPDATE meeting_requests
+        SET status = 'expired', updated_at = now()
+        WHERE status = 'open' AND expires_at < now()
+        RETURNING id
+        """,
+    )
+    return [r["id"] for r in rows]
+
+
+def get_participants(request: dict) -> list[str]:
+    """Return [initiator_id] + target_ids as strings."""
+    result = [str(request["initiator_id"])]
+    for t in request.get("target_ids", []):
+        result.append(str(t))
+    return result

--- a/db/pg_queries/scheduling.py
+++ b/db/pg_queries/scheduling.py
@@ -319,10 +319,10 @@ async def list_meetings_for_user(
         rows = await conn.fetch(
             """
             SELECT * FROM meeting_requests
-            WHERE status = $2
+            WHERE status = $1
             ORDER BY created_at DESC
             """,
-            user_id, status_filter,
+            status_filter,
         )
     else:
         rows = await conn.fetch(
@@ -330,7 +330,6 @@ async def list_meetings_for_user(
             SELECT * FROM meeting_requests
             ORDER BY created_at DESC
             """,
-            user_id,
         )
     return _rows(rows)
 

--- a/docs/api-bot-auth.md
+++ b/docs/api-bot-auth.md
@@ -1,0 +1,40 @@
+# Bot WebSocket Authentication
+
+The Tether API WebSocket endpoint (`/ws`) supports two authentication patterns:
+
+## Cookie-based (browser clients)
+
+The browser sends a `tether_token` cookie with a valid JWT. Authentication is validated before the connection is established.
+
+## Message-based (bot clients)
+
+For bot processes that cannot use cookies (e.g., the `tether-premium` scheduling bot running as a service), the WebSocket supports message-based authentication:
+
+1. Connect to `/ws` without a cookie.
+2. As the **first message**, send:
+   ```json
+   {"type": "auth", "token": "<jwt>"}
+   ```
+3. The server validates the JWT. On success, the connection is kept open and the bot can receive broadcast events. On failure, the server closes with code `1008`.
+
+The JWT must be generated with the same secret used by the API (`AUTH_SECRET` env var or config). The `user_id` claim in the payload identifies which user's events the connection receives.
+
+### Timeout
+
+If no auth message is received within 10 seconds of connection, the server closes with code `1008`.
+
+### Example (Python)
+
+```python
+import asyncio
+import json
+import websockets
+
+async def connect_bot(api_base: str, token: str):
+    uri = api_base.replace("http", "ws") + "/ws"
+    async with websockets.connect(uri) as ws:
+        await ws.send(json.dumps({"type": "auth", "token": token}))
+        async for msg in ws:
+            event = json.loads(msg)
+            print("Received:", event)
+```

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -11,6 +11,9 @@ from db.postgres import register_jsonb_codec
 TEST_USER_ID = "00000000-0000-0000-0000-000000000001"
 TEST_USERNAME = "testuser"
 
+TEST_USER_B_ID = "00000000-0000-0000-0000-000000000002"
+TEST_USER_B_NAME = "testuser2"
+
 
 def _db_url() -> str:
     url = os.environ.get("DATABASE_URL")
@@ -29,6 +32,21 @@ async def _ensure_test_user(url: str) -> None:
             ON CONFLICT (id) DO NOTHING
             """,
             TEST_USER_ID, TEST_USERNAME,
+        )
+    finally:
+        await c.close()
+
+
+async def _ensure_test_user_b(url: str) -> None:
+    c = await asyncpg.connect(dsn=url)
+    try:
+        await c.execute(
+            """
+            INSERT INTO users (id, username, email, password_hash, is_admin)
+            VALUES ($1::uuid, $2, 'testb@example.com', 'x', false)
+            ON CONFLICT (id) DO NOTHING
+            """,
+            TEST_USER_B_ID, TEST_USER_B_NAME,
         )
     finally:
         await c.close()
@@ -74,6 +92,40 @@ async def api_client(conn, pool):
     app.dependency_overrides[get_db_conn] = override_get_db_conn
 
     token = create_jwt(TEST_USER_ID, TEST_USERNAME, is_admin=False)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"tether_token": token},
+    ) as client:
+        yield client
+
+
+@pytest.fixture
+async def api_client_b(conn, pool):
+    """AsyncClient for user B. Shares the same DB connection as api_client so cross-user
+    row visibility works within the same transaction."""
+    from api.main import create_app
+    from db.pool_middleware import get_db_conn
+
+    url = _db_url()
+    await _ensure_test_user_b(url)
+
+    async def override_get_db_conn():
+        # Switch RLS to user B for the duration of this request
+        await conn.execute(
+            "SELECT set_config('app.current_user_id', $1, true)", TEST_USER_B_ID
+        )
+        yield conn
+        # Switch back to user A after request completes
+        await conn.execute(
+            "SELECT set_config('app.current_user_id', $1, true)", TEST_USER_ID
+        )
+
+    app = create_app()
+    app.state.pool = pool
+    app.dependency_overrides[get_db_conn] = override_get_db_conn
+
+    token = create_jwt(TEST_USER_B_ID, TEST_USER_B_NAME, is_admin=False)
     async with AsyncClient(
         transport=ASGITransport(app=app),
         base_url="http://test",

--- a/tests/api/test_connections.py
+++ b/tests/api/test_connections.py
@@ -1,0 +1,125 @@
+"""Tests for /api/connections endpoints."""
+from __future__ import annotations
+
+import asyncpg
+import pytest
+from httpx import AsyncClient
+
+from tests.api.conftest import TEST_USER_ID, TEST_USER_B_ID, TEST_USER_B_NAME
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_connection_direct(conn) -> int:
+    """Insert a connection directly using user A's conn (bypasses RLS via shared conn)."""
+    from db.pg_queries.scheduling import create_connection
+    result = await create_connection(conn, TEST_USER_ID, TEST_USER_B_ID, TEST_USER_ID)
+    return result["id"]
+
+
+# ─── POST /api/connections/request ────────────────────────────────────────────
+
+async def test_create_connection_happy_path(api_client, api_client_b, conn, pool):
+    """User A requests a connection to User B."""
+    resp = await api_client.post("/api/connections/request", json={"target_username": TEST_USER_B_NAME})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["status"] == "pending"
+    assert data["initiated_by"] == TEST_USER_ID
+    # Canonical ordering: user_a < user_b (UUID string comparison)
+    assert data["user_a"] < data["user_b"]
+
+
+async def test_create_connection_canonical_ordering(api_client, api_client_b, conn, pool):
+    """Canonical ordering is enforced regardless of who requests."""
+    # B requests A — same canonical result
+    resp = await api_client_b.post("/api/connections/request", json={"target_username": "testuser"})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["user_a"] < data["user_b"]
+    assert data["initiated_by"] == TEST_USER_B_ID
+
+
+async def test_create_connection_404_unknown_target(api_client, conn):
+    resp = await api_client.post("/api/connections/request", json={"target_username": "no_such_user"})
+    assert resp.status_code == 404
+
+
+async def test_create_connection_409_duplicate(api_client, conn):
+    """Second request between same users returns 409."""
+    resp1 = await api_client.post("/api/connections/request", json={"target_username": TEST_USER_B_NAME})
+    assert resp1.status_code == 201
+    resp2 = await api_client.post("/api/connections/request", json={"target_username": TEST_USER_B_NAME})
+    assert resp2.status_code == 409
+
+
+# ─── POST /api/connections/{id}/accept ────────────────────────────────────────
+
+async def test_accept_connection(api_client, api_client_b, conn, pool):
+    conn_id = await _create_connection_direct(conn)
+    resp = await api_client_b.post(f"/api/connections/{conn_id}/accept")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "accepted"
+
+
+async def test_accept_connection_403_initiator(api_client, conn):
+    """Initiator cannot accept their own request."""
+    conn_id = await _create_connection_direct(conn)
+    resp = await api_client.post(f"/api/connections/{conn_id}/accept")
+    assert resp.status_code == 403
+
+
+async def test_accept_connection_404_missing(api_client_b, conn):
+    resp = await api_client_b.post("/api/connections/99999/accept")
+    assert resp.status_code == 404
+
+
+# ─── POST /api/connections/{id}/decline ───────────────────────────────────────
+
+async def test_decline_connection_delete(api_client_b, conn, pool):
+    conn_id = await _create_connection_direct(conn)
+    resp = await api_client_b.post(f"/api/connections/{conn_id}/decline", json={"block": False})
+    assert resp.status_code == 200
+    assert resp.json().get("deleted") is True
+
+
+async def test_decline_connection_block(api_client_b, conn, pool):
+    conn_id = await _create_connection_direct(conn)
+    resp = await api_client_b.post(f"/api/connections/{conn_id}/decline", json={"block": True})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "blocked"
+
+
+async def test_decline_connection_403_initiator(api_client, conn):
+    """Initiator cannot decline their own request."""
+    conn_id = await _create_connection_direct(conn)
+    resp = await api_client.post(f"/api/connections/{conn_id}/decline", json={"block": False})
+    assert resp.status_code == 403
+
+
+# ─── GET /api/connections ─────────────────────────────────────────────────────
+
+async def test_list_connections(api_client, conn):
+    await _create_connection_direct(conn)
+    resp = await api_client.get("/api/connections")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    # Each item should have other_user_id
+    assert "other_user_id" in data[0]
+
+
+# ─── PATCH /api/connections/{id} ──────────────────────────────────────────────
+
+async def test_patch_connection_auto_schedule(api_client, conn):
+    conn_id = await _create_connection_direct(conn)
+    resp = await api_client.patch(f"/api/connections/{conn_id}", json={"auto_schedule": False})
+    assert resp.status_code == 200
+    assert resp.json()["auto_schedule"] is False
+
+
+async def test_patch_connection_404_missing(api_client, conn):
+    resp = await api_client.patch("/api/connections/99999", json={"auto_schedule": False})
+    assert resp.status_code == 404

--- a/tests/api/test_meetings.py
+++ b/tests/api/test_meetings.py
@@ -1,0 +1,290 @@
+"""Tests for /api/meetings endpoints."""
+from __future__ import annotations
+
+import pytest
+from datetime import datetime, timezone, timedelta
+
+from tests.api.conftest import TEST_USER_ID, TEST_USER_B_ID, TEST_USER_B_NAME
+
+
+pytestmark = pytest.mark.asyncio
+
+SAMPLE_SLOTS = ["2026-05-01T10:00:00Z", "2026-05-01T14:00:00Z"]
+
+
+async def _setup_accepted_connection(conn) -> int:
+    """Insert an accepted connection between user A and user B."""
+    from db.pg_queries.scheduling import create_connection, accept_connection
+    c = await create_connection(conn, TEST_USER_ID, TEST_USER_B_ID, TEST_USER_ID)
+    result = await accept_connection(conn, c["id"])
+    return result["id"]
+
+
+async def _create_meeting(api_client, conn) -> dict:
+    """Create a meeting request from user A to user B (requires accepted connection)."""
+    await _setup_accepted_connection(conn)
+    resp = await api_client.post(
+        "/api/meetings/request",
+        json={
+            "target_usernames": [TEST_USER_B_NAME],
+            "duration_minutes": 30,
+            "slots": SAMPLE_SLOTS,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# ─── POST /api/meetings/request ───────────────────────────────────────────────
+
+async def test_create_meeting_happy_path(api_client, conn):
+    meeting = await _create_meeting(api_client, conn)
+    assert meeting["status"] == "open"
+    assert "id" in meeting
+
+
+async def test_create_meeting_400_no_accepted_connection(api_client, conn):
+    """Creating meeting without accepted connection returns 400."""
+    resp = await api_client.post(
+        "/api/meetings/request",
+        json={
+            "target_usernames": [TEST_USER_B_NAME],
+            "duration_minutes": 30,
+            "slots": SAMPLE_SLOTS,
+        },
+    )
+    assert resp.status_code == 400
+
+
+async def test_create_meeting_400_empty_slots(api_client, conn):
+    await _setup_accepted_connection(conn)
+    resp = await api_client.post(
+        "/api/meetings/request",
+        json={
+            "target_usernames": [TEST_USER_B_NAME],
+            "duration_minutes": 30,
+            "slots": [],
+        },
+    )
+    assert resp.status_code == 400
+
+
+async def test_create_meeting_404_unknown_target(api_client, conn):
+    resp = await api_client.post(
+        "/api/meetings/request",
+        json={
+            "target_usernames": ["no_such_user"],
+            "duration_minutes": 30,
+            "slots": SAMPLE_SLOTS,
+        },
+    )
+    assert resp.status_code == 404
+
+
+# ─── POST /api/meetings/{id}/propose ──────────────────────────────────────────
+
+async def test_propose_happy_path(api_client, api_client_b, conn, pool):
+    meeting = await _create_meeting(api_client, conn)
+    meeting_id = meeting["id"]
+
+    resp = await api_client_b.post(
+        f"/api/meetings/{meeting_id}/propose",
+        json={"slots": ["2026-05-01T11:00:00Z"]},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "proposal_id" in data
+    assert data["request_id"] == meeting_id
+
+
+async def test_propose_403_initiator(api_client, conn):
+    """Initiator cannot propose on their own meeting."""
+    meeting = await _create_meeting(api_client, conn)
+    resp = await api_client.post(
+        f"/api/meetings/{meeting['id']}/propose",
+        json={"slots": SAMPLE_SLOTS},
+    )
+    assert resp.status_code == 403
+
+
+async def test_propose_404_missing(api_client_b, conn):
+    resp = await api_client_b.post(
+        "/api/meetings/99999/propose",
+        json={"slots": SAMPLE_SLOTS},
+    )
+    assert resp.status_code == 404
+
+
+async def test_propose_supersedes_previous(api_client, api_client_b, conn, pool):
+    """Second proposal from same user supersedes the first."""
+    meeting = await _create_meeting(api_client, conn)
+    meeting_id = meeting["id"]
+
+    await api_client_b.post(
+        f"/api/meetings/{meeting_id}/propose",
+        json={"slots": ["2026-05-01T11:00:00Z"]},
+    )
+    await api_client_b.post(
+        f"/api/meetings/{meeting_id}/propose",
+        json={"slots": ["2026-05-02T11:00:00Z"]},
+    )
+
+    # Get the meeting and check only one pending proposal from B
+    from db.pg_queries.scheduling import get_meeting_request
+    req = await get_meeting_request(conn, meeting_id)
+    b_proposals = [p for p in req["proposals"] if p["proposed_by"] == TEST_USER_B_ID]
+    pending_b = [p for p in b_proposals if p["status"] == "pending"]
+    assert len(pending_b) == 1
+    assert pending_b[0]["slots"] == ["2026-05-02T11:00:00Z"]
+
+
+async def test_propose_round_increments(api_client, api_client_b, conn, pool):
+    """Round increments when all targets have proposed."""
+    meeting = await _create_meeting(api_client, conn)
+    meeting_id = meeting["id"]
+
+    # Before proposal, round is 0
+    from db.pg_queries.scheduling import get_meeting_request
+    req = await get_meeting_request(conn, meeting_id)
+    assert req["round"] == 0
+
+    # B proposes — now all targets have proposed (only B is a target)
+    await api_client_b.post(
+        f"/api/meetings/{meeting_id}/propose",
+        json={"slots": ["2026-05-01T11:00:00Z"]},
+    )
+
+    req = await get_meeting_request(conn, meeting_id)
+    assert req["round"] == 1
+
+
+# ─── POST /api/meetings/{id}/accept ───────────────────────────────────────────
+
+async def test_accept_slot_happy_path(api_client, api_client_b, conn, pool):
+    meeting = await _create_meeting(api_client, conn)
+    meeting_id = meeting["id"]
+    target_slot = "2026-05-01T11:00:00Z"
+
+    await api_client_b.post(
+        f"/api/meetings/{meeting_id}/propose",
+        json={"slots": [target_slot]},
+    )
+
+    resp = await api_client.post(
+        f"/api/meetings/{meeting_id}/accept",
+        json={"slot": target_slot},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "agreed"
+    assert data["agreed_slot"] == target_slot
+
+
+async def test_accept_slot_403_not_initiator(api_client_b, conn, pool):
+    """Only initiator can accept a slot."""
+    from db.pg_queries.scheduling import create_meeting_request
+    await _setup_accepted_connection(conn)
+    req = await create_meeting_request(
+        conn, TEST_USER_ID, [TEST_USER_B_ID], 30, None, SAMPLE_SLOTS
+    )
+    meeting_id = req["id"]
+
+    resp = await api_client_b.post(
+        f"/api/meetings/{meeting_id}/accept",
+        json={"slot": SAMPLE_SLOTS[0]},
+    )
+    assert resp.status_code == 403
+
+
+async def test_accept_slot_400_slot_not_in_proposals(api_client, conn):
+    """Accepting a slot that's not in any proposal returns 400."""
+    meeting = await _create_meeting(api_client, conn)
+    resp = await api_client.post(
+        f"/api/meetings/{meeting['id']}/accept",
+        json={"slot": "2026-12-31T00:00:00Z"},
+    )
+    assert resp.status_code == 400
+
+
+# ─── POST /api/meetings/{id}/cancel ───────────────────────────────────────────
+
+async def test_cancel_meeting(api_client, conn):
+    meeting = await _create_meeting(api_client, conn)
+    resp = await api_client.post(f"/api/meetings/{meeting['id']}/cancel")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "cancelled"
+
+
+# ─── GET /api/meetings ────────────────────────────────────────────────────────
+
+async def test_list_meetings(api_client, conn):
+    await _create_meeting(api_client, conn)
+    resp = await api_client.get("/api/meetings")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) >= 1
+
+
+async def test_list_meetings_status_filter(api_client, conn):
+    await _create_meeting(api_client, conn)
+    resp = await api_client.get("/api/meetings?status=open")
+    assert resp.status_code == 200
+    for item in resp.json():
+        assert item["status"] == "open"
+
+
+# ─── GET /api/meetings/incoming ───────────────────────────────────────────────
+
+async def test_list_incoming(api_client, api_client_b, conn, pool):
+    meeting = await _create_meeting(api_client, conn)
+    resp = await api_client_b.get("/api/meetings/incoming")
+    assert resp.status_code == 200
+    data = resp.json()
+    ids = [m["id"] for m in data]
+    assert meeting["id"] in ids
+
+
+# ─── GET /api/meetings/{id} ───────────────────────────────────────────────────
+
+async def test_get_meeting(api_client, conn):
+    meeting = await _create_meeting(api_client, conn)
+    resp = await api_client.get(f"/api/meetings/{meeting['id']}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == meeting["id"]
+    assert "proposals" in data
+
+
+async def test_get_meeting_404_missing(api_client, conn):
+    resp = await api_client.get("/api/meetings/99999")
+    assert resp.status_code == 404
+
+
+# ─── expire_old_requests unit test ────────────────────────────────────────────
+
+async def test_expire_old_requests(conn):
+    """Manually insert a meeting with past expires_at, verify it gets expired."""
+    import uuid
+    from db.pg_queries.scheduling import expire_old_requests
+
+    # Insert past-expired meeting directly
+    past = datetime.now(timezone.utc) - timedelta(hours=1)
+    row = await conn.fetchrow(
+        """
+        INSERT INTO meeting_requests (initiator_id, target_ids, duration_minutes, expires_at, status)
+        VALUES ($1::uuid, $2::uuid[], 30, $3, 'open')
+        RETURNING id
+        """,
+        TEST_USER_ID,
+        [uuid.UUID(TEST_USER_B_ID)],
+        past,
+    )
+    req_id = row["id"]
+
+    expired_ids = await expire_old_requests(conn)
+    assert req_id in expired_ids
+
+    # Verify status
+    row2 = await conn.fetchrow("SELECT status FROM meeting_requests WHERE id = $1", req_id)
+    assert row2["status"] == "expired"

--- a/tests/api/test_ws_meetings.py
+++ b/tests/api/test_ws_meetings.py
@@ -1,0 +1,54 @@
+"""Tests for WebSocket message-based authentication (bot auth pattern)."""
+from __future__ import annotations
+
+import json
+import pytest
+from starlette.testclient import TestClient
+
+from api.auth import create_jwt
+from tests.api.conftest import TEST_USER_ID, TEST_USERNAME
+
+
+def _make_app():
+    from api.main import create_app
+    return create_app(lifespan_override=None)
+
+
+def test_ws_message_auth_accepted(pool):
+    """Bot sends auth message with valid JWT — connection accepted, stays open."""
+    app = _make_app()
+    app.state.pool = pool
+    token = create_jwt(TEST_USER_ID, TEST_USERNAME, is_admin=False)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        with client.websocket_connect("/ws") as ws:
+            ws.send_text(json.dumps({"type": "auth", "token": token}))
+            # Connection stays open — send a ping and verify no error
+            # If the auth failed the connection would have been closed
+            # We verify by just not raising WebSocketDisconnect on send
+            ws.send_text("ping")
+
+
+def test_ws_message_auth_bad_token(pool):
+    """Bot sends auth message with invalid JWT — connection closed with 1008."""
+    app = _make_app()
+    app.state.pool = pool
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        with pytest.raises(Exception):
+            with client.websocket_connect("/ws") as ws:
+                ws.send_text(json.dumps({"type": "auth", "token": "bad.token.here"}))
+                # Should be closed
+                ws.receive_text()
+
+
+def test_ws_message_auth_missing_auth_message(pool):
+    """Bot sends wrong first message — connection closed."""
+    app = _make_app()
+    app.state.pool = pool
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        with pytest.raises(Exception):
+            with client.websocket_connect("/ws") as ws:
+                ws.send_text(json.dumps({"type": "not_auth"}))
+                ws.receive_text()


### PR DESCRIPTION
## Summary

- Alembic migration adding `connections`, `meeting_requests`, `meeting_proposals` tables with RLS policies (OR-based for cross-user isolation)
- `db/pg_queries/scheduling.py` — full async query layer (connections CRUD + meeting request/propose/accept/cancel/expire)
- `api/routes/connections.py` — 5 endpoints for bilateral connection management
- `api/routes/meetings.py` — 7 endpoints for meeting request/proposal/accept/cancel lifecycle
- `api/main.py` — WS endpoint extended with message-based bot auth (`{"type":"auth","token":"..."}` first-message pattern); lifespan wrapped with hourly expiry background task
- Bot fix: `tether_premium/bot/scheduling/inbound.py` — `target_ids` deserialization updated to match native `uuid[]` API response

## Test plan

- [ ] 13 connection tests pass (`tests/api/test_connections.py`)
- [ ] 19 meeting tests pass (`tests/api/test_meetings.py`)
- [ ] 3 WS auth tests pass (`tests/api/test_ws_meetings.py`)
- [ ] Full regression: `pytest -q` — 20 pre-existing failures in auth/plan_reader/server are unrelated to this PR
- [ ] Smoke test end-to-end with bot once `feature/scheduling-public` (bot wiring) is merged