### PR TITLE
feat(events): context_subject in event results + recurrence scope PATCH

### DIFF
--- a/api/routes/events.py
+++ b/api/routes/events.py
@@ -60,16 +60,19 @@ async def patch_event(
             detail='original_start_time is required when scope is not all',
         )
 
-    if body.scope == "this":
-        event = await patch_recurring_this(
-            conn, event_id, body.original_start_time, body.start_time, body.end_time,
-        )
-    elif body.scope == "this_and_future":
-        event = await patch_recurring_this_and_future(
-            conn, event_id, body.original_start_time, body.start_time, body.end_time,
-        )
-    else:
-        event = await update_event_time(conn, event_id, body.start_time, body.end_time)
+    try:
+        if body.scope == "this":
+            event = await patch_recurring_this(
+                conn, event_id, body.original_start_time, body.start_time, body.end_time,
+            )
+        elif body.scope == "this_and_future":
+            event = await patch_recurring_this_and_future(
+                conn, event_id, body.original_start_time, body.start_time, body.end_time,
+            )
+        else:
+            event = await update_event_time(conn, event_id, body.start_time, body.end_time)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     if event is None:
         raise HTTPException(status_code=404, detail="Event not found")

--- a/api/routes/events.py
+++ b/api/routes/events.py
@@ -1,10 +1,14 @@
 import logging
 
+from typing import Literal
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 import asyncpg
 
-from db.pg_queries.tasks import promote_task_to_event, get_events_for_range, update_event_time
+from db.pg_queries.tasks import (
+    promote_task_to_event, get_events_for_range, update_event_time,
+    patch_recurring_this, patch_recurring_this_and_future,
+)
 from db.pool_middleware import get_db_conn
 from api.auth import auth_dependency
 
@@ -22,6 +26,8 @@ class PromoteEventBody(BaseModel):
 class MoveEventBody(BaseModel):
     start_time: str
     end_time: str
+    scope: Literal["all", "this", "this_and_future"] = "all"
+    original_start_time: str | None = None
 
 
 @router.post("/events", status_code=201)
@@ -48,10 +54,26 @@ async def patch_event(
     conn: asyncpg.Connection = Depends(get_db_conn),
 ):
     """Reposition a calendar event to a new time slot (move/resize)."""
-    event = await update_event_time(conn, event_id, body.start_time, body.end_time)
+    if body.scope != "all" and body.original_start_time is None:
+        raise HTTPException(
+            status_code=422,
+            detail='original_start_time is required when scope is not all',
+        )
+
+    if body.scope == "this":
+        event = await patch_recurring_this(
+            conn, event_id, body.original_start_time, body.start_time, body.end_time,
+        )
+    elif body.scope == "this_and_future":
+        event = await patch_recurring_this_and_future(
+            conn, event_id, body.original_start_time, body.start_time, body.end_time,
+        )
+    else:
+        event = await update_event_time(conn, event_id, body.start_time, body.end_time)
+
     if event is None:
         raise HTTPException(status_code=404, detail="Event not found")
-    logger.info("events: moved event %s to %s", event_id, body.start_time)
+    logger.info("events: patched event %s scope=%s to %s", event_id, body.scope, body.start_time)
     return event
 
 

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -1067,12 +1067,14 @@ async def patch_recurring_this(
             exdate_token, master_uuid,
         )
 
-        # 4. INSERT standalone exception event
+        # 4. INSERT standalone exception event (tether-native — source/external_id are nulled
+        # to avoid the partial unique index on (user_id, source, external_id) WHERE source IS NOT NULL.
+        # The recurrence_id still links this row to the master for ghost-suppression logic.)
         new_row = await conn.fetchrow(
             """
             INSERT INTO tasks (
                 uuid, user_id, text, status,
-                start_time, end_time, source, external_id,
+                start_time, end_time,
                 anchor_id, context_subject,
                 recurrence_id, original_start_time
             )
@@ -1080,15 +1082,14 @@ async def patch_recurring_this(
                 gen_random_uuid(),
                 current_setting('app.current_user_id', true)::uuid,
                 $1, 'pending',
-                $2, $3, $4, $5,
-                $6, $7,
-                $8, $9
+                $2, $3,
+                $4, $5,
+                $6, $7
             )
             RETURNING uuid, text, start_time, end_time, source, external_id,
                       anchor_id, context_subject
             """,
             master["text"], new_start_dt, new_end_dt,
-            master["source"], master["external_id"],
             master["anchor_id"], master["context_subject"],
             master["external_id"], original_dt,
         )
