### PR TITLE
fix: guard crypto.randomUUID for non-secure HTTP contexts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,7 @@ jobs:
                  tests/db/test_pg_nodes.py \
                  tests/db/test_pg_sections.py \
                  tests/db/test_pg_auth_queries.py \
+                 tests/db/test_pg_integrations.py \
                  tests/api/ \
                  -v
 

--- a/api/auth.py
+++ b/api/auth.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import bcrypt
 import jwt
 from datetime import datetime, timedelta
-from fastapi import Request, HTTPException, WebSocket
+from fastapi import Request, HTTPException, WebSocket, WebSocketException, status
 import api.config as cfg
 
 
@@ -52,14 +52,11 @@ async def ws_auth_dependency(websocket: WebSocket):
     try:
         payload = _decode_token_from_cookies(websocket.cookies)
     except ValueError:
-        await websocket.close(code=1008)
-        return
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION, reason="Unauthorized")
     except jwt.ExpiredSignatureError:
-        await websocket.close(code=1008)
-        return
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION, reason="Unauthorized")
     except jwt.InvalidTokenError:
-        await websocket.close(code=1008)
-        return
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION, reason="Unauthorized")
     websocket.state.user_id = payload["user_id"]
     websocket.state.username = payload["username"]
     websocket.state.is_admin = payload.get("is_admin", False)

--- a/api/main.py
+++ b/api/main.py
@@ -1,6 +1,9 @@
 import asyncio
 import json
+import logging
 import asyncpg
+
+logging.basicConfig(level=logging.INFO)
 from contextlib import asynccontextmanager
 from pathlib import Path
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect

