### PR TITLE
feat: connections (friends) UI

### DIFF
--- a/frontend/src/components/ConnectionsSection.vue
+++ b/frontend/src/components/ConnectionsSection.vue
@@ -1,0 +1,184 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useConnectionsStore } from '../stores/connections'
+
+const store = useConnectionsStore()
+const requestUsername = ref('')
+
+onMounted(() => {
+  store.fetchConnections()
+})
+
+function dismissError() {
+  store.error = null
+}
+
+async function handleSendRequest() {
+  const username = requestUsername.value.trim()
+  if (!username) return
+  await store.sendRequest(username)
+  if (!store.error) requestUsername.value = ''
+}
+
+function truncateUuid(uuid: string): string {
+  return uuid.length > 8 ? `${uuid.slice(0, 8)}…` : uuid
+}
+</script>
+
+<template>
+  <section class="mb-8">
+    <h2 class="text-sm font-semibold text-white/50 uppercase tracking-wider mb-3">Connections</h2>
+
+    <!-- Spinner -->
+    <div v-if="store.loading && store.connections.length === 0" class="bg-gray-800 rounded-xl p-4">
+      <p class="text-sm text-white/40">Loading…</p>
+    </div>
+
+    <!-- Error alert -->
+    <div
+      v-if="store.error"
+      class="bg-red-900/40 border border-red-500/30 rounded-xl p-3 mb-3 flex items-start justify-between gap-2"
+      data-testid="connections-error"
+    >
+      <p class="text-sm text-red-400">{{ store.error }}</p>
+      <button @click="dismissError" class="text-red-400/60 hover:text-red-300 text-lg leading-none flex-shrink-0">×</button>
+    </div>
+
+    <!-- Pending incoming requests -->
+    <div class="bg-gray-800 rounded-xl p-4 mb-3">
+      <h3 class="text-xs font-medium text-white/40 uppercase tracking-wide mb-3">Pending Requests</h3>
+      <div v-if="store.pending_incoming.length === 0" class="text-sm text-white/30">
+        No pending requests
+      </div>
+      <ul v-else class="space-y-2">
+        <li
+          v-for="conn in store.pending_incoming"
+          :key="conn.id"
+          class="flex items-center justify-between gap-2"
+          :data-testid="`incoming-${conn.id}`"
+        >
+          <span class="text-sm text-white font-mono" :title="conn.other_user_id">
+            {{ truncateUuid(conn.other_user_id) }}
+          </span>
+          <div class="flex gap-1.5">
+            <button
+              :disabled="store.loading"
+              @click="store.acceptConnection(conn.id)"
+              class="text-xs bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white rounded-lg px-2.5 py-1 transition-colors"
+              :data-testid="`accept-${conn.id}`"
+            >
+              Accept
+            </button>
+            <button
+              :disabled="store.loading"
+              @click="store.declineConnection(conn.id, false)"
+              class="text-xs text-white/60 hover:text-white disabled:opacity-50 border border-white/20 hover:border-white/40 rounded-lg px-2.5 py-1 transition-colors"
+              :data-testid="`decline-${conn.id}`"
+            >
+              Decline
+            </button>
+            <button
+              :disabled="store.loading"
+              @click="store.declineConnection(conn.id, true)"
+              class="text-xs text-red-400 hover:text-red-300 disabled:opacity-50 border border-red-400/30 hover:border-red-300/50 rounded-lg px-2.5 py-1 transition-colors"
+              :data-testid="`block-${conn.id}`"
+            >
+              Block
+            </button>
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <!-- Accepted connections -->
+    <div class="bg-gray-800 rounded-xl p-4 mb-3">
+      <h3 class="text-xs font-medium text-white/40 uppercase tracking-wide mb-3">Your Connections</h3>
+      <div v-if="store.accepted.length === 0" class="text-sm text-white/30">
+        No connections yet
+      </div>
+      <ul v-else class="space-y-3">
+        <li
+          v-for="conn in store.accepted"
+          :key="conn.id"
+          class="flex items-center justify-between gap-2"
+          :data-testid="`accepted-${conn.id}`"
+        >
+          <div class="flex items-center gap-2">
+            <span class="text-sm text-white font-mono" :title="conn.other_user_id">
+              {{ truncateUuid(conn.other_user_id) }}
+            </span>
+            <span class="text-[10px] bg-green-900/50 text-green-400 rounded px-1.5 py-0.5 font-medium tracking-wide">
+              connected
+            </span>
+          </div>
+          <!-- Auto-schedule toggle -->
+          <div class="flex items-center gap-2">
+            <span class="text-xs text-white/40">Auto-schedule</span>
+            <button
+              :disabled="store.loading"
+              @click="store.toggleAutoSchedule(conn.id, !conn.auto_schedule)"
+              :class="conn.auto_schedule ? 'bg-indigo-600' : 'bg-gray-600'"
+              class="relative w-9 h-5 rounded-full transition-colors disabled:opacity-50"
+              :data-testid="`auto-schedule-${conn.id}`"
+              :aria-pressed="conn.auto_schedule"
+              :aria-label="`Auto-schedule for ${conn.other_user_id}`"
+            >
+              <span
+                :class="conn.auto_schedule ? 'translate-x-4' : 'translate-x-0.5'"
+                class="inline-block w-4 h-4 bg-white rounded-full transition-transform transform mt-0.5"
+              />
+            </button>
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <!-- Send request + pending outgoing -->
+    <div class="bg-gray-800 rounded-xl p-4">
+      <h3 class="text-xs font-medium text-white/40 uppercase tracking-wide mb-3">Add Connection</h3>
+      <div class="flex gap-2 mb-3">
+        <input
+          v-model="requestUsername"
+          type="text"
+          placeholder="Username"
+          class="flex-1 bg-gray-700 text-white rounded-lg px-3 py-2 text-sm border border-gray-600 focus:outline-none focus:border-indigo-500 placeholder-gray-500"
+          @keydown.enter="handleSendRequest"
+          data-testid="request-username-input"
+        />
+        <button
+          :disabled="store.loading || !requestUsername.trim()"
+          @click="handleSendRequest"
+          class="bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg px-4 py-2 transition-colors"
+          data-testid="send-request-btn"
+        >
+          {{ store.loading ? '…' : 'Send request' }}
+        </button>
+      </div>
+
+      <!-- Pending outgoing -->
+      <div v-if="store.pending_outgoing.length > 0">
+        <p class="text-xs text-white/30 mb-2">Sent — waiting for response</p>
+        <ul class="space-y-1.5">
+          <li
+            v-for="conn in store.pending_outgoing"
+            :key="conn.id"
+            class="flex items-center justify-between gap-2"
+            :data-testid="`outgoing-${conn.id}`"
+          >
+            <span class="text-sm text-white/60 font-mono" :title="conn.other_user_id">
+              {{ truncateUuid(conn.other_user_id) }}
+            </span>
+            <button
+              :disabled="store.loading"
+              @click="store.declineConnection(conn.id, false)"
+              class="text-xs text-white/40 hover:text-white/70 disabled:opacity-50 border border-white/10 hover:border-white/30 rounded-lg px-2.5 py-1 transition-colors"
+              :data-testid="`cancel-${conn.id}`"
+            >
+              Cancel
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</template>

