### PR TITLE
feat(frontend): RRULE recurrence support for calendar events

### DIFF
--- a/frontend/src/components/CalendarEventBlock.vue
+++ b/frontend/src/components/CalendarEventBlock.vue
@@ -40,6 +40,13 @@ function eventColor(event: CalendarEvent): string {
       >
         {{ event.source === 'google_calendar' ? 'G' : '↗' }}
       </span>
+      <!-- Recurring indicator for master events and synthesized occurrences -->
+      <span
+        v-if="event.is_recurring || event.is_occurrence"
+        data-testid="recurring-indicator"
+        class="text-[9px] flex-shrink-0 opacity-80"
+        title="Recurring event"
+      >↻</span>
       <span class="truncate font-medium text-white">{{ event.title }}</span>
     </div>
   </div>

--- a/frontend/src/components/RecurrencePicker.vue
+++ b/frontend/src/components/RecurrencePicker.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+const props = defineProps<{
+  modelValue: string | null
+  startTime: string  // ISO 8601 — used to derive day-of-week for weekly preset
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string | null): void
+}>()
+
+type Preset = 'none' | 'daily' | 'weekly' | 'weekdays' | 'monthly' | 'custom'
+
+const DOW_NAMES: readonly string[] = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA']
+
+/** Derive BYDAY abbreviation from an ISO start_time string. */
+function dowFromISO(iso: string): string {
+  return DOW_NAMES[new Date(iso).getDay()]
+}
+
+/** Map a known rrule string to its preset key, or 'custom' if unrecognised. */
+function rruleToPreset(rrule: string | null): Preset {
+  if (!rrule) return 'none'
+  if (rrule === 'FREQ=DAILY') return 'daily'
+  if (rrule.startsWith('FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR')) return 'weekdays'
+  if (/^FREQ=WEEKLY;BYDAY=[A-Z]{2}$/.test(rrule)) return 'weekly'
+  if (rrule === 'FREQ=MONTHLY') return 'monthly'
+  return 'custom'
+}
+
+// Local preset tracks UI selection independently of modelValue so that choosing
+// "Custom" immediately shows the text input without needing the parent to round-trip.
+const localPreset = ref<Preset>(rruleToPreset(props.modelValue))
+
+// Sync inbound modelValue changes (e.g. parent reset) back to localPreset
+watch(() => props.modelValue, (v) => {
+  localPreset.value = rruleToPreset(v)
+})
+
+// Holds the raw text when user picks "custom"
+const customRrule = ref<string>(
+  localPreset.value === 'custom' ? (props.modelValue ?? '') : '',
+)
+
+function onPresetChange(e: Event) {
+  const preset = (e.target as HTMLSelectElement).value as Preset
+  localPreset.value = preset
+  switch (preset) {
+    case 'none':
+      emit('update:modelValue', null)
+      break
+    case 'daily':
+      emit('update:modelValue', 'FREQ=DAILY')
+      break
+    case 'weekly':
+      emit('update:modelValue', `FREQ=WEEKLY;BYDAY=${dowFromISO(props.startTime)}`)
+      break
+    case 'weekdays':
+      emit('update:modelValue', 'FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR')
+      break
+    case 'monthly':
+      emit('update:modelValue', 'FREQ=MONTHLY')
+      break
+    case 'custom':
+      // Don't emit yet — wait for the text input
+      customRrule.value = props.modelValue ?? ''
+      break
+  }
+}
+
+function onCustomChange(e: Event) {
+  const val = (e.target as HTMLInputElement).value.trim()
+  customRrule.value = val
+  if (val) emit('update:modelValue', val)
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-1.5">
+    <label class="text-xs text-white/40">Repeat</label>
+    <select
+      :value="localPreset"
+      @change="onPresetChange"
+      class="bg-gray-800 text-white text-sm rounded px-2 py-1 border border-white/20 outline-none focus:border-white/40"
+    >
+      <option value="none">Does not repeat</option>
+      <option value="daily">Daily</option>
+      <option value="weekly">Weekly</option>
+      <option value="weekdays">Every weekday (Mon–Fri)</option>
+      <option value="monthly">Monthly</option>
+      <option value="custom">Custom (RRULE)</option>
+    </select>
+    <input
+      v-if="localPreset === 'custom'"
+      data-testid="rrule-custom-input"
+      type="text"
+      :value="customRrule"
+      placeholder="e.g. FREQ=WEEKLY;BYDAY=MO,WE"
+      @change="onCustomChange"
+      class="bg-gray-800 text-white text-sm rounded px-2 py-1 border border-white/20 outline-none focus:border-white/40 font-mono"
+    />
+  </div>
+</template>

--- a/frontend/src/components/RecurrencePicker.vue
+++ b/frontend/src/components/RecurrencePicker.vue
@@ -14,9 +14,12 @@ type Preset = 'none' | 'daily' | 'weekly' | 'weekdays' | 'monthly' | 'custom'
 
 const DOW_NAMES: readonly string[] = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA']
 
-/** Derive BYDAY abbreviation from an ISO start_time string. */
+/** Derive BYDAY abbreviation from an ISO start_time string.
+ *  Falls back to 'MO' if the date is unparseable. */
 function dowFromISO(iso: string): string {
-  return DOW_NAMES[new Date(iso).getDay()]
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return 'MO'
+  return DOW_NAMES[d.getDay()]
 }
 
 /** Map a known rrule string to its preset key, or 'custom' if unrecognised. */

--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -2,6 +2,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { api } from '../lib/api'
 import SearchAutocomplete from './SearchAutocomplete.vue'
+import RecurrencePicker from './RecurrencePicker.vue'
 import type { SearchResult } from './SearchAutocomplete.vue'
 import { usePlanStore } from '../stores/plan'
 import { useMilestoneStore } from '../stores/milestones'
@@ -308,6 +309,11 @@ async function onCalendarEndChange(e: Event) {
   await eventStore.moveEvent(taskEvent.value.id, taskEvent.value.start_time, new Date(val).toISOString())
 }
 
+async function onRecurrenceChange(rrule: string | null) {
+  if (!taskEvent.value) return
+  await eventStore.setRecurrence(taskEvent.value.id, rrule)
+}
+
 onMounted(async () => {
   if (!planStore.plan) await planStore.fetchPlan()
   if (!milestoneStore.all.length) await milestoneStore.fetchAll()
@@ -388,6 +394,12 @@ onMounted(async () => {
                   @change="onCalendarEndChange"
                   class="bg-gray-800 text-white text-sm rounded px-2 py-1 border border-white/20 outline-none focus:border-white/40" />
               </label>
+              <!-- Recurrence picker — shown only when event exists -->
+              <RecurrencePicker
+                :model-value="taskEvent.rrule ?? null"
+                :start-time="taskEvent.start_time"
+                @update:model-value="onRecurrenceChange"
+              />
             </div>
           </template>
           <template v-else>

--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -396,7 +396,7 @@ onMounted(async () => {
               </label>
               <!-- Recurrence picker — shown only when event exists -->
               <RecurrencePicker
-                :model-value="taskEvent.rrule ?? null"
+                :model-value="taskEvent.rrule"
                 :start-time="taskEvent.start_time"
                 @update:model-value="onRecurrenceChange"
               />

--- a/frontend/src/components/__tests__/CalendarEventBlock.test.ts
+++ b/frontend/src/components/__tests__/CalendarEventBlock.test.ts
@@ -77,4 +77,38 @@ describe('CalendarEventBlock', () => {
     await wrapper.trigger('click')
     expect(wrapper.emitted('click')).toBeTruthy()
   })
+
+  // --- Recurring indicator tests ---
+
+  it('shows recurring indicator when is_recurring is true', async () => {
+    const { default: CalendarEventBlock } = await import('../CalendarEventBlock.vue')
+    const wrapper = mount(CalendarEventBlock, {
+      props: {
+        event: { ...baseEvent, is_recurring: true },
+        topPx: 0,
+        heightPx: 30,
+      },
+    })
+    expect(wrapper.find('[data-testid="recurring-indicator"]').exists()).toBe(true)
+  })
+
+  it('shows recurring indicator when is_occurrence is true', async () => {
+    const { default: CalendarEventBlock } = await import('../CalendarEventBlock.vue')
+    const wrapper = mount(CalendarEventBlock, {
+      props: {
+        event: { ...baseEvent, is_occurrence: true },
+        topPx: 0,
+        heightPx: 30,
+      },
+    })
+    expect(wrapper.find('[data-testid="recurring-indicator"]').exists()).toBe(true)
+  })
+
+  it('does not show recurring indicator for non-recurring events', async () => {
+    const { default: CalendarEventBlock } = await import('../CalendarEventBlock.vue')
+    const wrapper = mount(CalendarEventBlock, {
+      props: { event: baseEvent, topPx: 0, heightPx: 30 },
+    })
+    expect(wrapper.find('[data-testid="recurring-indicator"]').exists()).toBe(false)
+  })
 })

--- a/frontend/src/components/__tests__/CalendarEventBlock.test.ts
+++ b/frontend/src/components/__tests__/CalendarEventBlock.test.ts
@@ -22,6 +22,9 @@ const baseEvent: CalendarEvent = {
   task_id: null,
   anchor_id: null,
   color: null,
+  is_recurring: false,
+  is_occurrence: false,
+  rrule: null,
 }
 
 describe('CalendarEventBlock', () => {

--- a/frontend/src/components/__tests__/RecurrencePicker.test.ts
+++ b/frontend/src/components/__tests__/RecurrencePicker.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ path: '/calendar' }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: true, json: async () => [] })),
+}))
+
+describe('RecurrencePicker', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders a select with preset options', async () => {
+    const { default: RecurrencePicker } = await import('../RecurrencePicker.vue')
+    const wrapper = mount(RecurrencePicker, {
+      props: { modelValue: null, startTime: '2024-06-10T09:00:00Z' },
+    })
+    const select = wrapper.find('select')
+    expect(select.exists()).toBe(true)
+    const options = select.findAll('option')
+    const values = options.map(o => o.element.value)
+    expect(values).toContain('none')
+    expect(values).toContain('daily')
+    expect(values).toContain('weekly')
+    expect(values).toContain('weekdays')
+    expect(values).toContain('monthly')
+    expect(values).toContain('custom')
+  })
+
+  it('emits null when "Does not repeat" selected', async () => {
+    const { default: RecurrencePicker } = await import('../RecurrencePicker.vue')
+    const wrapper = mount(RecurrencePicker, {
+      props: { modelValue: 'FREQ=DAILY', startTime: '2024-06-10T09:00:00Z' },
+    })
+    const select = wrapper.find('select')
+    await select.setValue('none')
+    const emitted = wrapper.emitted('update:modelValue')
+    expect(emitted).toBeTruthy()
+    expect(emitted![0][0]).toBeNull()
+  })
+
+  it('emits FREQ=DAILY for daily preset', async () => {
+    const { default: RecurrencePicker } = await import('../RecurrencePicker.vue')
+    const wrapper = mount(RecurrencePicker, {
+      props: { modelValue: null, startTime: '2024-06-10T09:00:00Z' },
+    })
+    await wrapper.find('select').setValue('daily')
+    const emitted = wrapper.emitted('update:modelValue')
+    expect(emitted![0][0]).toBe('FREQ=DAILY')
+  })
+
+  it('emits FREQ=WEEKLY;BYDAY=MO for a Monday start_time', async () => {
+    const { default: RecurrencePicker } = await import('../RecurrencePicker.vue')
+    // 2024-06-10 is a Monday
+    const wrapper = mount(RecurrencePicker, {
+      props: { modelValue: null, startTime: '2024-06-10T09:00:00Z' },
+    })
+    await wrapper.find('select').setValue('weekly')
+    const emitted = wrapper.emitted('update:modelValue')
+    expect(emitted![0][0]).toBe('FREQ=WEEKLY;BYDAY=MO')
+  })
+
+  it('emits FREQ=WEEKLY;BYDAY=TU for a Tuesday start_time', async () => {
+    const { default: RecurrencePicker } = await import('../RecurrencePicker.vue')
+    // 2024-06-11 is a Tuesday
+    const wrapper = mount(RecurrencePicker, {
+      props: { modelValue: null, startTime: '2024-06-11T09:00:00Z' },
+    })
+    await wrapper.find('select').setValue('weekly')
+    const emitted = wrapper.emitted('update:modelValue')
+    expect(emitted![0][0]).toBe('FREQ=WEEKLY;BYDAY=TU')
+  })
+
+  it('emits FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR for weekdays preset', async () => {
+    const { default: RecurrencePicker } = await import('../RecurrencePicker.vue')
+    const wrapper = mount(RecurrencePicker, {
+      props: { modelValue: null, startTime: '2024-06-10T09:00:00Z' },
+    })
+    await wrapper.find('select').setValue('weekdays')
+    const emitted = wrapper.emitted('update:modelValue')
+    expect(emitted![0][0]).toBe('FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR')
+  })
+
+  it('emits FREQ=MONTHLY for monthly preset', async () => {
+    const { default: RecurrencePicker } = await import('../RecurrencePicker.vue')
+    const wrapper = mount(RecurrencePicker, {
+      props: { modelValue: null, startTime: '2024-06-10T09:00:00Z' },
+    })
+    await wrapper.find('select').setValue('monthly')
+    const emitted = wrapper.emitted('update:modelValue')
+    expect(emitted![0][0]).toBe('FREQ=MONTHLY')
+  })
+
+  it('shows custom text input when custom is selected', async () => {
+    const { default: RecurrencePicker } = await import('../RecurrencePicker.vue')
+    const wrapper = mount(RecurrencePicker, {
+      props: { modelValue: null, startTime: '2024-06-10T09:00:00Z' },
+    })
+    await wrapper.find('select').setValue('custom')
+    expect(wrapper.find('[data-testid="rrule-custom-input"]').exists()).toBe(true)
+  })
+
+  it('emits raw rrule string from custom text input', async () => {
+    const { default: RecurrencePicker } = await import('../RecurrencePicker.vue')
+    const wrapper = mount(RecurrencePicker, {
+      props: { modelValue: null, startTime: '2024-06-10T09:00:00Z' },
+    })
+    await wrapper.find('select').setValue('custom')
+    const input = wrapper.find('[data-testid="rrule-custom-input"]')
+    await input.setValue('FREQ=YEARLY;BYMONTH=6;BYMONTHDAY=10')
+    await input.trigger('change')
+    const emitted = wrapper.emitted('update:modelValue')
+    expect(emitted).toBeTruthy()
+    const lastEmit = emitted![emitted!.length - 1][0]
+    expect(lastEmit).toBe('FREQ=YEARLY;BYMONTH=6;BYMONTHDAY=10')
+  })
+
+  it('selects "none" when modelValue is null', async () => {
+    const { default: RecurrencePicker } = await import('../RecurrencePicker.vue')
+    const wrapper = mount(RecurrencePicker, {
+      props: { modelValue: null, startTime: '2024-06-10T09:00:00Z' },
+    })
+    const select = wrapper.find('select')
+    expect((select.element as HTMLSelectElement).value).toBe('none')
+  })
+
+  it('selects "daily" when modelValue is FREQ=DAILY', async () => {
+    const { default: RecurrencePicker } = await import('../RecurrencePicker.vue')
+    const wrapper = mount(RecurrencePicker, {
+      props: { modelValue: 'FREQ=DAILY', startTime: '2024-06-10T09:00:00Z' },
+    })
+    const select = wrapper.find('select')
+    expect((select.element as HTMLSelectElement).value).toBe('daily')
+  })
+
+  it('selects "custom" when modelValue is an unrecognized rrule', async () => {
+    const { default: RecurrencePicker } = await import('../RecurrencePicker.vue')
+    const wrapper = mount(RecurrencePicker, {
+      props: { modelValue: 'FREQ=YEARLY', startTime: '2024-06-10T09:00:00Z' },
+    })
+    const select = wrapper.find('select')
+    expect((select.element as HTMLSelectElement).value).toBe('custom')
+  })
+})

