### PR TITLE
fix: resolve offset-naive/aware TypeError in expand_recurring

### DIFF
--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -799,6 +799,28 @@ def expand_recurring(task: dict, window_start: _datetime, window_end: _datetime)
             exdate_dates.add((dt.year, dt.month, dt.day))
 
     rule = rrulestr(rrule_str, dtstart=dtstart, ignoretz=False)
+
+    # Normalize window bounds to match dtstart's tz-awareness so rule.between()
+    # never raises "can't compare offset-naive and offset-aware datetimes".
+    #
+    # Typical case: dtstart is tz-aware (asyncpg TIMESTAMPTZ) but window bounds
+    # are naive (API query params sent without timezone offset → _parse_ts returns
+    # naive). Treat naive bounds as UTC.
+    #
+    # Symmetric guard: if dtstart is naive (unexpected, but possible if the column
+    # ever returns TIMESTAMP instead of TIMESTAMPTZ), strip tz from aware bounds.
+    from datetime import timezone as _tz
+    if dtstart.tzinfo is not None:
+        if window_start.tzinfo is None:
+            window_start = window_start.replace(tzinfo=_tz.utc)
+        if window_end.tzinfo is None:
+            window_end = window_end.replace(tzinfo=_tz.utc)
+    else:
+        if window_start.tzinfo is not None:
+            window_start = window_start.replace(tzinfo=None)
+        if window_end.tzinfo is not None:
+            window_end = window_end.replace(tzinfo=None)
+
     occurrences = []
     for dt in rule.between(window_start, window_end, inc=True):
         if (dt.year, dt.month, dt.day) in exdate_dates:

--- a/tests/api/test_rrule_expansion.py
+++ b/tests/api/test_rrule_expansion.py
@@ -156,6 +156,45 @@ def test_expand_recurring_comma_separated_exdates():
     assert date(2026, 5, 18) not in occurrence_dates
 
 
+def test_expand_recurring_naive_window_bounds_with_aware_task():
+    """Reproduces production 500: naive window bounds + tz-aware task dtstart.
+
+    The API may receive query params without timezone offset (e.g. "2026-05-01T00:00:00").
+    _parse_ts returns a naive datetime. But dtstart comes from asyncpg TIMESTAMPTZ and is
+    tz-aware. rrulestr then generates tz-aware datetimes; rule.between(naive, naive) raises
+    "can't compare offset-naive and offset-aware datetimes".
+    """
+    start = datetime(2026, 5, 4, 9, 0, tzinfo=timezone.utc)  # tz-aware (from asyncpg)
+    end = datetime(2026, 5, 4, 9, 30, tzinfo=timezone.utc)
+    task = _make_task("RRULE:FREQ=WEEKLY", start, end)
+
+    # Naive window bounds — what _parse_ts returns for strings like "2026-05-01T00:00:00"
+    window_start = datetime(2026, 5, 1)
+    window_end = datetime(2026, 5, 31, 23, 59, 59)
+
+    occurrences = expand_recurring(task, window_start, window_end)
+    assert len(occurrences) == 4
+
+
+def test_expand_recurring_naive_dtstart_aware_window_does_not_raise():
+    """Inverse case: naive task dtstart + aware window bounds must not raise TypeError.
+
+    Unlikely in production (asyncpg TIMESTAMPTZ always returns tz-aware), but
+    the symmetric guard in expand_recurring covers this to prevent a crash if
+    a TIMESTAMP column ever returns a naive datetime.
+    """
+    start = datetime(2026, 5, 4, 9, 0)  # naive — no tzinfo
+    end = datetime(2026, 5, 4, 9, 30)
+    task = _make_task("RRULE:FREQ=WEEKLY", start, end)
+
+    window_start = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    window_end = datetime(2026, 5, 31, 23, 59, 59, tzinfo=timezone.utc)
+
+    # Must not raise — returns 4 occurrences (naive rule, bounds stripped to naive)
+    occurrences = expand_recurring(task, window_start, window_end)
+    assert len(occurrences) == 4
+
+
 def test_expand_recurring_all_day_exdate_suppresses_occurrence():
     """EXDATE with bare date token (all-day, no time) suppresses the matching occurrence.
 


### PR DESCRIPTION
## Summary

- `GET /api/events` returned 500 on every request due to `TypeError: can't compare offset-naive and offset-aware datetimes` in `expand_recurring()` at `rule.between(window_start, window_end)`
- Root cause: API query params arrive without timezone offset → `_parse_ts` returns naive datetimes for window bounds, but `dtstart` from asyncpg TIMESTAMPTZ is tz-aware → `rrulestr` generates tz-aware datetimes → `between(naive, naive)` fails
- Fix: normalize window bounds to match `dtstart`'s tz-awareness in `expand_recurring()`. Naive bounds treated as UTC. Symmetric guard added for the inverse case.
- Two new regression tests added: one reproducing the production TypeError, one documenting the symmetric (naive dtstart + aware bounds) case.

## Test plan

- [x] New test `test_expand_recurring_naive_window_bounds_with_aware_task` fails before fix, passes after
- [x] New test `test_expand_recurring_naive_dtstart_aware_window_does_not_raise` covers symmetric guard
- [x] All 10 tests in `tests/api/test_rrule_expansion.py` pass
- [x] Full suite: 431 passed, 327 skipped (1 more pass than before)

## Concerns for follow-up (pre-existing, not introduced here)

- `_parse_exdate` has a bare `except Exception:` with no logging — exdate suppression can fail silently
- `get_events_for_range` has no per-row isolation around `expand_recurring` — one bad recurring task could crash the entire event fetch
- `_parse_ts` docstring claims it returns "an aware datetime" but does not enforce it