### PR TITLE
fix: calendar event interactions — click to open panel, drag to move

### DIFF
--- a/frontend/src/stores/__tests__/events.test.ts
+++ b/frontend/src/stores/__tests__/events.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: false, json: async () => ({}) })),
+}))
+
+describe('useEventStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('moveEvent updates start_time and end_time of the matching event', async () => {
+    const { useEventStore } = await import('../events')
+    const store = useEventStore()
+
+    // Seed a known event directly
+    store.events.push({
+      id: 'ev-1',
+      title: 'Test',
+      start_time: '2024-06-10T09:00:00.000Z',
+      end_time: '2024-06-10T10:00:00.000Z',
+      source: 'tether',
+      external_id: null,
+      task_id: null,
+      anchor_id: null,
+      color: null,
+    })
+
+    await store.moveEvent('ev-1', '2024-06-10T14:00:00.000Z', '2024-06-10T15:00:00.000Z')
+
+    expect(store.events[0].start_time).toBe('2024-06-10T14:00:00.000Z')
+    expect(store.events[0].end_time).toBe('2024-06-10T15:00:00.000Z')
+  })
+
+  it('moveEvent is a no-op for an unknown event id', async () => {
+    const { useEventStore } = await import('../events')
+    const store = useEventStore()
+    // Should not throw
+    await expect(store.moveEvent('nonexistent', '2024-01-01T00:00:00Z', '2024-01-01T01:00:00Z')).resolves.toBeUndefined()
+  })
+})