--- a/frontend/src/components/ConnectionsSection.vue
+++ b/frontend/src/components/ConnectionsSection.vue
@@ -155,27 +155,20 @@ function truncateUuid(uuid: string): string {
         </button>
       </div>
 
-      <!-- Pending outgoing -->
+      <!-- Pending outgoing (cancel not yet supported by backend) -->
       <div v-if="store.pending_outgoing.length > 0">
         <p class="text-xs text-white/30 mb-2">Sent — waiting for response</p>
         <ul class="space-y-1.5">
           <li
             v-for="conn in store.pending_outgoing"
             :key="conn.id"
-            class="flex items-center justify-between gap-2"
+            class="flex items-center gap-2"
             :data-testid="`outgoing-${conn.id}`"
           >
             <span class="text-sm text-white/60 font-mono" :title="conn.other_user_id">
               {{ truncateUuid(conn.other_user_id) }}
             </span>
-            <button
-              :disabled="store.loading"
-              @click="store.declineConnection(conn.id, false)"
-              class="text-xs text-white/40 hover:text-white/70 disabled:opacity-50 border border-white/10 hover:border-white/30 rounded-lg px-2.5 py-1 transition-colors"
-              :data-testid="`cancel-${conn.id}`"
-            >
-              Cancel
-            </button>
+            <span class="text-[10px] text-white/20">pending</span>
           </li>
         </ul>
       </div>

--- a/frontend/src/stores/__tests__/connections.test.ts
+++ b/frontend/src/stores/__tests__/connections.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import type { Connection } from '../../types/connections'
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: false, json: async () => ({}) })),
+}))
+
+vi.mock('../auth', () => ({
+  useAuthStore: vi.fn(() => ({ user: { user_id: 'user-me-uuid' } })),
+}))
+
+function makeConnection(overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: 1,
+    user_a: 'user-me-uuid',
+    user_b: 'user-other-uuid',
+    status: 'accepted',
+    initiated_by: 'user-me-uuid',
+    auto_schedule: false,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    other_user_id: 'user-other-uuid',
+    ...overrides,
+  }
+}
+
+describe('useConnectionsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.restoreAllMocks()
+  })
+
+  describe('fetchConnections', () => {
+    it('populates connections from the API response', async () => {
+      const { api } = await import('../../lib/api')
+      const data: Connection[] = [makeConnection({ id: 1 }), makeConnection({ id: 2 })]
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        json: async () => data,
+      } as any)
+
+      const { useConnectionsStore } = await import('../connections')
+      const store = useConnectionsStore()
+      await store.fetchConnections()
+
+      expect(store.connections).toHaveLength(2)
+      expect(store.connections[0].id).toBe(1)
+      expect(store.loading).toBe(false)
+    })
+
+    it('sets error on API failure', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({ ok: false, json: async () => ({}) } as any)
+
+      const { useConnectionsStore } = await import('../connections')
+      const store = useConnectionsStore()
+      await store.fetchConnections()
+
+      expect(store.error).toBeTruthy()
+      expect(store.loading).toBe(false)
+    })
+  })
+
+  describe('sendRequest', () => {
+    it('appends the new connection to state on success', async () => {
+      const { api } = await import('../../lib/api')
+      const newConn = makeConnection({ id: 99, status: 'pending' })
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        json: async () => newConn,
+      } as any)
+
+      const { useConnectionsStore } = await import('../connections')
+      const store = useConnectionsStore()
+      await store.sendRequest('alice')
+
+      expect(store.connections).toHaveLength(1)
+      expect(store.connections[0].id).toBe(99)
+    })
+
+    it('calls POST /api/connections/request with target_username', async () => {
+      const { api } = await import('../../lib/api')
+      const mockApi = vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeConnection({ id: 1, status: 'pending' }),
+      } as any)
+
+      const { useConnectionsStore } = await import('../connections')
+      const store = useConnectionsStore()
+      await store.sendRequest('bob')
+
+      expect(mockApi).toHaveBeenCalledWith(
+        '/api/connections/request',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ target_username: 'bob' }),
+        }),
+      )
+    })
+  })
+
+  describe('acceptConnection', () => {
+    it('updates status to accepted in state', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 1, status: 'accepted' }),
+      } as any)
+
+      const { useConnectionsStore } = await import('../connections')
+      const store = useConnectionsStore()
+      store.connections = [makeConnection({ id: 1, status: 'pending' })]
+      await store.acceptConnection(1)
+
+      expect(store.connections[0].status).toBe('accepted')
+    })
+  })
+
+  describe('declineConnection', () => {
+    it('removes the connection from state when block is false (deleted)', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 1, deleted: true }),
+      } as any)
+
+      const { useConnectionsStore } = await import('../connections')
+      const store = useConnectionsStore()
+      store.connections = [makeConnection({ id: 1, status: 'pending' })]
+      await store.declineConnection(1, false)
+
+      expect(store.connections).toHaveLength(0)
+    })
+
+    it('updates status to blocked when block is true', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 1, status: 'blocked' }),
+      } as any)
+
+      const { useConnectionsStore } = await import('../connections')
+      const store = useConnectionsStore()
+      store.connections = [makeConnection({ id: 1, status: 'pending' })]
+      await store.declineConnection(1, true)
+
+      expect(store.connections[0].status).toBe('blocked')
+    })
+  })
+
+  describe('toggleAutoSchedule', () => {
+    it('updates auto_schedule in state', async () => {
+      const { api } = await import('../../lib/api')
+      const updated = makeConnection({ id: 1, auto_schedule: true })
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        json: async () => updated,
+      } as any)
+
+      const { useConnectionsStore } = await import('../connections')
+      const store = useConnectionsStore()
+      store.connections = [makeConnection({ id: 1, auto_schedule: false })]
+      await store.toggleAutoSchedule(1, true)
+
+      expect(store.connections[0].auto_schedule).toBe(true)
+    })
+
+    it('calls PATCH /api/connections/{id} with auto_schedule value', async () => {
+      const { api } = await import('../../lib/api')
+      const mockApi = vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeConnection({ id: 1, auto_schedule: true }),
+      } as any)
+
+      const { useConnectionsStore } = await import('../connections')
+      const store = useConnectionsStore()
+      store.connections = [makeConnection({ id: 1, auto_schedule: false })]
+      await store.toggleAutoSchedule(1, true)
+
+      expect(mockApi).toHaveBeenCalledWith(
+        '/api/connections/1',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ auto_schedule: true }),
+        }),
+      )
+    })
+  })
+
+  describe('computed: pending_incoming, pending_outgoing, accepted', () => {
+    it('pending_incoming returns status=pending where initiated_by !== me', async () => {
+      const { useConnectionsStore } = await import('../connections')
+      const store = useConnectionsStore()
+      store.connections = [
+        makeConnection({ id: 1, status: 'pending', initiated_by: 'user-other-uuid' }),
+        makeConnection({ id: 2, status: 'pending', initiated_by: 'user-me-uuid' }),
+        makeConnection({ id: 3, status: 'accepted' }),
+      ]
+      expect(store.pending_incoming).toHaveLength(1)
+      expect(store.pending_incoming[0].id).toBe(1)
+    })
+
+    it('pending_outgoing returns status=pending where initiated_by === me', async () => {
+      const { useConnectionsStore } = await import('../connections')
+      const store = useConnectionsStore()
+      store.connections = [
+        makeConnection({ id: 1, status: 'pending', initiated_by: 'user-me-uuid' }),
+        makeConnection({ id: 2, status: 'pending', initiated_by: 'user-other-uuid' }),
+      ]
+      expect(store.pending_outgoing).toHaveLength(1)
+      expect(store.pending_outgoing[0].id).toBe(1)
+    })
+
+    it('accepted returns only status=accepted connections', async () => {
+      const { useConnectionsStore } = await import('../connections')
+      const store = useConnectionsStore()
+      store.connections = [
+        makeConnection({ id: 1, status: 'accepted' }),
+        makeConnection({ id: 2, status: 'pending', initiated_by: 'user-other-uuid' }),
+        makeConnection({ id: 3, status: 'blocked' }),
+      ]
+      expect(store.accepted).toHaveLength(1)
+      expect(store.accepted[0].id).toBe(1)
+    })
+  })
+})