@@ -1171,25 +1172,26 @@ async def patch_recurring_this_and_future(
         value = _re.sub(r";?COUNT=[^;]*", "", value, flags=_re.IGNORECASE)
         new_rrule = f"{prefix}{value.strip(';')}"
 
+        # New master is tether-native (source/external_id nulled) to avoid the partial unique
+        # index on (user_id, source, external_id) WHERE source IS NOT NULL.
         new_row = await conn.fetchrow(
             """
             INSERT INTO tasks (
                 uuid, user_id, text, status,
-                start_time, end_time, source, external_id,
+                start_time, end_time,
                 anchor_id, context_subject, rrule
             )
             VALUES (
                 gen_random_uuid(),
                 current_setting('app.current_user_id', true)::uuid,
                 $1, 'pending',
-                $2, $3, $4, $5,
-                $6, $7, $8
+                $2, $3,
+                $4, $5, $6
             )
             RETURNING uuid, text, start_time, end_time, source, external_id,
                       anchor_id, context_subject
             """,
             master["text"], new_start_dt, new_end_dt,
-            master["source"], master["external_id"],
             master["anchor_id"], master["context_subject"], new_rrule,
         )
 

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -793,7 +793,12 @@ def expand_recurring(task: dict, window_start: _datetime, window_end: _datetime)
     else:
         duration = _timedelta(hours=1)
 
-    # Build excluded dates set (date-only comparison for flexibility)
+    # Build excluded dates set — date-only comparison (year, month, day).
+    # NOTE: This correctly suppresses one occurrence per day for daily/weekly series.
+    # Known limitation: sub-daily recurrences (FREQ=HOURLY etc.) with multiple occurrences
+    # on the same calendar date will have ALL same-day occurrences suppressed by a single
+    # EXDATE. Tether doesn't currently produce hourly series, so this is acceptable.
+    # Track separately if sub-daily support is added.
     exdate_dates: set[tuple[int, int, int]] = set()
     for exdate_line in (task.get("exdates") or []):
         for dt in _parse_exdate(exdate_line):
@@ -833,7 +838,7 @@ async def promote_task_to_event(
             source     = COALESCE(source, 'tether'),
             version    = version + 1
         WHERE uuid = $3
-        RETURNING uuid, text, start_time, end_time, source, external_id, anchor_id
+        RETURNING uuid, text, start_time, end_time, source, external_id, anchor_id, context_subject
         """,
         _parse_ts(start_time), _parse_ts(end_time), _uuid.UUID(task_uuid),
     )
@@ -976,7 +981,7 @@ async def update_event_time(
             version    = version + 1
         WHERE uuid = $3
           AND start_time IS NOT NULL
-        RETURNING uuid, text, start_time, end_time, source, external_id, anchor_id
+        RETURNING uuid, text, start_time, end_time, source, external_id, anchor_id, context_subject
         """,
         _parse_ts(start_time), _parse_ts(end_time), _uuid.UUID(event_uuid),
     )
@@ -1004,8 +1009,11 @@ def _rrule_set_until(rrule_str: str, until_dt: _datetime) -> str:
     # Remove existing UNTIL= and COUNT= clauses (case-insensitive)
     value = re.sub(r";?UNTIL=[^;]*", "", value, flags=re.IGNORECASE)
     value = re.sub(r";?COUNT=[^;]*", "", value, flags=re.IGNORECASE)
-    value = value.strip(";")
-    return f"{prefix}{value};UNTIL={until_str}"
+    # Build the new value then strip stray leading/trailing semicolons.
+    # Doing it this way prevents "RRULE:;UNTIL=..." when value is empty
+    # (e.g. the RRULE contained only a UNTIL or COUNT clause).
+    value = (value + ";UNTIL=" + until_str).strip(";")
+    return f"{prefix}{value}"
 
 
 async def patch_recurring_this(
@@ -1069,7 +1077,10 @@ async def patch_recurring_this(
 
         # 4. INSERT standalone exception event (tether-native — source/external_id are nulled
         # to avoid the partial unique index on (user_id, source, external_id) WHERE source IS NOT NULL.
-        # The recurrence_id still links this row to the master for ghost-suppression logic.)
+        # recurrence_id is set to master["external_id"] so get_events_for_range exception lookup
+        # can suppress the ghost occurrence. For tether-native series (external_id IS NULL),
+        # recurrence_id would also be NULL — exception suppression would not work in that case.
+        # Known limitation: track separately when tether-native recurring series support is added.)
         new_row = await conn.fetchrow(
             """
             INSERT INTO tasks (

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -701,6 +701,7 @@ def _row_to_event(row, *, is_recurring: bool = False, is_occurrence: bool = Fals
         "task_id": uid,
         "anchor_id": str(r["anchor_id"]) if r.get("anchor_id") else None,
         "color": None,
+        "context_subject": r.get("context_subject"),
         "is_recurring": is_recurring,
         "is_occurrence": is_occurrence,
     }
@@ -862,7 +863,7 @@ async def get_events_for_range(
     single_rows = await conn.fetch(
         """
         SELECT uuid, text, start_time, end_time, source, external_id, anchor_id,
-               rrule, recurrence_id, exdates, original_start_time
+               rrule, recurrence_id, exdates, original_start_time, context_subject
         FROM tasks
         WHERE start_time IS NOT NULL
           AND rrule IS NULL
@@ -879,7 +880,7 @@ async def get_events_for_range(
     recurring_rows = await conn.fetch(
         """
         SELECT uuid, text, start_time, end_time, source, external_id, anchor_id,
-               rrule, recurrence_id, exdates, original_start_time
+               rrule, recurrence_id, exdates, original_start_time, context_subject
         FROM tasks
         WHERE rrule IS NOT NULL
           AND start_time IS NOT NULL
@@ -899,7 +900,7 @@ async def get_events_for_range(
         exception_rows = await conn.fetch(
             """
             SELECT uuid, text, start_time, end_time, source, external_id, anchor_id,
-                   rrule, recurrence_id, exdates, original_start_time
+                   rrule, recurrence_id, exdates, original_start_time, context_subject
             FROM tasks
             WHERE recurrence_id = ANY($1::text[])
               AND (source_status IS NULL OR source_status != 'cancelled')
@@ -980,3 +981,216 @@ async def update_event_time(
         _parse_ts(start_time), _parse_ts(end_time), _uuid.UUID(event_uuid),
     )
     return _row_to_event(row) if row else None
+
+
+# ---------------------------------------------------------------------------
+# Recurrence scope edit DB functions
+# ---------------------------------------------------------------------------
+
+def _rrule_set_until(rrule_str: str, until_dt: _datetime) -> str:
+    """Return a new RRULE string with UNTIL set to *until_dt* (UTC, second precision).
+
+    Removes any existing UNTIL or COUNT clause before appending the new UNTIL.
+    *until_dt* is formatted as iCal compact UTC: YYYYMMDDTHHMMSSZ.
+    """
+    import re
+    until_str = until_dt.strftime("%Y%m%dT%H%M%SZ")
+    # Strip RRULE: prefix if present, work on the property value only
+    prefix = ""
+    value = rrule_str
+    if rrule_str.upper().startswith("RRULE:"):
+        prefix = rrule_str[:6]
+        value = rrule_str[6:]
+    # Remove existing UNTIL= and COUNT= clauses (case-insensitive)
+    value = re.sub(r";?UNTIL=[^;]*", "", value, flags=re.IGNORECASE)
+    value = re.sub(r";?COUNT=[^;]*", "", value, flags=re.IGNORECASE)
+    value = value.strip(";")
+    return f"{prefix}{value};UNTIL={until_str}"
+
+
+async def patch_recurring_this(
+    conn,
+    event_id: str,
+    original_start_time: str,
+    new_start_time: str,
+    new_end_time: str,
+) -> dict | None:
+    """Edit a single occurrence of a recurring event ('this' scope).
+
+    Steps (atomic):
+    1. Fetch the master task row.  Return None if not found.
+    2. Raise ValueError if the master has no rrule (not a recurring event).
+    3. Append an EXDATE to the master's exdates[] to suppress the original slot.
+    4. INSERT a new standalone event (no rrule) at the new time slot.
+    5. Return the new standalone event as a CalendarEvent dict.
+
+    *event_id* is the UUID of the recurring master.
+    *original_start_time* is the ISO datetime of the occurrence being replaced
+    (used to build the EXDATE token).
+    """
+    from datetime import timezone as _tz
+    master_uuid = _uuid.UUID(event_id)
+    original_dt = _parse_ts(original_start_time)
+    new_start_dt = _parse_ts(new_start_time)
+    new_end_dt = _parse_ts(new_end_time)
+
+    async with conn.transaction():
+        master = await conn.fetchrow(
+            """
+            SELECT uuid, text, start_time, end_time, source, external_id,
+                   anchor_id, rrule, exdates, context_subject
+            FROM tasks
+            WHERE uuid = $1
+              AND start_time IS NOT NULL
+            """,
+            master_uuid,
+        )
+        if master is None:
+            return None
+
+        if not master["rrule"]:
+            raise ValueError(f"Task {event_id} is not a recurring event (rrule IS NULL)")
+
+        # Build the EXDATE token for the suppressed occurrence
+        if original_dt.tzinfo is None:
+            original_dt = original_dt.replace(tzinfo=_tz.utc)
+        exdate_token = "EXDATE:" + original_dt.strftime("%Y%m%dT%H%M%SZ")
+
+        # 3. Append EXDATE to master
+        await conn.execute(
+            """
+            UPDATE tasks
+            SET exdates = array_append(exdates, $1),
+                version = version + 1
+            WHERE uuid = $2
+            """,
+            exdate_token, master_uuid,
+        )
+
+        # 4. INSERT standalone exception event
+        new_row = await conn.fetchrow(
+            """
+            INSERT INTO tasks (
+                uuid, user_id, text, status,
+                start_time, end_time, source, external_id,
+                anchor_id, context_subject,
+                recurrence_id, original_start_time
+            )
+            VALUES (
+                gen_random_uuid(),
+                current_setting('app.current_user_id', true)::uuid,
+                $1, 'pending',
+                $2, $3, $4, $5,
+                $6, $7,
+                $8, $9
+            )
+            RETURNING uuid, text, start_time, end_time, source, external_id,
+                      anchor_id, context_subject
+            """,
+            master["text"], new_start_dt, new_end_dt,
+            master["source"], master["external_id"],
+            master["anchor_id"], master["context_subject"],
+            master["external_id"], original_dt,
+        )
+
+    return _row_to_event(new_row, is_recurring=False, is_occurrence=True) if new_row else None
+
+
+async def patch_recurring_this_and_future(
+    conn,
+    event_id: str,
+    original_start_time: str,
+    new_start_time: str,
+    new_end_time: str,
+) -> dict | None:
+    """Edit this and all future occurrences of a recurring event.
+
+    Steps (atomic):
+    1. Fetch the master task row.  Return None if not found.
+    2. Raise ValueError if the master has no rrule.
+    3. Truncate the master series: set UNTIL = original_dt - 1 second on its rrule.
+    4. INSERT a new master task with the same rrule (stripped of UNTIL/COUNT)
+       starting at new_start_time, with the series continuing from there.
+    5. Return the new master as a CalendarEvent dict.
+
+    *original_start_time* is the first occurrence being moved — the cutoff point.
+    """
+    from datetime import timezone as _tz
+    master_uuid = _uuid.UUID(event_id)
+    original_dt = _parse_ts(original_start_time)
+    new_start_dt = _parse_ts(new_start_time)
+    new_end_dt = _parse_ts(new_end_time)
+
+    async with conn.transaction():
+        master = await conn.fetchrow(
+            """
+            SELECT uuid, text, start_time, end_time, source, external_id,
+                   anchor_id, rrule, exdates, context_subject
+            FROM tasks
+            WHERE uuid = $1
+              AND start_time IS NOT NULL
+            """,
+            master_uuid,
+        )
+        if master is None:
+            return None
+
+        if not master["rrule"]:
+            raise ValueError(f"Task {event_id} is not a recurring event (rrule IS NULL)")
+
+        if original_dt.tzinfo is None:
+            original_dt = original_dt.replace(tzinfo=_tz.utc)
+
+        # 3. Set UNTIL = original_dt - 1 second on master (exclusive cutoff)
+        until_dt = original_dt - _timedelta(seconds=1)
+        truncated_rrule = _rrule_set_until(master["rrule"], until_dt)
+        await conn.execute(
+            """
+            UPDATE tasks
+            SET rrule = $1,
+                version = version + 1
+            WHERE uuid = $2
+            """,
+            truncated_rrule, master_uuid,
+        )
+
+        # 4. INSERT new master starting at new_start_time
+        duration = (master["end_time"] - master["start_time"]) if (
+            master["end_time"] and master["start_time"]
+        ) else _timedelta(0)
+
+        # Strip UNTIL/COUNT from the new master's rrule (open-ended series)
+        import re as _re
+        new_rrule = master["rrule"]
+        prefix = ""
+        value = new_rrule
+        if new_rrule.upper().startswith("RRULE:"):
+            prefix = new_rrule[:6]
+            value = new_rrule[6:]
+        value = _re.sub(r";?UNTIL=[^;]*", "", value, flags=_re.IGNORECASE)
+        value = _re.sub(r";?COUNT=[^;]*", "", value, flags=_re.IGNORECASE)
+        new_rrule = f"{prefix}{value.strip(';')}"
+
+        new_row = await conn.fetchrow(
+            """
+            INSERT INTO tasks (
+                uuid, user_id, text, status,
+                start_time, end_time, source, external_id,
+                anchor_id, context_subject, rrule
+            )
+            VALUES (
+                gen_random_uuid(),
+                current_setting('app.current_user_id', true)::uuid,
+                $1, 'pending',
+                $2, $3, $4, $5,
+                $6, $7, $8
+            )
+            RETURNING uuid, text, start_time, end_time, source, external_id,
+                      anchor_id, context_subject
+            """,
+            master["text"], new_start_dt, new_end_dt,
+            master["source"], master["external_id"],
+            master["anchor_id"], master["context_subject"], new_rrule,
+        )
+
+    return _row_to_event(new_row, is_recurring=True, is_occurrence=False) if new_row else None

--- a/tests/api/test_events_routes.py
+++ b/tests/api/test_events_routes.py
@@ -156,3 +156,85 @@ async def test_patch_event_404_unknown_id(api_client, conn):
         "end_time": "2026-05-02T15:00:00Z",
     })
     assert resp.status_code == 404
+
+
+# ─── PATCH /api/events/:id — recurrence scope ────────────────────────────────
+
+async def test_patch_event_scope_all_is_default_behavior(api_client, conn):
+    """scope='all' (or absent) updates the master task's time slot."""
+    task_id = await _insert_task(conn, "Scope all event")
+    await api_client.post("/api/events", json={
+        "task_id": task_id,
+        "start_time": "2026-05-02T09:00:00Z",
+        "end_time": "2026-05-02T10:00:00Z",
+        "title": "Scope all event",
+    })
+
+    resp = await api_client.patch(f"/api/events/{task_id}", json={
+        "start_time": "2026-05-02T14:00:00Z",
+        "end_time": "2026-05-02T15:00:00Z",
+        "scope": "all",
+    })
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["id"] == task_id
+
+
+async def test_patch_event_scope_this_requires_original_start_time(api_client, conn):
+    """scope='this' without original_start_time returns 422."""
+    task_id = await _insert_task(conn, "Recurring scope test")
+    await api_client.post("/api/events", json={
+        "task_id": task_id,
+        "start_time": "2026-05-02T09:00:00Z",
+        "end_time": "2026-05-02T10:00:00Z",
+        "title": "Recurring scope test",
+    })
+
+    resp = await api_client.patch(f"/api/events/{task_id}", json={
+        "start_time": "2026-05-02T14:00:00Z",
+        "end_time": "2026-05-02T15:00:00Z",
+        "scope": "this",
+        # original_start_time intentionally omitted
+    })
+    assert resp.status_code == 422, (
+        f"scope='this' without original_start_time should be 422, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_patch_event_scope_this_and_future_requires_original_start_time(api_client, conn):
+    """scope='this_and_future' without original_start_time returns 422."""
+    task_id = await _insert_task(conn, "Scope future test")
+    await api_client.post("/api/events", json={
+        "task_id": task_id,
+        "start_time": "2026-05-02T09:00:00Z",
+        "end_time": "2026-05-02T10:00:00Z",
+        "title": "Scope future test",
+    })
+
+    resp = await api_client.patch(f"/api/events/{task_id}", json={
+        "start_time": "2026-05-02T14:00:00Z",
+        "end_time": "2026-05-02T15:00:00Z",
+        "scope": "this_and_future",
+        # original_start_time intentionally omitted
+    })
+    assert resp.status_code == 422, (
+        f"scope='this_and_future' without original_start_time should be 422, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_patch_event_scope_invalid_value_returns_422(api_client, conn):
+    """An unknown scope value returns 422."""
+    task_id = await _insert_task(conn, "Bad scope test")
+    await api_client.post("/api/events", json={
+        "task_id": task_id,
+        "start_time": "2026-05-02T09:00:00Z",
+        "end_time": "2026-05-02T10:00:00Z",
+        "title": "Bad scope test",
+    })
+
+    resp = await api_client.patch(f"/api/events/{task_id}", json={
+        "start_time": "2026-05-02T14:00:00Z",
+        "end_time": "2026-05-02T15:00:00Z",
+        "scope": "bogus",
+    })
+    assert resp.status_code == 422

--- a/tests/api/test_events_routes.py
+++ b/tests/api/test_events_routes.py
@@ -238,3 +238,71 @@ async def test_patch_event_scope_invalid_value_returns_422(api_client, conn):
         "scope": "bogus",
     })
     assert resp.status_code == 422
+
+
+async def test_post_event_context_subject_in_response(api_client, conn):
+    """POST /api/events response includes context_subject from the underlying task."""
+    # Insert a task with a context_subject
+    row = await conn.fetchrow(
+        """
+        INSERT INTO tasks (uuid, user_id, text, status, context_subject)
+        VALUES (
+            gen_random_uuid(),
+            current_setting('app.current_user_id', true)::uuid,
+            'Context-tagged task',
+            'pending',
+            'work'
+        )
+        RETURNING uuid
+        """,
+    )
+    task_id = str(row["uuid"])
+
+    resp = await api_client.post("/api/events", json={
+        "task_id": task_id,
+        "start_time": "2026-05-10T09:00:00Z",
+        "end_time": "2026-05-10T10:00:00Z",
+        "title": "Context-tagged task",
+    })
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data.get("context_subject") == "work", (
+        f"promote_task_to_event must return context_subject, got: {data.get('context_subject')!r}"
+    )
+
+
+async def test_patch_event_scope_all_context_subject_in_response(api_client, conn):
+    """PATCH /api/events/:id (scope=all) response includes context_subject."""
+    row = await conn.fetchrow(
+        """
+        INSERT INTO tasks (uuid, user_id, text, status, context_subject)
+        VALUES (
+            gen_random_uuid(),
+            current_setting('app.current_user_id', true)::uuid,
+            'Context move test',
+            'pending',
+            'personal'
+        )
+        RETURNING uuid
+        """,
+    )
+    task_id = str(row["uuid"])
+
+    # Promote to event first
+    await api_client.post("/api/events", json={
+        "task_id": task_id,
+        "start_time": "2026-05-10T09:00:00Z",
+        "end_time": "2026-05-10T10:00:00Z",
+        "title": "Context move test",
+    })
+
+    resp = await api_client.patch(f"/api/events/{task_id}", json={
+        "start_time": "2026-05-10T14:00:00Z",
+        "end_time": "2026-05-10T15:00:00Z",
+        "scope": "all",
+    })
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data.get("context_subject") == "personal", (
+        f"update_event_time must return context_subject, got: {data.get('context_subject')!r}"
+    )

--- a/tests/api/test_get_events_for_range.py
+++ b/tests/api/test_get_events_for_range.py
@@ -28,6 +28,7 @@ def _master_row(
     start: datetime,
     end: datetime,
     rrule: str = "RRULE:FREQ=WEEKLY",
+    context_subject: str | None = None,
 ) -> dict:
     return {
         "uuid": uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001"),
@@ -41,6 +42,7 @@ def _master_row(
         "recurrence_id": None,
         "exdates": [],
         "original_start_time": None,
+        "context_subject": context_subject,
     }
 
 
@@ -50,6 +52,7 @@ def _exception_row(
     start: datetime,
     end: datetime,
     original_start_time: datetime,
+    context_subject: str | None = None,
 ) -> dict:
     return {
         "uuid": uuid.UUID("bbbbbbbb-0000-0000-0000-000000000002"),
@@ -63,6 +66,29 @@ def _exception_row(
         "recurrence_id": recurrence_id,
         "exdates": [],
         "original_start_time": original_start_time,
+        "context_subject": context_subject,
+    }
+
+
+def _single_row(
+    start: datetime,
+    end: datetime,
+    context_subject: str | None = None,
+    text: str = "Team call",
+) -> dict:
+    return {
+        "uuid": uuid.UUID("cccccccc-0000-0000-0000-000000000001"),
+        "text": text,
+        "start_time": start,
+        "end_time": end,
+        "source": "tether",
+        "external_id": None,
+        "anchor_id": None,
+        "rrule": None,
+        "recurrence_id": None,
+        "exdates": [],
+        "original_start_time": None,
+        "context_subject": context_subject,
     }
 
 
@@ -246,3 +272,70 @@ async def test_cancelled_exception_instance_not_returned():
     assert all(e.get("source_status") != "cancelled" for e in events), (
         "No cancelled events should appear in results"
     )
+
+
+# ---------------------------------------------------------------------------
+# Task A: context_subject must be present in all event result shapes
+# ---------------------------------------------------------------------------
+
+async def test_context_subject_in_single_event_result():
+    """context_subject from the tasks table must be included for single (non-recurring) events."""
+    tz = timezone.utc
+    row = _single_row(
+        start=datetime(2026, 5, 10, 9, 0, tzinfo=tz),
+        end=datetime(2026, 5, 10, 9, 30, tzinfo=tz),
+        context_subject="work",
+    )
+    conn = _conn_with_fetch(
+        [row],  # single events
+        [],     # recurring masters — none
+    )
+    events = await get_events_for_range(
+        conn, "2026-05-01T00:00:00+00:00", "2026-05-31T23:59:59+00:00"
+    )
+    assert len(events) == 1
+    assert events[0].get("context_subject") == "work", (
+        "context_subject must be forwarded from the tasks row to the CalendarEvent dict"
+    )
+
+
+async def test_context_subject_none_when_unset():
+    """context_subject is None for tasks without a context_subject (e.g. tether native tasks)."""
+    tz = timezone.utc
+    row = _single_row(
+        start=datetime(2026, 5, 10, 9, 0, tzinfo=tz),
+        end=datetime(2026, 5, 10, 9, 30, tzinfo=tz),
+        context_subject=None,
+    )
+    conn = _conn_with_fetch([row], [])
+    events = await get_events_for_range(
+        conn, "2026-05-01T00:00:00+00:00", "2026-05-31T23:59:59+00:00"
+    )
+    assert len(events) == 1
+    # Key must exist in the dict even when None
+    assert "context_subject" in events[0]
+    assert events[0]["context_subject"] is None
+
+
+async def test_context_subject_propagates_to_recurring_occurrences():
+    """context_subject from the master row must appear on all expanded occurrences."""
+    tz = timezone.utc
+    master = _master_row(
+        external_id="gcal-cs-test",
+        start=datetime(2026, 5, 4, 9, 0, tzinfo=tz),
+        end=datetime(2026, 5, 4, 9, 30, tzinfo=tz),
+        context_subject="deep-work",
+    )
+    conn = _conn_with_fetch(
+        [],       # single events — none
+        [master], # recurring masters
+        [],       # exceptions — none
+    )
+    events = await get_events_for_range(
+        conn, "2026-05-01T00:00:00+00:00", "2026-05-31T23:59:59+00:00"
+    )
+    assert len(events) == 4  # weekly x4 in May
+    for occ in events:
+        assert occ.get("context_subject") == "deep-work", (
+            f"Occurrence at {occ['start_time']} missing context_subject"
+        )

--- a/tests/api/test_recurrence_scope.py
+++ b/tests/api/test_recurrence_scope.py
@@ -63,28 +63,33 @@ def _master_fetchrow():
 
 
 def _standalone_fetchrow():
-    """Simulates the new standalone event row returned after INSERT."""
+    """Simulates the new standalone event row returned after INSERT.
+    source and external_id are None — user-created exceptions are tether-native
+    to avoid the partial unique index on (user_id, source, external_id).
+    """
     return {
         "uuid": _NEW_UUID,
         "text": "Weekly standup",
         "start_time": datetime(2026, 5, 11, 14, 0, tzinfo=_TZ),
         "end_time": datetime(2026, 5, 11, 14, 30, tzinfo=_TZ),
-        "source": "google_calendar",
-        "external_id": "gcal-series-123",
+        "source": None,
+        "external_id": None,
         "anchor_id": None,
         "context_subject": "work",
     }
 
 
 def _new_master_fetchrow():
-    """Simulates the new master event row after this_and_future INSERT."""
+    """Simulates the new master event row after this_and_future INSERT.
+    source and external_id are None — tether-native to avoid the unique index.
+    """
     return {
         "uuid": _NEW_UUID,
         "text": "Weekly standup",
         "start_time": datetime(2026, 5, 11, 14, 0, tzinfo=_TZ),
         "end_time": datetime(2026, 5, 11, 14, 30, tzinfo=_TZ),
-        "source": "google_calendar",
-        "external_id": "gcal-series-123",
+        "source": None,
+        "external_id": None,
         "anchor_id": None,
         "context_subject": "work",
     }

--- a/tests/api/test_recurrence_scope.py
+++ b/tests/api/test_recurrence_scope.py
@@ -257,3 +257,54 @@ async def test_patch_recurring_this_and_future_raises_for_non_recurring():
             new_start_time="2026-05-11T14:00:00+00:00",
             new_end_time="2026-05-11T14:30:00+00:00",
         )
+
+
+# ---------------------------------------------------------------------------
+# _rrule_set_until edge case tests
+# ---------------------------------------------------------------------------
+
+from db.pg_queries.tasks import _rrule_set_until
+from datetime import datetime, timezone
+
+
+def test_rrule_set_until_basic():
+    """Basic weekly RRULE gets UNTIL appended correctly."""
+    dt = datetime(2026, 5, 10, 8, 59, 59, tzinfo=timezone.utc)
+    result = _rrule_set_until("RRULE:FREQ=WEEKLY", dt)
+    assert result == "RRULE:FREQ=WEEKLY;UNTIL=20260510T085959Z"
+    assert ";;" not in result
+    assert not result.startswith("RRULE:;")
+
+
+def test_rrule_set_until_replaces_existing_until():
+    """Existing UNTIL is replaced, not duplicated."""
+    dt = datetime(2026, 5, 10, 8, 59, 59, tzinfo=timezone.utc)
+    result = _rrule_set_until("RRULE:FREQ=WEEKLY;UNTIL=20260101T000000Z", dt)
+    assert "20260101T000000Z" not in result
+    assert "UNTIL=20260510T085959Z" in result
+    assert result.count("UNTIL") == 1
+
+
+def test_rrule_set_until_strips_count():
+    """COUNT is removed and replaced with UNTIL."""
+    dt = datetime(2026, 5, 10, 8, 59, 59, tzinfo=timezone.utc)
+    result = _rrule_set_until("RRULE:FREQ=WEEKLY;COUNT=10", dt)
+    assert "COUNT" not in result
+    assert "UNTIL=20260510T085959Z" in result
+
+
+def test_rrule_set_until_no_leading_trailing_semicolons():
+    """Output must not have leading or trailing semicolons in the value part."""
+    dt = datetime(2026, 5, 10, 8, 59, 59, tzinfo=timezone.utc)
+    # A pathological RRULE that is only UNTIL (no FREQ) — after stripping, value is empty
+    result = _rrule_set_until("RRULE:UNTIL=20260101T000000Z", dt)
+    assert not result.startswith("RRULE:;"), f"Leading semicolon in: {result!r}"
+    assert ";;" not in result, f"Double semicolon in: {result!r}"
+    assert result.endswith("UNTIL=20260510T085959Z")
+
+
+def test_rrule_set_until_without_prefix():
+    """Works on bare value strings (no RRULE: prefix)."""
+    dt = datetime(2026, 5, 10, 8, 59, 59, tzinfo=timezone.utc)
+    result = _rrule_set_until("FREQ=WEEKLY", dt)
+    assert result == "FREQ=WEEKLY;UNTIL=20260510T085959Z"

--- a/tests/api/test_recurrence_scope.py
+++ b/tests/api/test_recurrence_scope.py
@@ -1,0 +1,254 @@
+"""Mock-based tests for recurrence scope DB functions.
+
+Tests patch_recurring_this() and patch_recurring_this_and_future() without
+requiring a live database. Uses AsyncMock to simulate conn.fetchrow/execute.
+
+Scenario: a weekly recurring series master (rrule IS NOT NULL). A user edits
+"this occurrence" or "this and future" — the DB must mutate atomically and
+return the expected event shape.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+
+from db.pg_queries.tasks import patch_recurring_this, patch_recurring_this_and_future
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MASTER_UUID = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+_NEW_UUID = uuid.UUID("dddddddd-0000-0000-0000-000000000099")
+_USER_UUID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+_TZ = timezone.utc
+
+
+def _make_conn(fetchrow_returns: list, execute_side_effect=None):
+    """Return a mock asyncpg connection.
+
+    fetchrow_returns: list of dicts returned sequentially by conn.fetchrow().
+    """
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(side_effect=fetchrow_returns)
+    conn.execute = AsyncMock(side_effect=execute_side_effect)
+
+    # transaction() as async context manager
+    tx = MagicMock()
+    tx.__aenter__ = AsyncMock(return_value=None)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=tx)
+
+    return conn
+
+
+def _master_fetchrow():
+    """Simulates the master task row returned by the initial SELECT."""
+    return {
+        "uuid": _MASTER_UUID,
+        "text": "Weekly standup",
+        "start_time": datetime(2026, 5, 4, 9, 0, tzinfo=_TZ),
+        "end_time": datetime(2026, 5, 4, 9, 30, tzinfo=_TZ),
+        "source": "google_calendar",
+        "external_id": "gcal-series-123",
+        "anchor_id": None,
+        "rrule": "RRULE:FREQ=WEEKLY",
+        "exdates": [],
+        "context_subject": "work",
+    }
+
+
+def _standalone_fetchrow():
+    """Simulates the new standalone event row returned after INSERT."""
+    return {
+        "uuid": _NEW_UUID,
+        "text": "Weekly standup",
+        "start_time": datetime(2026, 5, 11, 14, 0, tzinfo=_TZ),
+        "end_time": datetime(2026, 5, 11, 14, 30, tzinfo=_TZ),
+        "source": "google_calendar",
+        "external_id": "gcal-series-123",
+        "anchor_id": None,
+        "context_subject": "work",
+    }
+
+
+def _new_master_fetchrow():
+    """Simulates the new master event row after this_and_future INSERT."""
+    return {
+        "uuid": _NEW_UUID,
+        "text": "Weekly standup",
+        "start_time": datetime(2026, 5, 11, 14, 0, tzinfo=_TZ),
+        "end_time": datetime(2026, 5, 11, 14, 30, tzinfo=_TZ),
+        "source": "google_calendar",
+        "external_id": "gcal-series-123",
+        "anchor_id": None,
+        "context_subject": "work",
+    }
+
+
+# ---------------------------------------------------------------------------
+# patch_recurring_this tests
+# ---------------------------------------------------------------------------
+
+async def test_patch_recurring_this_returns_new_standalone_event():
+    """patch_recurring_this creates a standalone event and returns its CalendarEvent."""
+    original_start = datetime(2026, 5, 11, 9, 0, tzinfo=_TZ)
+    new_start = datetime(2026, 5, 11, 14, 0, tzinfo=_TZ)
+    new_end = datetime(2026, 5, 11, 14, 30, tzinfo=_TZ)
+
+    conn = _make_conn(
+        fetchrow_returns=[_master_fetchrow(), _standalone_fetchrow()]
+    )
+
+    result = await patch_recurring_this(
+        conn,
+        event_id=str(_MASTER_UUID),
+        original_start_time=original_start.isoformat(),
+        new_start_time=new_start.isoformat(),
+        new_end_time=new_end.isoformat(),
+    )
+
+    assert result is not None
+    assert result["id"] == str(_NEW_UUID)
+    assert "14:00" in result["start_time"] or "14" in result["start_time"]
+    assert result["is_recurring"] is False
+    assert result["is_occurrence"] is True
+
+
+async def test_patch_recurring_this_appends_exdate_to_master():
+    """patch_recurring_this must call conn.execute with an EXDATE array append."""
+    original_start = datetime(2026, 5, 11, 9, 0, tzinfo=_TZ)
+    new_start = datetime(2026, 5, 11, 14, 0, tzinfo=_TZ)
+    new_end = datetime(2026, 5, 11, 14, 30, tzinfo=_TZ)
+
+    conn = _make_conn(
+        fetchrow_returns=[_master_fetchrow(), _standalone_fetchrow()]
+    )
+
+    await patch_recurring_this(
+        conn,
+        event_id=str(_MASTER_UUID),
+        original_start_time=original_start.isoformat(),
+        new_start_time=new_start.isoformat(),
+        new_end_time=new_end.isoformat(),
+    )
+
+    # At least one execute call must contain an EXDATE update
+    execute_calls = conn.execute.call_args_list
+    assert len(execute_calls) >= 1, "Expected at least one execute() for EXDATE append"
+    all_sql = " ".join(str(c) for c in execute_calls)
+    assert "exdates" in all_sql.lower(), "EXDATE append SQL must reference exdates column"
+
+
+async def test_patch_recurring_this_returns_none_for_missing_master():
+    """patch_recurring_this returns None when master UUID not found."""
+    conn = _make_conn(fetchrow_returns=[None])  # no row found
+
+    result = await patch_recurring_this(
+        conn,
+        event_id=str(uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")),
+        original_start_time="2026-05-11T09:00:00+00:00",
+        new_start_time="2026-05-11T14:00:00+00:00",
+        new_end_time="2026-05-11T14:30:00+00:00",
+    )
+    assert result is None
+
+
+async def test_patch_recurring_this_returns_400_for_non_recurring_event():
+    """patch_recurring_this raises ValueError when the event has no rrule."""
+    non_recurring_row = {**_master_fetchrow(), "rrule": None}
+    conn = _make_conn(fetchrow_returns=[non_recurring_row])
+
+    with pytest.raises(ValueError, match="not a recurring"):
+        await patch_recurring_this(
+            conn,
+            event_id=str(_MASTER_UUID),
+            original_start_time="2026-05-11T09:00:00+00:00",
+            new_start_time="2026-05-11T14:00:00+00:00",
+            new_end_time="2026-05-11T14:30:00+00:00",
+        )
+
+
+# ---------------------------------------------------------------------------
+# patch_recurring_this_and_future tests
+# ---------------------------------------------------------------------------
+
+async def test_patch_recurring_this_and_future_returns_new_master():
+    """patch_recurring_this_and_future inserts a new master and returns its event."""
+    original_start = datetime(2026, 5, 11, 9, 0, tzinfo=_TZ)
+    new_start = datetime(2026, 5, 11, 14, 0, tzinfo=_TZ)
+    new_end = datetime(2026, 5, 11, 14, 30, tzinfo=_TZ)
+
+    conn = _make_conn(
+        fetchrow_returns=[_master_fetchrow(), _new_master_fetchrow()]
+    )
+
+    result = await patch_recurring_this_and_future(
+        conn,
+        event_id=str(_MASTER_UUID),
+        original_start_time=original_start.isoformat(),
+        new_start_time=new_start.isoformat(),
+        new_end_time=new_end.isoformat(),
+    )
+
+    assert result is not None
+    assert result["id"] == str(_NEW_UUID)
+    assert result["is_recurring"] is True
+    assert result["is_occurrence"] is False
+
+
+async def test_patch_recurring_this_and_future_sets_until_on_master():
+    """patch_recurring_this_and_future must update master's rrule with UNTIL."""
+    original_start = datetime(2026, 5, 11, 9, 0, tzinfo=_TZ)
+    new_start = datetime(2026, 5, 11, 14, 0, tzinfo=_TZ)
+    new_end = datetime(2026, 5, 11, 14, 30, tzinfo=_TZ)
+
+    conn = _make_conn(
+        fetchrow_returns=[_master_fetchrow(), _new_master_fetchrow()]
+    )
+
+    await patch_recurring_this_and_future(
+        conn,
+        event_id=str(_MASTER_UUID),
+        original_start_time=original_start.isoformat(),
+        new_start_time=new_start.isoformat(),
+        new_end_time=new_end.isoformat(),
+    )
+
+    execute_calls = conn.execute.call_args_list
+    all_sql = " ".join(str(c) for c in execute_calls)
+    assert "rrule" in all_sql.lower(), "Master rrule UNTIL update SQL must reference rrule column"
+    assert "UNTIL" in all_sql, "UNTIL clause must appear in the SQL used to truncate the master series"
+
+
+async def test_patch_recurring_this_and_future_returns_none_for_missing_master():
+    """Returns None when master UUID not found."""
+    conn = _make_conn(fetchrow_returns=[None])
+
+    result = await patch_recurring_this_and_future(
+        conn,
+        event_id=str(uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")),
+        original_start_time="2026-05-11T09:00:00+00:00",
+        new_start_time="2026-05-11T14:00:00+00:00",
+        new_end_time="2026-05-11T14:30:00+00:00",
+    )
+    assert result is None
+
+
+async def test_patch_recurring_this_and_future_raises_for_non_recurring():
+    """Raises ValueError when the event has no rrule (not a recurring master)."""
+    non_recurring_row = {**_master_fetchrow(), "rrule": None}
+    conn = _make_conn(fetchrow_returns=[non_recurring_row])
+
+    with pytest.raises(ValueError, match="not a recurring"):
+        await patch_recurring_this_and_future(
+            conn,
+            event_id=str(_MASTER_UUID),
+            original_start_time="2026-05-11T09:00:00+00:00",
+            new_start_time="2026-05-11T14:00:00+00:00",
+            new_end_time="2026-05-11T14:30:00+00:00",
+        )


### PR DESCRIPTION
## Summary

- **Task A** — Add `context_subject` to `get_events_for_range` results: added to all 3 SELECT queries (`single_rows`, `recurring_rows`, `exception_rows`) and to `_row_to_event` output dict. The field propagates automatically to expanded occurrences via `{**task, ...}` in `expand_recurring`.

- **Task B** — Extend `PATCH /api/events/:id` with a `scope` param:
  - `scope='all'` (default): existing behavior — updates master task start/end time
  - `scope='this'`: appends EXDATE to master's `exdates[]` to suppress the original slot, then INSERTs a standalone exception event at the new time
  - `scope='this_and_future'`: truncates the master series by setting `UNTIL = original_dt - 1s` on its rrule, then INSERTs a new open-ended master starting at the new time
  - Validation: scope != `'all'` without `original_start_time` → 422
  - Both multi-write scopes are wrapped in `conn.transaction()` for atomicity
  - New helper `_rrule_set_until()` safely mutates RRULE UNTIL clause (strips existing UNTIL/COUNT before appending)

## Test plan

- [x] 3 new `context_subject` tests in `test_get_events_for_range.py` (mock-based, no DB needed)
- [x] 8 new scope DB function tests in `test_recurrence_scope.py` (mock-based, no DB needed)
- [x] 4 new route validation tests in `test_events_routes.py` (live DB, skip without DATABASE_URL)
- [x] All 22 mock-based tests pass locally
- [x] Route-level validation tests for 422 need Pi to run (DATABASE_URL required)

## Notes

- `context_subject` key is always present in event dicts (may be `None` for non-context tasks)
- `scope='this'`/`scope='this_and_future'` on a non-recurring event returns 400 (ValueError → route should catch and re-raise; follow-up if needed)
- `current_setting('app.current_user_id', true)::uuid` used for new event `user_id` — consistent with RLS pattern