--- a/frontend/src/stores/events.ts
+++ b/frontend/src/stores/events.ts
@@ -60,6 +60,25 @@ export const useEventStore = defineStore('events', () => {
   }
 
   /**
+   * Move an existing event to a new time slot (drag-to-reposition).
+   * PATCH /api/events/:id — not yet implemented; updates optimistically.
+   */
+  async function moveEvent(eventId: string, startTime: string, endTime: string): Promise<void> {
+    const ev = events.value.find(e => e.id === eventId)
+    if (!ev) return
+    // Optimistic update
+    ev.start_time = startTime
+    ev.end_time = endTime
+    try {
+      await api(`/api/events/${eventId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ start_time: startTime, end_time: endTime }),
+      })
+    } catch { /* ignore — optimistic update stays */ }
+  }
+
+  /**
    * Demote a calendar event back to a plain task (removes time constraint).
    * DELETE /api/events/:id/time-constraint
    */
@@ -70,5 +89,5 @@ export const useEventStore = defineStore('events', () => {
     events.value = events.value.filter(e => e.id !== eventId)
   }
 
-  return { events, loading, error, fetchEvents, promoteTask, demoteEvent }
+  return { events, loading, error, fetchEvents, promoteTask, moveEvent, demoteEvent }
 })

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -4,6 +4,7 @@ import { useAnchorStore } from '../stores/anchors'
 import { useEventStore } from '../stores/events'
 import { usePlanStore } from '../stores/plan'
 import { useCalendarFocus } from '../composables/useCalendarFocus'
+import { useSlideOver } from '../composables/useSlideOver'
 import type { CalendarEvent } from '../types/events'
 import type { Anchor } from '../stores/anchors'
 
@@ -11,6 +12,7 @@ const anchorStore = useAnchorStore()
 const eventStore = useEventStore()
 const planStore = usePlanStore()
 const { focusedDay, setFocusedDay } = useCalendarFocus()
+const { push: pushPanel } = useSlideOver()
 
 // ─── View state ───────────────────────────────────────────────
 const anchorPanelOpen = ref(true)
@@ -171,28 +173,48 @@ async function onDrop(e: DragEvent, day: Date) {
   const raw = e.dataTransfer?.getData('text/plain')
   if (!raw || !(e.currentTarget instanceof HTMLElement)) return
 
-  let taskId: string | undefined
-  try { taskId = JSON.parse(raw).taskId } catch { return }
-  if (!taskId) return
-
-  // Find task title in current plan; fall back to 'Task' for backlog/unknown.
-  let title = 'Task'
-  for (const anchorPlan of Object.values(planStore.plan?.anchors ?? {})) {
-    const found = anchorPlan.tasks.find(t => t.id === taskId)
-    if (found) { title = found.text; break }
-  }
+  let payload: { taskId?: string; eventId?: string }
+  try { payload = JSON.parse(raw) } catch { return }
 
   // Map drop position to a quarter-hour slot.
   const rect = e.currentTarget.getBoundingClientRect()
   const relY = e.clientY - rect.top
   const hour = Math.floor(relY / HOUR_HEIGHT) + START_HOUR
   const minute = Math.round(((relY % HOUR_HEIGHT) / HOUR_HEIGHT) * 60 / 15) * 15
-
   const startDate = new Date(day)
   startDate.setHours(hour, minute, 0, 0)
-  const endDate = new Date(startDate.getTime() + 60 * 60 * 1000) // 1 hour default
 
-  await eventStore.promoteTask(taskId, startDate.toISOString(), endDate.toISOString(), title)
+  if (payload.eventId) {
+    // Repositioning an existing event — preserve its duration.
+    const existing = eventStore.events.find(ev => ev.id === payload.eventId)
+    if (!existing) return
+    const durationMs = new Date(existing.end_time).getTime() - new Date(existing.start_time).getTime()
+    const endDate = new Date(startDate.getTime() + durationMs)
+    await eventStore.moveEvent(payload.eventId, startDate.toISOString(), endDate.toISOString())
+    return
+  }
+
+  if (!payload.taskId) return
+
+  // Promoting a sidebar task to an event.
+  let title = 'Task'
+  for (const anchorPlan of Object.values(planStore.plan?.anchors ?? {})) {
+    const found = anchorPlan.tasks.find(t => t.id === payload.taskId)
+    if (found) { title = found.text; break }
+  }
+  const endDate = new Date(startDate.getTime() + 60 * 60 * 1000) // 1 hour default
+  await eventStore.promoteTask(payload.taskId, startDate.toISOString(), endDate.toISOString(), title)
+}
+
+// ─── Panel navigation ─────────────────────────────────────────
+function openEventPanel(event: CalendarEvent) {
+  // Promoted tasks: open the source task detail so the user can edit it.
+  // Standalone events: open via kind:'event' (wired to TaskDetailPanel by SlideOverStack).
+  if (event.task_id) {
+    pushPanel({ kind: 'task', entityId: event.task_id })
+  } else {
+    pushPanel({ kind: 'event', entityId: event.id })
+  }
 }
 
 // ─── Data loading ──────────────────────────────────────────────
@@ -254,6 +276,7 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
               draggable="true"
               class="text-xs px-1.5 py-1 rounded cursor-grab hover:bg-white/5 text-white/60 hover:text-white/90 transition-colors truncate"
               :class="task.status === 'done' ? 'line-through opacity-40' : ''"
+              @click.stop="pushPanel({ kind: 'task', entityId: task.id })"
               @dragstart="(e: DragEvent) => {
                 if (e.dataTransfer) {
                   e.dataTransfer.effectAllowed = 'copy'
@@ -374,15 +397,23 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
             <div
               v-for="event in eventsByDay[dayKeys[i]]"
               :key="event.id"
-              class="absolute inset-x-1 rounded overflow-hidden text-xs px-1.5 py-0.5 cursor-pointer shadow-md hover:brightness-110 transition-all z-10"
+              draggable="true"
+              class="absolute inset-x-1 rounded overflow-hidden text-xs px-1.5 py-0.5 cursor-grab shadow-md hover:brightness-110 transition-all z-10"
               :style="{
                 top: `${eventTopPx(event)}px`,
                 height: `${eventHeightPx(event)}px`,
                 backgroundColor: eventColor(event),
                 opacity: event.source !== 'tether' ? 0.75 : 1,
               }"
+              @click.stop="openEventPanel(event)"
+              @dragstart.stop="(e: DragEvent) => {
+                if (e.dataTransfer) {
+                  e.dataTransfer.effectAllowed = 'move'
+                  e.dataTransfer.setData('text/plain', JSON.stringify({ eventId: event.id }))
+                }
+              }"
             >
-              <div class="flex items-center gap-1 truncate">
+              <div class="flex items-center gap-1 truncate pointer-events-none">
                 <!-- Provider badge for synced events -->
                 <span v-if="event.source !== 'tether'" class="text-[9px] bg-black/20 rounded px-0.5 flex-shrink-0" title="Synced from external calendar">
                   {{ event.source === 'google_calendar' ? 'G' : '↗' }}


### PR DESCRIPTION
## Summary

### Bug 1 — Sidebar task click opens task detail panel
Added `@click.stop="pushPanel({ kind: 'task', entityId: task.id })"` to each task `<li>` in the anchor panel. Uses the same `useSlideOver` → `pushPanel` pattern as KanbanView.

### Bug 2 — Event blocks are now draggable and clickable
- **Click**: `@click.stop="openEventPanel(event)"` — promoted tasks open `kind: 'task'` with the source `task_id` (so TaskDetailPanel loads the right record); standalone events open `kind: 'event'` with `event.id`.
- **Drag to reposition**: added `draggable="true"` + `@dragstart` that puts `{ eventId }` in dataTransfer. `onDrop` now branches on `eventId` vs `taskId`: event drops preserve the event's original duration and call the new `eventStore.moveEvent()`.
- Inner content div gets `pointer-events-none` to prevent child elements swallowing clicks/drags.

### Bug 3 — POST /api/events 405 (backend)
No frontend change needed — `promoteTask` was already calling `POST /api/events` correctly. Flagged to `api-2` agent for backend fix.

## New store action
`eventStore.moveEvent(eventId, newStart, newEnd)` — optimistic update of `start_time`/`end_time`, then `PATCH /api/events/:id` (backend not yet implemented; optimistic update persists locally).

## Test plan
- [ ] `npm run build` — zero type errors ✅
- [ ] Click a task in the anchor panel → TaskDetailPanel slide-over opens
- [ ] Click an event block → slide-over opens (task detail for promoted tasks)
- [ ] Drag an event block to a new time slot → event repositions, duration preserved
- [ ] Dragging a sidebar task still promotes it to a new event (unchanged behaviour)