### PR TITLE
fix: drop extra user_id arg from get_all_user_settings

### DIFF
--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -15,7 +15,7 @@ class SetSettingBody(BaseModel):
 @router.get("/settings")
 async def list_settings(request: Request, _auth=Depends(auth_dependency),
                         conn: asyncpg.Connection = Depends(get_db_conn)):
-    return await get_all_user_settings(conn, request.state.user_id)
+    return await get_all_user_settings(conn)
 
 
 @router.put("/settings/{key}")


### PR DESCRIPTION
## Summary
- `GET /api/settings` was returning 500 due to a TypeError: `get_all_user_settings(conn)` only accepts one argument but was called with two
- RLS on the connection already scopes the query to the current user — passing `user_id` explicitly was wrong
- One-line fix: remove `request.state.user_id` from the call

## Test plan
- [x] Existing settings tests pass (`pytest tests/ -k "settings"` → 5 passed)