### PR TITLE
feat(mcp): upsert_tasks event scheduling — start_time, end_time, rrule, color

### DIFF
--- a/tests/mcp/test_upsert_tasks_events.py
+++ b/tests/mcp/test_upsert_tasks_events.py
@@ -1,0 +1,152 @@
+"""Tests for event scheduling fields in execute_upsert_tasks."""
+import contextlib
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+PATCH_TARGETS = [
+    "tether_mcp.tools.upsert_tasks.get_task_by_uuid",
+    "tether_mcp.tools.upsert_tasks.patch_task_fields",
+    "tether_mcp.tools.upsert_tasks.upsert_plan",
+    "tether_mcp.tools.upsert_tasks.move_task_atomic",
+    "tether_mcp.tools.upsert_tasks.create_unscheduled_task",
+    "tether_mcp.tools.upsert_tasks.link_task_to_node",
+    "tether_mcp.tools.upsert_tasks.unlink_task_from_node",
+    "tether_mcp.tools.upsert_tasks.link_milestone_task",
+    "tether_mcp.tools.upsert_tasks.add_dependency",
+    "tether_mcp.tools.upsert_tasks.remove_dependency",
+    "tether_mcp.tools.upsert_tasks.get_dependencies_for",
+    "tether_mcp.tools.upsert_tasks.get_node_by_path",
+    "tether_mcp.tools.upsert_tasks.create_subtask",
+    "tether_mcp.tools.upsert_tasks.update_subtask",
+    "tether_mcp.tools.upsert_tasks.delete_subtask",
+    "tether_mcp.tools.upsert_tasks.get_subtasks",
+    "tether_mcp.tools.upsert_tasks.promote_task_to_event",
+    "tether_mcp.tools.upsert_tasks.update_event_time",
+]
+
+
+def make_mocks():
+    return {target.split(".")[-1]: AsyncMock() for target in PATCH_TARGETS}
+
+
+@pytest.fixture
+def conn():
+    return AsyncMock()
+
+
+@pytest.fixture
+def mocks():
+    return make_mocks()
+
+
+async def run_upsert(conn, tasks, mocks):
+    with contextlib.ExitStack() as stack:
+        for t in PATCH_TARGETS:
+            stack.enter_context(patch(t, mocks[t.split(".")[-1]]))
+        from tether_mcp.tools.upsert_tasks import execute_upsert_tasks
+        return await execute_upsert_tasks(conn, tasks)
+
+
+@pytest.mark.asyncio
+async def test_create_task_with_event_times_promotes(conn, mocks):
+    mocks["create_unscheduled_task"].return_value = {"id": "task-1"}
+    mocks["get_task_by_uuid"].return_value = {
+        "id": "task-1", "text": "Meeting", "status": "pending",
+        "description": None, "context_subject": None, "plan_date": None, "anchor_id": None,
+    }
+    mocks["promote_task_to_event"].return_value = {"id": "task-1"}
+
+    await run_upsert(conn, [{
+        "text": "Meeting",
+        "start_time": "2026-04-27T09:00:00",
+        "end_time": "2026-04-27T10:00:00",
+    }], mocks)
+
+    mocks["promote_task_to_event"].assert_called_once_with(
+        conn, "task-1", "2026-04-27T09:00:00", "2026-04-27T10:00:00"
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_task_with_event_times_calls_update_event_time(conn, mocks):
+    mocks["get_task_by_uuid"].return_value = {
+        "id": "task-1", "text": "Meeting", "status": "pending",
+        "description": None, "context_subject": None, "plan_date": None, "anchor_id": None,
+    }
+    mocks["update_event_time"].return_value = {"id": "task-1"}
+
+    await run_upsert(conn, [{
+        "task_uuid": "task-1",
+        "start_time": "2026-04-27T10:00:00",
+        "end_time": "2026-04-27T11:00:00",
+    }], mocks)
+
+    mocks["update_event_time"].assert_called_once_with(
+        conn, "task-1", "2026-04-27T10:00:00", "2026-04-27T11:00:00"
+    )
+
+
+@pytest.mark.asyncio
+async def test_rrule_field_patched_on_task(conn, mocks):
+    mocks["get_task_by_uuid"].return_value = {
+        "id": "task-1", "text": "Meeting", "status": "pending",
+        "description": None, "context_subject": None, "plan_date": None, "anchor_id": None,
+    }
+
+    await run_upsert(conn, [{
+        "task_uuid": "task-1",
+        "rrule": "FREQ=WEEKLY;BYDAY=MO",
+    }], mocks)
+
+    calls = mocks["patch_task_fields"].call_args_list
+    rrule_call = next((c for c in calls if "rrule" in c.args[2]), None)
+    assert rrule_call is not None
+    assert rrule_call.args[2]["rrule"] == "FREQ=WEEKLY;BYDAY=MO"
+
+
+@pytest.mark.asyncio
+async def test_color_field_patched_on_task(conn, mocks):
+    mocks["get_task_by_uuid"].return_value = {
+        "id": "task-1", "text": "Meeting", "status": "pending",
+        "description": None, "context_subject": None, "plan_date": None, "anchor_id": None,
+    }
+
+    await run_upsert(conn, [{
+        "task_uuid": "task-1",
+        "color": "#ff0000",
+    }], mocks)
+
+    calls = mocks["patch_task_fields"].call_args_list
+    color_call = next((c for c in calls if "color" in c.args[2]), None)
+    assert color_call is not None
+    assert color_call.args[2]["color"] == "#ff0000"
+
+
+@pytest.mark.asyncio
+async def test_start_without_end_raises(conn, mocks):
+    mocks["create_unscheduled_task"].return_value = {"id": "task-1"}
+
+    with pytest.raises(ValueError, match="end_time"):
+        await run_upsert(conn, [{"text": "Meeting", "start_time": "2026-04-27T09:00:00"}], mocks)
+
+
+@pytest.mark.asyncio
+async def test_end_without_start_raises(conn, mocks):
+    mocks["create_unscheduled_task"].return_value = {"id": "task-1"}
+
+    with pytest.raises(ValueError, match="start_time"):
+        await run_upsert(conn, [{"text": "Meeting", "end_time": "2026-04-27T10:00:00"}], mocks)
+
+
+@pytest.mark.asyncio
+async def test_no_event_times_does_not_call_promote(conn, mocks):
+    mocks["create_unscheduled_task"].return_value = {"id": "task-1"}
+    mocks["get_task_by_uuid"].return_value = {
+        "id": "task-1", "text": "Plain task", "status": "pending",
+        "description": None, "context_subject": None, "plan_date": None, "anchor_id": None,
+    }
+
+    await run_upsert(conn, [{"text": "Plain task"}], mocks)
+
+    mocks["promote_task_to_event"].assert_not_called()

--- a/tests/mcp/test_upsert_tasks_events.py
+++ b/tests/mcp/test_upsert_tasks_events.py
@@ -48,6 +48,13 @@ async def run_upsert(conn, tasks, mocks):
         return await execute_upsert_tasks(conn, tasks)
 
 
+def _patch_dict_for(call):
+    """Pull the fields dict out of a patch_task_fields call, positional or kw."""
+    if len(call.args) > 2:
+        return call.args[2]
+    return call.kwargs.get("patch") or call.kwargs.get("fields") or {}
+
+
 @pytest.mark.asyncio
 async def test_create_task_with_event_times_promotes(conn, mocks):
     mocks["create_unscheduled_task"].return_value = {"id": "task-1"}
@@ -100,9 +107,9 @@ async def test_rrule_field_patched_on_task(conn, mocks):
     }], mocks)
 
     calls = mocks["patch_task_fields"].call_args_list
