### PR TITLE
fix(ci): run alembic upgrade head in deploy-db workflow

### DIFF
--- a/.github/workflows/deploy-db.yml
+++ b/.github/workflows/deploy-db.yml
@@ -35,6 +35,14 @@ jobs:
             POSTGRES_PASSWORD=${POSTGRES_PASSWORD} \
             TETHER_APP_PASSWORD=${TETHER_APP_PASSWORD}
 
+      - name: Run Alembic migrations
+        env:
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+        run: |
+          cd /home/toast/tether
+          DATABASE_URL=postgresql://tether:${POSTGRES_PASSWORD}@localhost:5432/tether \
+            alembic upgrade head
+
       - name: Run DB migrations
         run: |
           cd /home/toast/tether


### PR DESCRIPTION
Adds an Alembic migration step to the deploy-db workflow so schema migrations run automatically on every push to main that touches db/ or alembic.ini.

Previously only `migrate_data_model.py` (the SQLite data migration script) ran — Alembic was only invoked in CI tests. This meant any Alembic migration (e.g. SECURITY DEFINER functions, new tables, index changes) required a manual `DATABASE_URL=... alembic upgrade head` on the Pi after each deploy.

Runs as `tether` (the database owner/superuser) which has BYPASSRLS — required for migrations that create SECURITY DEFINER functions.