### PR TITLE
feat: POST /api/events — task promotion to calendar event

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -27,6 +27,7 @@ from api.routes import nodes as nodes_routes
 from api.routes import settings as settings_routes
 from api.routes import connections as connections_routes
 from api.routes import meetings as meetings_routes
+from api.routes import events as events_routes
 from api.ws import manager
 from api.auth import decode_jwt
 from db.pool_middleware import lifespan as _pool_lifespan
@@ -117,6 +118,7 @@ def create_app(lifespan_override=None) -> FastAPI:
     app.include_router(settings_routes.router, prefix="/api")
     app.include_router(connections_routes.router, prefix="/api")
     app.include_router(meetings_routes.router, prefix="/api")
+    app.include_router(events_routes.router, prefix="/api")
 
     # --- Premium plugin hook ---
     try:

--- a/api/routes/events.py
+++ b/api/routes/events.py
@@ -1,0 +1,46 @@
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+import asyncpg
+
+from db.pg_queries.tasks import promote_task_to_event, get_events_for_range
+from db.pool_middleware import get_db_conn
+from api.auth import auth_dependency
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+class PromoteEventBody(BaseModel):
+    task_id: str
+    start_time: str
+    end_time: str
+    title: str | None = None  # informational — task text is already set in the DB
+
+
+@router.post("/events", status_code=201)
+async def post_event(
+    body: PromoteEventBody,
+    _auth=Depends(auth_dependency),
+    conn: asyncpg.Connection = Depends(get_db_conn),
+):
+    """Promote an existing task to a calendar event by stamping start/end time."""
+    event = await promote_task_to_event(
+        conn, body.task_id, body.start_time, body.end_time
+    )
+    if event is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    logger.info("events: promoted task %s to event at %s", body.task_id, body.start_time)
+    return event
+
+
+@router.get("/events")
+async def get_events(
+    start: str,
+    end: str,
+    _auth=Depends(auth_dependency),
+    conn: asyncpg.Connection = Depends(get_db_conn),
+):
+    """Return all calendar events (promoted tasks) whose start_time falls in [start, end]."""
+    return await get_events_for_range(conn, start, end)

--- a/api/routes/events.py
+++ b/api/routes/events.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 import asyncpg
 
-from db.pg_queries.tasks import promote_task_to_event, get_events_for_range
+from db.pg_queries.tasks import promote_task_to_event, get_events_for_range, update_event_time
 from db.pool_middleware import get_db_conn
 from api.auth import auth_dependency
 
@@ -17,6 +17,11 @@ class PromoteEventBody(BaseModel):
     start_time: str
     end_time: str
     title: str | None = None  # informational — task text is already set in the DB
+
+
+class MoveEventBody(BaseModel):
+    start_time: str
+    end_time: str
 
 
 @router.post("/events", status_code=201)