--- a/frontend/src/components/__tests__/TaskDetailPanelCalendar.test.ts
+++ b/frontend/src/components/__tests__/TaskDetailPanelCalendar.test.ts
@@ -109,6 +109,9 @@ describe('TaskDetailPanel — Calendar section RecurrencePicker', () => {
       task_id: 'task-1',
       anchor_id: null,
       color: null,
+      is_recurring: false,
+      is_occurrence: false,
+      rrule: null,
     })
 
     const { default: TaskDetailPanel } = await import('../TaskDetailPanel.vue')

--- a/frontend/src/components/__tests__/TaskDetailPanelCalendar.test.ts
+++ b/frontend/src/components/__tests__/TaskDetailPanelCalendar.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+// Full mock of vue-router
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ path: '/', query: {} }),
+  RouterLink: { template: '<a><slot /></a>' },
+}))
+
+// Mock all composables that touch the network
+vi.mock('../../composables/useSubtasks', () => ({
+  useSubtasks: () => ({ subtasks: { value: [] }, create: vi.fn(), update: vi.fn(), remove: vi.fn() }),
+}))
+vi.mock('../../composables/useLinks', () => ({
+  useLinks: () => ({ links: { value: [] }, create: vi.fn(), remove: vi.fn() }),
+}))
+vi.mock('../../composables/useDependencies', () => {
+  const { ref } = require('vue')
+  return {
+    useDependencies: () => ({ deps: ref({ blocked_by: [], blocks: [] }), add: vi.fn(), remove: vi.fn() }),
+  }
+})
+vi.mock('../../composables/useTaskContexts', () => {
+  const { ref } = require('vue')
+  return {
+    useTaskContexts: () => ({ contexts: ref([]), link: vi.fn(), unlink: vi.fn() }),
+  }
+})
+vi.mock('../../composables/useSlideOver', () => ({
+  useSlideOver: () => ({ push: vi.fn(), pop: vi.fn() }),
+}))
+
+// Mock api
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(async () => ({ ok: true, json: async () => [] })),
+}))
+
+const today = new Date().toISOString().slice(0, 10)
+
+// Mock stores that trigger async fetches in onMounted or have complex state
+vi.mock('../../stores/plan', () => ({
+  usePlanStore: () => ({
+    plan: null,
+    today,
+    activeDate: today,
+    fetchPlan: vi.fn(),
+  }),
+}))
+vi.mock('../../stores/milestones', () => ({
+  useMilestoneStore: () => ({
+    all: [],
+    taskMilestones: {},
+    fetchAll: vi.fn(),
+  }),
+}))
+vi.mock('../../stores/anchors', () => ({
+  useAnchorStore: () => ({
+    anchors: [],
+    fetchAnchors: vi.fn(),
+  }),
+}))
+
+// backlogStore is controlled per-test via a module-level ref so we can seed tasks
+const backlogTasksRef = ref<any[]>([])
+vi.mock('../../stores/backlog', () => ({
+  useBacklogStore: () => ({
+    get tasks() { return backlogTasksRef.value },
+    fetchTasks: vi.fn(),
+  }),
+}))
+
+const GLOBAL_STUBS = {
+  SearchAutocomplete: true,
+  RecurrencePicker: { template: '<div data-testid="recurrence-picker-stub" />' },
+  'router-link': { template: '<a><slot /></a>' },
+}
+
+const MOCK_TASK = {
+  id: 'task-1',
+  text: 'Test task',
+  status: 'pending',
+  description: null,
+  followup_config: null,
+}
+
+describe('TaskDetailPanel — Calendar section RecurrencePicker', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    backlogTasksRef.value = []
+  })
+
+  it('renders RecurrencePicker inside Calendar section when taskEvent exists', async () => {
+    const { useEventStore } = await import('../../stores/events')
+    const eventStore = useEventStore()
+
+    // Seed task so it's found immediately (no async wait needed)
+    backlogTasksRef.value = [MOCK_TASK]
+    // Seed a calendar event linked to task-1
+    eventStore.events.push({
+      id: 'ev-1',
+      title: 'Test task',
+      start_time: '2024-06-10T09:00:00Z',
+      end_time: '2024-06-10T10:00:00Z',
+      source: 'tether',
+      external_id: null,
+      task_id: 'task-1',
+      anchor_id: null,
+      color: null,
+    })
+
+    const { default: TaskDetailPanel } = await import('../TaskDetailPanel.vue')
+    const wrapper = mount(TaskDetailPanel, {
+      props: { taskId: 'task-1' },
+      global: { stubs: GLOBAL_STUBS },
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="recurrence-picker-stub"]').exists()).toBe(true)
+  })
+
+  it('does not render RecurrencePicker when no taskEvent exists for this task', async () => {
+    // Task exists but no calendar event is linked to it
+    backlogTasksRef.value = [MOCK_TASK]
+
+    const { default: TaskDetailPanel } = await import('../TaskDetailPanel.vue')
+    const wrapper = mount(TaskDetailPanel, {
+      props: { taskId: 'task-1' },
+      global: { stubs: GLOBAL_STUBS },
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="recurrence-picker-stub"]').exists()).toBe(false)
+  })
+})

