### PR TITLE
feat(frontend): Google Calendar integration UI in Settings

### DIFF
--- a/frontend/src/components/GoogleCalendarSection.vue
+++ b/frontend/src/components/GoogleCalendarSection.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useIntegrationsStore } from '../stores/integrations'
+
+const store = useIntegrationsStore()
+
+onMounted(() => {
+  store.fetchGCalStatus()
+})
+</script>
+
+<template>
+  <section class="mb-8">
+    <h2 class="text-sm font-semibold text-white/50 uppercase tracking-wider mb-3">Google Calendar</h2>
+    <div class="bg-gray-800 rounded-xl p-4">
+      <!-- Status row -->
+      <div class="flex items-center justify-between mb-4">
+        <div class="flex items-center gap-2">
+          <!-- Google Calendar icon -->
+          <svg class="w-5 h-5 flex-shrink-0" viewBox="0 0 24 24" aria-hidden="true">
+            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+          </svg>
+          <div>
+            <div class="text-sm font-medium text-white">Google Calendar</div>
+            <div v-if="store.gcalConnected" class="text-xs text-green-400 flex items-center gap-1">
+              <span>✓</span>
+              <span>Connected</span>
+            </div>
+            <div v-else class="text-xs text-white/40">Not connected</div>
+          </div>
+        </div>
+
+        <!-- Action button -->
+        <button
+          v-if="store.gcalConnected"
+          data-testid="gcal-disconnect"
+          :disabled="store.loading"
+          @click="store.disconnectGCal()"
+          class="text-sm text-red-400 hover:text-red-300 disabled:opacity-50 border border-red-400/30 hover:border-red-300/50 rounded-lg px-3 py-1.5 transition-colors"
+        >
+          {{ store.loading ? '…' : 'Disconnect' }}
+        </button>
+        <button
+          v-else
+          data-testid="gcal-connect"
+          :disabled="store.loading"
+          @click="store.connectGCal()"
+          class="text-sm bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white font-medium rounded-lg px-3 py-1.5 transition-colors"
+        >
+          {{ store.loading ? '…' : 'Connect' }}
+        </button>
+      </div>
+
+      <!-- Info text when not connected -->
+      <p v-if="!store.gcalConnected" class="text-xs text-white/40">
+        Connect your Google Calendar to see events alongside your Tether tasks.
+      </p>
+
+      <!-- Error message -->
+      <p v-if="store.error" class="text-xs text-red-400 mt-2">{{ store.error }}</p>
+    </div>
+  </section>
+</template>

