### PR TITLE
fix(ci): per-service deploy concurrency groups

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -23,7 +23,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy
+  group: pi-deploy-api
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/deploy-bot.yml
+++ b/.github/workflows/deploy-bot.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy
+  group: pi-deploy-bot
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/deploy-db.yml
+++ b/.github/workflows/deploy-db.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy
+  group: pi-deploy-db
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy
+  group: pi-deploy-frontend
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy
+  group: pi-deploy-mcp
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
Splits the shared \`pi-deploy\` concurrency group into per-service groups (\`pi-deploy-api\`, \`-bot\`, \`-db\`, \`-frontend\`, \`-mcp\`).

## Why
GitHub Actions concurrency groups hold **at most 1 running + 1 pending** job. With \`cancel-in-progress: false\`, a third trigger cancels the *previously-pending* job, not the new one. With all 5 deploy workflows sharing one group, a single push touching multiple service paths triggered 5 workflows but only 2 ever ran — the other 3 were cancelled (shown as "skipped").

## Behavior after merge
- **Within a service**: latest push still wins (deduplication preserved — no point deploying stale code)
- **Across services**: all triggered deploys queue, none get cancelled
- **Serialization**: still preserved by the single self-hosted runner on the Pi (one job at a time at the runner level, independent of concurrency groups). No risk of parallel deploys overloading the Pi.

## Follow-up
\`deploy-sync.yml\` is added in #202 with the old shared \`pi-deploy\` group. After #202 merges, needs a one-line update to \`pi-deploy-sync\` for consistency. (Not done here to keep this PR cleanly off main.)

## Test plan
- [ ] Merge → next multi-service push triggers all matching workflows, all queue, all run sequentially through the runner
- [ ] Two rapid pushes to the same service → only the latest deploy runs