### PR TITLE
fix(ci): per-service group for sync + trigger-all-deploys dispatcher

### DIFF
--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy
+  group: pi-deploy-sync
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/trigger-all-deploys.yml
+++ b/.github/workflows/trigger-all-deploys.yml
@@ -1,0 +1,47 @@
+name: Trigger all per-service deploys
+
+# Fan-out dispatcher: kicks off every per-service deploy workflow.
+# Each runs as its own independent run with its own concurrency group
+# (pi-deploy-<service>) and queues at the runner level. Use this when
+# you want each service redeployed via its normal path-aware workflow.
+#
+# For a single-log, fully-inline rebuild of all services, use
+# force-deploy-all.yml instead.
+
+on:
+  workflow_dispatch:
+    inputs:
+      no_cache:
+        description: "Force --no-cache build"
+        required: false
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  trigger-all:
+    name: Dispatch every service deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger each service deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NO_CACHE: ${{ inputs.no_cache }}
+          REPO: ${{ github.repository }}
+          REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          for wf in deploy-api deploy-bot deploy-mcp deploy-frontend deploy-sync deploy-db; do
+            echo "Dispatching $wf.yml (no_cache=$NO_CACHE, ref=$REF)"
+            gh workflow run "$wf.yml" \
+              --repo "$REPO" \
+              --ref "$REF" \
+              -f no_cache="$NO_CACHE"
+          done
+          echo
+          echo "Dispatched. Each workflow will queue independently and run"
+          echo "sequentially through the single self-hosted runner."


### PR DESCRIPTION
## Summary
- `deploy-sync.yml`: concurrency group `pi-deploy` → `pi-deploy-sync` (follow-up to #203, sync wasn't on main when #203 was authored)
- `trigger-all-deploys.yml`: new lightweight fan-out workflow that dispatches every per-service deploy via `gh workflow run`. Each triggered run uses its own per-service concurrency group; the single Pi runner serializes them.

## Why two "deploy everything" workflows?
- `force-deploy-all.yml` (unchanged): single inline job, single log — useful when you want a clean from-scratch rebuild and a single linear view.
- `trigger-all-deploys.yml` (new): just dispatches the per-service workflows, each runs as its own normal deploy. Better when you want to use each service's standard pipeline (path filters, per-service concurrency, etc).

## Test plan
- [ ] Run `trigger-all-deploys` via Actions tab — confirms 6 deploy workflows queue and execute sequentially through the runner
- [ ] Push touching `sync/**` only — only deploy-sync triggers (per-service group works)