### PR TITLE
feat(api): auto-sync Google Calendar on OAuth callback

### DIFF
--- a/api/routes/integrations.py
+++ b/api/routes/integrations.py
@@ -15,7 +15,7 @@ import logging
 
 import asyncpg
 import httpx
-from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Request
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 
@@ -31,6 +31,7 @@ from integrations.google_calendar.auth import (
     GoogleCalendarAuth,
     verify_oauth_state,
 )
+from integrations.google_calendar.sync import GoogleCalendarSync
 from sync.dispatch import dispatch_sync  # re-exported so tests can monkeypatch at this name
 
 logger = logging.getLogger(__name__)
@@ -71,16 +72,81 @@ async def google_connect(
 # 2. GET /integrations/google/callback (unauthenticated — Google redirects here)
 # ---------------------------------------------------------------------------
 
+async def _initial_sync_and_register(pool: asyncpg.Pool, user_id: str) -> None:
+    """Background task fired immediately after OAuth callback completes.
+
+    For each selected calendar (default ``["primary"]``):
+      * dispatches an initial poll sync via PG NOTIFY so events appear right away,
+      * registers a Google push-notification webhook so future changes flow in.
+
+    Webhook registration is best-effort — the dev tunnel may be down, and
+    failure must not prevent the initial sync from running. Sync dispatch
+    failures are also caught per-calendar so one bad calendar can't starve
+    the rest.
+    """
+    import db.postgres as pg
+
+    async with pg.get_conn(pool, user_id=user_id) as conn:
+        row = await get_integration(conn, user_id, _PROVIDER)
+
+    if row is None:
+        logger.info(
+            "initial_sync_and_register: no integration row for user %s; skipping",
+            user_id,
+        )
+        return
+
+    integration_id = str(row["id"])
+    metadata = row.get("metadata") or {}
+    calendar_ids: list[str] = metadata.get("selected_calendar_ids", ["primary"])
+
+    sync_provider = GoogleCalendarSync(pool)
+
+    for calendar_id in calendar_ids:
+        try:
+            await dispatch_sync(
+                pool,
+                integration_id,
+                calendar_id,
+                provider=_PROVIDER,
+                notify_type="poll",
+            )
+        except Exception:
+            logger.exception(
+                "initial_sync_and_register: dispatch_sync failed for %s/%s",
+                integration_id,
+                calendar_id,
+            )
+
+        try:
+            await sync_provider.register_webhook(integration_id, calendar_id)
+        except Exception:
+            # Webhook registration is best-effort: dev tunnel may be down,
+            # Google may rate-limit, etc. Log and continue.
+            logger.warning(
+                "initial_sync_and_register: register_webhook failed for %s/%s "
+                "(continuing — initial poll sync still scheduled)",
+                integration_id,
+                calendar_id,
+                exc_info=True,
+            )
+
+
 @router.get("/integrations/google/callback")
 async def google_callback(
     request: Request,
     code: str,
     state: str,
+    background_tasks: BackgroundTasks,
 ):
     """Exchange authorization code for tokens and persist them.
 
     User identity is recovered from the signed `state` parameter — no cookie
     is reliably available on this cross-site redirect.
+
+    After persisting tokens, schedules a background task that fires the
+    initial sync and registers the Google push webhook. The redirect to
+    /plan/day is not blocked on either operation.
     """
     try:
         user_id = verify_oauth_state(state)
@@ -95,6 +161,12 @@ async def google_callback(
     except Exception:
         logger.exception("Google Calendar callback failed for user %s", user_id)
         raise HTTPException(status_code=502, detail="Token exchange failed")
+
+    background_tasks.add_task(
+        _initial_sync_and_register,
+        request.app.state.pool,
+        user_id,
+    )
 
     return RedirectResponse("/plan/day")
 

--- a/tests/api/test_integrations.py
+++ b/tests/api/test_integrations.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import urllib.parse
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -442,3 +443,196 @@ async def test_calendars_patch_no_integration_returns_404(api_client):
         json={"calendar_ids": ["primary"]},
     )
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# 8. Callback fires initial sync + webhook registration as background task
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_callback_schedules_initial_sync_background_task(api_client, monkeypatch):
+    """After successful callback, the helper that runs initial sync +
+    webhook registration is dispatched as a FastAPI BackgroundTask."""
+    state = _make_state(TEST_USER_ID)
+
+    # Stub the OAuth token exchange so the callback succeeds without HTTP.
+    async def fake_handle_callback(self, user_id, code):
+        return None
+    monkeypatch.setattr(
+        "api.routes.integrations.GoogleCalendarAuth.handle_callback",
+        fake_handle_callback,
+    )
+
+    called: dict = {}
+
+    async def fake_helper(pool, user_id):
+        called["pool"] = pool
+        called["user_id"] = user_id
+
+    monkeypatch.setattr(
+        "api.routes.integrations._initial_sync_and_register",
+        fake_helper,
+    )
+
+    resp = await api_client.get(
+        f"/api/integrations/google/callback?code=auth_code&state={state}",
+        follow_redirects=False,
+    )
+
+    assert resp.status_code in (302, 307)
+    # Background task must have been dispatched with the user_id from state.
+    assert called.get("user_id") == TEST_USER_ID
+    assert called.get("pool") is not None
+
+
+@pytest.mark.asyncio
+async def test_initial_sync_dispatches_for_each_selected_calendar(monkeypatch):
+    """_initial_sync_and_register dispatches a poll sync per selected calendar
+    and registers a webhook per selected calendar."""
+    from api.routes import integrations as routes
+
+    fake_row = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "metadata": {"selected_calendar_ids": ["primary", "cal2@group.calendar.google.com"]},
+    }
+
+    @asynccontextmanager
+    async def fake_get_conn(pool, user_id=None):
+        yield None
+
+    async def fake_get_integration(conn, user_id, provider):
+        return fake_row
+
+    dispatched: list[dict] = []
+
+    async def fake_dispatch(pool, integration_id, calendar_id, *, provider, notify_type="poll", **extra):
+        dispatched.append({
+            "integration_id": integration_id,
+            "calendar_id": calendar_id,
+            "provider": provider,
+            "notify_type": notify_type,
+        })
+
+    registered: list[tuple] = []
+
+    async def fake_register(self, integration_id, calendar_id):
+        registered.append((integration_id, calendar_id))
+
+    monkeypatch.setattr("db.postgres.get_conn", fake_get_conn)
+    monkeypatch.setattr("api.routes.integrations.get_integration", fake_get_integration)
+    monkeypatch.setattr("api.routes.integrations.dispatch_sync", fake_dispatch)
+    monkeypatch.setattr(
+        "api.routes.integrations.GoogleCalendarSync.register_webhook",
+        fake_register,
+    )
+
+    await routes._initial_sync_and_register(pool=None, user_id=TEST_USER_ID)
+
+    cal_ids = {d["calendar_id"] for d in dispatched}
+    assert cal_ids == {"primary", "cal2@group.calendar.google.com"}
+    assert all(d["provider"] == "google_calendar" for d in dispatched)
+    assert all(d["notify_type"] == "poll" for d in dispatched)
+    reg_ids = {r[1] for r in registered}
+    assert reg_ids == {"primary", "cal2@group.calendar.google.com"}
+
+
+@pytest.mark.asyncio
+async def test_initial_sync_tolerates_webhook_failure(monkeypatch):
+    """register_webhook is best-effort: dispatch still happens and the
+    helper does not raise even if webhook registration blows up."""
+    from api.routes import integrations as routes
+
+    fake_row = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "metadata": {"selected_calendar_ids": ["primary"]},
+    }
+
+    @asynccontextmanager
+    async def fake_get_conn(pool, user_id=None):
+        yield None
+
+    async def fake_get_integration(conn, user_id, provider):
+        return fake_row
+
+    dispatched: list[str] = []
+
+    async def fake_dispatch(pool, integration_id, calendar_id, *, provider, notify_type="poll", **extra):
+        dispatched.append(calendar_id)
+
+    async def fake_register_fail(self, integration_id, calendar_id):
+        raise RuntimeError("tunnel down")
+
+    monkeypatch.setattr("db.postgres.get_conn", fake_get_conn)
+    monkeypatch.setattr("api.routes.integrations.get_integration", fake_get_integration)
+    monkeypatch.setattr("api.routes.integrations.dispatch_sync", fake_dispatch)
+    monkeypatch.setattr(
+        "api.routes.integrations.GoogleCalendarSync.register_webhook",
+        fake_register_fail,
+    )
+
+    # Must not raise.
+    await routes._initial_sync_and_register(pool=None, user_id=TEST_USER_ID)
+    assert dispatched == ["primary"]
+
+
+@pytest.mark.asyncio
+async def test_initial_sync_no_integration_returns_silently(monkeypatch):
+    """If the integration row is missing, helper logs and returns without
+    dispatching or raising."""
+    from api.routes import integrations as routes
+
+    @asynccontextmanager
+    async def fake_get_conn(pool, user_id=None):
+        yield None
+
+    async def fake_get_integration(conn, user_id, provider):
+        return None
+
+    dispatched: list = []
+
+    async def fake_dispatch(*args, **kwargs):
+        dispatched.append(1)
+
+    monkeypatch.setattr("db.postgres.get_conn", fake_get_conn)
+    monkeypatch.setattr("api.routes.integrations.get_integration", fake_get_integration)
+    monkeypatch.setattr("api.routes.integrations.dispatch_sync", fake_dispatch)
+
+    await routes._initial_sync_and_register(pool=None, user_id=TEST_USER_ID)
+    assert dispatched == []
+
+
+@pytest.mark.asyncio
+async def test_initial_sync_defaults_to_primary_when_no_metadata(monkeypatch):
+    """If the integration has no selected_calendar_ids, defaults to ['primary']."""
+    from api.routes import integrations as routes
+
+    fake_row = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "metadata": None,
+    }
+
+    @asynccontextmanager
+    async def fake_get_conn(pool, user_id=None):
+        yield None
+
+    async def fake_get_integration(conn, user_id, provider):
+        return fake_row
+
+    dispatched: list[str] = []
+
+    async def fake_dispatch(pool, integration_id, calendar_id, *, provider, notify_type="poll", **extra):
+        dispatched.append(calendar_id)
+
+    async def fake_register(self, integration_id, calendar_id):
+        pass
+
+    monkeypatch.setattr("db.postgres.get_conn", fake_get_conn)
+    monkeypatch.setattr("api.routes.integrations.get_integration", fake_get_integration)
+    monkeypatch.setattr("api.routes.integrations.dispatch_sync", fake_dispatch)
+    monkeypatch.setattr(
+        "api.routes.integrations.GoogleCalendarSync.register_webhook",
+        fake_register,
+    )
+
+    await routes._initial_sync_and_register(pool=None, user_id=TEST_USER_ID)
+    assert dispatched == ["primary"]


### PR DESCRIPTION
## Summary
- After Google OAuth completes, schedule a FastAPI BackgroundTask that dispatches an initial poll sync for each selected calendar (so events appear immediately) and registers a Google push webhook (so future changes flow in).
- Webhook registration is best-effort — logs and continues if it fails (e.g. dev tunnel down). Initial poll sync still runs.
- Both operations run via BackgroundTasks after the redirect to /plan/day, so the user-facing redirect is never blocked.
- Defaults selected_calendar_ids to ['primary'] when no metadata is set.

## Files
- api/routes/integrations.py — adds _initial_sync_and_register helper; wires BackgroundTasks in google_callback
- tests/api/test_integrations.py — TDD tests for helper + callback scheduling

## Test plan
- [x] tests/api/test_integrations.py — new helper tests pass
- [x] tests/integrations/ — no regressions (17 passed)
- [x] Syntax / static checks clean