### PR TITLE
fix: drag-to-create and TaskDetailPanel calendar time section

### DIFF
--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -7,6 +7,7 @@ import { usePlanStore } from '../stores/plan'
 import { useMilestoneStore } from '../stores/milestones'
 import { useAnchorStore } from '../stores/anchors'
 import { useBacklogStore } from '../stores/backlog'
+import { useEventStore } from '../stores/events'
 import { useSubtasks } from '../composables/useSubtasks'
 import { useLinks } from '../composables/useLinks'
 import { useDependencies } from '../composables/useDependencies'
@@ -21,6 +22,10 @@ const planStore = usePlanStore()
 const milestoneStore = useMilestoneStore()
 const anchorStore = useAnchorStore()
 const backlogStore = useBacklogStore()
+const eventStore = useEventStore()
+
+// Calendar event linked to this task (if it has been scheduled on the calendar)
+const taskEvent = computed(() => eventStore.events.find(e => e.task_id === props.taskId) ?? null)
 
 // Find the task from the plan OR from the backlog
 const taskAndAnchor = computed(() => {
@@ -275,6 +280,31 @@ function depLabel(type: string, entityId: string): string {
   return entityId.slice(0, 8) + '…'
 }
 
+// Calendar time helpers — convert ISO ↔ datetime-local input value (YYYY-MM-DDTHH:MM)
+function isoToDatetimeLocal(iso: string): string {
+  const d = new Date(iso)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+async function onCalendarStartChange(e: Event) {
+  if (!taskEvent.value) return
+  const val = (e.target as HTMLInputElement).value
+  if (!val) return
+  const newStart = new Date(val).toISOString()
+  // Preserve original duration
+  const dur = new Date(taskEvent.value.end_time).getTime() - new Date(taskEvent.value.start_time).getTime()
+  const newEnd = new Date(new Date(val).getTime() + dur).toISOString()
+  await eventStore.moveEvent(taskEvent.value.id, newStart, newEnd)
+}
+
+async function onCalendarEndChange(e: Event) {
+  if (!taskEvent.value) return
+  const val = (e.target as HTMLInputElement).value
+  if (!val) return
+  await eventStore.moveEvent(taskEvent.value.id, taskEvent.value.start_time, new Date(val).toISOString())
+}
+
 onMounted(async () => {
   if (!planStore.plan) await planStore.fetchPlan()
   if (!milestoneStore.all.length) await milestoneStore.fetchAll()
@@ -332,6 +362,34 @@ onMounted(async () => {
             <option value="skipped">Skipped</option>
             <option value="blocked">Blocked</option>
           </select>
+        </div>
+
+        <!-- Calendar -->
+        <div class="flex flex-col gap-2">
+          <span class="text-xs text-white/50 uppercase tracking-wide">Calendar</span>
+          <template v-if="taskEvent">
+            <div class="flex flex-col gap-2">
+              <label class="flex flex-col gap-0.5">
+                <span class="text-xs text-white/40">Start</span>
+                <input
+                  type="datetime-local"
+                  :value="isoToDatetimeLocal(taskEvent.start_time)"
+                  @change="onCalendarStartChange"
+                  class="bg-gray-800 text-white text-sm rounded px-2 py-1 border border-white/20 outline-none focus:border-white/40" />
+              </label>
+              <label class="flex flex-col gap-0.5">
+                <span class="text-xs text-white/40">End</span>
+                <input
+                  type="datetime-local"
+                  :value="isoToDatetimeLocal(taskEvent.end_time)"
+                  @change="onCalendarEndChange"
+                  class="bg-gray-800 text-white text-sm rounded px-2 py-1 border border-white/20 outline-none focus:border-white/40" />
+              </label>
+            </div>
+          </template>
+          <template v-else>
+            <div class="text-xs text-white/30 italic">Not on calendar — drag it onto the time grid to schedule</div>
+          </template>
         </div>
 
         <!-- Schedule / Location -->

--- a/frontend/src/stores/__tests__/events.test.ts
+++ b/frontend/src/stores/__tests__/events.test.ts
@@ -40,36 +40,53 @@ describe('useEventStore', () => {
     await expect(store.moveEvent('nonexistent', '2024-01-01T00:00:00Z', '2024-01-01T01:00:00Z')).resolves.toBeUndefined()
   })
 
-  it('createEvent adds a local optimistic event when backend returns 4xx', async () => {
+  it('createTaskAndPromote returns null when task creation fails', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({ ok: false, json: async () => ({}) } as any)
     const { useEventStore } = await import('../events')
     const store = useEventStore()
-    const result = await store.createEvent('2024-06-10T09:00:00Z', '2024-06-10T10:00:00Z', 'New Event')
-    expect(result).not.toBeNull()
-    expect(store.events).toHaveLength(1)
-    expect(store.events[0].title).toBe('New Event')
-    expect(store.events[0].start_time).toBe('2024-06-10T09:00:00Z')
-    expect(store.events[0].source).toBe('tether')
-    expect(store.events[0].task_id).toBeNull()
+    const result = await store.createTaskAndPromote('2024-06-10T09:00:00Z', '2024-06-10T10:00:00Z')
+    expect(result).toBeNull()
+    expect(store.events).toHaveLength(0)
   })
 
-  it('createEvent uses server response when backend returns 2xx', async () => {
+  it('createTaskAndPromote returns taskId and adds event when both steps succeed', async () => {
     const { api } = await import('../../lib/api')
+    const mockTask = { id: 'task-123', text: 'New Event', status: 'pending' }
     const mockEvent = {
-      id: 'server-id',
+      id: 'ev-456',
       title: 'New Event',
       start_time: '2024-06-10T09:00:00Z',
       end_time: '2024-06-10T10:00:00Z',
       source: 'tether',
       external_id: null,
-      task_id: null,
+      task_id: 'task-123',
       anchor_id: null,
       color: null,
     }
-    vi.mocked(api).mockResolvedValueOnce({ ok: true, json: async () => mockEvent } as any)
+    vi.mocked(api)
+      .mockResolvedValueOnce({ ok: true, json: async () => mockTask } as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => mockEvent } as any)
     const { useEventStore } = await import('../events')
     const store = useEventStore()
-    const result = await store.createEvent('2024-06-10T09:00:00Z', '2024-06-10T10:00:00Z', 'New Event')
-    expect(result?.id).toBe('server-id')
-    expect(store.events[0].id).toBe('server-id')
+    const result = await store.createTaskAndPromote('2024-06-10T09:00:00Z', '2024-06-10T10:00:00Z')
+    expect(result).toBe('task-123')
+    expect(store.events).toHaveLength(1)
+    expect(store.events[0].task_id).toBe('task-123')
+    expect(store.events[0].id).toBe('ev-456')
+  })
+
+  it('createTaskAndPromote still returns taskId if event promotion fails', async () => {
+    const { api } = await import('../../lib/api')
+    const mockTask = { id: 'task-789', text: 'New Event', status: 'pending' }
+    vi.mocked(api)
+      .mockResolvedValueOnce({ ok: true, json: async () => mockTask } as any)
+      .mockResolvedValueOnce({ ok: false, json: async () => ({}) } as any)
+    const { useEventStore } = await import('../events')
+    const store = useEventStore()
+    const result = await store.createTaskAndPromote('2024-06-10T09:00:00Z', '2024-06-10T10:00:00Z')
+    expect(result).toBe('task-789')
+    // Event not added to store since promotion failed
+    expect(store.events).toHaveLength(0)
   })
 })

--- a/frontend/src/stores/events.ts
+++ b/frontend/src/stores/events.ts
@@ -79,37 +79,40 @@ export const useEventStore = defineStore('events', () => {
   }
 
   /**
-   * Create a new standalone event by drag-to-create on the time grid.
-   * POST /api/events with no task_id — if the backend rejects (e.g. task_id required),
-   * falls back to a fully optimistic local event.
+   * Drag-to-create: creates a real unscheduled task then immediately promotes it
+   * to a calendar event. Returns the new task's ID so the caller can open its
+   * detail panel. Returns null if either step fails.
    */
-  async function createEvent(startTime: string, endTime: string, title: string): Promise<CalendarEvent | null> {
+  async function createTaskAndPromote(startTime: string, endTime: string): Promise<string | null> {
+    // Step 1 — create a real unscheduled task
+    let taskId: string
     try {
-      const resp = await api('/api/events', {
+      const taskResp = await api('/api/tasks/unscheduled', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ start_time: startTime, end_time: endTime, title, task_id: null }),
+        body: JSON.stringify({ text: 'New Event', status: 'pending' }),
       })
-      if (resp.ok) {
-        const event: CalendarEvent = await resp.json()
-        events.value.push(event)
-        return event
-      }
-    } catch { /* fall through */ }
-    // Optimistic local insert — backend may not support taskless events yet
-    const optimistic: CalendarEvent = {
-      id: crypto.randomUUID?.() ?? (Math.random().toString(36).slice(2) + Date.now().toString(36)),
-      title,
-      start_time: startTime,
-      end_time: endTime,
-      source: 'tether',
-      external_id: null,
-      task_id: null,
-      anchor_id: null,
-      color: null,
+      if (!taskResp.ok) return null
+      const task = await taskResp.json()
+      taskId = task.id
+    } catch {
+      return null
     }
-    events.value.push(optimistic)
-    return optimistic
+
+    // Step 2 — promote the task to a calendar event
+    try {
+      const eventResp = await api('/api/events', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ task_id: taskId, start_time: startTime, end_time: endTime }),
+      })
+      if (eventResp.ok) {
+        const event: CalendarEvent = await eventResp.json()
+        events.value.push(event)
+      }
+    } catch { /* event promotion failed — task exists but isn't on calendar yet */ }
+
+    return taskId
   }
 
   /**
@@ -123,5 +126,5 @@ export const useEventStore = defineStore('events', () => {
     events.value = events.value.filter(e => e.id !== eventId)
   }
 
-  return { events, loading, error, fetchEvents, promoteTask, createEvent, moveEvent, demoteEvent }
+  return { events, loading, error, fetchEvents, promoteTask, createTaskAndPromote, moveEvent, demoteEvent }
 })

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -171,7 +171,10 @@ async function onWindowMouseup(e: MouseEvent) {
     const endDate = new Date(state.dayKey + 'T00:00:00')
     endDate.setHours(endHour, endMin, 0, 0)
 
-    await eventStore.createEvent(startDate.toISOString(), endDate.toISOString(), 'New Event')
+    const taskId = await eventStore.createTaskAndPromote(startDate.toISOString(), endDate.toISOString())
+    if (taskId) {
+      pushPanel({ kind: 'task', entityId: taskId })
+    }
     return
   }
 }


### PR DESCRIPTION
## Summary

- **`createTaskAndPromote` store action** — replaces the broken `createEvent` (which tried `POST /api/events` with `task_id: null`, rejected by backend). New action does the correct 2-step sequence: (1) `POST /api/tasks/unscheduled` to create a real task, (2) `POST /api/events` to promote it; returns the `taskId` so the caller can open the detail panel. Returns `null` if task creation fails; still returns `taskId` if event promotion fails (task exists, just not yet on calendar).
- **Drag-to-create mouseup handler** — updated to call `createTaskAndPromote`, then immediately calls `pushPanel({ kind: 'task', entityId: taskId })` so the user can rename the event and fill in details.
- **Calendar section in `TaskDetailPanel`** — added after the Status section. If the task has an associated event (`eventStore.events.find(e => e.task_id === taskId)`), shows editable `datetime-local` start/end inputs; changes call `eventStore.moveEvent()`. If no event, shows "Not on calendar — drag it onto the time grid to schedule".

## Root cause of the "task not found" bug

The old `createEvent` created a `CalendarEvent` with `task_id: null`. When clicking that event block, `openEventPanel` tried `pushPanel({ kind: 'task', entityId: event.task_id })` with a null ID — hence "task not found". Fixing the creation sequence (real task first) eliminates this entirely.

## Test plan

- [ ] `npm run test` — 92/92 pass ✅
- [ ] `npm run build` — zero TypeScript errors ✅
- [ ] Drag on empty calendar column → creates event block + immediately opens TaskDetailPanel named "New Event"
- [ ] TaskDetailPanel Calendar section shows start/end inputs for the dragged event
- [ ] Editing start time preserves event duration; editing end time moves end independently
- [ ] Tasks without calendar events show "Not on calendar" in the Calendar section