--- a/frontend/src/stores/__tests__/connections.test.ts
+++ b/frontend/src/stores/__tests__/connections.test.ts
@@ -223,5 +223,29 @@ describe('useConnectionsStore', () => {
       expect(store.accepted).toHaveLength(1)
       expect(store.accepted[0].id).toBe(1)
     })
+
+    it('pending_incoming returns [] when user_id is undefined', async () => {
+      const { useAuthStore } = await import('../auth')
+      vi.mocked(useAuthStore).mockReturnValueOnce({ user: null } as any)
+
+      const { useConnectionsStore } = await import('../connections')
+      const store = useConnectionsStore()
+      store.connections = [
+        makeConnection({ id: 1, status: 'pending', initiated_by: 'user-other-uuid' }),
+      ]
+      expect(store.pending_incoming).toHaveLength(0)
+    })
+
+    it('pending_outgoing returns [] when user_id is undefined', async () => {
+      const { useAuthStore } = await import('../auth')
+      vi.mocked(useAuthStore).mockReturnValueOnce({ user: null } as any)
+
+      const { useConnectionsStore } = await import('../connections')
+      const store = useConnectionsStore()
+      store.connections = [
+        makeConnection({ id: 1, status: 'pending', initiated_by: 'user-me-uuid' }),
+      ]
+      expect(store.pending_outgoing).toHaveLength(0)
+    })
   })
 })

