### PR TITLE
feat: RRULE recurrence support for Google Calendar recurring events

### DIFF
--- a/db/migrations/versions/e1f2a3b4c5d6_rrule_recurrence_columns.py
+++ b/db/migrations/versions/e1f2a3b4c5d6_rrule_recurrence_columns.py
@@ -24,8 +24,12 @@ def upgrade() -> None:
     # recurrence_id — GCal recurringEventId for one-off exception instances
     op.execute("ALTER TABLE tasks ADD COLUMN recurrence_id TEXT NULL")
 
-    # exdates — excluded dates from the series (ISO date strings)
+    # exdates — excluded dates from the series (EXDATE lines from iCalendar recurrence array)
     op.execute("ALTER TABLE tasks ADD COLUMN exdates TEXT[] NULL DEFAULT '{}'")
+
+    # original_start_time — the original slot being replaced for moved exception instances;
+    # required for correct exception substitution when keying by original date
+    op.execute("ALTER TABLE tasks ADD COLUMN original_start_time TIMESTAMPTZ NULL")
 
     # Partial index for fast lookups of exception instances by series
     op.execute(
@@ -36,6 +40,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.execute("DROP INDEX IF EXISTS tasks_recurrence_id_idx")
+    op.execute("ALTER TABLE tasks DROP COLUMN IF EXISTS original_start_time")
     op.execute("ALTER TABLE tasks DROP COLUMN IF EXISTS exdates")
     op.execute("ALTER TABLE tasks DROP COLUMN IF EXISTS recurrence_id")
     op.execute("ALTER TABLE tasks DROP COLUMN IF EXISTS rrule")

--- a/db/migrations/versions/e1f2a3b4c5d6_rrule_recurrence_columns.py
+++ b/db/migrations/versions/e1f2a3b4c5d6_rrule_recurrence_columns.py
@@ -1,0 +1,41 @@
+"""rrule recurrence columns on tasks
+
+Store recurring Google Calendar events as a single task row per series,
+with RRULE string for occurrence expansion at query time.
+
+Revision ID: e1f2a3b4c5d6
+Revises: d2e3f4a5b6c7
+Create Date: 2026-04-26
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "e1f2a3b4c5d6"
+down_revision: Union[str, Sequence[str], None] = "d2e3f4a5b6c7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # rrule — RRULE string for recurring series master rows (e.g. "RRULE:FREQ=WEEKLY;BYDAY=MO")
+    op.execute("ALTER TABLE tasks ADD COLUMN rrule TEXT NULL")
+
+    # recurrence_id — GCal recurringEventId for one-off exception instances
+    op.execute("ALTER TABLE tasks ADD COLUMN recurrence_id TEXT NULL")
+
+    # exdates — excluded dates from the series (ISO date strings)
+    op.execute("ALTER TABLE tasks ADD COLUMN exdates TEXT[] NULL DEFAULT '{}'")
+
+    # Partial index for fast lookups of exception instances by series
+    op.execute(
+        "CREATE INDEX tasks_recurrence_id_idx ON tasks(user_id, recurrence_id)"
+        " WHERE recurrence_id IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS tasks_recurrence_id_idx")
+    op.execute("ALTER TABLE tasks DROP COLUMN IF EXISTS exdates")
+    op.execute("ALTER TABLE tasks DROP COLUMN IF EXISTS recurrence_id")
+    op.execute("ALTER TABLE tasks DROP COLUMN IF EXISTS rrule")

--- a/db/migrations/versions/e1f2a3b4c5d6_rrule_recurrence_columns.py
+++ b/db/migrations/versions/e1f2a3b4c5d6_rrule_recurrence_columns.py
@@ -12,7 +12,7 @@ from typing import Sequence, Union
 from alembic import op
 
 revision: str = "e1f2a3b4c5d6"
-down_revision: Union[str, Sequence[str], None] = "d2e3f4a5b6c7"
+down_revision: Union[str, Sequence[str], None] = "e3f4a5b6c7d8"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/db/pg_queries/integrations.py
+++ b/db/pg_queries/integrations.py
@@ -107,9 +107,9 @@ async def upsert_sync_state(
         VALUES ($1, $2, $3, $4, $5, $6)
         ON CONFLICT (integration_id, calendar_id) DO UPDATE SET
             sync_cursor       = EXCLUDED.sync_cursor,
-            watch_channel_id  = EXCLUDED.watch_channel_id,
-            watch_expiry      = EXCLUDED.watch_expiry,
-            watch_resource_id = EXCLUDED.watch_resource_id,
+            watch_channel_id  = COALESCE(EXCLUDED.watch_channel_id,  integration_sync_state.watch_channel_id),
+            watch_expiry      = COALESCE(EXCLUDED.watch_expiry,       integration_sync_state.watch_expiry),
+            watch_resource_id = COALESCE(EXCLUDED.watch_resource_id,  integration_sync_state.watch_resource_id),
             updated_at        = now()
         RETURNING *
         """,

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -670,7 +670,7 @@ async def upsert_task_from_draft(
 
 # ─── Event queries (tasks with start_time/end_time set) ───────────────────────
 
-from datetime import datetime as _datetime
+from datetime import datetime as _datetime, timedelta as _timedelta
 
 
 def _parse_ts(s: str) -> _datetime:
@@ -683,7 +683,7 @@ def _parse_ts(s: str) -> _datetime:
     return _datetime.fromisoformat(s.replace("Z", "+00:00"))
 
 
-def _row_to_event(row) -> dict:
+def _row_to_event(row, *, is_recurring: bool = False, is_occurrence: bool = False) -> dict:
     """Map a task row that has event fields to CalendarEvent shape."""
     r = dict(row)
     st = r.get("start_time")
@@ -699,7 +699,86 @@ def _row_to_event(row) -> dict:
         "task_id": uid,
         "anchor_id": str(r["anchor_id"]) if r.get("anchor_id") else None,
         "color": None,
+        "is_recurring": is_recurring,
+        "is_occurrence": is_occurrence,
     }
+
+
+def _parse_exdate(exdate_line: str) -> _datetime | None:
+    """Extract datetime from an EXDATE line like 'EXDATE;TZID=UTC:20260511T090000Z'.
+
+    Returns a UTC-aware datetime, or None if parsing fails.
+    """
+    try:
+        # Value is after the last colon
+        value = exdate_line.rsplit(":", 1)[-1].strip()
+        # Normalise: replace trailing Z, ensure isoformat-compatible string
+        value = value.replace("Z", "+00:00")
+        # iCalendar compact form: 20260511T090000+00:00
+        if "T" in value and len(value) >= 15:
+            # Insert separators if missing: YYYYMMDDTHHMMSS → YYYY-MM-DDTHH:MM:SS
+            if "-" not in value[:8]:
+                value = f"{value[:4]}-{value[4:6]}-{value[6:8]}T{value[9:11]}:{value[11:13]}:{value[13:15]}{value[15:]}"
+        dt = _datetime.fromisoformat(value)
+        if dt.tzinfo is None:
+            from datetime import timezone as _tz
+            dt = dt.replace(tzinfo=_tz.utc)
+        return dt
+    except Exception:
+        return None
+
+
+def expand_recurring(task: dict, window_start: _datetime, window_end: _datetime) -> list[dict]:
+    """Expand a recurring task's RRULE into concrete occurrences within the window.
+
+    Args:
+        task: CalendarEvent-shaped dict with rrule, start_time, end_time, exdates.
+        window_start: inclusive start of the query window (tz-aware).
+        window_end: inclusive end of the query window (tz-aware).
+
+    Returns:
+        List of CalendarEvent dicts, one per occurrence, with is_occurrence=True.
+        Occurrences matching any exdate are excluded.
+    """
+    from dateutil.rrule import rrulestr
+
+    rrule_str = task.get("rrule")
+    if not rrule_str:
+        return []
+
+    raw_start = task.get("start_time")
+    raw_end = task.get("end_time")
+    if not raw_start:
+        return []
+
+    dtstart = _parse_ts(raw_start) if isinstance(raw_start, str) else raw_start
+    if raw_end:
+        dtend = _parse_ts(raw_end) if isinstance(raw_end, str) else raw_end
+        duration = dtend - dtstart
+    else:
+        duration = _timedelta(hours=1)
+
+    # Build excluded dates set (date-only comparison for flexibility)
+    exdate_dates: set[tuple[int, int, int]] = set()
+    for exdate_line in (task.get("exdates") or []):
+        dt = _parse_exdate(exdate_line)
+        if dt:
+            exdate_dates.add((dt.year, dt.month, dt.day))
+
+    rule = rrulestr(rrule_str, dtstart=dtstart, ignoretz=False)
+    occurrences = []
+    for dt in rule.between(window_start, window_end, inc=True):
+        if (dt.year, dt.month, dt.day) in exdate_dates:
+            continue
+        occ = {
+            **task,
+            "start_time": dt.isoformat(),
+            "end_time": (dt + duration).isoformat(),
+            "is_occurrence": True,
+            "is_recurring": True,
+        }
+        occurrences.append(occ)
+    return occurrences
 
 
 async def promote_task_to_event(
@@ -732,19 +811,92 @@ async def get_events_for_range(
     start: str,
     end: str,
 ) -> list[dict]:
-    """Return all tasks that have been promoted to events within [start, end]."""
-    rows = await conn.fetch(
+    """Return all calendar events whose occurrence falls within [start, end].
+
+    Handles two kinds of tasks:
+    1. Single events (rrule IS NULL): start_time must fall in the window.
+       Exception instances (recurrence_id IS NOT NULL) are treated as single
+       events — they override a specific occurrence of a series.
+    2. Recurring series masters (rrule IS NOT NULL): fetched separately and
+       expanded via RRULE; occurrences outside the window are dropped.
+       Exception instances from the same user are fetched and substitute
+       the computed occurrence for their specific date.
+    """
+    window_start = _parse_ts(start)
+    window_end = _parse_ts(end)
+
+    # 1. Single events (non-recurring, non-exception): rrule IS NULL and no recurrence_id
+    single_rows = await conn.fetch(
         """
-        SELECT uuid, text, start_time, end_time, source, external_id, anchor_id
+        SELECT uuid, text, start_time, end_time, source, external_id, anchor_id, rrule, recurrence_id, exdates
         FROM tasks
         WHERE start_time IS NOT NULL
+          AND rrule IS NULL
+          AND recurrence_id IS NULL
           AND start_time >= $1
           AND start_time <= $2
         ORDER BY start_time
         """,
-        _parse_ts(start), _parse_ts(end),
+        window_start, window_end,
     )
-    return [_row_to_event(r) for r in rows]
+    results: list[dict] = [_row_to_event(r) for r in single_rows]
+
+    # 2. Recurring series masters: expand via RRULE
+    recurring_rows = await conn.fetch(
+        """
+        SELECT uuid, text, start_time, end_time, source, external_id, anchor_id, rrule, recurrence_id, exdates
+        FROM tasks
+        WHERE rrule IS NOT NULL
+          AND start_time IS NOT NULL
+        ORDER BY start_time
+        """,
+    )
+
+    if not recurring_rows:
+        return sorted(results, key=lambda e: e["start_time"] or "")
+
+    # Fetch all exception instances (recurrence_id IS NOT NULL) for series in window
+    master_external_ids = [str(r["external_id"]) for r in recurring_rows if r["external_id"]]
+    exception_rows: list = []
+    if master_external_ids:
+        exception_rows = await conn.fetch(
+            """
+            SELECT uuid, text, start_time, end_time, source, external_id, anchor_id, rrule, recurrence_id, exdates
+            FROM tasks
+            WHERE recurrence_id = ANY($1::text[])
+              AND start_time >= $2
+              AND start_time <= $3
+            """,
+            master_external_ids, window_start, window_end,
+        )
+
+    # Key exceptions by (recurrence_id, date) for substitution
+    exception_by_key: dict[tuple[str, tuple[int, int, int]], dict] = {}
+    for exc_row in exception_rows:
+        exc = _row_to_event(exc_row, is_occurrence=True, is_recurring=True)
+        rid = exc_row["recurrence_id"]
+        if exc["start_time"] and rid:
+            dt = _parse_ts(exc["start_time"])
+            exception_by_key[(str(rid), (dt.year, dt.month, dt.day))] = exc
+
+    # Expand each recurring master and substitute exception instances
+    for master_row in recurring_rows:
+        task = _row_to_event(master_row, is_recurring=True)
+        task["rrule"] = master_row["rrule"]
+        task["exdates"] = list(master_row["exdates"] or [])
+        task["start_time"] = master_row["start_time"].isoformat() if master_row["start_time"] else None
+        task["end_time"] = master_row["end_time"].isoformat() if master_row["end_time"] else None
+
+        for occ in expand_recurring(task, window_start, window_end):
+            occ_dt = _parse_ts(occ["start_time"])
+            key = (str(master_row["external_id"] or ""), (occ_dt.year, occ_dt.month, occ_dt.day))
+            if key in exception_by_key:
+                # Exception instance overrides this occurrence
+                results.append(exception_by_key[key])
+            else:
+                results.append(occ)
+
+    return sorted(results, key=lambda e: e["start_time"] or "")
 
 
 async def update_event_time(

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -897,7 +897,7 @@ async def get_events_for_range(
     # Key exceptions by (recurrence_id, original_date) for substitution.
     # original_start_time is the slot being replaced (what expand_recurring would compute).
     # start_time is where the exception actually appears (may differ for moved exceptions).
-    exception_by_key: dict[tuple[str, tuple[int, int, int]], dict] = {}
+    exception_by_key: dict[tuple[str, tuple[int, int, int]], dict | None] = {}
     for exc_row in exception_rows:
         rid = exc_row["recurrence_id"]
         if not rid:
@@ -918,7 +918,7 @@ async def get_events_for_range(
             exception_by_key[(str(rid), key_date)] = exc
         else:
             # Moved outside window — still register the key to suppress the ghost occurrence
-            exception_by_key[(str(rid), key_date)] = None  # type: ignore[assignment]
+            exception_by_key[(str(rid), key_date)] = None
 
     # Expand each recurring master and substitute exception instances
     for master_row in recurring_rows:

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -704,21 +704,21 @@ def _row_to_event(row, *, is_recurring: bool = False, is_occurrence: bool = Fals
     }
 
 
-def _parse_exdate(exdate_line: str) -> _datetime | None:
-    """Extract datetime from an EXDATE line like 'EXDATE;TZID=UTC:20260511T090000Z'.
+def _parse_exdate_value(value: str) -> _datetime | None:
+    """Parse a single EXDATE datetime token into a UTC-aware datetime.
 
-    Returns a UTC-aware datetime, or None if parsing fails.
+    Handles iCalendar compact form without hyphens/colons, e.g. 20260511T090000Z.
+    Returns None if parsing fails.
     """
     try:
-        # Value is after the last colon
-        value = exdate_line.rsplit(":", 1)[-1].strip()
-        # Normalise: replace trailing Z, ensure isoformat-compatible string
-        value = value.replace("Z", "+00:00")
-        # iCalendar compact form: 20260511T090000+00:00
+        value = value.strip().replace("Z", "+00:00")
         if "T" in value and len(value) >= 15:
             # Insert separators if missing: YYYYMMDDTHHMMSS → YYYY-MM-DDTHH:MM:SS
             if "-" not in value[:8]:
-                value = f"{value[:4]}-{value[4:6]}-{value[6:8]}T{value[9:11]}:{value[11:13]}:{value[13:15]}{value[15:]}"
+                value = (
+                    f"{value[:4]}-{value[4:6]}-{value[6:8]}"
+                    f"T{value[9:11]}:{value[11:13]}:{value[13:15]}{value[15:]}"
+                )
         dt = _datetime.fromisoformat(value)
         if dt.tzinfo is None:
             from datetime import timezone as _tz
@@ -726,6 +726,26 @@ def _parse_exdate(exdate_line: str) -> _datetime | None:
         return dt
     except Exception:
         return None
+
+
+def _parse_exdate(exdate_line: str) -> list[_datetime]:
+    """Extract datetimes from an EXDATE line.
+
+    Handles single and comma-separated RFC 5545 formats:
+      EXDATE;TZID=UTC:20260511T090000Z
+      EXDATE;TZID=UTC:20260511T090000Z,20260518T090000Z
+
+    Returns a list of UTC-aware datetimes (may be empty on parse failure).
+    """
+    try:
+        # Value portion is everything after the last colon
+        value_part = exdate_line.rsplit(":", 1)[-1].strip()
+        return [
+            dt for raw in value_part.split(",")
+            if (dt := _parse_exdate_value(raw)) is not None
+        ]
+    except Exception:
+        return []
 
 
 def expand_recurring(task: dict, window_start: _datetime, window_end: _datetime) -> list[dict]:
@@ -761,8 +781,7 @@ def expand_recurring(task: dict, window_start: _datetime, window_end: _datetime)
     # Build excluded dates set (date-only comparison for flexibility)
     exdate_dates: set[tuple[int, int, int]] = set()
     for exdate_line in (task.get("exdates") or []):
-        dt = _parse_exdate(exdate_line)
-        if dt:
+        for dt in _parse_exdate(exdate_line):
             exdate_dates.add((dt.year, dt.month, dt.day))
 
     rule = rrulestr(rrule_str, dtstart=dtstart, ignoretz=False)

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -709,24 +709,36 @@ def _row_to_event(row, *, is_recurring: bool = False, is_occurrence: bool = Fals
 def _parse_exdate_value(value: str) -> _datetime | None:
     """Parse a single EXDATE datetime token into a UTC-aware datetime.
 
-    Handles iCalendar compact form without hyphens/colons, e.g. 20260511T090000Z.
-    Returns None if parsing fails.
+    Handles iCalendar compact form without hyphens/colons, e.g. 20260511T090000Z,
+    and all-day date tokens without a time component, e.g. 20260511 or 2026-05-11.
+    Returns None (with a warning) if parsing fails.
     """
+    import logging
+    _logger = logging.getLogger(__name__)
     try:
         value = value.strip().replace("Z", "+00:00")
-        if "T" in value and len(value) >= 15:
-            # Insert separators if missing: YYYYMMDDTHHMMSS → YYYY-MM-DDTHH:MM:SS
-            if "-" not in value[:8]:
+        if "T" in value:
+            if len(value) >= 15 and "-" not in value[:8]:
+                # Insert separators: YYYYMMDDTHHMMSS → YYYY-MM-DDTHH:MM:SS
                 value = (
                     f"{value[:4]}-{value[4:6]}-{value[6:8]}"
                     f"T{value[9:11]}:{value[11:13]}:{value[13:15]}{value[15:]}"
                 )
+        else:
+            # All-day date token (VALUE=DATE format): "20260511" or "2026-05-11"
+            from datetime import date as _date, timezone as _tz
+            bare = value.replace("+00:00", "").strip()
+            if len(bare) == 8 and "-" not in bare:
+                bare = f"{bare[:4]}-{bare[4:6]}-{bare[6:8]}"
+            d = _date.fromisoformat(bare)
+            return _datetime(d.year, d.month, d.day, tzinfo=_tz.utc)
         dt = _datetime.fromisoformat(value)
         if dt.tzinfo is None:
             from datetime import timezone as _tz
             dt = dt.replace(tzinfo=_tz.utc)
         return dt
-    except Exception:
+    except ValueError:
+        _logger.warning("EXDATE token could not be parsed, occurrence will NOT be suppressed: %r", value)
         return None
 
 
@@ -890,6 +902,7 @@ async def get_events_for_range(
                    rrule, recurrence_id, exdates, original_start_time
             FROM tasks
             WHERE recurrence_id = ANY($1::text[])
+              AND (source_status IS NULL OR source_status != 'cancelled')
             """,
             master_external_ids,
         )

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -632,17 +632,21 @@ async def upsert_task_from_draft(
         INSERT INTO tasks
             (uuid, user_id, text, source, external_id,
              start_time, end_time, description, external_url, source_status,
+             rrule, recurrence_id, exdates,
              status, position)
-        VALUES ($1, $2::uuid, $3, $4, $5, $6, $7, $8, $9, $10, 'pending', 0)
+        VALUES ($1, $2::uuid, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, 'pending', 0)
         ON CONFLICT (user_id, source, external_id) WHERE source IS NOT NULL
         DO UPDATE SET
-            text         = EXCLUDED.text,
-            start_time   = EXCLUDED.start_time,
-            end_time     = EXCLUDED.end_time,
-            description  = EXCLUDED.description,
-            external_url = EXCLUDED.external_url,
+            text          = EXCLUDED.text,
+            start_time    = EXCLUDED.start_time,
+            end_time      = EXCLUDED.end_time,
+            description   = EXCLUDED.description,
+            external_url  = EXCLUDED.external_url,
             source_status = EXCLUDED.source_status,
-            version      = tasks.version + 1
+            rrule         = EXCLUDED.rrule,
+            recurrence_id = EXCLUDED.recurrence_id,
+            exdates       = EXCLUDED.exdates,
+            version       = tasks.version + 1
         RETURNING
             uuid, text, status, position, followup_config,
             description, context_subject, context_node_id, version
@@ -657,6 +661,9 @@ async def upsert_task_from_draft(
         draft.description,
         draft.external_url,
         draft.source_status,
+        draft.rrule,
+        draft.recurrence_id,
+        draft.exdates or [],
     )
     return _row_to_task(row)
 

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -632,21 +632,22 @@ async def upsert_task_from_draft(
         INSERT INTO tasks
             (uuid, user_id, text, source, external_id,
              start_time, end_time, description, external_url, source_status,
-             rrule, recurrence_id, exdates,
+             rrule, recurrence_id, exdates, original_start_time,
              status, position)
-        VALUES ($1, $2::uuid, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, 'pending', 0)
+        VALUES ($1, $2::uuid, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, 'pending', 0)
         ON CONFLICT (user_id, source, external_id) WHERE source IS NOT NULL
         DO UPDATE SET
-            text          = EXCLUDED.text,
-            start_time    = EXCLUDED.start_time,
-            end_time      = EXCLUDED.end_time,
-            description   = EXCLUDED.description,
-            external_url  = EXCLUDED.external_url,
-            source_status = EXCLUDED.source_status,
-            rrule         = EXCLUDED.rrule,
-            recurrence_id = EXCLUDED.recurrence_id,
-            exdates       = EXCLUDED.exdates,
-            version       = tasks.version + 1
+            text               = EXCLUDED.text,
+            start_time         = EXCLUDED.start_time,
+            end_time           = EXCLUDED.end_time,
+            description        = EXCLUDED.description,
+            external_url       = EXCLUDED.external_url,
+            source_status      = EXCLUDED.source_status,
+            rrule              = EXCLUDED.rrule,
+            recurrence_id      = EXCLUDED.recurrence_id,
+            exdates            = EXCLUDED.exdates,
+            original_start_time = EXCLUDED.original_start_time,
+            version            = tasks.version + 1
         RETURNING
             uuid, text, status, position, followup_config,
             description, context_subject, context_node_id, version
@@ -664,6 +665,7 @@ async def upsert_task_from_draft(
         draft.rrule,
         draft.recurrence_id,
         draft.exdates or [],
+        draft.original_start_time,
     )
     return _row_to_task(row)
 
@@ -847,7 +849,8 @@ async def get_events_for_range(
     # 1. Single events (non-recurring, non-exception): rrule IS NULL and no recurrence_id
     single_rows = await conn.fetch(
         """
-        SELECT uuid, text, start_time, end_time, source, external_id, anchor_id, rrule, recurrence_id, exdates
+        SELECT uuid, text, start_time, end_time, source, external_id, anchor_id,
+               rrule, recurrence_id, exdates, original_start_time
         FROM tasks
         WHERE start_time IS NOT NULL
           AND rrule IS NULL
@@ -863,7 +866,8 @@ async def get_events_for_range(
     # 2. Recurring series masters: expand via RRULE
     recurring_rows = await conn.fetch(
         """
-        SELECT uuid, text, start_time, end_time, source, external_id, anchor_id, rrule, recurrence_id, exdates
+        SELECT uuid, text, start_time, end_time, source, external_id, anchor_id,
+               rrule, recurrence_id, exdates, original_start_time
         FROM tasks
         WHERE rrule IS NOT NULL
           AND start_time IS NOT NULL
@@ -874,29 +878,47 @@ async def get_events_for_range(
     if not recurring_rows:
         return sorted(results, key=lambda e: e["start_time"] or "")
 
-    # Fetch all exception instances (recurrence_id IS NOT NULL) for series in window
+    # Fetch all exception instances (recurrence_id IS NOT NULL) for series in window.
+    # No time filter here — moved exceptions may fall outside the query window in
+    # start_time but still need to suppress the computed occurrence.
     master_external_ids = [str(r["external_id"]) for r in recurring_rows if r["external_id"]]
     exception_rows: list = []
     if master_external_ids:
         exception_rows = await conn.fetch(
             """
-            SELECT uuid, text, start_time, end_time, source, external_id, anchor_id, rrule, recurrence_id, exdates
+            SELECT uuid, text, start_time, end_time, source, external_id, anchor_id,
+                   rrule, recurrence_id, exdates, original_start_time
             FROM tasks
             WHERE recurrence_id = ANY($1::text[])
-              AND start_time >= $2
-              AND start_time <= $3
             """,
-            master_external_ids, window_start, window_end,
+            master_external_ids,
         )
 
-    # Key exceptions by (recurrence_id, date) for substitution
+    # Key exceptions by (recurrence_id, original_date) for substitution.
+    # original_start_time is the slot being replaced (what expand_recurring would compute).
+    # start_time is where the exception actually appears (may differ for moved exceptions).
     exception_by_key: dict[tuple[str, tuple[int, int, int]], dict] = {}
     for exc_row in exception_rows:
-        exc = _row_to_event(exc_row, is_occurrence=True, is_recurring=True)
         rid = exc_row["recurrence_id"]
-        if exc["start_time"] and rid:
-            dt = _parse_ts(exc["start_time"])
-            exception_by_key[(str(rid), (dt.year, dt.month, dt.day))] = exc
+        if not rid:
+            continue
+        # Use original_start_time to key the occurrence being replaced; fall back to start_time
+        original_st = exc_row.get("original_start_time") or exc_row.get("start_time")
+        if not original_st:
+            continue
+        if hasattr(original_st, "date"):
+            key_date = (original_st.year, original_st.month, original_st.day)
+        else:
+            dt = _parse_ts(str(original_st))
+            key_date = (dt.year, dt.month, dt.day)
+        # Only include in results if the exception itself falls within the window
+        exc_start = exc_row.get("start_time")
+        if exc_start and window_start <= exc_start <= window_end:
+            exc = _row_to_event(exc_row, is_occurrence=True, is_recurring=True)
+            exception_by_key[(str(rid), key_date)] = exc
+        else:
+            # Moved outside window — still register the key to suppress the ghost occurrence
+            exception_by_key[(str(rid), key_date)] = None  # type: ignore[assignment]
 
     # Expand each recurring master and substitute exception instances
     for master_row in recurring_rows:
@@ -910,8 +932,11 @@ async def get_events_for_range(
             occ_dt = _parse_ts(occ["start_time"])
             key = (str(master_row["external_id"] or ""), (occ_dt.year, occ_dt.month, occ_dt.day))
             if key in exception_by_key:
-                # Exception instance overrides this occurrence
-                results.append(exception_by_key[key])
+                # exception_by_key[key] is None when the moved exception falls outside the
+                # query window — suppress the ghost occurrence but emit nothing.
+                exc = exception_by_key[key]
+                if exc is not None:
+                    results.append(exc)
             else:
                 results.append(occ)
 

--- a/integrations/google_calendar/mapping.py
+++ b/integrations/google_calendar/mapping.py
@@ -79,7 +79,7 @@ def _extract_recurrence(raw: dict) -> tuple[str | None, list[str]]:
     - rrule: the first "RRULE:..." line joined as a single string, or None
     - exdates: all lines starting with "EXDATE"
     """
-    lines: list[str] = raw.get("recurrence", [])
+    lines: list[str] = raw.get("recurrence") or []
     rrule_lines = [l for l in lines if l.startswith("RRULE:")]
     exdate_lines = [l for l in lines if l.startswith("EXDATE")]
     rrule = rrule_lines[0] if rrule_lines else None

--- a/integrations/google_calendar/mapping.py
+++ b/integrations/google_calendar/mapping.py
@@ -115,6 +115,7 @@ def map_event(raw: dict) -> TaskDraft:
 
     rrule, exdates = _extract_recurrence(raw)
     recurrence_id: str | None = raw.get("recurringEventId")
+    original_start_time = _parse_dt(raw.get("originalStartTime"))
 
     return TaskDraft(
         title=title,
@@ -128,4 +129,5 @@ def map_event(raw: dict) -> TaskDraft:
         rrule=rrule,
         recurrence_id=recurrence_id,
         exdates=exdates,
+        original_start_time=original_start_time,
     )

--- a/integrations/google_calendar/mapping.py
+++ b/integrations/google_calendar/mapping.py
@@ -97,7 +97,9 @@ def map_event(raw: dict) -> TaskDraft:
     - Exception instances: extracts recurringEventId → recurrence_id
     """
     title = raw.get("summary") or "(No title)"
-    external_id = raw.get("id", "")
+    external_id = raw.get("id")
+    if not external_id:
+        raise ValueError(f"Google Calendar event missing 'id' field: {raw!r}")
     description = _strip_html(raw.get("description"))
 
     start_time = _parse_dt(raw.get("start"))

--- a/integrations/google_calendar/mapping.py
+++ b/integrations/google_calendar/mapping.py
@@ -72,6 +72,20 @@ def _conference_url(event: dict) -> str | None:
     return None
 
 
+def _extract_recurrence(raw: dict) -> tuple[str | None, list[str]]:
+    """Extract RRULE string and EXDATE lines from a GCal event's recurrence array.
+
+    Returns (rrule, exdates) where:
+    - rrule: the first "RRULE:..." line joined as a single string, or None
+    - exdates: all lines starting with "EXDATE"
+    """
+    lines: list[str] = raw.get("recurrence", [])
+    rrule_lines = [l for l in lines if l.startswith("RRULE:")]
+    exdate_lines = [l for l in lines if l.startswith("EXDATE")]
+    rrule = rrule_lines[0] if rrule_lines else None
+    return rrule, exdate_lines
+
+
 def map_event(raw: dict) -> TaskDraft:
     """Convert a raw Google Calendar event dict to a TaskDraft.
 
@@ -79,6 +93,8 @@ def map_event(raw: dict) -> TaskDraft:
     - Regular and all-day events
     - Conference links (Meet preferred, htmlLink fallback)
     - Cancelled status → source_status='cancelled'
+    - Recurring series: extracts rrule and exdates from recurrence array
+    - Exception instances: extracts recurringEventId → recurrence_id
     """
     title = raw.get("summary") or "(No title)"
     external_id = raw.get("id", "")
@@ -97,6 +113,9 @@ def map_event(raw: dict) -> TaskDraft:
 
     source_status = "cancelled" if raw.get("status") == "cancelled" else None
 
+    rrule, exdates = _extract_recurrence(raw)
+    recurrence_id: str | None = raw.get("recurringEventId")
+
     return TaskDraft(
         title=title,
         source=_SOURCE,
@@ -106,4 +125,7 @@ def map_event(raw: dict) -> TaskDraft:
         description=description,
         external_url=external_url,
         source_status=source_status,
+        rrule=rrule,
+        recurrence_id=recurrence_id,
+        exdates=exdates,
     )

--- a/integrations/google_calendar/sync.py
+++ b/integrations/google_calendar/sync.py
@@ -180,6 +180,14 @@ class GoogleCalendarSync(SyncProvider):
     ) -> str:
         """Fetch incremental changes via Google's syncToken mechanism.
 
+        Uses singleEvents=false so recurring event series are returned as a single
+        master row (with an RRULE string) rather than expanded into individual
+        occurrences. This avoids the 250-item page limit that expansion causes.
+
+        Paginates through all pages via nextPageToken — each subsequent request
+        uses only pageToken (not syncToken). nextSyncToken appears on the final
+        page and is persisted as the new cursor.
+
         Iterates all returned items:
           - cancelled items  → soft_delete_task_by_external_id
           - active items     → normalize_event() → upsert_task_from_draft()
@@ -194,38 +202,47 @@ class GoogleCalendarSync(SyncProvider):
         user_id = info["user_id"]
 
         url = _CALENDAR_EVENTS_URL.format(calendar_id=calendar_id)
-        params: dict = {"singleEvents": "true"}
+        # Build initial params — singleEvents omitted (false is the default) so
+        # recurring events come back as series masters with RRULE, not expanded.
+        initial_params: dict = {}
         if since_cursor:
-            params["syncToken"] = since_cursor
+            initial_params["syncToken"] = since_cursor
         else:
             # Initial import: 30 days back, no end limit
             thirty_days_ago = (
                 datetime.now(timezone.utc) - timedelta(days=30)
             ).isoformat()
-            params["timeMin"] = thirty_days_ago
+            initial_params["timeMin"] = thirty_days_ago
 
+        all_items: list[dict] = []
+        new_token = ""
+
+        # Pagination loop: first request uses initial_params; subsequent requests
+        # use only pageToken (drop syncToken per Google API spec).
+        params = initial_params
         async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                url,
-                headers={"Authorization": f"Bearer {access_token}"},
-                params=params,
-            )
+            while True:
+                resp = await client.get(
+                    url,
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    params=params,
+                )
+                if resp.status_code == 410:
+                    raise ValueError("Sync token invalidated (410) — full resync needed")
+                resp.raise_for_status()
+                data = resp.json()
 
-        if resp.status_code == 410:
-            raise ValueError("Sync token invalidated (410) — full resync needed")
-        resp.raise_for_status()
-        data = resp.json()
+                all_items.extend(data.get("items", []))
+                new_token = data.get("nextSyncToken", new_token)
 
-        if data.get("nextPageToken"):
-            logger.warning(
-                "poll: nextPageToken present for integration=%s calendar=%s — "
-                "pagination is not yet implemented; some items may be truncated",
-                integration_id,
-                calendar_id,
-            )
+                next_page = data.get("nextPageToken")
+                if not next_page:
+                    break
+                # Subsequent pages: use only pageToken, not syncToken
+                params = {"pageToken": next_page}
 
         async with pg.get_conn(self._pool, user_id=user_id) as conn:
-            for item in data.get("items", []):
+            for item in all_items:
                 if item.get("status") == "cancelled":
                     await soft_delete_task_by_external_id(
                         conn, user_id, "google_calendar", item["id"]
@@ -234,7 +251,6 @@ class GoogleCalendarSync(SyncProvider):
                     draft = await self.normalize_event(item)
                     await upsert_task_from_draft(conn, user_id, draft)
 
-            new_token = data.get("nextSyncToken", "")
             if new_token:
                 await upsert_sync_state(
                     conn, integration_id, calendar_id, sync_cursor=new_token

--- a/integrations/models.py
+++ b/integrations/models.py
@@ -26,6 +26,7 @@ class TaskDraft:
     rrule: str | None = None                          # e.g. "RRULE:FREQ=WEEKLY;BYDAY=MO"
     recurrence_id: str | None = None                  # GCal recurringEventId (exception instances)
     exdates: list[str] = field(default_factory=list)  # EXDATE lines from recurrence array
+    original_start_time: datetime | None = None       # originalStartTime for moved exceptions
 
 
 @dataclass

--- a/integrations/models.py
+++ b/integrations/models.py
@@ -22,6 +22,11 @@ class TaskDraft:
     external_url: str | None = None
     source_status: str | None = None   # "cancelled" triggers soft-delete
 
+    # Recurrence fields (Google Calendar recurring events)
+    rrule: str | None = None                          # e.g. "RRULE:FREQ=WEEKLY;BYDAY=MO"
+    recurrence_id: str | None = None                  # GCal recurringEventId (exception instances)
+    exdates: list[str] = field(default_factory=list)  # EXDATE lines from recurrence array
+
 
 @dataclass
 class WebhookPayload:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "apscheduler>=3.10,<4",
     "slowapi>=0.1.9",
     "werkzeug>=3.0",
+    "python-dateutil>=2.8",
 ]
 
 [project.optional-dependencies]

--- a/tests/api/test_get_events_for_range.py
+++ b/tests/api/test_get_events_for_range.py
@@ -189,3 +189,60 @@ async def test_exception_moved_outside_window_suppresses_ghost_emits_nothing():
 
     june1 = datetime(2026, 6, 1, 9, 0, tzinfo=tz).isoformat()
     assert june1 not in start_times, "June-1 exception is outside window — must not appear"
+
+
+async def test_cancelled_exception_instance_not_returned():
+    """Soft-deleted (cancelled) exception instances must not appear in event results.
+
+    GCal sync marks cancelled instances with source_status='cancelled' via
+    soft_delete_task_by_external_id. The exception query must filter these out
+    so they don't land in results as visible events.
+    """
+    tz = timezone.utc
+    series_id = "gcal-series-cancelled-exc"
+
+    master = _master_row(
+        external_id=series_id,
+        start=datetime(2026, 5, 4, 9, 0, tzinfo=tz),
+        end=datetime(2026, 5, 4, 9, 30, tzinfo=tz),
+    )
+    # Cancelled exception for the May 11 slot
+    cancelled_exc = {
+        "uuid": uuid.UUID("cccccccc-0000-0000-0000-000000000003"),
+        "text": "Weekly standup (cancelled instance)",
+        "start_time": datetime(2026, 5, 11, 9, 0, tzinfo=tz),   # within window
+        "end_time": datetime(2026, 5, 11, 9, 30, tzinfo=tz),
+        "source": "google_calendar",
+        "external_id": "gcal-exception-cancelled",
+        "anchor_id": None,
+        "rrule": None,
+        "recurrence_id": series_id,
+        "exdates": [],
+        "original_start_time": datetime(2026, 5, 11, 9, 0, tzinfo=tz),
+        "source_status": "cancelled",
+    }
+
+    # The exception query should filter source_status='cancelled' — so we simulate
+    # the DB returning an empty list for exceptions (as it should after the fix).
+    conn = _conn_with_fetch(
+        [],       # single events — none
+        [master], # recurring masters — one weekly series
+        [],       # exception instances — empty (cancelled row filtered by SQL)
+    )
+
+    events = await get_events_for_range(
+        conn,
+        "2026-05-01T00:00:00+00:00",
+        "2026-05-31T23:59:59+00:00",
+    )
+
+    start_times = [e["start_time"] for e in events]
+
+    # Should have 4 computed occurrences (no exception substitution)
+    assert len(events) == 4, (
+        f"Expected 4 computed occurrences, got {len(events)}: {start_times}"
+    )
+    # Cancelled exception must NOT appear
+    assert all(e.get("source_status") != "cancelled" for e in events), (
+        "No cancelled events should appear in results"
+    )

--- a/tests/api/test_get_events_for_range.py
+++ b/tests/api/test_get_events_for_range.py
@@ -1,0 +1,191 @@
+"""Mock-based tests for get_events_for_range exception substitution.
+
+Tests the moved-exception substitution path in get_events_for_range() without
+requiring a live database. Uses AsyncMock to simulate conn.fetch returns.
+
+Key scenario: a Google Calendar recurring event where one instance is moved
+to a different time on the same day. The function must:
+  1. Suppress the "ghost" computed occurrence at the original slot.
+  2. Emit the actual exception instance at its real (moved) time.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from db.pg_queries.tasks import get_events_for_range
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build row dicts that duck-type asyncpg.Record
+# ---------------------------------------------------------------------------
+
+def _master_row(
+    external_id: str,
+    start: datetime,
+    end: datetime,
+    rrule: str = "RRULE:FREQ=WEEKLY",
+) -> dict:
+    return {
+        "uuid": uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001"),
+        "text": "Weekly standup",
+        "start_time": start,
+        "end_time": end,
+        "source": "google_calendar",
+        "external_id": external_id,
+        "anchor_id": None,
+        "rrule": rrule,
+        "recurrence_id": None,
+        "exdates": [],
+        "original_start_time": None,
+    }
+
+
+def _exception_row(
+    external_id: str,
+    recurrence_id: str,
+    start: datetime,
+    end: datetime,
+    original_start_time: datetime,
+) -> dict:
+    return {
+        "uuid": uuid.UUID("bbbbbbbb-0000-0000-0000-000000000002"),
+        "text": "Weekly standup (moved)",
+        "start_time": start,
+        "end_time": end,
+        "source": "google_calendar",
+        "external_id": external_id,
+        "anchor_id": None,
+        "rrule": None,
+        "recurrence_id": recurrence_id,
+        "exdates": [],
+        "original_start_time": original_start_time,
+    }
+
+
+def _conn_with_fetch(*fetch_results) -> MagicMock:
+    """Return a mock connection whose fetch() returns successive result sets."""
+    conn = MagicMock()
+    conn.fetch = AsyncMock(side_effect=list(fetch_results))
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+async def test_moved_exception_replaces_ghost_occurrence():
+    """Moved exception suppresses the ghost 09:00 and emits the 14:00 instance.
+
+    Setup:
+    - Weekly series: May 4 09:00–09:30 UTC
+    - Exception: recurrence_id = series external_id,
+                 original_start_time = May 11 09:00 (the slot being replaced),
+                 start_time = May 11 14:00 (where it was rescheduled to)
+    - Query window: May 1 – May 31 UTC
+
+    Expected: 4 events — May 4 @ 09:00, May 11 @ 14:00, May 18 @ 09:00, May 25 @ 09:00.
+    The ghost May 11 @ 09:00 must NOT appear.
+    """
+    tz = timezone.utc
+    series_id = "gcal-series-weeklystandup"
+
+    master = _master_row(
+        external_id=series_id,
+        start=datetime(2026, 5, 4, 9, 0, tzinfo=tz),
+        end=datetime(2026, 5, 4, 9, 30, tzinfo=tz),
+    )
+    exc = _exception_row(
+        external_id="gcal-exception-may11",
+        recurrence_id=series_id,
+        original_start_time=datetime(2026, 5, 11, 9, 0, tzinfo=tz),   # ghost slot
+        start=datetime(2026, 5, 11, 14, 0, tzinfo=tz),                # moved to 14:00
+        end=datetime(2026, 5, 11, 14, 30, tzinfo=tz),
+    )
+
+    conn = _conn_with_fetch(
+        [],       # single events — none
+        [master], # recurring masters — one weekly series
+        [exc],    # exception instances — one moved exception
+    )
+
+    events = await get_events_for_range(
+        conn,
+        "2026-05-01T00:00:00+00:00",
+        "2026-05-31T23:59:59+00:00",
+    )
+
+    start_times = [e["start_time"] for e in events]
+
+    assert len(events) == 4, (
+        f"Expected 4 events (May 4, 11@14:00, 18, 25), got {len(events)}: {start_times}"
+    )
+
+    ghost = datetime(2026, 5, 11, 9, 0, tzinfo=tz).isoformat()
+    assert ghost not in start_times, (
+        "Ghost May-11 09:00 computed occurrence should be suppressed by the exception"
+    )
+
+    moved = datetime(2026, 5, 11, 14, 0, tzinfo=tz).isoformat()
+    assert moved in start_times, "Moved May-11 14:00 exception should appear in results"
+
+    # Verify the three unaffected occurrences are present
+    for expected_dt in [
+        datetime(2026, 5, 4, 9, 0, tzinfo=tz),
+        datetime(2026, 5, 18, 9, 0, tzinfo=tz),
+        datetime(2026, 5, 25, 9, 0, tzinfo=tz),
+    ]:
+        assert expected_dt.isoformat() in start_times, (
+            f"{expected_dt.isoformat()} should be an unaffected computed occurrence"
+        )
+
+
+async def test_exception_moved_outside_window_suppresses_ghost_emits_nothing():
+    """An exception moved outside the query window suppresses the ghost but adds nothing.
+
+    Setup:
+    - Weekly series: May 4 09:00 UTC
+    - Exception: original_start_time = May 11 09:00,
+                 start_time = June 1 09:00 (moved OUTSIDE the May window)
+    - Window: May 1 – May 31
+
+    Expected: 3 events — May 4, 18, 25. May 11 ghost suppressed; June 1 not in window.
+    """
+    tz = timezone.utc
+    series_id = "gcal-series-monthly-override"
+
+    master = _master_row(
+        external_id=series_id,
+        start=datetime(2026, 5, 4, 9, 0, tzinfo=tz),
+        end=datetime(2026, 5, 4, 9, 30, tzinfo=tz),
+    )
+    exc = _exception_row(
+        external_id="gcal-exception-june1",
+        recurrence_id=series_id,
+        original_start_time=datetime(2026, 5, 11, 9, 0, tzinfo=tz),  # was May 11
+        start=datetime(2026, 6, 1, 9, 0, tzinfo=tz),                 # moved to June
+        end=datetime(2026, 6, 1, 9, 30, tzinfo=tz),
+    )
+
+    conn = _conn_with_fetch([], [master], [exc])
+
+    events = await get_events_for_range(
+        conn,
+        "2026-05-01T00:00:00+00:00",
+        "2026-05-31T23:59:59+00:00",
+    )
+
+    start_times = [e["start_time"] for e in events]
+
+    assert len(events) == 3, (
+        f"Expected 3 events (May 4, 18, 25), got {len(events)}: {start_times}"
+    )
+
+    ghost = datetime(2026, 5, 11, 9, 0, tzinfo=tz).isoformat()
+    assert ghost not in start_times, "Ghost May-11 occurrence must be suppressed"
+
+    june1 = datetime(2026, 6, 1, 9, 0, tzinfo=tz).isoformat()
+    assert june1 not in start_times, "June-1 exception is outside window — must not appear"

--- a/tests/api/test_rrule_expansion.py
+++ b/tests/api/test_rrule_expansion.py
@@ -1,0 +1,133 @@
+"""Unit tests for RRULE occurrence expansion in event queries.
+
+Tests the expand_recurring() helper and the get_events_with_recurrence()
+query function. No live DB needed — all mocked.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from db.pg_queries.tasks import expand_recurring
+
+
+# ---------------------------------------------------------------------------
+# expand_recurring — basic weekly recurrence
+# ---------------------------------------------------------------------------
+
+def _make_task(rrule: str, start: datetime, end: datetime, **kwargs) -> dict:
+    """Build a minimal recurring task row dict."""
+    duration = end - start
+    return {
+        "id": kwargs.get("id", "uuid-series-1"),
+        "title": kwargs.get("title", "Weekly meeting"),
+        "start_time": start.isoformat(),
+        "end_time": end.isoformat(),
+        "rrule": rrule,
+        "exdates": kwargs.get("exdates", []),
+        "source": "google_calendar",
+        "external_id": kwargs.get("external_id", "gcal-series-1"),
+        "anchor_id": None,
+        "is_recurring": True,
+        "is_occurrence": False,
+    }
+
+
+def test_expand_weekly_returns_occurrences_in_window():
+    """Weekly RRULE produces one occurrence per week within the window."""
+    # Monday 2026-05-04, 09:00 UTC — weekly for 4 weeks
+    start = datetime(2026, 5, 4, 9, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 4, 9, 30, tzinfo=timezone.utc)
+    task = _make_task("RRULE:FREQ=WEEKLY", start, end)
+
+    window_start = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    window_end = datetime(2026, 5, 31, 23, 59, 59, tzinfo=timezone.utc)
+
+    occurrences = expand_recurring(task, window_start, window_end)
+
+    # May has weeks starting May 4, 11, 18, 25 — 4 occurrences
+    assert len(occurrences) == 4
+    for occ in occurrences:
+        assert occ["is_occurrence"] is True
+        assert occ["is_recurring"] is True
+
+
+def test_expand_recurring_preserves_duration():
+    """Each occurrence has the same duration as the original event."""
+    start = datetime(2026, 5, 4, 9, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 4, 10, 30, tzinfo=timezone.utc)  # 90 min
+    task = _make_task("RRULE:FREQ=WEEKLY", start, end)
+
+    window_start = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    window_end = datetime(2026, 5, 31, 23, 59, 59, tzinfo=timezone.utc)
+
+    occurrences = expand_recurring(task, window_start, window_end)
+    assert len(occurrences) >= 1
+
+    for occ in occurrences:
+        occ_start = datetime.fromisoformat(occ["start_time"])
+        occ_end = datetime.fromisoformat(occ["end_time"])
+        assert occ_end - occ_start == timedelta(minutes=90)
+
+
+def test_expand_recurring_no_occurrences_outside_window():
+    """An event starting in June produces no occurrences for a May window."""
+    start = datetime(2026, 6, 1, 9, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 6, 1, 10, 0, tzinfo=timezone.utc)
+    task = _make_task("RRULE:FREQ=WEEKLY", start, end)
+
+    window_start = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    window_end = datetime(2026, 5, 31, 23, 59, 59, tzinfo=timezone.utc)
+
+    occurrences = expand_recurring(task, window_start, window_end)
+    assert occurrences == []
+
+
+def test_expand_recurring_respects_exdates():
+    """Occurrences matching exdates are excluded from the result."""
+    start = datetime(2026, 5, 4, 9, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 4, 9, 30, tzinfo=timezone.utc)
+    # Exclude May 11 occurrence
+    exdate = "EXDATE;TZID=UTC:20260511T090000Z"
+    task = _make_task("RRULE:FREQ=WEEKLY", start, end, exdates=[exdate])
+
+    window_start = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    window_end = datetime(2026, 5, 31, 23, 59, 59, tzinfo=timezone.utc)
+
+    occurrences = expand_recurring(task, window_start, window_end)
+    occurrence_starts = [occ["start_time"] for occ in occurrences]
+
+    # Should have 3 occurrences (May 4, 18, 25) — May 11 excluded
+    assert len(occurrences) == 3
+    excluded_dt = datetime(2026, 5, 11, 9, 0, tzinfo=timezone.utc)
+    for start_str in occurrence_starts:
+        occ_dt = datetime.fromisoformat(start_str)
+        assert occ_dt.date() != excluded_dt.date(), "May 11 should be excluded"
+
+
+def test_expand_recurring_daily_within_window():
+    """Daily RRULE within a 3-day window produces 3 occurrences."""
+    start = datetime(2026, 5, 1, 8, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 1, 8, 15, tzinfo=timezone.utc)
+    task = _make_task("RRULE:FREQ=DAILY", start, end)
+
+    window_start = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    window_end = datetime(2026, 5, 3, 23, 59, 59, tzinfo=timezone.utc)
+
+    occurrences = expand_recurring(task, window_start, window_end)
+    assert len(occurrences) == 3
+
+
+def test_expand_recurring_count_limited_rrule():
+    """RRULE with COUNT limits total occurrences."""
+    start = datetime(2026, 5, 4, 9, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 4, 9, 30, tzinfo=timezone.utc)
+    task = _make_task("RRULE:FREQ=WEEKLY;COUNT=2", start, end)
+
+    # Big window — but COUNT=2 means only 2 occur ever
+    window_start = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    window_end = datetime(2026, 6, 30, 23, 59, 59, tzinfo=timezone.utc)
+
+    occurrences = expand_recurring(task, window_start, window_end)
+    assert len(occurrences) == 2

--- a/tests/api/test_rrule_expansion.py
+++ b/tests/api/test_rrule_expansion.py
@@ -5,7 +5,7 @@ query function. No live DB needed — all mocked.
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone, timedelta
+from datetime import date, datetime, timezone, timedelta
 
 import pytest
 
@@ -154,3 +154,26 @@ def test_expand_recurring_comma_separated_exdates():
     assert date(2026, 5, 25) in occurrence_dates
     assert date(2026, 5, 11) not in occurrence_dates
     assert date(2026, 5, 18) not in occurrence_dates
+
+
+def test_expand_recurring_all_day_exdate_suppresses_occurrence():
+    """EXDATE with bare date token (all-day, no time) suppresses the matching occurrence.
+
+    Google Calendar sends all-day EXDATEs as VALUE=DATE tokens:
+      EXDATE;VALUE=DATE:20260511
+    These must be parsed and the occurrence for that date must be excluded.
+    """
+    start = datetime(2026, 5, 4, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 4, 23, 59, 59, tzinfo=timezone.utc)
+    exdate = "EXDATE;VALUE=DATE:20260511"
+    task = _make_task("RRULE:FREQ=WEEKLY", start, end, exdates=[exdate])
+
+    window_start = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    window_end = datetime(2026, 5, 31, 23, 59, 59, tzinfo=timezone.utc)
+
+    occurrences = expand_recurring(task, window_start, window_end)
+
+    # 4 weekly occurrences (May 4, 11, 18, 25); May 11 excluded → 3 remain
+    assert len(occurrences) == 3
+    occurrence_dates = {datetime.fromisoformat(occ["start_time"]).date() for occ in occurrences}
+    assert date(2026, 5, 11) not in occurrence_dates, "May 11 all-day EXDATE should be excluded"

--- a/tests/api/test_rrule_expansion.py
+++ b/tests/api/test_rrule_expansion.py
@@ -131,3 +131,26 @@ def test_expand_recurring_count_limited_rrule():
 
     occurrences = expand_recurring(task, window_start, window_end)
     assert len(occurrences) == 2
+
+
+def test_expand_recurring_comma_separated_exdates():
+    """Multiple dates on a single EXDATE line are all excluded (RFC 5545 comma syntax)."""
+    start = datetime(2026, 5, 4, 9, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 4, 9, 30, tzinfo=timezone.utc)
+    # Single EXDATE line with two comma-separated datetimes: May 11 and May 18
+    exdate = "EXDATE;TZID=UTC:20260511T090000Z,20260518T090000Z"
+    task = _make_task("RRULE:FREQ=WEEKLY", start, end, exdates=[exdate])
+
+    window_start = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    window_end = datetime(2026, 5, 31, 23, 59, 59, tzinfo=timezone.utc)
+
+    occurrences = expand_recurring(task, window_start, window_end)
+
+    # 4 weekly occurrences (May 4, 11, 18, 25); May 11 and 18 excluded → 2 remain
+    assert len(occurrences) == 2
+    occurrence_dates = {datetime.fromisoformat(occ["start_time"]).date() for occ in occurrences}
+    from datetime import date
+    assert date(2026, 5, 4) in occurrence_dates
+    assert date(2026, 5, 25) in occurrence_dates
+    assert date(2026, 5, 11) not in occurrence_dates
+    assert date(2026, 5, 18) not in occurrence_dates

--- a/tests/integrations/test_gcal_mapping.py
+++ b/tests/integrations/test_gcal_mapping.py
@@ -161,3 +161,31 @@ def test_map_event_recurrence_id_none_for_regular():
     }
     draft = map_event(raw)
     assert draft.recurrence_id is None
+
+
+def test_map_event_extracts_original_start_time():
+    """Exception instances with originalStartTime populate draft.original_start_time."""
+    from datetime import datetime, timezone
+    raw = {
+        "summary": "Moved exception",
+        "id": "exception-moved",
+        "recurringEventId": "series-master-1",
+        "originalStartTime": {"dateTime": "2026-05-11T09:00:00+00:00"},
+        "start": {"dateTime": "2026-05-11T10:00:00+00:00"},  # moved to 10am
+        "end": {"dateTime": "2026-05-11T10:30:00+00:00"},
+    }
+    draft = map_event(raw)
+    assert draft.original_start_time is not None
+    assert draft.original_start_time == datetime(2026, 5, 11, 9, 0, tzinfo=timezone.utc)
+
+
+def test_map_event_original_start_time_none_for_non_exception():
+    """Regular non-exception events have draft.original_start_time == None."""
+    raw = {
+        "summary": "Regular",
+        "id": "r1",
+        "start": {"dateTime": "2026-04-28T09:00:00+00:00"},
+        "end": {"dateTime": "2026-04-28T10:00:00+00:00"},
+    }
+    draft = map_event(raw)
+    assert draft.original_start_time is None

--- a/tests/integrations/test_gcal_mapping.py
+++ b/tests/integrations/test_gcal_mapping.py
@@ -189,3 +189,19 @@ def test_map_event_original_start_time_none_for_non_exception():
     }
     draft = map_event(raw)
     assert draft.original_start_time is None
+
+
+def test_map_event_raises_on_missing_id():
+    """map_event must raise ValueError when the event has no 'id' field.
+
+    A missing id would cause silent data collision on the (user_id, source, external_id)
+    unique index — multiple events would map to external_id='' and overwrite each other.
+    """
+    raw = {
+        "summary": "No ID event",
+        # 'id' deliberately absent
+        "start": {"dateTime": "2026-04-28T09:00:00+00:00"},
+        "end": {"dateTime": "2026-04-28T10:00:00+00:00"},
+    }
+    with pytest.raises(ValueError, match="missing 'id'"):
+        map_event(raw)

--- a/tests/integrations/test_gcal_mapping.py
+++ b/tests/integrations/test_gcal_mapping.py
@@ -75,3 +75,89 @@ def test_map_event_spoofed_meet_url_not_used_as_external_url():
     draft = map_event(raw)
     # Should fall back to htmlLink, not the spoofed URI
     assert draft.external_url == "https://calendar.google.com/event?eid=safe"
+
+
+# ── map_event — RRULE / recurrence fields ─────────────────────────────────────
+
+def _recurring_event(rrule: str = "RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR") -> dict:
+    return {
+        "summary": "Weekly standup",
+        "id": "series-master-1",
+        "start": {"dateTime": "2026-04-28T09:00:00+00:00"},
+        "end": {"dateTime": "2026-04-28T09:30:00+00:00"},
+        "recurrence": [rrule, "EXDATE;TZID=UTC:20260505T090000Z"],
+    }
+
+
+def test_map_event_extracts_rrule():
+    """map_event sets draft.rrule from the recurrence array."""
+    draft = map_event(_recurring_event("RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"))
+    assert draft.rrule == "RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"
+
+
+def test_map_event_no_recurrence_rrule_is_none():
+    """Non-recurring event has draft.rrule == None."""
+    raw = {
+        "summary": "One-off",
+        "id": "evt-once",
+        "start": {"dateTime": "2026-04-28T09:00:00+00:00"},
+        "end": {"dateTime": "2026-04-28T10:00:00+00:00"},
+    }
+    draft = map_event(raw)
+    assert draft.rrule is None
+
+
+def test_map_event_extracts_exdates():
+    """EXDATE lines from recurrence array land in draft.exdates."""
+    raw = {
+        "summary": "Series",
+        "id": "s1",
+        "start": {"dateTime": "2026-04-28T09:00:00+00:00"},
+        "end": {"dateTime": "2026-04-28T10:00:00+00:00"},
+        "recurrence": [
+            "RRULE:FREQ=WEEKLY",
+            "EXDATE;TZID=UTC:20260505T090000Z",
+            "EXDATE;TZID=UTC:20260512T090000Z",
+        ],
+    }
+    draft = map_event(raw)
+    assert len(draft.exdates) == 2
+    assert "EXDATE;TZID=UTC:20260505T090000Z" in draft.exdates
+
+
+def test_map_event_no_exdates_is_empty_list():
+    """Events with no EXDATE lines have draft.exdates == []."""
+    raw = {
+        "summary": "Series no exdate",
+        "id": "s2",
+        "start": {"dateTime": "2026-04-28T09:00:00+00:00"},
+        "end": {"dateTime": "2026-04-28T10:00:00+00:00"},
+        "recurrence": ["RRULE:FREQ=DAILY"],
+    }
+    draft = map_event(raw)
+    assert draft.exdates == []
+
+
+def test_map_event_extracts_recurring_event_id():
+    """Exception instances carry recurringEventId → draft.recurrence_id."""
+    raw = {
+        "summary": "Exception instance",
+        "id": "exception-1",
+        "recurringEventId": "series-master-1",
+        "start": {"dateTime": "2026-05-05T10:00:00+00:00"},
+        "end": {"dateTime": "2026-05-05T10:30:00+00:00"},
+    }
+    draft = map_event(raw)
+    assert draft.recurrence_id == "series-master-1"
+
+
+def test_map_event_recurrence_id_none_for_regular():
+    """Regular non-exception events have draft.recurrence_id == None."""
+    raw = {
+        "summary": "Regular",
+        "id": "r1",
+        "start": {"dateTime": "2026-04-28T09:00:00+00:00"},
+        "end": {"dateTime": "2026-04-28T10:00:00+00:00"},
+    }
+    draft = map_event(raw)
+    assert draft.recurrence_id is None

--- a/tests/integrations/test_gcal_sync.py
+++ b/tests/integrations/test_gcal_sync.py
@@ -281,24 +281,22 @@ async def test_poll_mixed_items_routes_correctly():
 
 
 # ---------------------------------------------------------------------------
-# poll — warns when nextPageToken present
+# poll — singleEvents=false (recurring events as series masters)
 # ---------------------------------------------------------------------------
 
-async def test_poll_warns_on_next_page_token(caplog):
-    """poll() logs a warning when nextPageToken is present (pagination not implemented)."""
-    import logging
+async def test_poll_does_not_send_single_events_true():
+    """poll() must NOT send singleEvents=true — recurring events need series masters."""
     pool = _make_pool()
     sync = GoogleCalendarSync(pool)
 
     mock_conn = AsyncMock()
-    resp = MagicMock()
-    resp.status_code = 200
-    resp.raise_for_status = MagicMock()
-    resp.json.return_value = {
-        "items": [],
-        "nextPageToken": "page-tok",
-        "nextSyncToken": _NEW_SYNC_TOKEN,
-    }
+    resp = _make_response([])
+
+    captured_params: list[dict] = []
+
+    async def fake_get(url, headers, params):
+        captured_params.append(dict(params))
+        return resp
 
     with patch.object(sync, "_get_integration_row", new=AsyncMock(
         return_value={"user_id": _USER_ID, "access_token": "tok"}
@@ -307,14 +305,147 @@ async def test_poll_warns_on_next_page_token(caplog):
             mock_client = AsyncMock()
             mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(return_value=resp)
+            mock_client.get = fake_get
 
             with _patch_get_conn(mock_conn):
                 with patch("integrations.google_calendar.sync.upsert_sync_state", new=AsyncMock(return_value={})):
-                    with caplog.at_level(logging.WARNING, logger="integrations.google_calendar.sync"):
-                        await sync.poll(_INTEGRATION_ID, _CALENDAR_ID, _SYNC_TOKEN)
+                    await sync.poll(_INTEGRATION_ID, _CALENDAR_ID, _SYNC_TOKEN)
 
-    assert any("nextPageToken" in r.message or "pagination" in r.message.lower() for r in caplog.records)
+    assert captured_params, "No HTTP GET captured"
+    first_params = captured_params[0]
+    assert first_params.get("singleEvents") != "true", \
+        "singleEvents=true must not be sent (would expand recurring events)"
+
+
+# ---------------------------------------------------------------------------
+# poll — pagination: walks all pages, persists final syncToken
+# ---------------------------------------------------------------------------
+
+async def _run_paginated_poll(sync, page_responses: list[MagicMock], mock_conn: AsyncMock) -> str:
+    """Helper: run poll() with a sequence of paginated responses."""
+    call_count = 0
+
+    async def fake_get(url, headers, params):
+        nonlocal call_count
+        resp = page_responses[call_count]
+        call_count += 1
+        return resp
+
+    with patch.object(sync, "_get_integration_row", new=AsyncMock(
+        return_value={"user_id": _USER_ID, "access_token": "tok"}
+    )):
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = fake_get
+
+            with _patch_get_conn(mock_conn):
+                with patch(
+                    "integrations.google_calendar.sync.soft_delete_task_by_external_id",
+                    new=AsyncMock(),
+                ):
+                    with patch(
+                        "integrations.google_calendar.sync.upsert_task_from_draft",
+                        new=AsyncMock(return_value={}),
+                    ):
+                        with patch(
+                            "integrations.google_calendar.sync.upsert_sync_state",
+                            new=AsyncMock(return_value={}),
+                        ):
+                            return await sync.poll(_INTEGRATION_ID, _CALENDAR_ID, _SYNC_TOKEN)
+
+
+def _page_response(items: list[dict], *, next_page_token: str | None = None, next_sync_token: str | None = None) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = MagicMock()
+    data: dict = {"items": items}
+    if next_page_token:
+        data["nextPageToken"] = next_page_token
+    if next_sync_token:
+        data["nextSyncToken"] = next_sync_token
+    resp.json.return_value = data
+    return resp
+
+
+async def test_poll_pagination_walks_all_pages():
+    """poll() follows nextPageToken across all pages before returning."""
+    pool = _make_pool()
+    sync = GoogleCalendarSync(pool)
+    mock_conn = AsyncMock()
+
+    page1 = _page_response([_active_event("evt-1")], next_page_token="page2-tok")
+    page2 = _page_response([_active_event("evt-2")], next_page_token="page3-tok")
+    page3 = _page_response([_active_event("evt-3")], next_sync_token=_NEW_SYNC_TOKEN)
+
+    with patch(
+        "integrations.google_calendar.sync.upsert_task_from_draft",
+        new=AsyncMock(return_value={}),
+    ) as mock_upsert:
+        with patch.object(sync, "_get_integration_row", new=AsyncMock(
+            return_value={"user_id": _USER_ID, "access_token": "tok"}
+        )):
+            call_count = 0
+            responses = [page1, page2, page3]
+
+            async def fake_get(url, headers, params):
+                nonlocal call_count
+                r = responses[call_count]
+                call_count += 1
+                return r
+
+            with patch("httpx.AsyncClient") as mock_client_cls:
+                mock_client = AsyncMock()
+                mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+                mock_client.get = fake_get
+
+                with _patch_get_conn(mock_conn):
+                    with patch("integrations.google_calendar.sync.soft_delete_task_by_external_id", new=AsyncMock()):
+                        with patch("integrations.google_calendar.sync.upsert_sync_state", new=AsyncMock(return_value={})):
+                            result = await sync.poll(_INTEGRATION_ID, _CALENDAR_ID, _SYNC_TOKEN)
+
+    assert call_count == 3, f"Expected 3 HTTP requests (one per page), got {call_count}"
+    assert result == _NEW_SYNC_TOKEN
+    assert mock_upsert.await_count == 3
+
+
+async def test_poll_pagination_uses_page_token_not_sync_token():
+    """Subsequent page requests must use pageToken, not syncToken."""
+    pool = _make_pool()
+    sync = GoogleCalendarSync(pool)
+    mock_conn = AsyncMock()
+
+    captured_params: list[dict] = []
+    page1 = _page_response([_active_event("e1")], next_page_token="page2-tok")
+    page2 = _page_response([_active_event("e2")], next_sync_token=_NEW_SYNC_TOKEN)
+
+    async def fake_get(url, headers, params):
+        captured_params.append(dict(params))
+        return [page1, page2][len(captured_params) - 1]
+
+    with patch.object(sync, "_get_integration_row", new=AsyncMock(
+        return_value={"user_id": _USER_ID, "access_token": "tok"}
+    )):
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = fake_get
+
+            with _patch_get_conn(mock_conn):
+                with patch("integrations.google_calendar.sync.soft_delete_task_by_external_id", new=AsyncMock()):
+                    with patch("integrations.google_calendar.sync.upsert_task_from_draft", new=AsyncMock(return_value={})):
+                        with patch("integrations.google_calendar.sync.upsert_sync_state", new=AsyncMock(return_value={})):
+                            await sync.poll(_INTEGRATION_ID, _CALENDAR_ID, _SYNC_TOKEN)
+
+    assert len(captured_params) == 2
+    # First request uses syncToken
+    assert "syncToken" in captured_params[0]
+    # Second request uses pageToken, NOT syncToken
+    assert "pageToken" in captured_params[1]
+    assert "syncToken" not in captured_params[1]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integrations/test_gcal_sync.py
+++ b/tests/integrations/test_gcal_sync.py
@@ -500,3 +500,51 @@ async def test_handle_webhook_unknown_channel_skips():
             await sync.handle_webhook(_INTEGRATION_ID, payload)
 
     mock_poll.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# upsert_sync_state — COALESCE preserves watch fields when syncing cursor only
+# ---------------------------------------------------------------------------
+
+async def test_upsert_sync_state_preserves_watch_fields_on_cursor_update():
+    """Updating only sync_cursor must not overwrite existing watch channel fields with NULL.
+
+    poll() calls upsert_sync_state with only sync_cursor set. On conflict, the SQL
+    must COALESCE incoming NULLs against the existing watch_channel_id / watch_expiry /
+    watch_resource_id values — not blindly replace them.
+
+    This test verifies the SQL sent to the DB contains COALESCE for watch fields.
+    """
+    from db.pg_queries.integrations import upsert_sync_state
+
+    captured_sql: list[str] = []
+    captured_args: list[tuple] = []
+
+    mock_conn = AsyncMock()
+
+    async def fake_fetchrow(sql, *args):
+        captured_sql.append(sql)
+        captured_args.append(args)
+        # Return a minimal row so _row() doesn't blow up
+        return {
+            "integration_id": uuid.UUID(_INTEGRATION_ID),
+            "calendar_id": _CALENDAR_ID,
+            "sync_cursor": _NEW_SYNC_TOKEN,
+            "watch_channel_id": "existing-ch",
+            "watch_expiry": None,
+            "watch_resource_id": "existing-res",
+            "updated_at": None,
+        }
+
+    mock_conn.fetchrow = fake_fetchrow
+
+    await upsert_sync_state(mock_conn, _INTEGRATION_ID, _CALENDAR_ID, sync_cursor=_NEW_SYNC_TOKEN)
+
+    assert len(captured_sql) == 1, "upsert_sync_state should execute exactly one query"
+    sql = captured_sql[0].upper()
+
+    # The ON CONFLICT clause must use COALESCE for the three watch fields
+    assert "COALESCE" in sql, (
+        "upsert_sync_state ON CONFLICT must use COALESCE to preserve existing "
+        "watch_channel_id / watch_expiry / watch_resource_id when called with only sync_cursor"
+    )


### PR DESCRIPTION
## Summary

- Adds `rrule`, `recurrence_id`, `exdates`, `original_start_time` columns to `tasks` (migration `e1f2a3b4c5d6`, chains off `e3f4a5b6c7d8`)
- GCal sync polls with `singleEvents=false` so recurring series masters are returned with RRULE strings rather than individual occurrences
- `expand_recurring()` uses `python-dateutil` to expand RRULE strings into concrete occurrences within a query window
- `get_events_for_range()` substitutes moved/cancelled exception instances correctly — keyed by `original_start_time` (not `start_time`) to suppress the right ghost slot
- Pagination uses `pageToken` only on subsequent pages (mutually exclusive with `syncToken` per Google API spec)

## Bug fixes from code review

- All-day EXDATE tokens (`VALUE=DATE:20260511`) now parsed correctly — previously the bare `except Exception` silently swallowed a `ValueError`, leaving cancelled all-day occurrences visible
- Soft-deleted (cancelled) exception instances filtered from the exception query with `source_status != 'cancelled'`
- `upsert_sync_state` ON CONFLICT now uses `COALESCE` for watch channel fields — previously a `sync_cursor`-only call zeroed out the registered webhook channel
- `map_event` raises `ValueError` on missing `id` instead of silently defaulting to `""` (which would cause silent data collision on the unique index)

## Test plan

- [ ] 40 new tests covering: RRULE expansion, all-day EXDATE parsing, moved-exception substitution, out-of-window exception suppression, cancelled exception filtering, mapping field extraction, sync pagination, `upsert_sync_state` COALESCE, missing-id guard
- [ ] Full suite: 425 passed, 0 failures