### PR TITLE
feat(frontend): add Sync now button to Google Calendar settings

### DIFF
--- a/frontend/src/components/GoogleCalendarSection.vue
+++ b/frontend/src/components/GoogleCalendarSection.vue
@@ -1,11 +1,41 @@
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useIntegrationsStore } from '../stores/integrations'
 
 const store = useIntegrationsStore()
 
+// Tick every 30s so the "Last synced X ago" caption stays fresh.
+const now = ref(Date.now())
+let tickHandle: ReturnType<typeof setInterval> | null = null
+
 onMounted(() => {
   store.fetchGCalStatus()
+  tickHandle = setInterval(() => {
+    now.value = Date.now()
+  }, 30_000)
+})
+
+onUnmounted(() => {
+  if (tickHandle !== null) clearInterval(tickHandle)
+})
+
+function formatRelative(iso: string, currentMs: number): string {
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return iso
+  const diffSec = Math.max(0, Math.round((currentMs - then) / 1000))
+  if (diffSec < 5) return 'just now'
+  if (diffSec < 60) return `${diffSec}s ago`
+  const diffMin = Math.round(diffSec / 60)
+  if (diffMin < 60) return `${diffMin}m ago`
+  const diffHr = Math.round(diffMin / 60)
+  if (diffHr < 24) return `${diffHr}h ago`
+  const diffDay = Math.round(diffHr / 24)
+  return `${diffDay}d ago`
+}
+
+const lastSyncedLabel = computed(() => {
+  if (!store.lastSyncedAt) return null
+  return formatRelative(store.lastSyncedAt, now.value)
 })
 </script>
 
@@ -33,16 +63,25 @@ onMounted(() => {
           </div>
         </div>
 
-        <!-- Action button -->
-        <button
-          v-if="store.gcalConnected"
-          data-testid="gcal-disconnect"
-          :disabled="store.loading"
-          @click="store.disconnectGCal()"
-          class="text-sm text-red-400 hover:text-red-300 disabled:opacity-50 border border-red-400/30 hover:border-red-300/50 rounded-lg px-3 py-1.5 transition-colors"
-        >
-          {{ store.loading ? '…' : 'Disconnect' }}
-        </button>
+        <!-- Action buttons -->
+        <div v-if="store.gcalConnected" class="flex items-center gap-2">
+          <button
+            data-testid="gcal-sync-now"
+            :disabled="store.loading"
+            @click="store.syncNow()"
+            class="text-xs text-white/70 hover:text-white disabled:opacity-50 border border-white/20 hover:border-white/40 rounded-lg px-2.5 py-1.5 transition-colors"
+          >
+            {{ store.loading ? '…' : 'Sync now' }}
+          </button>
+          <button
+            data-testid="gcal-disconnect"
+            :disabled="store.loading"
+            @click="store.disconnectGCal()"
+            class="text-sm text-red-400 hover:text-red-300 disabled:opacity-50 border border-red-400/30 hover:border-red-300/50 rounded-lg px-3 py-1.5 transition-colors"
+          >
+            {{ store.loading ? '…' : 'Disconnect' }}
+          </button>
+        </div>
         <button
           v-else
           data-testid="gcal-connect"
@@ -53,6 +92,15 @@ onMounted(() => {
           {{ store.loading ? '…' : 'Connect' }}
         </button>
       </div>
+
+      <!-- Last synced caption -->
+      <p
+        v-if="store.gcalConnected && lastSyncedLabel"
+        data-testid="gcal-last-synced"
+        class="text-xs text-white/40 -mt-2 mb-2"
+      >
+        Last synced {{ lastSyncedLabel }}
+      </p>
 
       <!-- Info text when not connected -->
       <p v-if="!store.gcalConnected" class="text-xs text-white/40">

--- a/frontend/src/stores/__tests__/integrations.test.ts
+++ b/frontend/src/stores/__tests__/integrations.test.ts
@@ -134,6 +134,69 @@ describe('useIntegrationsStore', () => {
     })
   })
 
+  describe('syncNow', () => {
+    it('sets lastSyncedAt to a valid ISO string and clears error on success', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.syncNow()
+
+      expect(store.lastSyncedAt).toBeTypeOf('string')
+      expect(() => new Date(store.lastSyncedAt as string).toISOString()).not.toThrow()
+      expect(store.error).toBeNull()
+      expect(store.loading).toBe(false)
+    })
+
+    it('calls POST /api/integrations/google/sync', async () => {
+      const { api } = await import('../../lib/api')
+      const mockApi = vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.syncNow()
+
+      expect(mockApi).toHaveBeenCalledWith(
+        '/api/integrations/google/sync',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+
+    it('sets an error message and leaves lastSyncedAt null on failure', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ detail: 'oops' }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.syncNow()
+
+      expect(store.error).toBe('Sync failed. Please try again.')
+      expect(store.lastSyncedAt).toBeNull()
+    })
+
+    it('sets an error message on network error', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockRejectedValueOnce(new Error('Network error'))
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.syncNow()
+
+      expect(store.error).toBe('Sync failed. Please try again.')
+      expect(store.loading).toBe(false)
+    })
+  })
+
   describe('connectGCal', () => {
     it('navigates to the Google Calendar OAuth URL', async () => {
       // happy-dom allows direct assignment to window.location.href

--- a/frontend/src/stores/integrations.ts
+++ b/frontend/src/stores/integrations.ts
@@ -6,6 +6,7 @@ export const useIntegrationsStore = defineStore('integrations', () => {
   const gcalConnected = ref(false)
   const loading = ref(false)
   const error = ref<string | null>(null)
+  const lastSyncedAt = ref<string | null>(null)
 
   /**
    * Check Google Calendar connection status.
@@ -54,5 +55,35 @@ export const useIntegrationsStore = defineStore('integrations', () => {
     }
   }
 
-  return { gcalConnected, loading, error, fetchGCalStatus, connectGCal, disconnectGCal }
+  /**
+   * Trigger an explicit Google Calendar sync.
+   * POST /api/integrations/google/sync — re-pulls calendar events.
+   */
+  async function syncNow() {
+    loading.value = true
+    error.value = null
+    try {
+      const resp = await api('/api/integrations/google/sync', { method: 'POST' })
+      if (resp.ok) {
+        lastSyncedAt.value = new Date().toISOString()
+      } else {
+        error.value = 'Sync failed. Please try again.'
+      }
+    } catch {
+      error.value = 'Sync failed. Please try again.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    gcalConnected,
+    loading,
+    error,
+    lastSyncedAt,
+    fetchGCalStatus,
+    connectGCal,
+    disconnectGCal,
+    syncNow,
+  }
 })


### PR DESCRIPTION
## Summary
- Adds a `syncNow()` action to the integrations Pinia store that POSTs `/api/integrations/google/sync`, tracks `lastSyncedAt`, and surfaces a friendly error on failure.
- Adds a secondary **Sync now** button next to Disconnect in `GoogleCalendarSection.vue`, plus a "Last synced X ago" caption that auto-refreshes.
- Button carries `data-testid=\"gcal-sync-now\"` for tests.

## Why base is `feature/gcal-ui`
This depends on `GoogleCalendarSection.vue` and `stores/integrations.ts` introduced in PR #201, which has not yet merged to main. Will retarget to main once #201 lands.

## Test plan
- [x] New Vitest cases cover success, failure (`resp.ok=false`), and network-error paths for `syncNow()`
- [x] All 114 frontend tests pass
- [x] `vue-tsc -b` reports zero type errors