--- a/api/routes/bot.py
+++ b/api/routes/bot.py
@@ -29,9 +29,9 @@ async def bot_health(_auth=Depends(auth_dependency),
 @router.websocket("/bot/chat")
 async def bot_chat(websocket: WebSocket,
                    _auth=Depends(ws_auth_dependency)):
+    await websocket.accept()
     pool = websocket.app.state.pool
     user_id = websocket.state.user_id
-    await websocket.accept()
     logger.info("bot_chat: connection accepted, user_id=%s", user_id)
 
     try:
@@ -56,10 +56,13 @@ async def bot_chat(websocket: WebSocket,
             await websocket.send_json({"type": "chunk", "content": full_response})
             await websocket.send_json({"type": "done"})
     except WebSocketDisconnect:
-        # cancel heartbeat, clean up
         return
     except Exception as e:
         logger.error("bot_chat: unhandled exception user_id=%s: %s: %s", user_id, type(e).__name__, e, exc_info=True)
+        try:
+            await websocket.send_json({"type": "error", "message": "Internal error"})
+        except Exception:
+            pass
         raise
 
 

--- a/api/routes/bot.py
+++ b/api/routes/bot.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 import asyncpg, asyncio
 from db.pg_queries import get_last_bot_activity
@@ -6,6 +8,7 @@ from api.auth import auth_dependency, ws_auth_dependency
 from bot.message_handler import handle_message
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @router.get("/bot/health")
@@ -29,22 +32,25 @@ async def bot_chat(websocket: WebSocket,
     pool = websocket.app.state.pool
     user_id = websocket.state.user_id
     await websocket.accept()
-
+    logger.info("bot_chat: connection accepted, user_id=%s", user_id)
 
     try:
         while True:
             data = await websocket.receive_json()
+            logger.info("bot_chat: received message type=%s", data.get("type"))
             # expected: {"type": "user", "content": "..."}
             response_parts = []
             def send_fn(msg: str):
                 response_parts.append(msg)
 
             #pass content into the bot pipeline
-            await handle_message(data['content'], 
+            logger.info("bot_chat: calling handle_message")
+            await handle_message(data['content'],
                                  send_fn=send_fn,
                                  pool=pool,
                                  user_id=user_id
                             )
+            logger.info("bot_chat: handle_message returned, response_len=%d", sum(len(p) for p in response_parts))
 
             full_response = "".join(response_parts)
             await websocket.send_json({"type": "chunk", "content": full_response})
@@ -52,5 +58,8 @@ async def bot_chat(websocket: WebSocket,
     except WebSocketDisconnect:
         # cancel heartbeat, clean up
         return
+    except Exception as e:
+        logger.error("bot_chat: unhandled exception user_id=%s: %s: %s", user_id, type(e).__name__, e, exc_info=True)
+        raise
 
 

--- a/bot/message_handler.py
+++ b/bot/message_handler.py
@@ -998,9 +998,11 @@ def _log_preview(text: str, n: int = 120) -> str:
 
 async def handle_message(text: str, send_fn: Callable[[str], None], pool, user_id: str) -> None:
     today = str(date_type.today())
+    logger.info("handle_message: entered, text_len=%d", len(text or ""))
     async with pg.get_conn(pool, user_id) as conn:
         await upsert_plan(conn, today)
         anchors = await get_anchors(conn)
+    logger.info("handle_message: DB init done")
     current_anchor = get_current_anchor(anchors)
 
     logger.info("msg received: len=%d preview=%r", len(text or ""), _log_preview(text))

--- a/db/pg_queries/integrations.py
+++ b/db/pg_queries/integrations.py
@@ -1,11 +1,20 @@
-"""Integration query stubs — user_integrations + integration_sync_state.
-
-These will be filled in by the Google Calendar adapter implementation.
-All functions take conn: asyncpg.Connection as first argument.
-"""
+"""Async Postgres queries — user_integrations + integration_sync_state."""
 from __future__ import annotations
 
+import uuid as _uuid
+from datetime import datetime, timezone
+
 import asyncpg
+
+
+def _row(row: asyncpg.Record | None) -> dict | None:
+    if row is None:
+        return None
+    d = dict(row)
+    for k, v in d.items():
+        if isinstance(v, _uuid.UUID):
+            d[k] = str(v)
+    return d
 
 
 async def get_integration(
@@ -13,8 +22,11 @@ async def get_integration(
     user_id: str,
     provider: str,
 ) -> dict | None:
-    """Return the user_integrations row for (user_id, provider), or None."""
-    raise NotImplementedError
+    row = await conn.fetchrow(
+        "SELECT * FROM user_integrations WHERE user_id = $1 AND provider = $2",
+        user_id, provider,
+    )
+    return _row(row)
 
 
 async def upsert_integration(
@@ -24,13 +36,30 @@ async def upsert_integration(
     *,
     access_token: str | None = None,
     refresh_token: str | None = None,
-    token_expiry=None,
+    token_expiry: datetime | None = None,
     scopes: list[str] | None = None,
     metadata: dict | None = None,
     enabled: bool = True,
 ) -> dict:
-    """Insert or update a user_integrations row. Returns the resulting row."""
-    raise NotImplementedError
+    row = await conn.fetchrow(
+        """
+        INSERT INTO user_integrations
+            (user_id, provider, access_token, refresh_token, token_expiry,
+             scopes, metadata, enabled)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        ON CONFLICT (user_id, provider) DO UPDATE SET
+            access_token  = EXCLUDED.access_token,
+            refresh_token = EXCLUDED.refresh_token,
+            token_expiry  = EXCLUDED.token_expiry,
+            scopes        = EXCLUDED.scopes,
+            metadata      = EXCLUDED.metadata,
+            enabled       = EXCLUDED.enabled
+        RETURNING *
+        """,
+        user_id, provider, access_token, refresh_token, token_expiry,
+        scopes, metadata, enabled,
+    )
+    return _row(row)
 
 
 async def delete_integration(
@@ -38,8 +67,11 @@ async def delete_integration(
     user_id: str,
     provider: str,
 ) -> bool:
-    """Delete the integration for (user_id, provider). Returns True if a row was deleted."""
-    raise NotImplementedError
+    result = await conn.execute(
+        "DELETE FROM user_integrations WHERE user_id = $1 AND provider = $2",
+        user_id, provider,
+    )
+    return result == "DELETE 1"
 
 
 async def get_sync_state(
@@ -47,8 +79,14 @@ async def get_sync_state(
     integration_id: str,
     calendar_id: str,
 ) -> dict | None:
-    """Return the integration_sync_state row for (integration_id, calendar_id), or None."""
-    raise NotImplementedError
+    row = await conn.fetchrow(
+        """
+        SELECT * FROM integration_sync_state
+        WHERE integration_id = $1 AND calendar_id = $2
+        """,
+        _uuid.UUID(integration_id), calendar_id,
+    )
+    return _row(row)
 
 
 async def upsert_sync_state(
@@ -58,8 +96,41 @@ async def upsert_sync_state(
     *,
     sync_cursor: str | None = None,
     watch_channel_id: str | None = None,
-    watch_expiry=None,
+    watch_expiry: datetime | None = None,
     watch_resource_id: str | None = None,
 ) -> dict:
-    """Insert or update an integration_sync_state row. Returns the resulting row."""
-    raise NotImplementedError
+    row = await conn.fetchrow(
+        """
+        INSERT INTO integration_sync_state
+            (integration_id, calendar_id, sync_cursor,
+             watch_channel_id, watch_expiry, watch_resource_id)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        ON CONFLICT (integration_id, calendar_id) DO UPDATE SET
+            sync_cursor       = EXCLUDED.sync_cursor,
+            watch_channel_id  = EXCLUDED.watch_channel_id,
+            watch_expiry      = EXCLUDED.watch_expiry,
+            watch_resource_id = EXCLUDED.watch_resource_id,
+            updated_at        = now()
+        RETURNING *
+        """,
+        _uuid.UUID(integration_id), calendar_id, sync_cursor,
+        watch_channel_id, watch_expiry, watch_resource_id,
+    )
+    return _row(row)
+
+
+async def soft_delete_task_by_external_id(
+    conn: asyncpg.Connection,
+    user_id: str,
+    source: str,
+    external_id: str,
+) -> bool:
+    result = await conn.execute(
+        """
+        UPDATE tasks
+        SET source_status = 'cancelled'
+        WHERE user_id = $1::uuid AND source = $2 AND external_id = $3
+        """,
+        user_id, source, external_id,
+    )
+    return result == "UPDATE 1"

--- a/db/pg_queries/integrations.py
+++ b/db/pg_queries/integrations.py
@@ -48,11 +48,11 @@ async def upsert_integration(
              scopes, metadata, enabled)
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
         ON CONFLICT (user_id, provider) DO UPDATE SET
-            access_token  = EXCLUDED.access_token,
-            refresh_token = EXCLUDED.refresh_token,
-            token_expiry  = EXCLUDED.token_expiry,
-            scopes        = EXCLUDED.scopes,
-            metadata      = EXCLUDED.metadata,
+            access_token  = COALESCE(EXCLUDED.access_token,  user_integrations.access_token),
+            refresh_token = COALESCE(EXCLUDED.refresh_token, user_integrations.refresh_token),
+            token_expiry  = COALESCE(EXCLUDED.token_expiry,  user_integrations.token_expiry),
+            scopes        = COALESCE(EXCLUDED.scopes,        user_integrations.scopes),
+            metadata      = COALESCE(EXCLUDED.metadata,      user_integrations.metadata),
             enabled       = EXCLUDED.enabled
         RETURNING *
         """,

--- a/db/postgres.py
+++ b/db/postgres.py
@@ -12,12 +12,16 @@ Usage:
         await conn.execute("INSERT INTO tasks ...")  # auto-commits on exit
 """
 
+import asyncio
 import json
+import logging
 import os
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
 
 import asyncpg
+
+logger = logging.getLogger(__name__)
 
 
 async def register_jsonb_codec(conn: asyncpg.Connection) -> None:
@@ -76,13 +80,17 @@ async def get_conn(pool: asyncpg.Pool, user_id: str | None = None):
         yield existing
         return
 
-    async with pool.acquire() as conn:
-        async with conn.transaction():
-            if user_id is not None:
-                await conn.execute(
-                    "SELECT set_config('app.current_user_id', $1, true)", str(user_id)
-                )
-            yield conn
+    try:
+        async with pool.acquire(timeout=30) as conn:
+            async with conn.transaction():
+                if user_id is not None:
+                    await conn.execute(
+                        "SELECT set_config('app.current_user_id', $1, true)", str(user_id)
+                    )
+                yield conn
+    except asyncio.TimeoutError:
+        logger.error("get_conn: pool.acquire timed out after 30s — pool exhausted")
+        raise
 
 
 @asynccontextmanager
@@ -97,14 +105,18 @@ async def transaction(pool: asyncpg.Pool, user_id: str | None = None):
         yield existing
         return
 
-    async with pool.acquire() as conn:
-        async with conn.transaction():
-            if user_id is not None:
-                await conn.execute(
-                    "SELECT set_config('app.current_user_id', $1, true)", str(user_id)
-                )
-            token = _current_conn.set(conn)
-            try:
-                yield conn
-            finally:
-                _current_conn.reset(token)
+    try:
+        async with pool.acquire(timeout=30) as conn:
+            async with conn.transaction():
+                if user_id is not None:
+                    await conn.execute(
+                        "SELECT set_config('app.current_user_id', $1, true)", str(user_id)
+                    )
+                token = _current_conn.set(conn)
+                try:
+                    yield conn
+                finally:
+                    _current_conn.reset(token)
+    except asyncio.TimeoutError:
+        logger.error("transaction: pool.acquire timed out after 30s — pool exhausted")
+        raise

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,9 @@ services:
       - "8000:8000"
     volumes:
       - ${TETHER_DATA_DIR:-~/.tether-config}:/data
+      # Mount your Claude Code credentials so the bot can authenticate.
+      # Self-hosters: change the left side if your credentials aren't at ~/.claude.
+      - ${CLAUDE_CREDENTIALS_PATH:-~/.claude}:/root/.claude
     environment:
       - TETHER_CONFIG_DIR=/data
       - PYTHONUNBUFFERED=1

--- a/frontend/src/composables/useBotTransport.ts
+++ b/frontend/src/composables/useBotTransport.ts
@@ -45,24 +45,75 @@ export function createWebSocketTransport(): BotTransport {
   const proto = location.protocol === 'https:' ? 'wss' : 'ws'
   const ws = new WebSocket(`${proto}://${location.host}/api/bot/chat`)
 
-  let resolve: ((val: MessageEvent) => void) | null = null
-  const queue: MessageEvent[] = []
+  // C1: resolved once the socket is ready; awaited before every send.
+  let resolveOpen!: () => void
+  let rejectOpen!: (err: Error) => void
+  const openPromise = new Promise<void>((resolve, reject) => {
+    resolveOpen = resolve
+    rejectOpen = reject
+  })
+
+  // C2: slot for the currently-awaited recv; reject path lets a closed
+  // socket surface an error instead of hanging the `while (true)` loop.
+  let pendingResolve: ((val: MessageEvent) => void) | null = null
+  let pendingReject: ((err: Error) => void) | null = null
+  const incoming: MessageEvent[] = []
+
+  // H2: single heartbeat subscriber, driven by real socket events.
+  let heartbeatCb: ((alive: boolean) => void) | null = null
+
+  function failPending(err: Error): void {
+    pendingReject?.(err)
+    pendingResolve = null
+    pendingReject = null
+  }
+
+  ws.onopen = () => {
+    resolveOpen()
+    heartbeatCb?.(true)
+  }
 
   ws.onmessage = (evt) => {
-    if (resolve) { resolve(evt); resolve = null }
-    else queue.push(evt)
+    if (pendingResolve) {
+      pendingResolve(evt)
+      pendingResolve = null
+      pendingReject = null
+    } else {
+      incoming.push(evt)
+    }
+  }
+
+  ws.onerror = () => {
+    const err = new Error('WebSocket error')
+    rejectOpen(err)
+    failPending(err)
+    heartbeatCb?.(false)
+  }
+
+  ws.onclose = () => {
+    failPending(new Error('WebSocket closed'))
+    heartbeatCb?.(false)
   }
 
   return {
     async *send(text: string) {
-      // 1. send the message
-      ws.send(JSON.stringify({ type: 'user', content: text}))
+      // C1: don't send until the socket has opened.
+      await openPromise
 
-      // 2. wait for chunks until "done"
+      // H1: take a private snapshot of any buffered messages so concurrent
+      // sends don't steal each other's chunks via the shared `incoming` queue.
+      const localQueue: MessageEvent[] = incoming.splice(0)
+
+      ws.send(JSON.stringify({ type: 'user', content: text }))
+
+      // C2: each recv registers both resolve and reject, so onerror/onclose
+      // can break us out of this loop.
       while (true) {
-        const evt: MessageEvent = await new Promise(r => {
-          if (queue.length) r(queue.shift()!)
-            else resolve = r
+        const evt: MessageEvent = await new Promise((resolve, reject) => {
+          if (localQueue.length) return resolve(localQueue.shift()!)
+          if (incoming.length) return resolve(incoming.shift()!)
+          pendingResolve = resolve
+          pendingReject = reject
         })
         const msg = JSON.parse(evt.data)
         if (msg.type === 'chunk') yield msg.content
@@ -71,14 +122,23 @@ export function createWebSocketTransport(): BotTransport {
     },
 
     onHeartbeat(cb) {
-      // listen for {"type": "heartbeat"}
-      // backend doesnt send thi. just call as true immediately
-      cb(true)
-      return () => {}
+      heartbeatCb = cb
+      // Reflect current readyState immediately so subscribers don't wait
+      // for the next socket event to see the right status.
+      switch (ws.readyState) {
+        case WebSocket.OPEN:
+          cb(true)
+          break
+        case WebSocket.CLOSING:
+        case WebSocket.CLOSED:
+          cb(false)
+          break
+      }
+      return () => { heartbeatCb = null }
     },
-    
+
     close() {
       ws.close()
-    }
+    },
   }
 }

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -3,6 +3,11 @@ import { ref } from 'vue'
 import type { ChatMessage } from '../types/chat'
 import { getBotTransport } from '../composables/useBotTransport'
 
+function makeId(): string {
+  if (location.protocol === 'https:') return crypto.randomUUID()
+  return Math.random().toString(36).slice(2) + Date.now().toString(36)
+}
+
 export const useChatStore = defineStore('chat', () => {
   const messages = ref<ChatMessage[]>([])
   const isStreaming = ref(false)
@@ -12,26 +17,18 @@ export const useChatStore = defineStore('chat', () => {
   transport.onHeartbeat(a => { heartbeat.value = a })
 
   async function send(text: string): Promise<void> {
-    const userMsg: ChatMessage = {
-      id: location.protocol === 'https:' ? crypto.randomUUID() : Math.random().toString(36).slice(2) + Date.now().toString(36),
-      role: 'user',
-      content: text,
-      ts: Date.now(),
-    }
-    messages.value.push(userMsg)
+    messages.value.push({ id: makeId(), role: 'user', content: text, ts: Date.now() })
 
-    const botMsg: ChatMessage = {
-      id: location.protocol === 'https:' ? crypto.randomUUID() : Math.random().toString(36).slice(2) + Date.now().toString(36),
-      role: 'bot',
-      content: '',
-      ts: Date.now(),
-    }
-    messages.value.push(botMsg)
+    // Record the index before pushing the bot placeholder so we can write
+    // chunks through the reactive proxy (messages.value[botMsgIndex]) rather
+    // than a plain-object reference that bypasses Vue's Proxy set-trap.
+    const botMsgIndex = messages.value.length
+    messages.value.push({ id: makeId(), role: 'bot', content: '', ts: Date.now() })
+
     isStreaming.value = true
-
     try {
       for await (const chunk of transport.send(text)) {
-        botMsg.content += chunk
+        messages.value[botMsgIndex].content += chunk
       }
     } finally {
       isStreaming.value = false

--- a/tests/db/test_pg_integrations.py
+++ b/tests/db/test_pg_integrations.py
@@ -1,0 +1,202 @@
+"""Query-layer tests for db/pg_queries/integrations.py.
+
+Covers get/upsert/delete for user_integrations, get/upsert for
+integration_sync_state, and soft-delete of tasks by external id.
+
+All tests roll back via the `conn` fixture from pg_conftest — no
+persistent side effects.
+"""
+import pytest
+
+from db.pg_queries import integrations as q
+from tests.db.pg_conftest import conn, TEST_USER_ID  # noqa: F401
+
+PROVIDER = "google_calendar"
+
+
+# ---------------------------------------------------------------------------
+# get_integration — empty → None
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_integration_returns_none_when_missing(conn):  # noqa: F811
+    """get_integration returns None when no row exists for (user_id, provider)."""
+    result = await q.get_integration(conn, TEST_USER_ID, PROVIDER)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# upsert_integration — insert path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_upsert_integration_inserts_row(conn):  # noqa: F811
+    """upsert_integration creates a new row and returns it with an id."""
+    row = await q.upsert_integration(
+        conn, TEST_USER_ID, PROVIDER,
+        access_token="at_abc",
+        refresh_token="rt_xyz",
+        scopes=["calendar.readonly"],
+    )
+    assert row["user_id"] == TEST_USER_ID
+    assert row["provider"] == PROVIDER
+    assert row["access_token"] == "at_abc"
+    assert row["refresh_token"] == "rt_xyz"
+    assert "calendar.readonly" in row["scopes"]
+    assert row["id"] is not None
+
+
+# ---------------------------------------------------------------------------
+# get_integration — after upsert
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_integration_returns_row_after_upsert(conn):  # noqa: F811
+    """get_integration returns the row created by upsert_integration."""
+    await q.upsert_integration(conn, TEST_USER_ID, PROVIDER, access_token="tok")
+    row = await q.get_integration(conn, TEST_USER_ID, PROVIDER)
+    assert row is not None
+    assert row["access_token"] == "tok"
+
+
+# ---------------------------------------------------------------------------
+# upsert_integration — update path (idempotent on conflict)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_upsert_integration_updates_existing_row(conn):  # noqa: F811
+    """Second upsert updates the row rather than creating a duplicate."""
+    await q.upsert_integration(conn, TEST_USER_ID, PROVIDER, access_token="old_token")
+    updated = await q.upsert_integration(
+        conn, TEST_USER_ID, PROVIDER, access_token="new_token"
+    )
+    assert updated["access_token"] == "new_token"
+
+    # Confirm there is exactly one row
+    rows = await conn.fetch(
+        "SELECT id FROM user_integrations WHERE user_id = $1 AND provider = $2",
+        TEST_USER_ID, PROVIDER,
+    )
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# delete_integration
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_delete_integration_returns_true_when_row_exists(conn):  # noqa: F811
+    """delete_integration returns True and removes the row."""
+    await q.upsert_integration(conn, TEST_USER_ID, PROVIDER)
+    deleted = await q.delete_integration(conn, TEST_USER_ID, PROVIDER)
+    assert deleted is True
+
+    row = await q.get_integration(conn, TEST_USER_ID, PROVIDER)
+    assert row is None
+
+
+@pytest.mark.asyncio
+async def test_delete_integration_returns_false_when_missing(conn):  # noqa: F811
+    """delete_integration returns False if no row matched."""
+    deleted = await q.delete_integration(conn, TEST_USER_ID, PROVIDER)
+    assert deleted is False
+
+
+# ---------------------------------------------------------------------------
+# delete_integration cascades to sync_state
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_delete_integration_cascades_sync_state(conn):  # noqa: F811
+    """Deleting an integration removes its sync_state rows via ON DELETE CASCADE."""
+    row = await q.upsert_integration(conn, TEST_USER_ID, PROVIDER)
+    integration_id = str(row["id"])
+
+    await q.upsert_sync_state(conn, integration_id, "primary")
+
+    await q.delete_integration(conn, TEST_USER_ID, PROVIDER)
+
+    sync_row = await q.get_sync_state(conn, integration_id, "primary")
+    assert sync_row is None
+
+
+# ---------------------------------------------------------------------------
+# upsert_sync_state + get_sync_state
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_upsert_and_get_sync_state(conn):  # noqa: F811
+    """upsert_sync_state inserts a row; get_sync_state retrieves it."""
+    row = await q.upsert_integration(conn, TEST_USER_ID, PROVIDER)
+    integration_id = str(row["id"])
+
+    sync = await q.upsert_sync_state(
+        conn, integration_id, "primary",
+        sync_cursor="token_abc",
+        watch_channel_id="ch_001",
+    )
+    assert sync["calendar_id"] == "primary"
+    assert sync["sync_cursor"] == "token_abc"
+    assert sync["watch_channel_id"] == "ch_001"
+
+    fetched = await q.get_sync_state(conn, integration_id, "primary")
+    assert fetched is not None
+    assert fetched["sync_cursor"] == "token_abc"
+
+
+@pytest.mark.asyncio
+async def test_get_sync_state_returns_none_when_missing(conn):  # noqa: F811
+    """get_sync_state returns None for an unknown (integration_id, calendar_id)."""
+    fake_id = "00000000-0000-0000-0000-000000000000"
+    result = await q.get_sync_state(conn, fake_id, "primary")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_upsert_sync_state_updates_cursor(conn):  # noqa: F811
+    """Second upsert with a new sync_cursor updates the existing row."""
+    row = await q.upsert_integration(conn, TEST_USER_ID, PROVIDER)
+    integration_id = str(row["id"])
+
+    await q.upsert_sync_state(conn, integration_id, "primary", sync_cursor="old")
+    updated = await q.upsert_sync_state(conn, integration_id, "primary", sync_cursor="new")
+    assert updated["sync_cursor"] == "new"
+
+    # Still only one row
+    rows = await conn.fetch(
+        "SELECT id FROM integration_sync_state WHERE integration_id = $1 AND calendar_id = $2",
+        row["id"], "primary",
+    )
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# soft_delete_task_by_external_id
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_soft_delete_task_sets_source_status(conn):  # noqa: F811
+    """soft_delete_task_by_external_id sets source_status='cancelled' on the task."""
+    # Insert a synced task
+    task_uuid = await conn.fetchval(
+        "INSERT INTO tasks (user_id, text, status, source, external_id) "
+        "VALUES ($1::uuid, 'gcal event', 'pending', $2, $3) RETURNING uuid",
+        TEST_USER_ID, PROVIDER, "evt_001",
+    )
+
+    deleted = await q.soft_delete_task_by_external_id(conn, TEST_USER_ID, PROVIDER, "evt_001")
+    assert deleted is True
+
+    row = await conn.fetchrow(
+        "SELECT source_status FROM tasks WHERE uuid = $1", task_uuid
+    )
+    assert row["source_status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_task_returns_false_when_missing(conn):  # noqa: F811
+    """soft_delete_task_by_external_id returns False when no matching task exists."""
+    deleted = await q.soft_delete_task_by_external_id(
+        conn, TEST_USER_ID, PROVIDER, "no_such_event"
+    )
+    assert deleted is False

--- a/tests/db/test_pg_integrations.py
+++ b/tests/db/test_pg_integrations.py
@@ -81,6 +81,28 @@ async def test_upsert_integration_updates_existing_row(conn):  # noqa: F811
 
 
 # ---------------------------------------------------------------------------
+# upsert_integration — partial update preserves existing fields
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_upsert_integration_preserves_unmentioned_fields(conn):  # noqa: F811
+    """Updating only access_token must not wipe refresh_token or scopes."""
+    await q.upsert_integration(
+        conn, TEST_USER_ID, PROVIDER,
+        access_token="at_old",
+        refresh_token="rt_keep",
+        scopes=["calendar.readonly"],
+    )
+    updated = await q.upsert_integration(
+        conn, TEST_USER_ID, PROVIDER,
+        access_token="at_new",
+    )
+    assert updated["access_token"] == "at_new"
+    assert updated["refresh_token"] == "rt_keep"
+    assert "calendar.readonly" in updated["scopes"]
+
+
+# ---------------------------------------------------------------------------
 # delete_integration
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- `useSlideOver.ts`: replace bare `crypto.randomUUID()` in `decodeStack()` and `push()` with `crypto.randomUUID?.() ?? (Math.random().toString(36).slice(2) + Date.now().toString(36))`
- `events.ts`: same guard on the optimistic local event ID (line 48)
- `SlideOverStack.vue`: fix pre-existing type error — `pointerEvents` cast to `'auto' | 'none'` so `vue-tsc` accepts it (this was blocking `npm run build` on the base branch)

## Why
`crypto.randomUUID()` requires a secure context (HTTPS / localhost). The Pi is accessed via Tailscale IP over plain HTTP, so the call throws, breaking task card clicks in KanbanView.

## Test plan
- [ ] `npm run build` — zero type errors ✅
- [ ] Click task card on Pi over HTTP — slide-over panel opens without TypeError
- [ ] Restore `?panels=` query param on page load — no crash