-    rrule_call = next((c for c in calls if "rrule" in c.args[2]), None)
+    rrule_call = next((c for c in calls if "rrule" in _patch_dict_for(c)), None)
     assert rrule_call is not None
-    assert rrule_call.args[2]["rrule"] == "FREQ=WEEKLY;BYDAY=MO"
+    assert _patch_dict_for(rrule_call)["rrule"] == "FREQ=WEEKLY;BYDAY=MO"
 
 
 @pytest.mark.asyncio
@@ -118,9 +125,9 @@ async def test_color_field_patched_on_task(conn, mocks):
     }], mocks)
 
     calls = mocks["patch_task_fields"].call_args_list
-    color_call = next((c for c in calls if "color" in c.args[2]), None)
+    color_call = next((c for c in calls if "color" in _patch_dict_for(c)), None)
     assert color_call is not None
-    assert color_call.args[2]["color"] == "#ff0000"
+    assert _patch_dict_for(color_call)["color"] == "#ff0000"
 
 
 @pytest.mark.asyncio
@@ -150,3 +157,140 @@ async def test_no_event_times_does_not_call_promote(conn, mocks):
     await run_upsert(conn, [{"text": "Plain task"}], mocks)
 
     mocks["promote_task_to_event"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_start_after_end_raises(conn, mocks):
+    """start_time must be strictly before end_time."""
+    mocks["create_unscheduled_task"].return_value = {"id": "task-1"}
+
+    with pytest.raises(ValueError, match="before end_time"):
+        await run_upsert(conn, [{
+            "text": "Bad meeting",
+            "start_time": "2026-04-27T11:00:00",
+            "end_time": "2026-04-27T10:00:00",
+        }], mocks)
+
+
+@pytest.mark.asyncio
+async def test_start_equal_end_raises(conn, mocks):
+    """Zero-length events are rejected."""
+    mocks["create_unscheduled_task"].return_value = {"id": "task-1"}
+
+    with pytest.raises(ValueError, match="before end_time"):
+        await run_upsert(conn, [{
+            "text": "Zero meeting",
+            "start_time": "2026-04-27T10:00:00",
+            "end_time": "2026-04-27T10:00:00",
+        }], mocks)
+
+
+@pytest.mark.asyncio
+async def test_update_start_without_end_raises(conn, mocks):
+    """Validation fires on the UPDATE path too."""
+    mocks["get_task_by_uuid"].return_value = {
+        "id": "task-1", "text": "Meeting", "status": "pending",
+        "description": None, "context_subject": None, "plan_date": None, "anchor_id": None,
+    }
+
+    with pytest.raises(ValueError, match="end_time"):
+        await run_upsert(conn, [{
+            "task_uuid": "task-1",
+            "start_time": "2026-04-27T09:00:00",
+        }], mocks)
+
+
+@pytest.mark.asyncio
+async def test_update_rrule_none_clears(conn, mocks):
+    """Explicit rrule=None on update should be patched (to clear the field)."""
+    mocks["get_task_by_uuid"].return_value = {
+        "id": "task-1", "text": "Meeting", "status": "pending",
+        "description": None, "context_subject": None, "plan_date": None, "anchor_id": None,
+    }
+
+    await run_upsert(conn, [{
+        "task_uuid": "task-1",
+        "rrule": None,
+    }], mocks)
+
+    calls = mocks["patch_task_fields"].call_args_list
+    rrule_call = next((c for c in calls if "rrule" in _patch_dict_for(c)), None)
+    assert rrule_call is not None
+    assert _patch_dict_for(rrule_call)["rrule"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_color_none_clears(conn, mocks):
+    """Explicit color=None on update should be patched (to clear the field)."""
+    mocks["get_task_by_uuid"].return_value = {
+        "id": "task-1", "text": "Meeting", "status": "pending",
+        "description": None, "context_subject": None, "plan_date": None, "anchor_id": None,
+    }
+
+    await run_upsert(conn, [{
+        "task_uuid": "task-1",
+        "color": None,
+    }], mocks)
+
+    calls = mocks["patch_task_fields"].call_args_list
+    color_call = next((c for c in calls if "color" in _patch_dict_for(c)), None)
+    assert color_call is not None
+    assert _patch_dict_for(color_call)["color"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_with_rrule_patches(conn, mocks):
+    """rrule on a new task should be patched after create."""
+    mocks["create_unscheduled_task"].return_value = {"id": "task-1"}
+    mocks["get_task_by_uuid"].return_value = {
+        "id": "task-1", "text": "Meeting", "status": "pending",
+        "description": None, "context_subject": None, "plan_date": None, "anchor_id": None,
+    }
+
+    await run_upsert(conn, [{
+        "text": "Meeting",
+        "rrule": "FREQ=DAILY",
+    }], mocks)
+
+    calls = mocks["patch_task_fields"].call_args_list
+    rrule_call = next((c for c in calls if "rrule" in _patch_dict_for(c)), None)
+    assert rrule_call is not None
+    assert _patch_dict_for(rrule_call)["rrule"] == "FREQ=DAILY"
+
+
+@pytest.mark.asyncio
+async def test_create_with_color_patches(conn, mocks):
+    """color on a new task should be patched after create."""
+    mocks["create_unscheduled_task"].return_value = {"id": "task-1"}
+    mocks["get_task_by_uuid"].return_value = {
+        "id": "task-1", "text": "Meeting", "status": "pending",
+        "description": None, "context_subject": None, "plan_date": None, "anchor_id": None,
+    }
+
+    await run_upsert(conn, [{
+        "text": "Meeting",
+        "color": "#00ff00",
+    }], mocks)
+
+    calls = mocks["patch_task_fields"].call_args_list
+    color_call = next((c for c in calls if "color" in _patch_dict_for(c)), None)
+    assert color_call is not None
+    assert _patch_dict_for(color_call)["color"] == "#00ff00"
+
+
+@pytest.mark.asyncio
+async def test_create_with_rrule_none_does_not_patch(conn, mocks):
+    """rrule=None on CREATE is a no-op (no need to clear a brand-new field)."""
+    mocks["create_unscheduled_task"].return_value = {"id": "task-1"}
+    mocks["get_task_by_uuid"].return_value = {
+        "id": "task-1", "text": "Meeting", "status": "pending",
+        "description": None, "context_subject": None, "plan_date": None, "anchor_id": None,
+    }
+
+    await run_upsert(conn, [{
+        "text": "Meeting",
+        "rrule": None,
+    }], mocks)
+
+    calls = mocks["patch_task_fields"].call_args_list
+    assert not any("rrule" in _patch_dict_for(c) for c in calls)

--- a/tether_mcp/tools/upsert_tasks.py
+++ b/tether_mcp/tools/upsert_tasks.py
@@ -74,6 +74,8 @@ async def execute_upsert_tasks(conn: asyncpg.Connection, tasks: list[dict]) -> l
             raise ValueError(
                 f"upsert_tasks: {missing} is required when the other event time field is provided"
             )
+        if start_time and end_time and start_time >= end_time:
+            raise ValueError("upsert_tasks: start_time must be before end_time")
 
         if task_uuid:
             # --- UPDATE path ---

--- a/tether_mcp/tools/upsert_tasks.py
+++ b/tether_mcp/tools/upsert_tasks.py
@@ -4,6 +4,32 @@ from __future__ import annotations
 
 import asyncpg
 
+from db.pg_queries import (
+    get_task_by_uuid,
+    patch_task_fields,
+    upsert_plan,
+    move_task_atomic,
+    create_unscheduled_task,
+    link_task_to_node,
+    unlink_task_from_node,
+    link_milestone_task,
+    add_dependency,
+    remove_dependency,
+    get_dependencies_for,
+    get_node_by_path,
+    create_subtask,
+    update_subtask,
+    delete_subtask,
+    get_subtasks,
+    promote_task_to_event,
+    update_event_time,
+)
+from tether_mcp.batch import validate_no_duplicates
+from tether_mcp.write_modes import apply_resolved_field
+
+
+_ABSENT = object()
+
 
 async def execute_upsert_tasks(conn: asyncpg.Connection, tasks: list[dict]) -> list[dict]:
     """Batch create or update tasks with write modes, scheduling, and linking.
@@ -11,32 +37,12 @@ async def execute_upsert_tasks(conn: asyncpg.Connection, tasks: list[dict]) -> l
     Each spec may contain:
         task_uuid, text, status, description, date, anchor_id, backlog,
         context_subject, node_ids, node_ids_remove, milestone_ids,
-        blocked_by, blocked_by_remove, subtasks, subtasks_remove
+        blocked_by, blocked_by_remove, subtasks, subtasks_remove,
+        start_time, end_time, rrule, color
 
     Returns list of {id, text, status, description, context_subject,
                      plan_date, anchor_id} dicts.
     """
-    from db.pg_queries import (
-        get_task_by_uuid,
-        patch_task_fields,
-        upsert_plan,
-        move_task_atomic,
-        create_unscheduled_task,
-        link_task_to_node,
-        unlink_task_from_node,
-        link_milestone_task,
-        add_dependency,
-        remove_dependency,
-        get_dependencies_for,
-        get_node_by_path,
-        create_subtask,
-        update_subtask,
-        delete_subtask,
-        get_subtasks,
-    )
-    from tether_mcp.batch import validate_no_duplicates
-    from tether_mcp.write_modes import apply_resolved_field
-
     validate_no_duplicates(tasks, key="task_uuid")
 
     results: list[dict] = []
@@ -58,14 +64,23 @@ async def execute_upsert_tasks(conn: asyncpg.Connection, tasks: list[dict]) -> l
         subtasks = spec.get("subtasks") or []
         subtasks_remove = spec.get("subtasks_remove") or []
 
+        start_time = spec.get("start_time") or ""
+        end_time = spec.get("end_time") or ""
+        rrule = spec.get("rrule", _ABSENT)
+        color = spec.get("color", _ABSENT)
+
+        if bool(start_time) != bool(end_time):
+            missing = "end_time" if start_time else "start_time"
+            raise ValueError(
+                f"upsert_tasks: {missing} is required when the other event time field is provided"
+            )
+
         if task_uuid:
             # --- UPDATE path ---
             patch_fields: dict = {}
 
-            # Fetch existing task once for write-mode resolution
             existing_task = await get_task_by_uuid(conn, task_uuid)
 
-            # Resolve text field
             new_text, _ = apply_resolved_field(
                 text_raw,
                 existing_task.get("text") if existing_task else None,
@@ -73,7 +88,6 @@ async def execute_upsert_tasks(conn: asyncpg.Connection, tasks: list[dict]) -> l
             if new_text is not None:
                 patch_fields["text"] = new_text
 
-            # Resolve description field
             new_desc, _ = apply_resolved_field(
                 description_raw,
                 existing_task.get("description") if existing_task else None,
@@ -81,19 +95,25 @@ async def execute_upsert_tasks(conn: asyncpg.Connection, tasks: list[dict]) -> l
             if new_desc is not None:
                 patch_fields["description"] = new_desc
 
-            # Scalar fields
             if status:
                 patch_fields["status"] = status
+
+            if rrule is not _ABSENT:
+                patch_fields["rrule"] = rrule
+            if color is not _ABSENT:
+                patch_fields["color"] = color
 
             if patch_fields:
                 await patch_task_fields(conn, task_uuid, patch_fields)
 
-            # Scheduling
             if backlog:
                 await move_task_atomic(conn, task_uuid, None, None)
             elif date and anchor_id:
                 await upsert_plan(conn, date)
                 await move_task_atomic(conn, task_uuid, date, anchor_id)
+
+            if start_time and end_time:
+                await update_event_time(conn, task_uuid, start_time, end_time)
 
             final_task_id = task_uuid
 
@@ -122,35 +142,40 @@ async def execute_upsert_tasks(conn: asyncpg.Connection, tasks: list[dict]) -> l
             if date and anchor_id:
                 await upsert_plan(conn, date)
                 await move_task_atomic(conn, final_task_id, date, anchor_id)
-            # context_subject already set on create; skip re-patching below if already done
-            context_subject = ""  # don't re-apply below since already set
+            # context_subject already set on create; skip re-patching below
+            context_subject = ""
+
+            if start_time and end_time:
+                await promote_task_to_event(conn, final_task_id, start_time, end_time)
+
+            event_fields: dict = {}
+            if rrule is not _ABSENT and rrule is not None:
+                event_fields["rrule"] = rrule
+            if color is not _ABSENT and color is not None:
+                event_fields["color"] = color
+            if event_fields:
+                await patch_task_fields(conn, final_task_id, event_fields)
 
         # --- Post create/update operations ---
 
-        # context_subject: patch + link via path
         if context_subject:
             await patch_task_fields(conn, final_task_id, {"context_subject": context_subject})
             node = await get_node_by_path(conn, context_subject)
             if node:
                 await link_task_to_node(conn, node["id"], final_task_id)
 
-        # node_ids: explicit link
         for nid in node_ids:
             await link_task_to_node(conn, nid, final_task_id)
 
-        # node_ids_remove: explicit unlink
         for nid in node_ids_remove:
             await unlink_task_from_node(conn, nid, final_task_id)
 
-        # milestone_ids: link
         for mid in milestone_ids:
             await link_milestone_task(conn, mid, final_task_id)
 
-        # blocked_by: add dependencies
         for blocker_id in blocked_by:
             await add_dependency(conn, "task", blocker_id, "task", final_task_id)
 
-        # blocked_by_remove: look up dep by entity_id then remove
         if blocked_by_remove:
             deps = await get_dependencies_for(conn, "task", final_task_id)
             for blocker_id in blocked_by_remove:
@@ -159,23 +184,19 @@ async def execute_upsert_tasks(conn: asyncpg.Connection, tasks: list[dict]) -> l
                         await remove_dependency(conn, dep["id"])
                         break
 
-        # subtasks: create new (no "id") or update existing (has "id")
         for sub in subtasks:
             if "id" in sub:
                 await update_subtask(conn, sub["id"], **{
                     k: v for k, v in sub.items() if k != "id"
                 })
             else:
-                # Determine position: after existing subtasks
                 existing_subs = await get_subtasks(conn, final_task_id)
                 pos = len(existing_subs)
                 await create_subtask(conn, final_task_id, sub["text"], position=pos)
 
-        # subtasks_remove: delete by id
         for sub_id in subtasks_remove:
             await delete_subtask(conn, sub_id)
 
-        # Fetch final state
         final = await get_task_by_uuid(conn, final_task_id)
         if final:
             results.append({


### PR DESCRIPTION
## Summary
- `execute_upsert_tasks` now accepts `start_time` + `end_time` (promotes task to calendar event on create via `promote_task_to_event`; repositions via `update_event_time` on update), `rrule` (sets recurrence rule), and `color` (sets display color)
- Validation: providing only one of `start_time` / `end_time` raises `ValueError`; `start_time` must be strictly before `end_time`
- DB import block moved from inside the function to module top-level so the new fields can be unit-tested with mocks
- 15 tests in `tests/mcp/test_upsert_tasks_events.py` covering both create and update paths, the `_ABSENT` sentinel for explicit None vs unset, and ordering/pairing validation

## Test plan
- [x] `pytest tests/mcp/test_upsert_tasks_events.py -v` — all 15 pass
- [x] `pytest -q` — full suite (446 passed, 339 skipped)
- [ ] Manual test via the bot: "schedule a meeting tomorrow at 10am for 1 hour" — verify event appears in the calendar

Follow-up: the tool description / system prompt should be updated separately so the model knows to use these new fields when scheduling.