--- a/frontend/src/components/__tests__/GoogleCalendarSection.test.ts
+++ b/frontend/src/components/__tests__/GoogleCalendarSection.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ path: '/settings' }),
+}))
+
+// Mock the integrations store module
+vi.mock('../../stores/integrations', () => ({
+  useIntegrationsStore: vi.fn(),
+}))
+
+import { useIntegrationsStore } from '../../stores/integrations'
+
+function makeStore(overrides: Partial<{
+  gcalConnected: boolean
+  loading: boolean
+  error: string | null
+  fetchGCalStatus: () => Promise<void>
+  connectGCal: () => void
+  disconnectGCal: () => Promise<void>
+}> = {}) {
+  return {
+    gcalConnected: false,
+    loading: false,
+    error: null,
+    fetchGCalStatus: vi.fn().mockResolvedValue(undefined),
+    connectGCal: vi.fn(),
+    disconnectGCal: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+describe('GoogleCalendarSection', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(useIntegrationsStore).mockReturnValue(makeStore() as any)
+  })
+
+  it('mounts without error', async () => {
+    const { default: GoogleCalendarSection } = await import('../GoogleCalendarSection.vue')
+    const wrapper = mount(GoogleCalendarSection)
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('shows "Not connected" status when gcalConnected is false', async () => {
+    vi.mocked(useIntegrationsStore).mockReturnValue(makeStore({ gcalConnected: false }) as any)
+    const { default: GoogleCalendarSection } = await import('../GoogleCalendarSection.vue')
+    const wrapper = mount(GoogleCalendarSection)
+    expect(wrapper.text()).toContain('Not connected')
+  })
+
+  it('shows "Connected" status when gcalConnected is true', async () => {
+    vi.mocked(useIntegrationsStore).mockReturnValue(makeStore({ gcalConnected: true }) as any)
+    const { default: GoogleCalendarSection } = await import('../GoogleCalendarSection.vue')
+    const wrapper = mount(GoogleCalendarSection)
+    expect(wrapper.text()).toContain('Connected')
+  })
+
+  it('shows a Connect button when not connected', async () => {
+    vi.mocked(useIntegrationsStore).mockReturnValue(makeStore({ gcalConnected: false }) as any)
+    const { default: GoogleCalendarSection } = await import('../GoogleCalendarSection.vue')
+    const wrapper = mount(GoogleCalendarSection)
+    const btn = wrapper.find('[data-testid="gcal-connect"]')
+    expect(btn.exists()).toBe(true)
+    expect(btn.text()).toContain('Connect')
+  })
+
+  it('shows a Disconnect button when connected', async () => {
+    vi.mocked(useIntegrationsStore).mockReturnValue(makeStore({ gcalConnected: true }) as any)
+    const { default: GoogleCalendarSection } = await import('../GoogleCalendarSection.vue')
+    const wrapper = mount(GoogleCalendarSection)
+    const btn = wrapper.find('[data-testid="gcal-disconnect"]')
+    expect(btn.exists()).toBe(true)
+    expect(btn.text()).toContain('Disconnect')
+  })
+
+  it('calls connectGCal when Connect button is clicked', async () => {
+    const connectGCal = vi.fn()
+    vi.mocked(useIntegrationsStore).mockReturnValue(makeStore({ gcalConnected: false, connectGCal }) as any)
+    const { default: GoogleCalendarSection } = await import('../GoogleCalendarSection.vue')
+    const wrapper = mount(GoogleCalendarSection)
+    await wrapper.find('[data-testid="gcal-connect"]').trigger('click')
+    expect(connectGCal).toHaveBeenCalledOnce()
+  })
+
+  it('calls disconnectGCal when Disconnect button is clicked', async () => {
+    const disconnectGCal = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(useIntegrationsStore).mockReturnValue(makeStore({ gcalConnected: true, disconnectGCal }) as any)
+    const { default: GoogleCalendarSection } = await import('../GoogleCalendarSection.vue')
+    const wrapper = mount(GoogleCalendarSection)
+    await wrapper.find('[data-testid="gcal-disconnect"]').trigger('click')
+    expect(disconnectGCal).toHaveBeenCalledOnce()
+  })
+
+  it('calls fetchGCalStatus on mount', async () => {
+    const fetchGCalStatus = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(useIntegrationsStore).mockReturnValue(makeStore({ fetchGCalStatus }) as any)
+    const { default: GoogleCalendarSection } = await import('../GoogleCalendarSection.vue')
+    mount(GoogleCalendarSection)
+    expect(fetchGCalStatus).toHaveBeenCalledOnce()
+  })
+
+  it('shows loading state during operations', async () => {
+    vi.mocked(useIntegrationsStore).mockReturnValue(makeStore({ loading: true }) as any)
+    const { default: GoogleCalendarSection } = await import('../GoogleCalendarSection.vue')
+    const wrapper = mount(GoogleCalendarSection)
+    // Buttons should be disabled during loading
+    const buttons = wrapper.findAll('button')
+    const disabledBtn = buttons.find(b => (b.element as HTMLButtonElement).disabled)
+    expect(disabledBtn).toBeDefined()
+  })
+})

--- a/frontend/src/stores/__tests__/integrations.test.ts
+++ b/frontend/src/stores/__tests__/integrations.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: false, json: async () => ({}) })),
+}))
+
+describe('useIntegrationsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.restoreAllMocks()
+  })
+
+  describe('fetchGCalStatus', () => {
+    it('sets connected to true when calendars endpoint returns 200', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ calendars: [], selected_calendar_ids: [] }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.fetchGCalStatus()
+
+      expect(store.gcalConnected).toBe(true)
+    })
+
+    it('sets connected to false when calendars endpoint returns 404', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ detail: 'Google Calendar not connected' }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.fetchGCalStatus()
+
+      expect(store.gcalConnected).toBe(false)
+    })
+
+    it('sets connected to false when calendars endpoint returns 401', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: async () => ({ detail: 'Google token expired — reconnect' }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.fetchGCalStatus()
+
+      expect(store.gcalConnected).toBe(false)
+    })
+
+    it('sets loading to false after fetch completes', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ calendars: [], selected_calendar_ids: [] }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.fetchGCalStatus()
+
+      expect(store.loading).toBe(false)
+    })
+
+    it('sets connected to false on network error', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockRejectedValueOnce(new Error('Network error'))
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.fetchGCalStatus()
+
+      expect(store.gcalConnected).toBe(false)
+      expect(store.loading).toBe(false)
+    })
+  })
+
+  describe('disconnectGCal', () => {
+    it('sets connected to false after successful disconnect', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      store.gcalConnected = true
+      await store.disconnectGCal()
+
+      expect(store.gcalConnected).toBe(false)
+    })
+
+    it('calls POST /api/integrations/google/disconnect', async () => {
+      const { api } = await import('../../lib/api')
+      const mockApi = vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.disconnectGCal()
+
+      expect(mockApi).toHaveBeenCalledWith(
+        '/api/integrations/google/disconnect',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+
+    it('keeps connected true if disconnect request fails', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ detail: 'Error' }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      store.gcalConnected = true
+      await store.disconnectGCal()
+
+      expect(store.gcalConnected).toBe(true)
+    })
+  })
+
+  describe('connectGCal', () => {
+    it('navigates to the Google Calendar OAuth URL', async () => {
+      // happy-dom allows direct assignment to window.location.href
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      store.connectGCal()
+
+      expect(window.location.href).toContain('/api/integrations/google/connect')
+    })
+  })
+})

