### PR TITLE
fix: Dockerfile pip timeout, sync import, deploy-sync workflow

### DIFF
--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -1,0 +1,98 @@
+name: Deploy Sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'sync/**'
+      - 'integrations/**'
+      - 'db/**'
+      - 'config/**'
+      - 'Dockerfile'
+      - 'requirements.txt'
+      - 'pyproject.toml'
+  workflow_dispatch:
+    inputs:
+      no_cache:
+        description: "Force --no-cache build"
+        required: false
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pi-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy-sync:
+    name: Build and deploy sync service
+    runs-on: self-hosted
+    steps:
+      - name: Pull latest code
+        run: |
+          cd /home/toast/tether
+          git pull origin main
+
+      - name: Resolve version tag
+        id: version
+        run: |
+          SHA_TAG="sha-$(echo ${GITHUB_SHA} | cut -c1-7)"
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            SEMVER="${GITHUB_REF#refs/tags/}"
+            echo "tag=${SEMVER}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Resolve premium ref
+        id: premium
+        env:
+          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
+        run: |
+          REF=$(git ls-remote \
+            "https://${TETHER_PREMIUM_TOKEN}@github.com/jlunder00/tether-premium.git" \
+            HEAD | cut -f1 | cut -c1-7)
+          if [ -z "$REF" ]; then
+            echo "ERROR: Failed to resolve tether-premium HEAD ref" >&2
+            exit 1
+          fi
+          echo "ref=${REF}" >> $GITHUB_OUTPUT
+
+      - name: Build image
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          PREMIUM_REF: ${{ steps.premium.outputs.ref }}
+          NO_CACHE: ${{ github.event.inputs.no_cache }}
+          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
+        run: |
+          cd /home/toast/tether
+          BUILD_TARGET=$( [ "$NO_CACHE" = "true" ] && echo build-premium-no-cache || echo build-premium )
+          make ${BUILD_TARGET} \
+            IMAGE=tether-premium \
+            TAG=${TAG} \
+            PREMIUM_GIT_TOKEN=${TETHER_PREMIUM_TOKEN} \
+            PREMIUM_REF=${PREMIUM_REF}
+          docker tag tether-premium:${TAG} tether-premium:latest
+          grep -q "^IMAGE_TAG=" /home/toast/tether/.env \
+            && sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${TAG}/" /home/toast/tether/.env \
+            || echo "IMAGE_TAG=${TAG}" >> /home/toast/tether/.env
+
+      - name: Restart sync service
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          cd /home/toast/tether
+          TETHER_IMAGE=tether-premium IMAGE_TAG=${TAG} \
+            docker compose up -d --no-deps sync
+
+      - name: Prune old images (keep 3)
+        run: |
+          docker images tether-premium --format "{{.CreatedAt}}\t{{.ID}}\t{{.Tag}}" \
+            | sort -r \
+            | awk 'NR>3 && $3 != "latest" {print $2}' \
+            | xargs -r docker rmi --force 2>/dev/null || true
+          docker image prune -f

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ ARG PREMIUM_GIT_TOKEN=
 ARG PREMIUM_REF=unknown
 RUN if [ -n "$PREMIUM_GIT_TOKEN" ]; then \
       echo "Installing tether-premium @ ${PREMIUM_REF}" && \
-      pip install --no-cache-dir \
+      pip install --no-cache-dir --timeout 120 --retries 3 \
         "git+https://${PREMIUM_GIT_TOKEN}@github.com/jlunder00/tether-premium.git" && \
       python -c "from tether_premium.register import get_premium_handler; print('[ok] premium loaded')" ; \
     else \

--- a/integrations/google_calendar/sync.py
+++ b/integrations/google_calendar/sync.py
@@ -19,7 +19,6 @@ from datetime import datetime, timedelta, timezone
 import asyncpg
 import httpx
 
-import api.config as cfg
 from db.pg_queries.integrations import (
     get_sync_state,
     soft_delete_task_by_external_id,
@@ -72,6 +71,7 @@ class GoogleCalendarSync(SyncProvider):
         knows how to handle incoming notifications.
         """
         import uuid
+        import api.config as cfg
         access_token = await self._get_access_token(integration_id)
         channel_id = str(uuid.uuid4())
         # Watch channels expire after ~1 week (Google maximum)


### PR DESCRIPTION
## Summary
- Adds `--timeout 120 --retries 3` to the premium `pip install` in Dockerfile to survive transient network drops during build
- Moves `import api.config as cfg` inside `register_webhook()` in `sync.py` — module-level import triggered config validation (requires `JWT_SECRET`) at import time, breaking test environments
- Adds `.github/workflows/deploy-sync.yml` — mirrors `deploy-api.yml` but triggers on `sync/**` / `integrations/**` changes and restarts only the `sync` compose service; no config-write or DB migration steps

## Test plan
- [ ] Docker build completes without pip timeout on flaky network
- [ ] `pytest tests/integrations/test_gcal_sync.py` passes without `JWT_SECRET` set
- [ ] Push to main with a `sync/` change triggers deploy-sync workflow, not deploy-api