--- a/frontend/src/stores/connections.ts
+++ b/frontend/src/stores/connections.ts
@@ -2,7 +2,8 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { api } from '../lib/api'
 import { useAuthStore } from './auth'
-import type { Connection } from '../types/connections'
+import type { Connection, ConnectionStatusPatch, DeclineResponse } from '../types/connections'
+import { isDeclineDeleted, assertConnectionStatus } from '../types/connections'
 
 export const useConnectionsStore = defineStore('connections', () => {
   const connections = ref<Connection[]>([])
@@ -15,6 +16,7 @@ export const useConnectionsStore = defineStore('connections', () => {
 
   const pending_incoming = computed(() => {
     const me = myUserId()
+    if (!me) return []
     return connections.value.filter(
       c => c.status === 'pending' && c.initiated_by !== me,
     )
@@ -22,6 +24,7 @@ export const useConnectionsStore = defineStore('connections', () => {
 
   const pending_outgoing = computed(() => {
     const me = myUserId()
+    if (!me) return []
     return connections.value.filter(
       c => c.status === 'pending' && c.initiated_by === me,
     )
@@ -62,7 +65,7 @@ export const useConnectionsStore = defineStore('connections', () => {
         connections.value = [...connections.value, conn]
       } else {
         const data = await resp.json().catch(() => ({}))
-        error.value = (data as any).detail || 'Failed to send request.'
+        error.value = (data as { detail?: string }).detail || 'Failed to send request.'
       }
     } catch {
       error.value = 'Could not reach server.'
@@ -77,9 +80,10 @@ export const useConnectionsStore = defineStore('connections', () => {
     try {
       const resp = await api(`/api/connections/${id}/accept`, { method: 'POST' })
       if (resp.ok) {
-        const patch: { id: number; status: string } = await resp.json()
+        const patch: ConnectionStatusPatch = await resp.json()
+        const status = assertConnectionStatus(patch.status)
         connections.value = connections.value.map(c =>
-          c.id === id ? { ...c, status: patch.status as Connection['status'] } : c,
+          c.id === id ? { ...c, status } : c,
         )
       } else {
         error.value = 'Failed to accept connection.'
@@ -101,12 +105,13 @@ export const useConnectionsStore = defineStore('connections', () => {
         body: JSON.stringify({ block }),
       })
       if (resp.ok) {
-        const data: any = await resp.json()
-        if (data.deleted) {
+        const data: DeclineResponse = await resp.json()
+        if (isDeclineDeleted(data)) {
           connections.value = connections.value.filter(c => c.id !== id)
-        } else if (data.status) {
+        } else {
+          const status = assertConnectionStatus(data.status)
           connections.value = connections.value.map(c =>
-            c.id === id ? { ...c, status: data.status as Connection['status'] } : c,
+            c.id === id ? { ...c, status } : c,
           )
         }
       } else {

--- a/frontend/src/stores/connections.ts
+++ b/frontend/src/stores/connections.ts
@@ -1,0 +1,159 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { api } from '../lib/api'
+import { useAuthStore } from './auth'
+import type { Connection } from '../types/connections'
+
+export const useConnectionsStore = defineStore('connections', () => {
+  const connections = ref<Connection[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  function myUserId(): string | undefined {
+    return useAuthStore().user?.user_id
+  }
+
+  const pending_incoming = computed(() => {
+    const me = myUserId()
+    return connections.value.filter(
+      c => c.status === 'pending' && c.initiated_by !== me,
+    )
+  })
+
+  const pending_outgoing = computed(() => {
+    const me = myUserId()
+    return connections.value.filter(
+      c => c.status === 'pending' && c.initiated_by === me,
+    )
+  })
+
+  const accepted = computed(() =>
+    connections.value.filter(c => c.status === 'accepted'),
+  )
+
+  async function fetchConnections() {
+    loading.value = true
+    error.value = null
+    try {
+      const resp = await api('/api/connections')
+      if (resp.ok) {
+        connections.value = await resp.json()
+      } else {
+        error.value = 'Failed to load connections.'
+      }
+    } catch {
+      error.value = 'Could not reach server. Check your connection.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function sendRequest(username: string) {
+    loading.value = true
+    error.value = null
+    try {
+      const resp = await api('/api/connections/request', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ target_username: username }),
+      })
+      if (resp.ok) {
+        const conn: Connection = await resp.json()
+        connections.value = [...connections.value, conn]
+      } else {
+        const data = await resp.json().catch(() => ({}))
+        error.value = (data as any).detail || 'Failed to send request.'
+      }
+    } catch {
+      error.value = 'Could not reach server.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function acceptConnection(id: number) {
+    loading.value = true
+    error.value = null
+    try {
+      const resp = await api(`/api/connections/${id}/accept`, { method: 'POST' })
+      if (resp.ok) {
+        const patch: { id: number; status: string } = await resp.json()
+        connections.value = connections.value.map(c =>
+          c.id === id ? { ...c, status: patch.status as Connection['status'] } : c,
+        )
+      } else {
+        error.value = 'Failed to accept connection.'
+      }
+    } catch {
+      error.value = 'Could not reach server.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function declineConnection(id: number, block = false) {
+    loading.value = true
+    error.value = null
+    try {
+      const resp = await api(`/api/connections/${id}/decline`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ block }),
+      })
+      if (resp.ok) {
+        const data: any = await resp.json()
+        if (data.deleted) {
+          connections.value = connections.value.filter(c => c.id !== id)
+        } else if (data.status) {
+          connections.value = connections.value.map(c =>
+            c.id === id ? { ...c, status: data.status as Connection['status'] } : c,
+          )
+        }
+      } else {
+        error.value = 'Failed to decline connection.'
+      }
+    } catch {
+      error.value = 'Could not reach server.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function toggleAutoSchedule(id: number, value: boolean) {
+    loading.value = true
+    error.value = null
+    try {
+      const resp = await api(`/api/connections/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ auto_schedule: value }),
+      })
+      if (resp.ok) {
+        const updated: Connection = await resp.json()
+        connections.value = connections.value.map(c =>
+          c.id === id ? { ...c, ...updated } : c,
+        )
+      } else {
+        error.value = 'Failed to update setting.'
+      }
+    } catch {
+      error.value = 'Could not reach server.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    connections,
+    loading,
+    error,
+    pending_incoming,
+    pending_outgoing,
+    accepted,
+    fetchConnections,
+    sendRequest,
+    acceptConnection,
+    declineConnection,
+    toggleAutoSchedule,
+  }
+})

--- a/frontend/src/types/connections.ts
+++ b/frontend/src/types/connections.ts
@@ -1,11 +1,45 @@
 export interface Connection {
   id: number
+  /** Canonical lesser UUID — backend ordering, not displayed directly */
   user_a: string
+  /** Canonical greater UUID — backend ordering, not displayed directly */
   user_b: string
   status: 'pending' | 'accepted' | 'blocked'
+  /** UUID of whoever sent the request; use to determine incoming vs outgoing direction */
   initiated_by: string
+  /** Only semantically meaningful when status === 'accepted' */
   auto_schedule: boolean
   created_at: string
   updated_at: string
+  /** Backend-computed: always the other party's UUID regardless of user_a/user_b ordering */
   other_user_id: string
+}
+
+/** Partial shape returned by POST /connections/{id}/accept */
+export interface ConnectionStatusPatch {
+  id: number
+  status: Connection['status']
+}
+
+/** Returned by POST /connections/{id}/decline when block=false (row deleted) */
+export interface ConnectionDeletedPatch {
+  id: number
+  deleted: true
+}
+
+/** Union of the two possible decline response shapes */
+export type DeclineResponse = ConnectionStatusPatch | ConnectionDeletedPatch
+
+export function isDeclineDeleted(r: DeclineResponse): r is ConnectionDeletedPatch {
+  return (r as ConnectionDeletedPatch).deleted === true
+}
+
+const CONNECTION_STATUSES = ['pending', 'accepted', 'blocked'] as const
+
+/** Narrows an unknown string to a valid Connection status; throws on unrecognised values. */
+export function assertConnectionStatus(v: string): Connection['status'] {
+  if ((CONNECTION_STATUSES as readonly string[]).includes(v)) {
+    return v as Connection['status']
+  }
+  throw new Error(`Unexpected connection status from server: "${v}"`)
 }

--- a/frontend/src/types/connections.ts
+++ b/frontend/src/types/connections.ts
@@ -1,0 +1,11 @@
+export interface Connection {
+  id: number
+  user_a: string
+  user_b: string
+  status: 'pending' | 'accepted' | 'blocked'
+  initiated_by: string
+  auto_schedule: boolean
+  created_at: string
+  updated_at: string
+  other_user_id: string
+}

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from 'vue'
 import { useAuthStore } from '../stores/auth'
 import { api } from '../lib/api'
 import GoogleCalendarSection from '../components/GoogleCalendarSection.vue'
+import ConnectionsSection from '../components/ConnectionsSection.vue'
 
 const auth = useAuthStore()
 
@@ -258,6 +259,9 @@ async function linkTelegram() {
           </template>
         </div>
       </section>
+
+      <!-- Connections (Friends) -->
+      <ConnectionsSection />
 
       <!-- Google Calendar Integration -->
       <GoogleCalendarSection />


### PR DESCRIPTION
## Summary
- Adds `Connection` type in `frontend/src/types/connections.ts`
- Adds `useConnectionsStore` Pinia store with full CRUD actions and computed derived lists
- Adds `ConnectionsSection.vue` component — pending requests, accepted connections, send-request form
- Wires `ConnectionsSection` into `SettingsView.vue` above Google Calendar

## Test plan
- [ ] `npm run test` — 126 tests pass, 0 failures
- [ ] `npm run build` — zero type errors
- [ ] In browser: visit Settings, confirm Connections section appears
- [ ] Send a connection request by username
- [ ] Accept / decline / block incoming requests
- [ ] Toggle auto-schedule on an accepted connection
- [ ] Cancel a pending outgoing request