### PR TITLE
fix: SECURITY DEFINER function for sync worker integration lookup

### DIFF
--- a/db/migrations/versions/d2e3f4a5b6c7_sync_worker_integration_lookup.py
+++ b/db/migrations/versions/d2e3f4a5b6c7_sync_worker_integration_lookup.py
@@ -1,0 +1,54 @@
+"""sync worker: SECURITY DEFINER lookup for user_integrations
+
+The GCal sync worker is a background system process that must fetch
+(user_id, access_token) from user_integrations before it knows the
+user_id — so it cannot set app.current_user_id first. tether_app is
+NOBYPASSRLS and user_integrations has FORCE ROW LEVEL SECURITY, meaning
+an unscoped connection sees zero rows.
+
+Solution mirrors api_keys (c7d8e9f0a1b2): a SECURITY DEFINER function
+owned by postgres (BYPASSRLS) that performs this one lookup, returning
+only the columns the sync worker needs. RLS remains intact for all other
+access paths.
+
+Revision ID: d2e3f4a5b6c7
+Revises: c7d8e9f0a1b2
+Create Date: 2026-04-26
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = 'd2e3f4a5b6c7'
+down_revision: Union[str, Sequence[str], None] = 'c7d8e9f0a1b2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE OR REPLACE FUNCTION get_integration_for_sync(p_id uuid)
+        RETURNS TABLE(user_id uuid, access_token text)
+        LANGUAGE plpgsql
+        SECURITY DEFINER
+        SET search_path = public
+        AS $$
+        BEGIN
+            RETURN QUERY
+            SELECT ui.user_id, ui.access_token
+              FROM user_integrations ui
+             WHERE ui.id = p_id;
+        END;
+        $$
+    """)
+
+    op.execute(
+        "GRANT EXECUTE ON FUNCTION get_integration_for_sync(uuid) TO tether_app"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "REVOKE EXECUTE ON FUNCTION get_integration_for_sync(uuid) FROM tether_app"
+    )
+    op.execute("DROP FUNCTION IF EXISTS get_integration_for_sync(uuid)")

--- a/integrations/google_calendar/sync.py
+++ b/integrations/google_calendar/sync.py
@@ -46,14 +46,9 @@ class GoogleCalendarSync(SyncProvider):
         self._pool = pool
 
     async def _get_integration_row(self, integration_id: str) -> dict:
-        """Fetch user_id and access_token for an integration in one query.
-
-        Uses a direct pool acquire (no RLS setup) because the sync worker is a
-        background system process, not a per-user request.  pg.get_conn would
-        call SET LOCAL app.current_user_id only when user_id is supplied; without
-        it RLS on user_integrations hides all rows.
-        """
-        async with self._pool.acquire() as conn:
+        """Fetch user_id and access_token for an integration in one query."""
+        import db.postgres as pg
+        async with pg.get_conn(self._pool) as conn:
             row = await conn.fetchrow(
                 "SELECT user_id, access_token FROM user_integrations WHERE id = $1",
                 _uuid.UUID(integration_id),

--- a/integrations/google_calendar/sync.py
+++ b/integrations/google_calendar/sync.py
@@ -46,11 +46,23 @@ class GoogleCalendarSync(SyncProvider):
         self._pool = pool
 
     async def _get_integration_row(self, integration_id: str) -> dict:
-        """Fetch user_id and access_token for an integration in one query."""
+        """Fetch user_id and access_token for an integration.
+
+        The sync worker is a background system process — it cannot set
+        app.current_user_id before knowing the user_id.  Direct SQL on an
+        unscoped tether_app connection returns zero rows because
+        user_integrations has FORCE ROW LEVEL SECURITY and tether_app is
+        NOBYPASSRLS.
+
+        get_integration_for_sync() is a SECURITY DEFINER function owned by
+        postgres (BYPASSRLS).  It exposes only user_id and access_token and
+        executes as the function owner for that one call only, leaving RLS
+        intact for every other access path.
+        """
         import db.postgres as pg
         async with pg.get_conn(self._pool) as conn:
             row = await conn.fetchrow(
-                "SELECT user_id, access_token FROM user_integrations WHERE id = $1",
+                "SELECT user_id, access_token FROM get_integration_for_sync($1)",
                 _uuid.UUID(integration_id),
             )
         if not row:

--- a/integrations/google_calendar/sync.py
+++ b/integrations/google_calendar/sync.py
@@ -46,9 +46,14 @@ class GoogleCalendarSync(SyncProvider):
         self._pool = pool
 
     async def _get_integration_row(self, integration_id: str) -> dict:
-        """Fetch user_id and access_token for an integration in one query."""
-        import db.postgres as pg
-        async with pg.get_conn(self._pool) as conn:
+        """Fetch user_id and access_token for an integration in one query.
+
+        Uses a direct pool acquire (no RLS setup) because the sync worker is a
+        background system process, not a per-user request.  pg.get_conn would
+        call SET LOCAL app.current_user_id only when user_id is supplied; without
+        it RLS on user_integrations hides all rows.
+        """
+        async with self._pool.acquire() as conn:
             row = await conn.fetchrow(
                 "SELECT user_id, access_token FROM user_integrations WHERE id = $1",
                 _uuid.UUID(integration_id),


### PR DESCRIPTION
## Summary

- The GCal sync worker calls `_get_integration_row()` before it knows the user_id, so it cannot set `app.current_user_id` first
- `tether_app` is `NOBYPASSRLS` and `user_integrations` has `FORCE ROW LEVEL SECURITY` — an unscoped connection returns zero rows, causing `ValueError: Integration <uuid> not found` on every poll
- The originally proposed `pool.acquire()` fix was caught and rejected: it still connects as `tether_app` so RLS is still enforced — it would have been a no-op

## Fix

Mirrors the existing `api_keys` / `validate_api_key` pattern (migration `c7d8e9f0a1b2`):

1. **Migration** (`d2e3f4a5b6c7`): adds `get_integration_for_sync(uuid)` as a `SECURITY DEFINER` function owned by postgres. Exposes only `user_id` and `access_token`. `SET search_path = public` prevents search_path injection. `GRANT EXECUTE` to `tether_app`.
2. **App code**: `_get_integration_row` now calls `SELECT user_id, access_token FROM get_integration_for_sync($1)` via a normal `pg.get_conn(self._pool)` — no raw pool access, no RLS bypass in application code.

RLS remains fully enforced for all other access paths.

## Test plan

- [ ] Run `alembic upgrade head` — migration applies cleanly
- [ ] Deploy sync container — poll no longer raises `ValueError: Integration <uuid> not found`
- [ ] Verify a non-existent integration_id still raises `ValueError` (function returns no rows → app raises as before)
- [ ] Confirm write path in `poll()` still uses `pg.get_conn(..., user_id=user_id)` (unchanged)