### PR TITLE
fix(security): parse Meet URL hostname instead of substring match

### DIFF
--- a/integrations/google_calendar/mapping.py
+++ b/integrations/google_calendar/mapping.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime, timedelta, timezone
+from urllib.parse import urlparse
 
 from integrations.models import TaskDraft
 
@@ -52,12 +53,21 @@ def _parse_dt(dt_field: dict | None) -> datetime | None:
     return None
 
 
+def _is_meet_link(url: str) -> bool:
+    """Return True only if url's hostname is exactly meet.google.com."""
+    try:
+        parsed = urlparse(url)
+        return parsed.scheme in ("https", "http") and parsed.netloc == "meet.google.com"
+    except Exception:
+        return False
+
+
 def _conference_url(event: dict) -> str | None:
     """Return the first Meet/video link from conferenceData, if any."""
     conf = event.get("conferenceData", {})
     for ep in conf.get("entryPoints", []):
         uri = ep.get("uri", "")
-        if uri.startswith("https://meet.google.com") or ep.get("entryPointType") == "video":
+        if _is_meet_link(uri) or ep.get("entryPointType") == "video":
             return uri
     return None
 

--- a/tests/integrations/test_gcal_mapping.py
+++ b/tests/integrations/test_gcal_mapping.py
@@ -1,0 +1,77 @@
+"""Tests for integrations/google_calendar/mapping.py — URL parsing, event mapping."""
+from __future__ import annotations
+
+import pytest
+from integrations.google_calendar.mapping import map_event, _conference_url
+
+
+# ── _conference_url — Meet link extraction ────────────────────────────────────
+
+def _make_event(uri: str, entry_point_type: str = "video") -> dict:
+    return {
+        "conferenceData": {
+            "entryPoints": [{"uri": uri, "entryPointType": entry_point_type}]
+        }
+    }
+
+
+def test_valid_meet_link_accepted():
+    event = _make_event("https://meet.google.com/abc-defg-hij")
+    assert _conference_url(event) == "https://meet.google.com/abc-defg-hij"
+
+
+def test_spoofed_meet_link_in_query_param_rejected():
+    """https://evil.com?r=https://meet.google.com must NOT match — hostname is evil.com.
+
+    Uses entryPointType='phone' to isolate the Meet hostname check (video type
+    accepts any URI by design — the spoof is specifically about faking a Meet URL).
+    """
+    event = _make_event("https://evil.com?r=https://meet.google.com", entry_point_type="phone")
+    assert _conference_url(event) is None
+
+
+def test_spoofed_meet_link_as_subdomain_rejected():
+    """https://meet.google.com.evil.com must NOT match — startswith would accept this."""
+    event = _make_event("https://meet.google.com.evil.com/trap", entry_point_type="phone")
+    assert _conference_url(event) is None
+
+
+def test_http_meet_link_accepted():
+    """http:// scheme is also valid (non-HTTPS Meet links are rare but permitted)."""
+    event = _make_event("http://meet.google.com/xyz")
+    assert _conference_url(event) == "http://meet.google.com/xyz"
+
+
+def test_non_meet_video_endpoint_accepted_by_type():
+    """Non-Meet video entry points (e.g. Zoom) are accepted via entryPointType==video."""
+    event = _make_event("https://zoom.us/j/12345", entry_point_type="video")
+    assert _conference_url(event) == "https://zoom.us/j/12345"
+
+
+def test_no_conference_data_returns_none():
+    assert _conference_url({}) is None
+
+
+def test_empty_entry_points_returns_none():
+    assert _conference_url({"conferenceData": {"entryPoints": []}}) is None
+
+
+# ── map_event — conference URL flows through to external_url ──────────────────
+
+def test_map_event_spoofed_meet_url_not_used_as_external_url():
+    """A spoofed Meet URL in conferenceData must not appear as external_url."""
+    raw = {
+        "summary": "Evil meeting",
+        "id": "evil-id",
+        "start": {"dateTime": "2026-04-24T10:00:00+00:00"},
+        "end": {"dateTime": "2026-04-24T11:00:00+00:00"},
+        "conferenceData": {
+            "entryPoints": [
+                {"uri": "https://meet.google.com.evil.com/trap", "entryPointType": "phone"}
+            ]
+        },
+        "htmlLink": "https://calendar.google.com/event?eid=safe",
+    }
+    draft = map_event(raw)
+    # Should fall back to htmlLink, not the spoofed URI
+    assert draft.external_url == "https://calendar.google.com/event?eid=safe"


### PR DESCRIPTION
## Summary

Same CodeQL fix as PR #179 (feature/gcal-integration), cherry-picked to this branch.

- Replaces `uri.startswith("https://meet.google.com")` in `_conference_url()` with `_is_meet_link()` using `urlparse` hostname check
- `parsed.netloc == "meet.google.com"` rejects subdomain spoofs (`meet.google.com.evil.com`) and query-param spoofs (`evil.com?r=https://meet.google.com`)
- Adds `tests/integrations/test_gcal_mapping.py` (8 tests, no DB dependency)

## Test plan

- [ ] `test_valid_meet_link_accepted`
- [ ] `test_spoofed_meet_link_in_query_param_rejected`
- [ ] `test_spoofed_meet_link_as_subdomain_rejected`
- [ ] `test_http_meet_link_accepted`
- [ ] `test_non_meet_video_endpoint_accepted_by_type`
- [ ] `test_no_conference_data_returns_none` / `test_empty_entry_points_returns_none`
- [ ] `test_map_event_spoofed_meet_url_not_used_as_external_url`

309 passed, 0 failed locally.