@@ -32,6 +37,21 @@ async def post_event(
     if event is None:
         raise HTTPException(status_code=404, detail="Task not found")
     logger.info("events: promoted task %s to event at %s", body.task_id, body.start_time)
+    return event
+
+
+@router.patch("/events/{event_id}")
+async def patch_event(
+    event_id: str,
+    body: MoveEventBody,
+    _auth=Depends(auth_dependency),
+    conn: asyncpg.Connection = Depends(get_db_conn),
+):
+    """Reposition a calendar event to a new time slot (move/resize)."""
+    event = await update_event_time(conn, event_id, body.start_time, body.end_time)
+    if event is None:
+        raise HTTPException(status_code=404, detail="Event not found")
+    logger.info("events: moved event %s to %s", event_id, body.start_time)
     return event
 
 

--- a/db/pg_queries/__init__.py
+++ b/db/pg_queries/__init__.py
@@ -16,6 +16,7 @@ from db.pg_queries.tasks import (
     add_task_dependency, remove_task_dependency,
     get_subtasks, create_subtask, update_subtask, delete_subtask, reorder_subtasks,
     resolve_blocked_status,
+    promote_task_to_event, get_events_for_range,
 )
 from db.pg_queries.context import (
     upsert_context_entry, get_context_entries, delete_context_entry, rename_context_subject,

--- a/db/pg_queries/__init__.py
+++ b/db/pg_queries/__init__.py
@@ -16,7 +16,7 @@ from db.pg_queries.tasks import (
     add_task_dependency, remove_task_dependency,
     get_subtasks, create_subtask, update_subtask, delete_subtask, reorder_subtasks,
     resolve_blocked_status,
-    promote_task_to_event, get_events_for_range,
+    promote_task_to_event, get_events_for_range, update_event_time,
 )
 from db.pg_queries.context import (
     upsert_context_entry, get_context_entries, delete_context_entry, rename_context_subject,

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -568,3 +568,69 @@ async def reorder_subtasks(conn: asyncpg.Connection, task_id: str, id_order: lis
             "UPDATE subtasks SET position = $1 WHERE id = $2 AND task_id = $3",
             pos, subtask_id, task_id,
         )
+
+
+# ─── Event queries (tasks with start_time/end_time set) ───────────────────────
+
+def _row_to_event(row) -> dict:
+    """Map a task row that has event fields to CalendarEvent shape."""
+    r = dict(row)
+    st = r.get("start_time")
+    et = r.get("end_time")
+    uid = str(r["uuid"]) if r.get("uuid") else None
+    return {
+        "id": uid,
+        "title": r.get("text", ""),
+        "start_time": st.isoformat() if st else None,
+        "end_time": et.isoformat() if et else None,
+        "source": r.get("source") or "tether",
+        "external_id": r.get("external_id"),
+        "task_id": uid,
+        "anchor_id": str(r["anchor_id"]) if r.get("anchor_id") else None,
+        "color": None,
+    }
+
+
+async def promote_task_to_event(
+    conn: asyncpg.Connection,
+    task_uuid: str,
+    start_time: str,
+    end_time: str,
+) -> dict | None:
+    """Stamp an existing task with start/end time, making it a calendar event.
+
+    Returns CalendarEvent-shaped dict, or None if the task doesn't exist.
+    """
+    row = await conn.fetchrow(
+        """
+        UPDATE tasks
+        SET start_time = $1::timestamptz,
+            end_time   = $2::timestamptz,
+            source     = COALESCE(source, 'tether'),
+            version    = version + 1
+        WHERE uuid = $3
+        RETURNING uuid, text, start_time, end_time, source, external_id, anchor_id
+        """,
+        start_time, end_time, _uuid.UUID(task_uuid),
+    )
+    return _row_to_event(row) if row else None
+
+
+async def get_events_for_range(
+    conn: asyncpg.Connection,
+    start: str,
+    end: str,
+) -> list[dict]:
+    """Return all tasks that have been promoted to events within [start, end]."""
+    rows = await conn.fetch(
+        """
+        SELECT uuid, text, start_time, end_time, source, external_id, anchor_id
+        FROM tasks
+        WHERE start_time IS NOT NULL
+          AND start_time >= $1::timestamptz
+          AND start_time <= $2::timestamptz
+        ORDER BY start_time
+        """,
+        start, end,
+    )
+    return [_row_to_event(r) for r in rows]

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -572,6 +572,19 @@ async def reorder_subtasks(conn: asyncpg.Connection, task_id: str, id_order: lis
 
 # ─── Event queries (tasks with start_time/end_time set) ───────────────────────
 
+from datetime import datetime as _datetime
+
+
+def _parse_ts(s: str) -> _datetime:
+    """Parse an ISO 8601 timestamp string to an aware datetime for asyncpg.
+
+    asyncpg requires datetime objects for TIMESTAMPTZ parameters — it does not
+    coerce strings even when the SQL uses a ::timestamptz cast. Python 3.10's
+    fromisoformat() also rejects the 'Z' suffix, so we normalise it first.
+    """
+    return _datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
 def _row_to_event(row) -> dict:
     """Map a task row that has event fields to CalendarEvent shape."""
     r = dict(row)
@@ -604,14 +617,14 @@ async def promote_task_to_event(
     row = await conn.fetchrow(
         """
         UPDATE tasks
-        SET start_time = $1::timestamptz,
-            end_time   = $2::timestamptz,
+        SET start_time = $1,
+            end_time   = $2,
             source     = COALESCE(source, 'tether'),
             version    = version + 1
         WHERE uuid = $3
         RETURNING uuid, text, start_time, end_time, source, external_id, anchor_id
         """,
-        start_time, end_time, _uuid.UUID(task_uuid),
+        _parse_ts(start_time), _parse_ts(end_time), _uuid.UUID(task_uuid),
     )
     return _row_to_event(row) if row else None
 
@@ -627,11 +640,11 @@ async def get_events_for_range(
         SELECT uuid, text, start_time, end_time, source, external_id, anchor_id
         FROM tasks
         WHERE start_time IS NOT NULL
-          AND start_time >= $1::timestamptz
-          AND start_time <= $2::timestamptz
+          AND start_time >= $1
+          AND start_time <= $2
         ORDER BY start_time
         """,
-        start, end,
+        _parse_ts(start), _parse_ts(end),
     )
     return [_row_to_event(r) for r in rows]
 
@@ -650,13 +663,13 @@ async def update_event_time(
     row = await conn.fetchrow(
         """
         UPDATE tasks
-        SET start_time = $1::timestamptz,
-            end_time   = $2::timestamptz,
+        SET start_time = $1,
+            end_time   = $2,
             version    = version + 1
         WHERE uuid = $3
           AND start_time IS NOT NULL
         RETURNING uuid, text, start_time, end_time, source, external_id, anchor_id
         """,
-        start_time, end_time, _uuid.UUID(event_uuid),
+        _parse_ts(start_time), _parse_ts(end_time), _uuid.UUID(event_uuid),
     )
     return _row_to_event(row) if row else None

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -634,3 +634,29 @@ async def get_events_for_range(
         start, end,
     )
     return [_row_to_event(r) for r in rows]
+
+
+async def update_event_time(
+    conn: asyncpg.Connection,
+    event_uuid: str,
+    start_time: str,
+    end_time: str,
+) -> dict | None:
+    """Reposition a calendar event to a new time slot.
+
+    Only updates tasks that already have start_time set (i.e. are promoted events).
+    Returns CalendarEvent-shaped dict, or None if not found / not an event.
+    """
+    row = await conn.fetchrow(
+        """
+        UPDATE tasks
+        SET start_time = $1::timestamptz,
+            end_time   = $2::timestamptz,
+            version    = version + 1
+        WHERE uuid = $3
+          AND start_time IS NOT NULL
+        RETURNING uuid, text, start_time, end_time, source, external_id, anchor_id
+        """,
+        start_time, end_time, _uuid.UUID(event_uuid),
+    )
+    return _row_to_event(row) if row else None

--- a/tests/api/test_events_routes.py
+++ b/tests/api/test_events_routes.py
@@ -115,3 +115,44 @@ async def test_get_events_empty_outside_range(api_client, conn):
     events = resp.json()
     ids = [e["id"] for e in events]
     assert task_id not in ids
+
+
+# ─── PATCH /api/events/:id ────────────────────────────────────────────────────
+
+async def test_patch_event_moves_time(api_client, conn):
+    """Moving a promoted event to a new slot returns the updated CalendarEvent."""
+    task_id = await _insert_task(conn, "Movable event")
+    await api_client.post("/api/events", json={
+        "task_id": task_id,
+        "start_time": "2026-05-02T09:00:00Z",
+        "end_time": "2026-05-02T10:00:00Z",
+        "title": "Movable event",
+    })
+
+    resp = await api_client.patch(f"/api/events/{task_id}", json={
+        "start_time": "2026-05-02T14:00:00Z",
+        "end_time": "2026-05-02T15:00:00Z",
+    })
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["id"] == task_id
+    assert "14:00" in data["start_time"] or "14" in data["start_time"]
+    assert "15:00" in data["end_time"] or "15" in data["end_time"]
+
+
+async def test_patch_event_404_not_an_event(api_client, conn):
+    """Patching a task that was never promoted (no start_time) returns 404."""
+    task_id = await _insert_task(conn, "Plain task")
+    resp = await api_client.patch(f"/api/events/{task_id}", json={
+        "start_time": "2026-05-02T14:00:00Z",
+        "end_time": "2026-05-02T15:00:00Z",
+    })
+    assert resp.status_code == 404
+
+
+async def test_patch_event_404_unknown_id(api_client, conn):
+    resp = await api_client.patch("/api/events/00000000-0000-0000-0000-000000000099", json={
+        "start_time": "2026-05-02T14:00:00Z",
+        "end_time": "2026-05-02T15:00:00Z",
+    })
+    assert resp.status_code == 404

--- a/tests/api/test_events_routes.py
+++ b/tests/api/test_events_routes.py
@@ -1,0 +1,117 @@
+"""Tests for GET/POST /api/events endpoints."""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _insert_task(conn, text: str = "Test event task") -> str:
+    """Insert a bare task and return its UUID string."""
+    row = await conn.fetchrow(
+        """
+        INSERT INTO tasks (uuid, user_id, text, status)
+        VALUES (
+            gen_random_uuid(),
+            current_setting('app.current_user_id', true)::uuid,
+            $1,
+            'pending'
+        )
+        RETURNING uuid
+        """,
+        text,
+    )
+    return str(row["uuid"])
+
+
+# ─── POST /api/events ─────────────────────────────────────────────────────────
+
+async def test_post_event_promotes_task(api_client, conn):
+    task_id = await _insert_task(conn)
+
+    resp = await api_client.post("/api/events", json={
+        "task_id": task_id,
+        "start_time": "2026-04-25T09:00:00Z",
+        "end_time": "2026-04-25T10:00:00Z",
+        "title": "Test event task",
+    })
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["id"] == task_id
+    assert data["task_id"] == task_id
+    assert data["start_time"] is not None
+    assert data["end_time"] is not None
+    assert data["source"] == "tether"
+    assert data["external_id"] is None
+
+
+async def test_post_event_idempotent(api_client, conn):
+    """Promoting the same task twice updates the time rather than erroring."""
+    task_id = await _insert_task(conn)
+
+    await api_client.post("/api/events", json={
+        "task_id": task_id,
+        "start_time": "2026-04-25T09:00:00Z",
+        "end_time": "2026-04-25T10:00:00Z",
+        "title": "Test event task",
+    })
+    resp = await api_client.post("/api/events", json={
+        "task_id": task_id,
+        "start_time": "2026-04-25T14:00:00Z",
+        "end_time": "2026-04-25T15:00:00Z",
+        "title": "Test event task",
+    })
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert "14:00" in data["start_time"] or "14" in data["start_time"]
+
+
+async def test_post_event_404_unknown_task(api_client, conn):
+    resp = await api_client.post("/api/events", json={
+        "task_id": "00000000-0000-0000-0000-000000000099",
+        "start_time": "2026-04-25T09:00:00Z",
+        "end_time": "2026-04-25T10:00:00Z",
+        "title": "Ghost",
+    })
+    assert resp.status_code == 404
+
+
+async def test_post_event_422_missing_fields(api_client, conn):
+    resp = await api_client.post("/api/events", json={"task_id": "abc"})
+    assert resp.status_code == 422
+
+
+# ─── GET /api/events ──────────────────────────────────────────────────────────
+
+async def test_get_events_returns_promoted_task(api_client, conn):
+    task_id = await _insert_task(conn, "Calendar task")
+
+    await api_client.post("/api/events", json={
+        "task_id": task_id,
+        "start_time": "2026-05-01T10:00:00Z",
+        "end_time": "2026-05-01T11:00:00Z",
+        "title": "Calendar task",
+    })
+
+    resp = await api_client.get("/api/events?start=2026-05-01T00:00:00Z&end=2026-05-01T23:59:59Z")
+    assert resp.status_code == 200, resp.text
+    events = resp.json()
+    assert isinstance(events, list)
+    ids = [e["id"] for e in events]
+    assert task_id in ids
+
+
+async def test_get_events_empty_outside_range(api_client, conn):
+    task_id = await _insert_task(conn, "Out of range task")
+    await api_client.post("/api/events", json={
+        "task_id": task_id,
+        "start_time": "2026-05-01T10:00:00Z",
+        "end_time": "2026-05-01T11:00:00Z",
+        "title": "Out of range task",
+    })
+
+    resp = await api_client.get("/api/events?start=2026-06-01T00:00:00Z&end=2026-06-30T23:59:59Z")
+    assert resp.status_code == 200
+    events = resp.json()
+    ids = [e["id"] for e in events]
+    assert task_id not in ids


### PR DESCRIPTION
## Summary

- **Root cause**: `POST /api/events` returned 405 (no handler). `GET /api/events` also missing.
- **Design**: Per the integration data model (migration `a1b2c3d4e5f6`), tasks with `start_time`/`end_time` set *are* the calendar event entity — no separate table needed.

## Changes

**`db/pg_queries/tasks.py`**
- `promote_task_to_event(conn, task_uuid, start_time, end_time)` — UPDATEs an existing task with start/end time and sets `source = 'tether'` if not already set. Returns CalendarEvent-shaped dict.
- `get_events_for_range(conn, start, end)` — SELECTs tasks with `start_time IS NOT NULL` within [start, end], ordered by start_time.
- `_row_to_event(row)` — maps task columns to the `CalendarEvent` frontend type shape.

**`api/routes/events.py`** (new)
- `POST /api/events` — body: `{ task_id, start_time, end_time, title? }`. Returns 201 with CalendarEvent. 404 if task_id unknown.
- `GET /api/events?start=ISO&end=ISO` — returns CalendarEvent[].

**`api/main.py`** — registers events router under `/api`.

**`db/pg_queries/__init__.py`** — exports new query functions.

## Request/Response Schema

```
POST /api/events
{ "task_id": "uuid", "start_time": "ISO 8601", "end_time": "ISO 8601", "title": "string (optional)" }
→ 201 { "id": "uuid", "title": "...", "start_time": "ISO", "end_time": "ISO", "source": "tether", "external_id": null, "task_id": "uuid", "anchor_id": null|"uuid", "color": null }

GET /api/events?start=ISO&end=ISO
→ 200 CalendarEvent[]
```

## Test plan
- [ ] `tests/api/test_events_routes.py` — 6 tests (skip without DATABASE_URL, same pattern as all other API tests)
- [ ] POST promotes task: returns 201 with full CalendarEvent shape
- [ ] POST is idempotent: calling twice updates the time slot
- [ ] POST 404 on unknown task_id
- [ ] POST 422 on missing required fields
- [ ] GET returns promoted task within date range
- [ ] GET excludes events outside date range