### PR TITLE
fix: bot chat WebSocket auth, pool timeout, exception handling

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import bcrypt
 import jwt
 from datetime import datetime, timedelta
-from fastapi import Request, HTTPException, WebSocket
+from fastapi import Request, HTTPException, WebSocket, WebSocketException, status
 import api.config as cfg
 
 
@@ -52,14 +52,11 @@ async def ws_auth_dependency(websocket: WebSocket):
     try:
         payload = _decode_token_from_cookies(websocket.cookies)
     except ValueError:
-        await websocket.close(code=1008)
-        return
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION, reason="Unauthorized")
     except jwt.ExpiredSignatureError:
-        await websocket.close(code=1008)
-        return
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION, reason="Unauthorized")
     except jwt.InvalidTokenError:
-        await websocket.close(code=1008)
-        return
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION, reason="Unauthorized")
     websocket.state.user_id = payload["user_id"]
     websocket.state.username = payload["username"]
     websocket.state.is_admin = payload.get("is_admin", False)

--- a/api/main.py
+++ b/api/main.py
@@ -1,6 +1,9 @@
 import asyncio
 import json
+import logging
 import asyncpg
+
+logging.basicConfig(level=logging.INFO)
 from contextlib import asynccontextmanager
 from pathlib import Path
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect

--- a/api/routes/bot.py
+++ b/api/routes/bot.py
@@ -29,9 +29,9 @@ async def bot_health(_auth=Depends(auth_dependency),
 @router.websocket("/bot/chat")
 async def bot_chat(websocket: WebSocket,
                    _auth=Depends(ws_auth_dependency)):
+    await websocket.accept()
     pool = websocket.app.state.pool
     user_id = websocket.state.user_id
-    await websocket.accept()
     logger.info("bot_chat: connection accepted, user_id=%s", user_id)
 
     try:
@@ -56,10 +56,13 @@ async def bot_chat(websocket: WebSocket,
             await websocket.send_json({"type": "chunk", "content": full_response})
             await websocket.send_json({"type": "done"})
     except WebSocketDisconnect:
-        # cancel heartbeat, clean up
         return
     except Exception as e:
         logger.error("bot_chat: unhandled exception user_id=%s: %s: %s", user_id, type(e).__name__, e, exc_info=True)
+        try:
+            await websocket.send_json({"type": "error", "message": "Internal error"})
+        except Exception:
+            pass
         raise
 
 

--- a/db/postgres.py
+++ b/db/postgres.py
@@ -12,12 +12,16 @@ Usage:
         await conn.execute("INSERT INTO tasks ...")  # auto-commits on exit
 """
 
+import asyncio
 import json
+import logging
 import os
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
 
 import asyncpg
+
+logger = logging.getLogger(__name__)
 
 
 async def register_jsonb_codec(conn: asyncpg.Connection) -> None:
@@ -76,13 +80,17 @@ async def get_conn(pool: asyncpg.Pool, user_id: str | None = None):
         yield existing
         return
 
-    async with pool.acquire() as conn:
-        async with conn.transaction():
-            if user_id is not None:
-                await conn.execute(
-                    "SELECT set_config('app.current_user_id', $1, true)", str(user_id)
-                )
-            yield conn
+    try:
+        async with pool.acquire(timeout=30) as conn:
+            async with conn.transaction():
+                if user_id is not None:
+                    await conn.execute(
+                        "SELECT set_config('app.current_user_id', $1, true)", str(user_id)
+                    )
+                yield conn
+    except asyncio.TimeoutError:
+        logger.error("get_conn: pool.acquire timed out after 30s — pool exhausted")
+        raise
 
 
 @asynccontextmanager
@@ -97,14 +105,18 @@ async def transaction(pool: asyncpg.Pool, user_id: str | None = None):
         yield existing
         return
 
-    async with pool.acquire() as conn:
-        async with conn.transaction():
-            if user_id is not None:
-                await conn.execute(
-                    "SELECT set_config('app.current_user_id', $1, true)", str(user_id)
-                )
-            token = _current_conn.set(conn)
-            try:
-                yield conn
-            finally:
-                _current_conn.reset(token)
+    try:
+        async with pool.acquire(timeout=30) as conn:
+            async with conn.transaction():
+                if user_id is not None:
+                    await conn.execute(
+                        "SELECT set_config('app.current_user_id', $1, true)", str(user_id)
+                    )
+                token = _current_conn.set(conn)
+                try:
+                    yield conn
+                finally:
+                    _current_conn.reset(token)
+    except asyncio.TimeoutError:
+        logger.error("transaction: pool.acquire timed out after 30s — pool exhausted")
+        raise


### PR DESCRIPTION
## Summary

- **api/auth.py** — `ws_auth_dependency` now raises `WebSocketException(WS_1008_POLICY_VIOLATION)` on auth failure instead of returning `None`. Previously FastAPI would continue into the handler body, crashing with `AttributeError: 'State' object has no attribute 'user_id'`.
- **db/postgres.py** — Both `pool.acquire()` calls now use `timeout=30`. A `try/except asyncio.TimeoutError` logs an error and re-raises so pool exhaustion is visible in application logs instead of hanging silently.
- **api/routes/bot.py** — `websocket.accept()` moved before state attribute access. Broad `except Exception` block now attempts to send `{"type": "error", "message": "Internal error"}` to the client before re-raising, so pipeline errors surface to the frontend.

## Test plan
- [ ] All 293 existing tests pass (`pytest -x -q`)
- [ ] WebSocket connection with invalid/missing cookie closes with 1008 and handler body never executes
- [ ] Pool exhaustion (mocked `asyncio.TimeoutError`) logs error and propagates
- [ ] Exception in `handle_message` sends error JSON to client and re-raises