--- a/frontend/src/stores/integrations.ts
+++ b/frontend/src/stores/integrations.ts
@@ -1,0 +1,57 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { api } from '../lib/api'
+
+export const useIntegrationsStore = defineStore('integrations', () => {
+  const gcalConnected = ref(false)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  /**
+   * Check Google Calendar connection status.
+   * Uses GET /api/integrations/google/calendars as a proxy:
+   * - 200 → connected
+   * - 404 / 401 / network error → not connected
+   */
+  async function fetchGCalStatus() {
+    loading.value = true
+    error.value = null
+    try {
+      const resp = await api('/api/integrations/google/calendars')
+      gcalConnected.value = resp.ok
+    } catch {
+      gcalConnected.value = false
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /**
+   * Initiate Google Calendar OAuth flow.
+   * Navigates the page to the backend OAuth redirect endpoint.
+   */
+  function connectGCal() {
+    window.location.href = '/api/integrations/google/connect'
+  }
+
+  /**
+   * Disconnect Google Calendar integration.
+   * POST /api/integrations/google/disconnect — revokes tokens and deletes the row.
+   */
+  async function disconnectGCal() {
+    loading.value = true
+    error.value = null
+    try {
+      const resp = await api('/api/integrations/google/disconnect', { method: 'POST' })
+      if (resp.ok) {
+        gcalConnected.value = false
+      }
+    } catch {
+      // Leave connected state unchanged on network error
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { gcalConnected, loading, error, fetchGCalStatus, connectGCal, disconnectGCal }
+})

--- a/frontend/src/stores/integrations.ts
+++ b/frontend/src/stores/integrations.ts
@@ -21,6 +21,7 @@ export const useIntegrationsStore = defineStore('integrations', () => {
       gcalConnected.value = resp.ok
     } catch {
       gcalConnected.value = false
+      error.value = 'Could not reach server. Check your connection.'
     } finally {
       loading.value = false
     }
@@ -47,7 +48,7 @@ export const useIntegrationsStore = defineStore('integrations', () => {
         gcalConnected.value = false
       }
     } catch {
-      // Leave connected state unchanged on network error
+      error.value = 'Failed to disconnect. Please try again.'
     } finally {
       loading.value = false
     }

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from 'vue'
 import { useAuthStore } from '../stores/auth'
 import { api } from '../lib/api'
+import GoogleCalendarSection from '../components/GoogleCalendarSection.vue'
 
 const auth = useAuthStore()
 
@@ -257,6 +258,9 @@ async function linkTelegram() {
           </template>
         </div>
       </section>
+
+      <!-- Google Calendar Integration -->
+      <GoogleCalendarSection />
 
       <!-- OAuth Connections -->
       <section class="mb-8">


### PR DESCRIPTION
## Summary

- Adds `useIntegrationsStore` (Pinia, Composition API) with `fetchGCalStatus`, `connectGCal`, and `disconnectGCal` actions
- Adds `GoogleCalendarSection.vue` component showing connected/not-connected status with Connect/Disconnect buttons
- Wires the component into `SettingsView` between the Telegram and OAuth sections

## API contract used

Routes match `api/routes/integrations.py` (not the task description placeholders):
- Status check: `GET /api/integrations/google/calendars` (200 = connected, 404/401 = not connected)
- Connect: navigate to `GET /api/integrations/google/connect` (OAuth redirect)
- Disconnect: `POST /api/integrations/google/disconnect`

**Degraded UX note:** No `/status` endpoint or `last_synced_at` field exists in the current backend. The UI shows "Connected" / "Not connected" only — no account email or last-synced timestamp. Once a backend status endpoint lands, this can be enriched.

## Test plan

- [x] 9 unit tests for `useIntegrationsStore` (fetchStatus 200/404/401/network, disconnect success/failure, connectGCal URL)
- [x] 9 unit tests for `GoogleCalendarSection.vue` (mount, connected state, not-connected state, connect/disconnect buttons, loading disabled, fetchStatus on mount)
- [x] `npm run build` produces zero type errors
- [x] All 110 tests pass (16 test files)