--- a/frontend/src/stores/__tests__/events.test.ts
+++ b/frontend/src/stores/__tests__/events.test.ts
@@ -5,26 +5,34 @@ vi.mock('../../lib/api', () => ({
   api: vi.fn(() => Promise.resolve({ ok: false, json: async () => ({}) })),
 }))
 
+/** Minimal required fields for a non-recurring CalendarEvent. */
+const BASE_EVENT_FIELDS = {
+  source: 'tether' as const,
+  external_id: null,
+  anchor_id: null,
+  color: null,
+  is_recurring: false,
+  is_occurrence: false,
+  rrule: null,
+}
+
 describe('useEventStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
+    vi.clearAllMocks()
   })
 
   it('moveEvent updates start_time and end_time of the matching event', async () => {
     const { useEventStore } = await import('../events')
     const store = useEventStore()
 
-    // Seed a known event directly
     store.events.push({
+      ...BASE_EVENT_FIELDS,
       id: 'ev-1',
       title: 'Test',
       start_time: '2024-06-10T09:00:00.000Z',
       end_time: '2024-06-10T10:00:00.000Z',
-      source: 'tether',
-      external_id: null,
       task_id: null,
-      anchor_id: null,
-      color: null,
     })
 
     await store.moveEvent('ev-1', '2024-06-10T14:00:00.000Z', '2024-06-10T15:00:00.000Z')
@@ -36,7 +44,6 @@ describe('useEventStore', () => {
   it('moveEvent is a no-op for an unknown event id', async () => {
     const { useEventStore } = await import('../events')
     const store = useEventStore()
-    // Should not throw
     await expect(store.moveEvent('nonexistent', '2024-01-01T00:00:00Z', '2024-01-01T01:00:00Z')).resolves.toBeUndefined()
   })
 
@@ -54,15 +61,12 @@ describe('useEventStore', () => {
     const { api } = await import('../../lib/api')
     const mockTask = { id: 'task-123', text: 'New Event', status: 'pending' }
     const mockEvent = {
+      ...BASE_EVENT_FIELDS,
       id: 'ev-456',
       title: 'New Event',
       start_time: '2024-06-10T09:00:00Z',
       end_time: '2024-06-10T10:00:00Z',
-      source: 'tether',
-      external_id: null,
       task_id: 'task-123',
-      anchor_id: null,
-      color: null,
     }
     vi.mocked(api)
       .mockResolvedValueOnce({ ok: true, json: async () => mockTask } as any)
@@ -86,7 +90,6 @@ describe('useEventStore', () => {
     const store = useEventStore()
     const result = await store.createTaskAndPromote('2024-06-10T09:00:00Z', '2024-06-10T10:00:00Z')
     expect(result).toBe('task-789')
-    // Event not added to store since promotion failed
     expect(store.events).toHaveLength(0)
   })
 
@@ -96,29 +99,23 @@ describe('useEventStore', () => {
     const { api } = await import('../../lib/api')
     const mockEvents = [
       {
+        ...BASE_EVENT_FIELDS,
         id: 'ev-r1',
         title: 'Weekly standup',
         start_time: '2024-06-10T09:00:00Z',
         end_time: '2024-06-10T09:30:00Z',
-        source: 'tether',
-        external_id: null,
         task_id: null,
-        anchor_id: null,
-        color: null,
         is_recurring: true,
         is_occurrence: false,
         rrule: 'FREQ=WEEKLY;BYDAY=MO',
       },
       {
+        ...BASE_EVENT_FIELDS,
         id: 'ev-r2',
         title: 'Weekly standup',
         start_time: '2024-06-17T09:00:00Z',
         end_time: '2024-06-17T09:30:00Z',
-        source: 'tether',
-        external_id: null,
         task_id: null,
-        anchor_id: null,
-        color: null,
         is_recurring: false,
         is_occurrence: true,
         rrule: null,
@@ -140,15 +137,12 @@ describe('useEventStore', () => {
     const { useEventStore } = await import('../events')
     const store = useEventStore()
     store.events.push({
+      ...BASE_EVENT_FIELDS,
       id: 'ev-5',
       title: 'Recurring task',
       start_time: '2024-06-10T10:00:00Z',
       end_time: '2024-06-10T11:00:00Z',
-      source: 'tether',
-      external_id: null,
       task_id: 'task-5',
-      anchor_id: null,
-      color: null,
     })
 
     await store.setRecurrence('ev-5', 'FREQ=DAILY')
@@ -170,15 +164,12 @@ describe('useEventStore', () => {
     const { useEventStore } = await import('../events')
     const store = useEventStore()
     store.events.push({
+      ...BASE_EVENT_FIELDS,
       id: 'ev-6',
       title: 'Was recurring',
       start_time: '2024-06-10T10:00:00Z',
       end_time: '2024-06-10T11:00:00Z',
-      source: 'tether',
-      external_id: null,
       task_id: null,
-      anchor_id: null,
-      color: null,
       is_recurring: true,
       rrule: 'FREQ=WEEKLY',
     })
@@ -193,5 +184,27 @@ describe('useEventStore', () => {
     const { useEventStore } = await import('../events')
     const store = useEventStore()
     await expect(store.setRecurrence('nonexistent', 'FREQ=DAILY')).resolves.toBeUndefined()
+  })
+
+  it('setRecurrence is a no-op for an occurrence event (occurrences cannot own an rrule)', async () => {
+    const { api } = await import('../../lib/api')
+    const { useEventStore } = await import('../events')
+    const store = useEventStore()
+    store.events.push({
+      ...BASE_EVENT_FIELDS,
+      id: 'ev-occ',
+      title: 'Occurrence',
+      start_time: '2024-06-10T10:00:00Z',
+      end_time: '2024-06-10T11:00:00Z',
+      task_id: null,
+      is_occurrence: true,
+    })
+
+    await store.setRecurrence('ev-occ', 'FREQ=DAILY')
+
+    // API should not have been called, and rrule should remain null
+    expect(vi.mocked(api)).not.toHaveBeenCalled()
+    expect(store.events[0].rrule).toBeNull()
+    expect(store.events[0].is_recurring).toBe(false)
   })
 })

--- a/frontend/src/stores/__tests__/events.test.ts
+++ b/frontend/src/stores/__tests__/events.test.ts
@@ -89,4 +89,109 @@ describe('useEventStore', () => {
     // Event not added to store since promotion failed
     expect(store.events).toHaveLength(0)
   })
+
+  // --- RRULE / recurrence tests ---
+
+  it('fetchEvents passes through is_recurring and is_occurrence fields', async () => {
+    const { api } = await import('../../lib/api')
+    const mockEvents = [
+      {
+        id: 'ev-r1',
+        title: 'Weekly standup',
+        start_time: '2024-06-10T09:00:00Z',
+        end_time: '2024-06-10T09:30:00Z',
+        source: 'tether',
+        external_id: null,
+        task_id: null,
+        anchor_id: null,
+        color: null,
+        is_recurring: true,
+        is_occurrence: false,
+        rrule: 'FREQ=WEEKLY;BYDAY=MO',
+      },
+      {
+        id: 'ev-r2',
+        title: 'Weekly standup',
+        start_time: '2024-06-17T09:00:00Z',
+        end_time: '2024-06-17T09:30:00Z',
+        source: 'tether',
+        external_id: null,
+        task_id: null,
+        anchor_id: null,
+        color: null,
+        is_recurring: false,
+        is_occurrence: true,
+        rrule: null,
+      },
+    ]
+    vi.mocked(api).mockResolvedValueOnce({ ok: true, json: async () => mockEvents } as any)
+    const { useEventStore } = await import('../events')
+    const store = useEventStore()
+    await store.fetchEvents('2024-06-10', '2024-06-17')
+    expect(store.events).toHaveLength(2)
+    expect(store.events[0].is_recurring).toBe(true)
+    expect(store.events[0].rrule).toBe('FREQ=WEEKLY;BYDAY=MO')
+    expect(store.events[1].is_occurrence).toBe(true)
+  })
+
+  it('setRecurrence PATCHes the event and updates rrule in local state', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({ ok: true, json: async () => ({}) } as any)
+    const { useEventStore } = await import('../events')
+    const store = useEventStore()
+    store.events.push({
+      id: 'ev-5',
+      title: 'Recurring task',
+      start_time: '2024-06-10T10:00:00Z',
+      end_time: '2024-06-10T11:00:00Z',
+      source: 'tether',
+      external_id: null,
+      task_id: 'task-5',
+      anchor_id: null,
+      color: null,
+    })
+
+    await store.setRecurrence('ev-5', 'FREQ=DAILY')
+
+    expect(vi.mocked(api)).toHaveBeenCalledWith(
+      '/api/events/ev-5',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: expect.stringContaining('FREQ=DAILY'),
+      }),
+    )
+    expect(store.events[0].rrule).toBe('FREQ=DAILY')
+    expect(store.events[0].is_recurring).toBe(true)
+  })
+
+  it('setRecurrence with null clears rrule and is_recurring', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({ ok: true, json: async () => ({}) } as any)
+    const { useEventStore } = await import('../events')
+    const store = useEventStore()
+    store.events.push({
+      id: 'ev-6',
+      title: 'Was recurring',
+      start_time: '2024-06-10T10:00:00Z',
+      end_time: '2024-06-10T11:00:00Z',
+      source: 'tether',
+      external_id: null,
+      task_id: null,
+      anchor_id: null,
+      color: null,
+      is_recurring: true,
+      rrule: 'FREQ=WEEKLY',
+    })
+
+    await store.setRecurrence('ev-6', null)
+
+    expect(store.events[0].rrule).toBeNull()
+    expect(store.events[0].is_recurring).toBe(false)
+  })
+
+  it('setRecurrence is a no-op for unknown event id', async () => {
+    const { useEventStore } = await import('../events')
+    const store = useEventStore()
+    await expect(store.setRecurrence('nonexistent', 'FREQ=DAILY')).resolves.toBeUndefined()
+  })
 })

--- a/frontend/src/stores/events.ts
+++ b/frontend/src/stores/events.ts
@@ -135,5 +135,25 @@ export const useEventStore = defineStore('events', () => {
     events.value = events.value.filter(e => e.task_id !== taskId)
   }
 
-  return { events, loading, error, fetchEvents, promoteTask, createTaskAndPromote, moveEvent, demoteEvent, removeEventsForTask }
+  /**
+   * Set or clear the recurrence rule for a calendar event.
+   * Pass null to remove the recurrence entirely.
+   * PATCH /api/events/:id with { rrule } — updates optimistically.
+   */
+  async function setRecurrence(eventId: string, rrule: string | null): Promise<void> {
+    const ev = events.value.find(e => e.id === eventId)
+    if (!ev) return
+    // Optimistic update
+    ev.rrule = rrule
+    ev.is_recurring = rrule !== null
+    try {
+      await api(`/api/events/${eventId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rrule }),
+      })
+    } catch { /* ignore — optimistic update stays */ }
+  }
+
+  return { events, loading, error, fetchEvents, promoteTask, createTaskAndPromote, moveEvent, demoteEvent, removeEventsForTask, setRecurrence }
 })

--- a/frontend/src/stores/events.ts
+++ b/frontend/src/stores/events.ts
@@ -54,6 +54,9 @@ export const useEventStore = defineStore('events', () => {
       task_id: taskId,
       anchor_id: null,
       color: null,
+      is_recurring: false,
+      is_occurrence: false,
+      rrule: null,
     }
     events.value.push(optimistic)
     return optimistic
@@ -143,6 +146,8 @@ export const useEventStore = defineStore('events', () => {
   async function setRecurrence(eventId: string, rrule: string | null): Promise<void> {
     const ev = events.value.find(e => e.id === eventId)
     if (!ev) return
+    // Occurrences cannot carry their own rrule — only the master can.
+    if (ev.is_occurrence) return
     // Optimistic update
     ev.rrule = rrule
     ev.is_recurring = rrule !== null

--- a/frontend/src/types/events.ts
+++ b/frontend/src/types/events.ts
@@ -6,6 +6,9 @@
 //   POST /api/events                    → CalendarEvent  (promote task to event)
 //   PATCH /api/events/:id               → CalendarEvent
 //   DELETE /api/events/:id/time-constraint → void  (demote back to plain task)
+//
+// Note: backend contract uses numeric ids; frontend uses string ids throughout.
+// ID type reconciliation is tracked separately.
 
 export type EventSource = 'tether' | 'google_calendar' | 'ical'
 
@@ -19,4 +22,10 @@ export interface CalendarEvent {
   task_id: string | null  // FK to task if promoted; null for standalone/synced
   anchor_id: string | null
   color: string | null
+  /** True when this event is the master of a recurring series. */
+  is_recurring?: boolean
+  /** True when this event is a synthesized occurrence from an rrule expansion. */
+  is_occurrence?: boolean
+  /** RRULE string (e.g. "FREQ=WEEKLY;BYDAY=MO"). Present only on master events. */
+  rrule?: string | null
 }

--- a/frontend/src/types/events.ts
+++ b/frontend/src/types/events.ts
@@ -22,10 +22,10 @@ export interface CalendarEvent {
   task_id: string | null  // FK to task if promoted; null for standalone/synced
   anchor_id: string | null
   color: string | null
-  /** True when this event is the master of a recurring series. */
-  is_recurring?: boolean
-  /** True when this event is a synthesized occurrence from an rrule expansion. */
-  is_occurrence?: boolean
-  /** RRULE string (e.g. "FREQ=WEEKLY;BYDAY=MO"). Present only on master events. */
-  rrule?: string | null
+  /** True when this event is the master of a recurring series. Mutually exclusive with is_occurrence. */
+  is_recurring: boolean
+  /** True when this event is a synthesized occurrence from an rrule expansion. Mutually exclusive with is_recurring. */
+  is_occurrence: boolean
+  /** RRULE string (e.g. "FREQ=WEEKLY;BYDAY=MO"). Non-null only on master events (is_recurring === true). */
+  rrule: string | null
 }

--- a/frontend/src/views/__tests__/CalendarView.test.ts
+++ b/frontend/src/views/__tests__/CalendarView.test.ts
@@ -174,6 +174,9 @@ describe('CalendarView', () => {
         task_id: 'task-a',
         anchor_id: null,
         color: null,
+        is_recurring: false,
+        is_occurrence: false,
+        rrule: null,
       },
       {
         id: 'ev-b',
@@ -185,6 +188,9 @@ describe('CalendarView', () => {
         task_id: 'task-b',
         anchor_id: null,
         color: null,
+        is_recurring: false,
+        is_occurrence: false,
+        rrule: null,
       },
     )
     await nextTick()


### PR DESCRIPTION
## Summary

- **CalendarEvent type**: Added three new required fields `is_recurring: boolean`, `is_occurrence: boolean`, `rrule: string | null` — these are required (not optional) to enforce clear invariants and avoid three-state ambiguity.
- **CalendarEventBlock**: Renders a small ↻ indicator when `is_recurring || is_occurrence` is true (shows on both series masters and synthesized occurrences).
- **RecurrencePicker**: New component — dropdown with presets (Does not repeat / Daily / Weekly / Every weekday / Monthly / Custom RRULE text input). Weekly preset derives BYDAY from `start_time` day-of-week. Emits `update:modelValue` with `string | null`.
- **TaskDetailPanel**: Imports and wires `RecurrencePicker` into the Calendar section (visible only when `taskEvent` exists, matching the panel's live-edit pattern). Calls `eventStore.setRecurrence(id, rrule)` on change.
- **events store**: Added `setRecurrence(eventId, rrule | null)` action — optimistic update + PATCH `/api/events/:id`. Guards against setting rrule on occurrence events.

## Design notes

- ID type (`string` vs `number`) not changed — backend contract reconciliation tracked separately.
- Recurrence picker is shown only when `taskEvent` exists (matching existing live-edit pattern; no Save button needed).
- `setRecurrence` is a no-op on `is_occurrence` events — only masters can carry an rrule.
- The recurring indicator uses `is_recurring || is_occurrence` so both master and occurrence blocks show the ↻ icon.

## Test plan

- [ ] `npm run test` — 136 tests, all passing
- [ ] `npm run build` — zero type errors
- [ ] Code review (pr-review-toolkit): no blocking issues
- [ ] Type design review (pr-review-toolkit): recommendations applied (required booleans, occurrence guard, NaN fallback in dowFromISO)