### PR TITLE
feat(calendar): filter panel, overlap layout, color hierarchy, expanded RecurrencePicker

### DIFF
--- a/frontend/src/components/CalendarEventBlock.vue
+++ b/frontend/src/components/CalendarEventBlock.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import type { CalendarEvent } from '../types/events'
 
-defineProps<{
+const props = defineProps<{
   event: CalendarEvent
   topPx: number
   heightPx: number
+  leftPercent?: number
+  widthPercent?: number
+  resolvedColor?: string
 }>()
 
 const emit = defineEmits<{
@@ -12,26 +15,27 @@ const emit = defineEmits<{
   (e: 'mousedown', ev: MouseEvent): void
 }>()
 
-function eventColor(event: CalendarEvent): string {
-  if (event.source !== 'tether') return '#4285f4' // Google blue for synced
-  return event.color ?? '#6366f1' // indigo default
+function defaultColor(event: CalendarEvent): string {
+  if (event.source !== 'tether') return '#4285f4'
+  return event.color ?? '#6366f1'
 }
 </script>
 
 <template>
   <div
-    class="absolute inset-x-1 rounded overflow-hidden text-xs px-1.5 py-0.5 cursor-grab shadow-md hover:brightness-110 transition-all z-10"
+    class="absolute rounded overflow-hidden text-xs px-1.5 py-0.5 cursor-grab shadow-md hover:brightness-110 transition-all z-10"
     :style="{
       top: `${topPx}px`,
       height: `${heightPx}px`,
-      backgroundColor: eventColor(event),
+      left: `calc(${props.leftPercent ?? 0}% + 2px)`,
+      width: `calc(${props.widthPercent ?? 100}% - 4px)`,
+      backgroundColor: props.resolvedColor ?? defaultColor(event),
       opacity: event.source !== 'tether' ? 0.75 : 1,
     }"
     @click.stop="emit('click', event)"
     @mousedown.stop="(ev) => emit('mousedown', ev)"
   >
     <div class="flex items-center gap-1 truncate pointer-events-none">
-      <!-- Provider badge for synced events -->
       <span
         v-if="event.source !== 'tether'"
         data-testid="gcal-badge"
@@ -40,7 +44,6 @@ function eventColor(event: CalendarEvent): string {
       >
         {{ event.source === 'google_calendar' ? 'G' : '↗' }}
       </span>
-      <!-- Recurring indicator for master events and synthesized occurrences -->
       <span
         v-if="event.is_recurring || event.is_occurrence"
         data-testid="recurring-indicator"

--- a/frontend/src/components/CalendarFilterPanel.vue
+++ b/frontend/src/components/CalendarFilterPanel.vue
@@ -1,0 +1,191 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import type { Milestone } from '../stores/milestones'
+import type { ContextNode } from '../stores/context'
+import type { KanbanColumn } from '../stores/kanban'
+
+export interface CalendarFilter {
+  milestoneIds: Set<string>
+  contextNodeIds: Set<string>
+  kanbanColumnIds: Set<string>
+}
+
+const props = defineProps<{
+  modelValue: CalendarFilter
+  milestones: Milestone[]
+  contextNodes: ContextNode[]
+  kanbanColumns: KanbanColumn[]
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', v: CalendarFilter): void
+  (e: 'close'): void
+}>()
+
+const search = ref('')
+const collapsed = ref<Record<string, boolean>>({ milestones: false, context: false, kanban: false })
+
+const searchLower = computed(() => search.value.toLowerCase())
+
+const filteredMilestones = computed(() =>
+  props.milestones.filter(m => m.name.toLowerCase().includes(searchLower.value))
+)
+const filteredContextNodes = computed(() =>
+  props.contextNodes.filter(n => n.name.toLowerCase().includes(searchLower.value))
+)
+const filteredKanbanColumns = computed(() =>
+  props.kanbanColumns.filter(c => c.name.toLowerCase().includes(searchLower.value))
+)
+
+function toggleGroup(key: string) {
+  collapsed.value[key] = !collapsed.value[key]
+}
+
+function clone(): CalendarFilter {
+  return {
+    milestoneIds: new Set(props.modelValue.milestoneIds),
+    contextNodeIds: new Set(props.modelValue.contextNodeIds),
+    kanbanColumnIds: new Set(props.modelValue.kanbanColumnIds),
+  }
+}
+
+function toggleMilestone(id: string) {
+  const f = clone()
+  if (f.milestoneIds.has(id)) f.milestoneIds.delete(id)
+  else f.milestoneIds.add(id)
+  emit('update:modelValue', f)
+}
+
+function toggleContextNode(id: string) {
+  const f = clone()
+  if (f.contextNodeIds.has(id)) f.contextNodeIds.delete(id)
+  else f.contextNodeIds.add(id)
+  emit('update:modelValue', f)
+}
+
+function toggleKanban(id: string) {
+  const f = clone()
+  if (f.kanbanColumnIds.has(id)) f.kanbanColumnIds.delete(id)
+  else f.kanbanColumnIds.add(id)
+  emit('update:modelValue', f)
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') emit('close')
+}
+
+const totalActive = computed(() =>
+  props.modelValue.milestoneIds.size +
+  props.modelValue.contextNodeIds.size +
+  props.modelValue.kanbanColumnIds.size
+)
+</script>
+
+<template>
+  <div
+    class="w-72 bg-gray-800 border border-white/20 rounded-xl shadow-xl p-3 space-y-1"
+    tabindex="0"
+    @keydown="onKeydown"
+  >
+    <input
+      v-model="search"
+      data-testid="filter-search"
+      placeholder="Search filters…"
+      class="w-full text-xs bg-white/5 border border-white/10 rounded px-2 py-1.5 text-white placeholder-white/30 outline-none focus:border-indigo-500 mb-2"
+    />
+
+    <div class="flex items-center justify-between mb-1">
+      <span class="text-[10px] text-white/30 uppercase tracking-wide">Filters</span>
+      <button
+        v-if="totalActive > 0"
+        class="text-[10px] text-indigo-400 hover:text-indigo-300"
+        @click="emit('update:modelValue', { milestoneIds: new Set(), contextNodeIds: new Set(), kanbanColumnIds: new Set() })"
+      >Clear all ({{ totalActive }})</button>
+    </div>
+
+    <!-- Milestones group -->
+    <div>
+      <button
+        data-testid="filter-group-milestones"
+        class="flex items-center gap-1 w-full text-left text-[10px] text-white/40 uppercase tracking-wide py-1 hover:text-white/60"
+        @click="toggleGroup('milestones')"
+      >
+        <span class="transition-transform" :class="collapsed.milestones ? '-rotate-90' : ''">▾</span>
+        Milestones
+        <span v-if="modelValue.milestoneIds.size > 0" class="ml-auto text-indigo-400">{{ modelValue.milestoneIds.size }}</span>
+      </button>
+      <div v-if="!collapsed.milestones" class="space-y-0.5 pl-2">
+        <div v-if="!filteredMilestones.length" class="text-[11px] text-white/20 py-0.5">No matches</div>
+        <button
+          v-for="m in filteredMilestones"
+          :key="m.id"
+          :data-testid="`filter-item-milestone-${m.id}`"
+          class="flex items-center gap-2 w-full text-left px-2 py-1 rounded text-xs transition-colors"
+          :class="modelValue.milestoneIds.has(m.id) ? 'bg-indigo-500/20 text-indigo-200' : 'text-white/60 hover:bg-white/5'"
+          @click="toggleMilestone(m.id)"
+        >
+          <span class="w-2 h-2 rounded-full flex-shrink-0" :style="{ backgroundColor: m.color ?? '#6366f1' }" />
+          {{ m.name }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Context Nodes group -->
+    <div>
+      <button
+        data-testid="filter-group-context"
+        class="flex items-center gap-1 w-full text-left text-[10px] text-white/40 uppercase tracking-wide py-1 hover:text-white/60"
+        @click="toggleGroup('context')"
+      >
+        <span class="transition-transform" :class="collapsed.context ? '-rotate-90' : ''">▾</span>
+        Context Nodes
+        <span v-if="modelValue.contextNodeIds.size > 0" class="ml-auto text-indigo-400">{{ modelValue.contextNodeIds.size }}</span>
+      </button>
+      <div v-if="!collapsed.context" class="space-y-0.5 pl-2">
+        <div v-if="!filteredContextNodes.length" class="text-[11px] text-white/20 py-0.5">No matches</div>
+        <button
+          v-for="n in filteredContextNodes"
+          :key="n.id"
+          :data-testid="`filter-item-context-${n.id}`"
+          class="flex items-center gap-2 w-full text-left px-2 py-1 rounded text-xs transition-colors"
+          :class="modelValue.contextNodeIds.has(n.id) ? 'bg-indigo-500/20 text-indigo-200' : 'text-white/60 hover:bg-white/5'"
+          @click="toggleContextNode(n.id)"
+        >
+          <span class="w-2 h-2 rounded-full flex-shrink-0" :style="{ backgroundColor: n.color ?? '#6366f1' }" />
+          {{ n.name }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Kanban Columns group -->
+    <div>
+      <button
+        data-testid="filter-group-kanban"
+        class="flex items-center gap-1 w-full text-left text-[10px] text-white/40 uppercase tracking-wide py-1 hover:text-white/60"
+        @click="toggleGroup('kanban')"
+      >
+        <span class="transition-transform" :class="collapsed.kanban ? '-rotate-90' : ''">▾</span>
+        Kanban Columns
+        <span v-if="modelValue.kanbanColumnIds.size > 0" class="ml-auto text-indigo-400">{{ modelValue.kanbanColumnIds.size }}</span>
+      </button>
+      <div v-if="!collapsed.kanban" class="space-y-0.5 pl-2">
+        <div v-if="!filteredKanbanColumns.length" class="text-[11px] text-white/20 py-0.5">No matches</div>
+        <button
+          v-for="c in filteredKanbanColumns"
+          :key="c.id"
+          :data-testid="`filter-item-kanban-${c.id}`"
+          class="flex items-center gap-2 w-full text-left px-2 py-1 rounded text-xs transition-colors"
+          :class="modelValue.kanbanColumnIds.has(c.id) ? 'bg-indigo-500/20 text-indigo-200' : 'text-white/60 hover:bg-white/5'"
+          @click="toggleKanban(c.id)"
+        >
+          <span class="w-2 h-2 rounded-full flex-shrink-0" :style="{ backgroundColor: c.color ?? '#6366f1' }" />
+          {{ c.name }}
+        </button>
+      </div>
+    </div>
+
+    <div class="flex justify-end mt-2">
+      <button class="text-[10px] text-white/30 hover:text-white/60" @click="emit('close')">Done</button>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/RecurrencePicker.vue
+++ b/frontend/src/components/RecurrencePicker.vue
@@ -1,107 +1,225 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
+import { parseRrule, buildRrule, DOW_CODES, DOW_LABELS, type RruleState } from '../composables/useRruleParser'
 
 const props = defineProps<{
   modelValue: string | null
-  startTime: string  // ISO 8601 — used to derive day-of-week for weekly preset
+  startTime: string
 }>()
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: string | null): void
 }>()
 
-type Preset = 'none' | 'daily' | 'weekly' | 'weekdays' | 'monthly' | 'custom'
-
-const DOW_NAMES: readonly string[] = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA']
-
-/** Derive BYDAY abbreviation from an ISO start_time string.
- *  Falls back to 'MO' if the date is unparseable. */
-function dowFromISO(iso: string): string {
-  const d = new Date(iso)
-  if (isNaN(d.getTime())) return 'MO'
-  return DOW_NAMES[d.getDay()]
+function initialState(v: string | null): { state: RruleState; custom: string } {
+  if (!v) return { state: parseRrule(null), custom: '' }
+  const parsed = parseRrule(v)
+  // Anything we don't fully round-trip stays as custom
+  if (parsed.freq === 'custom' || (buildRrule(parsed) !== v && parsed.freq !== 'none')) {
+    return { state: { ...parsed, freq: 'custom' }, custom: v }
+  }
+  return { state: parsed, custom: '' }
 }
 
-/** Map a known rrule string to its preset key, or 'custom' if unrecognised. */
-function rruleToPreset(rrule: string | null): Preset {
-  if (!rrule) return 'none'
-  if (rrule === 'FREQ=DAILY') return 'daily'
-  if (rrule.startsWith('FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR')) return 'weekdays'
-  if (/^FREQ=WEEKLY;BYDAY=[A-Z]{2}$/.test(rrule)) return 'weekly'
-  if (rrule === 'FREQ=MONTHLY') return 'monthly'
-  return 'custom'
-}
+const init = initialState(props.modelValue)
+const state = ref<RruleState>(init.state)
+const customRrule = ref<string>(init.custom)
 
-// Local preset tracks UI selection independently of modelValue so that choosing
-// "Custom" immediately shows the text input without needing the parent to round-trip.
-const localPreset = ref<Preset>(rruleToPreset(props.modelValue))
-
-// Sync inbound modelValue changes (e.g. parent reset) back to localPreset
 watch(() => props.modelValue, (v) => {
-  localPreset.value = rruleToPreset(v)
+  const next = initialState(v)
+  state.value = next.state
+  customRrule.value = next.custom
 })
 
-// Holds the raw text when user picks "custom"
-const customRrule = ref<string>(
-  localPreset.value === 'custom' ? (props.modelValue ?? '') : '',
-)
+const startDow = computed(() => {
+  const d = new Date(props.startTime)
+  return isNaN(d.getTime()) ? 'MO' : DOW_CODES[d.getDay()]
+})
 
-function onPresetChange(e: Event) {
-  const preset = (e.target as HTMLSelectElement).value as Preset
-  localPreset.value = preset
-  switch (preset) {
-    case 'none':
-      emit('update:modelValue', null)
-      break
-    case 'daily':
-      emit('update:modelValue', 'FREQ=DAILY')
-      break
-    case 'weekly':
-      emit('update:modelValue', `FREQ=WEEKLY;BYDAY=${dowFromISO(props.startTime)}`)
-      break
-    case 'weekdays':
-      emit('update:modelValue', 'FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR')
-      break
-    case 'monthly':
-      emit('update:modelValue', 'FREQ=MONTHLY')
-      break
-    case 'custom':
-      // Don't emit yet — wait for the text input
-      customRrule.value = props.modelValue ?? ''
-      break
+function emitValue() {
+  if (state.value.freq === 'custom') {
+    emit('update:modelValue', customRrule.value || null)
+    return
   }
+  emit('update:modelValue', buildRrule(state.value))
 }
 
-function onCustomChange(e: Event) {
-  const val = (e.target as HTMLInputElement).value.trim()
-  customRrule.value = val
-  if (val) emit('update:modelValue', val)
+function onFreqChange(e: Event) {
+  const newFreq = (e.target as HTMLSelectElement).value as RruleState['freq']
+  state.value.freq = newFreq
+  if (newFreq === 'weekly' && state.value.byday.length === 0) {
+    state.value.byday = [startDow.value]
+  }
+  if (newFreq === 'monthly' && state.value.monthlyMode === 'byday' && state.value.byday.length === 0) {
+    state.value.byday = [startDow.value]
+  }
+  emitValue()
+}
+
+function onIntervalChange(e: Event) {
+  state.value.interval = Math.max(1, parseInt((e.target as HTMLInputElement).value) || 1)
+  emitValue()
+}
+
+function toggleDow(dow: string) {
+  const idx = state.value.byday.indexOf(dow)
+  if (idx >= 0) state.value.byday.splice(idx, 1)
+  else state.value.byday.push(dow)
+  emitValue()
+}
+
+function onMonthlyModeChange() {
+  if (state.value.monthlyMode === 'byday' && state.value.byday.length === 0) {
+    state.value.byday = [startDow.value]
+  }
+  emitValue()
+}
+
+function onNthWeekdayChange(e: Event) {
+  state.value.nthWeekday = parseInt((e.target as HTMLSelectElement).value) || 1
+  emitValue()
+}
+
+function onMonthlyDowChange(e: Event) {
+  state.value.byday = [(e.target as HTMLSelectElement).value]
+  emitValue()
+}
+
+function onCountChange(e: Event) {
+  state.value.count = Math.max(1, parseInt((e.target as HTMLInputElement).value) || 1)
+  emitValue()
+}
+
+function onUntilChange(e: Event) {
+  state.value.until = (e.target as HTMLInputElement).value
+  emitValue()
+}
+
+function onCustomInput(e: Event) {
+  customRrule.value = (e.target as HTMLInputElement).value.trim()
+  emitValue()
 }
 </script>
 
 <template>
-  <div class="flex flex-col gap-1.5">
-    <label class="text-xs text-white/40">Repeat</label>
-    <select
-      :value="localPreset"
-      @change="onPresetChange"
-      class="bg-gray-800 text-white text-sm rounded px-2 py-1 border border-white/20 outline-none focus:border-white/40"
-    >
-      <option value="none">Does not repeat</option>
-      <option value="daily">Daily</option>
-      <option value="weekly">Weekly</option>
-      <option value="weekdays">Every weekday (Mon–Fri)</option>
-      <option value="monthly">Monthly</option>
-      <option value="custom">Custom (RRULE)</option>
-    </select>
+  <div class="space-y-2 text-xs">
+    <!-- Frequency -->
+    <div class="flex items-center gap-2">
+      <label class="text-white/50 w-20 flex-shrink-0">Repeat</label>
+      <select
+        class="flex-1 bg-gray-800 border border-white/20 rounded px-2 py-1 text-white text-sm"
+        :value="state.freq"
+        @change="onFreqChange"
+      >
+        <option value="none">Does not repeat</option>
+        <option value="daily">Daily</option>
+        <option value="weekly">Weekly</option>
+        <option value="monthly">Monthly</option>
+        <option value="yearly">Yearly</option>
+        <option value="custom">Custom (RRULE)</option>
+      </select>
+    </div>
+
+    <!-- Interval (daily/weekly/monthly only) -->
+    <div v-if="state.freq === 'daily' || state.freq === 'weekly' || state.freq === 'monthly'" class="flex items-center gap-2">
+      <label class="text-white/50 w-20 flex-shrink-0">Every</label>
+      <input
+        type="number" min="1" max="99"
+        class="w-16 bg-white/5 border border-white/10 rounded px-2 py-1 text-white text-xs"
+        :value="state.interval"
+        @change="onIntervalChange"
+      />
+      <span class="text-white/40">{{ state.freq === 'daily' ? 'day(s)' : state.freq === 'weekly' ? 'week(s)' : 'month(s)' }}</span>
+    </div>
+
+    <!-- Weekly day-of-week picker -->
+    <div v-if="state.freq === 'weekly'" class="flex items-start gap-2 flex-wrap">
+      <label class="text-white/50 w-20 flex-shrink-0">On</label>
+      <div class="flex gap-1 flex-wrap">
+        <button
+          v-for="(d, i) in DOW_CODES"
+          :key="d"
+          type="button"
+          :data-testid="`rrule-dow-${d}`"
+          class="px-1.5 py-0.5 rounded text-[11px] border transition-colors"
+          :class="state.byday.includes(d) ? 'bg-indigo-500 text-white border-indigo-500' : 'text-white/40 border-white/10 hover:border-white/30'"
+          @click="toggleDow(d)"
+        >{{ DOW_LABELS[i] }}</button>
+      </div>
+    </div>
+
+    <!-- Monthly mode picker -->
+    <div v-if="state.freq === 'monthly'" class="flex flex-col gap-1 pl-22">
+      <label class="flex items-center gap-2 cursor-pointer">
+        <input type="radio" v-model="state.monthlyMode" value="date" @change="onMonthlyModeChange" />
+        <span class="text-white/60">Same date each month</span>
+      </label>
+      <label class="flex items-center gap-2 cursor-pointer flex-wrap">
+        <input type="radio" v-model="state.monthlyMode" value="byday" @change="onMonthlyModeChange" />
+        <span class="text-white/60">On the</span>
+        <select
+          v-if="state.monthlyMode === 'byday'"
+          data-testid="rrule-nth-weekday"
+          class="bg-gray-800 border border-white/20 rounded px-1 py-0.5 text-white text-xs"
+          :value="state.nthWeekday"
+          @change="onNthWeekdayChange"
+        >
+          <option value="1">1st</option>
+          <option value="2">2nd</option>
+          <option value="3">3rd</option>
+          <option value="4">4th</option>
+        </select>
+        <select
+          v-if="state.monthlyMode === 'byday'"
+          data-testid="rrule-monthly-dow"
+          class="bg-gray-800 border border-white/20 rounded px-1 py-0.5 text-white text-xs"
+          :value="state.byday[0] ?? 'MO'"
+          @change="onMonthlyDowChange"
+        >
+          <option v-for="(d, i) in DOW_CODES" :key="d" :value="d">{{ DOW_LABELS[i] }}</option>
+        </select>
+      </label>
+    </div>
+
+    <!-- End condition -->
+    <div v-if="state.freq !== 'none' && state.freq !== 'custom'" class="flex items-center gap-2 flex-wrap">
+      <label class="text-white/50 w-20 flex-shrink-0">Ends</label>
+      <select
+        class="bg-gray-800 border border-white/20 rounded px-2 py-1 text-white text-xs"
+        v-model="state.endMode"
+        @change="emitValue"
+      >
+        <option value="never">Never</option>
+        <option value="count">After N occurrences</option>
+        <option value="until">On date</option>
+      </select>
+      <input
+        v-if="state.endMode === 'count'"
+        type="number" min="1" max="999"
+        data-testid="rrule-count"
+        class="w-16 bg-white/5 border border-white/10 rounded px-2 py-1 text-white text-xs"
+        :value="state.count"
+        @change="onCountChange"
+      />
+      <input
+        v-if="state.endMode === 'until'"
+        type="date"
+        data-testid="rrule-until"
+        class="bg-white/5 border border-white/10 rounded px-2 py-1 text-white text-xs"
+        :value="state.until"
+        @change="onUntilChange"
+      />
+    </div>
+
+    <!-- Custom RRULE fallback -->
     <input
-      v-if="localPreset === 'custom'"
+      v-if="state.freq === 'custom'"
       data-testid="rrule-custom-input"
       type="text"
       :value="customRrule"
       placeholder="e.g. FREQ=WEEKLY;BYDAY=MO,WE"
-      @change="onCustomChange"
-      class="bg-gray-800 text-white text-sm rounded px-2 py-1 border border-white/20 outline-none focus:border-white/40 font-mono"
+      @change="onCustomInput"
+      class="bg-gray-800 text-white text-sm rounded px-2 py-1 border border-white/20 outline-none focus:border-white/40 font-mono w-full"
     />
   </div>
 </template>

--- a/frontend/src/components/__tests__/CalendarEventBlock.test.ts
+++ b/frontend/src/components/__tests__/CalendarEventBlock.test.ts
@@ -25,6 +25,7 @@ const baseEvent: CalendarEvent = {
   is_recurring: false,
   is_occurrence: false,
   rrule: null,
+  context_subject: null,
 }
 
 describe('CalendarEventBlock', () => {
@@ -113,5 +114,29 @@ describe('CalendarEventBlock', () => {
       props: { event: baseEvent, topPx: 0, heightPx: 30 },
     })
     expect(wrapper.find('[data-testid="recurring-indicator"]').exists()).toBe(false)
+  })
+
+  it('positions event using leftPercent and widthPercent', async () => {
+    const { default: CalendarEventBlock } = await import('../CalendarEventBlock.vue')
+    const wrapper = mount(CalendarEventBlock, {
+      props: {
+        event: baseEvent, topPx: 100, heightPx: 60,
+        leftPercent: 50, widthPercent: 50,
+      },
+    })
+    const style = wrapper.attributes('style') ?? ''
+    expect(style).toContain('50%')
+  })
+
+  it('uses resolvedColor when provided', async () => {
+    const { default: CalendarEventBlock } = await import('../CalendarEventBlock.vue')
+    const wrapper = mount(CalendarEventBlock, {
+      props: {
+        event: baseEvent, topPx: 0, heightPx: 30,
+        resolvedColor: 'rgb(255, 0, 0)',
+      },
+    })
+    const style = wrapper.attributes('style') ?? ''
+    expect(style).toContain('rgb(255, 0, 0)')
   })
 })

--- a/frontend/src/components/__tests__/CalendarFilterPanel.test.ts
+++ b/frontend/src/components/__tests__/CalendarFilterPanel.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import CalendarFilterPanel from '../CalendarFilterPanel.vue'
+
+const MILESTONES = [
+  { id: 'm1', context_subject: 'p', name: 'Alpha', description: null, target_date: null, status: 'pending' as const, status_override: false, color: '#f00', created_at: '', updated_at: '', task_count: 0, done_count: 0, task_ids: [], tasks: [] },
+  { id: 'm2', context_subject: 'p', name: 'Beta',  description: null, target_date: null, status: 'pending' as const, status_override: false, color: '#0f0', created_at: '', updated_at: '', task_count: 0, done_count: 0, task_ids: [], tasks: [] },
+]
+const CONTEXT_NODES = [
+  { id: 'n1', parent_id: null, name: 'Work', description: null, node_type: 'context' as const, archived: false, target_date: null, status: null, status_override: false, color: '#00f', created_at: '', updated_at: '' },
+  { id: 'n2', parent_id: null, name: 'Personal', description: null, node_type: 'context' as const, archived: false, target_date: null, status: null, status_override: false, color: null, created_at: '', updated_at: '' },
+]
+const KANBAN_COLUMNS = [
+  { id: 'k1', name: 'Todo', position: 0, color: null, match_rules: {}, entry_rules: {}, created_by: null },
+  { id: 'k2', name: 'Done', position: 1, color: '#888', match_rules: {}, entry_rules: {}, created_by: null },
+]
+const EMPTY_FILTER = { milestoneIds: new Set<string>(), contextNodeIds: new Set<string>(), kanbanColumnIds: new Set<string>() }
+
+function makeWrapper(overrides = {}) {
+  setActivePinia(createPinia())
+  return mount(CalendarFilterPanel, {
+    props: {
+      modelValue: EMPTY_FILTER,
+      milestones: MILESTONES,
+      contextNodes: CONTEXT_NODES,
+      kanbanColumns: KANBAN_COLUMNS,
+      ...overrides,
+    },
+  })
+}
+
+describe('CalendarFilterPanel', () => {
+  it('renders milestone section with all milestones', () => {
+    const w = makeWrapper()
+    expect(w.text()).toContain('Alpha')
+    expect(w.text()).toContain('Beta')
+  })
+
+  it('renders context node section', () => {
+    const w = makeWrapper()
+    expect(w.text()).toContain('Work')
+    expect(w.text()).toContain('Personal')
+  })
+
+  it('renders kanban column section', () => {
+    const w = makeWrapper()
+    expect(w.text()).toContain('Todo')
+    expect(w.text()).toContain('Done')
+  })
+
+  it('filters items by search query', async () => {
+    const w = makeWrapper()
+    const search = w.find('[data-testid="filter-search"]')
+    await search.setValue('Alpha')
+    expect(w.text()).toContain('Alpha')
+    expect(w.text()).not.toContain('Beta')
+  })
+
+  it('emits update:modelValue with toggled milestone', async () => {
+    const w = makeWrapper()
+    const btn = w.find('[data-testid="filter-item-milestone-m1"]')
+    await btn.trigger('click')
+    const emitted = w.emitted('update:modelValue')!
+    expect((emitted[0][0] as typeof EMPTY_FILTER).milestoneIds.has('m1')).toBe(true)
+  })
+
+  it('collapses milestone section on header click', async () => {
+    const w = makeWrapper()
+    const header = w.find('[data-testid="filter-group-milestones"]')
+    await header.trigger('click')
+    expect(w.find('[data-testid="filter-item-milestone-m1"]').exists()).toBe(false)
+  })
+
+  it('emits close on Escape key', async () => {
+    const w = makeWrapper()
+    await w.trigger('keydown', { key: 'Escape' })
+    expect(w.emitted('close')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/__tests__/RecurrencePicker.test.ts
+++ b/frontend/src/components/__tests__/RecurrencePicker.test.ts
@@ -16,7 +16,7 @@ describe('RecurrencePicker', () => {
     setActivePinia(createPinia())
   })
 
-  it('renders a select with preset options', async () => {
+  it('renders a select with frequency options', async () => {
     const { default: RecurrencePicker } = await import('../RecurrencePicker.vue')
     const wrapper = mount(RecurrencePicker, {
       props: { modelValue: null, startTime: '2024-06-10T09:00:00Z' },
@@ -28,8 +28,8 @@ describe('RecurrencePicker', () => {
     expect(values).toContain('none')
     expect(values).toContain('daily')
     expect(values).toContain('weekly')
-    expect(values).toContain('weekdays')
     expect(values).toContain('monthly')
+    expect(values).toContain('yearly')
     expect(values).toContain('custom')
   })
 
@@ -77,14 +77,14 @@ describe('RecurrencePicker', () => {
     expect(emitted![0][0]).toBe('FREQ=WEEKLY;BYDAY=TU')
   })
 
-  it('emits FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR for weekdays preset', async () => {
+  it('emits FREQ=YEARLY for yearly preset', async () => {
     const { default: RecurrencePicker } = await import('../RecurrencePicker.vue')
     const wrapper = mount(RecurrencePicker, {
       props: { modelValue: null, startTime: '2024-06-10T09:00:00Z' },
     })
-    await wrapper.find('select').setValue('weekdays')
+    await wrapper.find('select').setValue('yearly')
     const emitted = wrapper.emitted('update:modelValue')
-    expect(emitted![0][0]).toBe('FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR')
+    expect(emitted![0][0]).toBe('FREQ=YEARLY')
   })
 
   it('emits FREQ=MONTHLY for monthly preset', async () => {
@@ -142,7 +142,7 @@ describe('RecurrencePicker', () => {
   it('selects "custom" when modelValue is an unrecognized rrule', async () => {
     const { default: RecurrencePicker } = await import('../RecurrencePicker.vue')
     const wrapper = mount(RecurrencePicker, {
-      props: { modelValue: 'FREQ=YEARLY', startTime: '2024-06-10T09:00:00Z' },
+      props: { modelValue: 'FREQ=HOURLY;INTERVAL=2', startTime: '2024-06-10T09:00:00Z' },
     })
     const select = wrapper.find('select')
     expect((select.element as HTMLSelectElement).value).toBe('custom')

--- a/frontend/src/components/__tests__/TaskDetailPanelCalendar.test.ts
+++ b/frontend/src/components/__tests__/TaskDetailPanelCalendar.test.ts
@@ -112,6 +112,7 @@ describe('TaskDetailPanel — Calendar section RecurrencePicker', () => {
       is_recurring: false,
       is_occurrence: false,
       rrule: null,
+      context_subject: null,
     })
 
     const { default: TaskDetailPanel } = await import('../TaskDetailPanel.vue')

--- a/frontend/src/composables/__tests__/useColorResolver.test.ts
+++ b/frontend/src/composables/__tests__/useColorResolver.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { resolveEventColor } from '../useColorResolver'
+import type { CalendarEvent } from '../../types/events'
+import type { Milestone } from '../../stores/milestones'
+import type { ContextNode } from '../../stores/context'
+
+function makeEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: '1', title: 'Test',
+    start_time: '2026-04-27T09:00:00', end_time: '2026-04-27T10:00:00',
+    source: 'tether', external_id: null, task_id: 'task-1',
+    anchor_id: null, color: null,
+    is_recurring: false, is_occurrence: false, rrule: null,
+    context_subject: null,
+    ...overrides,
+  }
+}
+
+const MILESTONES: Milestone[] = [
+  { id: 'm1', context_subject: 'p', name: 'Alpha', description: null, target_date: null, status: 'pending', status_override: false, color: '#ff0000', created_at: '', updated_at: '', task_count: 1, done_count: 0, task_ids: ['task-1'], tasks: [] },
+]
+const CONTEXT_NODES: Record<string, ContextNode> = {
+  'n1': { id: 'n1', parent_id: null, name: 'Work', description: null, node_type: 'context', archived: false, target_date: null, status: null, status_override: false, color: '#00ff00', created_at: '', updated_at: '' },
+}
+
+describe('resolveEventColor', () => {
+  it('returns event.color when set', () => {
+    expect(resolveEventColor(makeEvent({ color: '#abc123' }), [], {})).toBe('#abc123')
+  })
+
+  it('falls back to milestone color', () => {
+    expect(resolveEventColor(makeEvent(), MILESTONES, {})).toBe('#ff0000')
+  })
+
+  it('falls back to context node color when context_subject matches node name', () => {
+    const ev = makeEvent({ task_id: null, context_subject: 'Work' })
+    expect(resolveEventColor(ev, [], CONTEXT_NODES)).toBe('#00ff00')
+  })
+
+  it('returns default indigo when no color anywhere', () => {
+    expect(resolveEventColor(makeEvent({ task_id: 'no-milestone-task' }), [], {})).toBe('#6366f1')
+  })
+
+  it('returns google blue for non-tether source', () => {
+    expect(resolveEventColor(makeEvent({ source: 'google_calendar', color: null }), [], {})).toBe('#4285f4')
+  })
+})

--- a/frontend/src/composables/__tests__/useOverlapLayout.test.ts
+++ b/frontend/src/composables/__tests__/useOverlapLayout.test.ts
@@ -38,6 +38,19 @@ describe('computeOverlapLayout', () => {
     expect(result['c'].widthPercent).toBeCloseTo(33.33, 0)
   })
 
+  it('chained overlap (A∩B, B∩C, A!∩C) sizes consistently across the component (no collision)', () => {
+    // A=9-11, B=10-12, C=11-13: A and C don't overlap; B overlaps both. With only
+    // 2 lanes needed (A,C share lane 0; B in lane 1), all three must size to width=50
+    // so B's strip 50-100 doesn't collide with C's strip 0-50 during 11-12.
+    const result = computeOverlapLayout([ev('a', 9, 11), ev('b', 10, 12), ev('c', 11, 13)])
+    expect(result['a'].widthPercent).toBe(50)
+    expect(result['b'].widthPercent).toBe(50)
+    expect(result['c'].widthPercent).toBe(50)
+    expect(result['a'].leftPercent).toBe(0)
+    expect(result['b'].leftPercent).toBe(50)
+    expect(result['c'].leftPercent).toBe(0)
+  })
+
   it('sequential overlapping groups are independent', () => {
     const result = computeOverlapLayout([
       ev('a', 9, 10), ev('b', 9, 10),

--- a/frontend/src/composables/__tests__/useOverlapLayout.test.ts
+++ b/frontend/src/composables/__tests__/useOverlapLayout.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { computeOverlapLayout, type LayoutEvent } from '../useOverlapLayout'
+
+function ev(id: string, startHour: number, endHour: number): LayoutEvent {
+  const date = '2026-04-27'
+  return {
+    id,
+    start_time: `${date}T${String(startHour).padStart(2,'0')}:00:00`,
+    end_time:   `${date}T${String(endHour).padStart(2,'0')}:00:00`,
+  }
+}
+
+describe('computeOverlapLayout', () => {
+  it('single event fills full width', () => {
+    const result = computeOverlapLayout([ev('a', 9, 10)])
+    expect(result['a'].leftPercent).toBe(0)
+    expect(result['a'].widthPercent).toBe(100)
+  })
+
+  it('two overlapping events split evenly', () => {
+    const result = computeOverlapLayout([ev('a', 9, 10), ev('b', 9, 10)])
+    expect(result['a'].leftPercent).toBe(0)
+    expect(result['a'].widthPercent).toBe(50)
+    expect(result['b'].leftPercent).toBe(50)
+    expect(result['b'].widthPercent).toBe(50)
+  })
+
+  it('non-overlapping events each fill full width', () => {
+    const result = computeOverlapLayout([ev('a', 9, 10), ev('b', 11, 12)])
+    expect(result['a'].widthPercent).toBe(100)
+    expect(result['b'].widthPercent).toBe(100)
+  })
+
+  it('three-way overlap splits into thirds', () => {
+    const result = computeOverlapLayout([ev('a', 9, 12), ev('b', 10, 11), ev('c', 10, 11)])
+    expect(result['a'].widthPercent).toBeCloseTo(33.33, 0)
+    expect(result['b'].widthPercent).toBeCloseTo(33.33, 0)
+    expect(result['c'].widthPercent).toBeCloseTo(33.33, 0)
+  })
+
+  it('sequential overlapping groups are independent', () => {
+    const result = computeOverlapLayout([
+      ev('a', 9, 10), ev('b', 9, 10),
+      ev('c', 11, 12), ev('d', 11, 12),
+    ])
+    expect(result['a'].widthPercent).toBe(50)
+    expect(result['c'].widthPercent).toBe(50)
+  })
+})

--- a/frontend/src/composables/__tests__/useRruleParser.test.ts
+++ b/frontend/src/composables/__tests__/useRruleParser.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { parseRrule, buildRrule } from '../useRruleParser'
+
+describe('parseRrule', () => {
+  it('parses null to none state', () => {
+    expect(parseRrule(null).freq).toBe('none')
+  })
+
+  it('parses FREQ=DAILY;INTERVAL=3', () => {
+    const s = parseRrule('FREQ=DAILY;INTERVAL=3')
+    expect(s.freq).toBe('daily')
+    expect(s.interval).toBe(3)
+  })
+
+  it('parses FREQ=WEEKLY;INTERVAL=2;BYDAY=MO', () => {
+    const s = parseRrule('FREQ=WEEKLY;INTERVAL=2;BYDAY=MO')
+    expect(s.freq).toBe('weekly')
+    expect(s.interval).toBe(2)
+    expect(s.byday).toEqual(['MO'])
+  })
+
+  it('parses FREQ=MONTHLY;BYDAY=3TU', () => {
+    const s = parseRrule('FREQ=MONTHLY;BYDAY=3TU')
+    expect(s.freq).toBe('monthly')
+    expect(s.monthlyMode).toBe('byday')
+    expect(s.nthWeekday).toBe(3)
+    expect(s.byday).toEqual(['TU'])
+  })
+
+  it('parses FREQ=YEARLY', () => {
+    expect(parseRrule('FREQ=YEARLY').freq).toBe('yearly')
+  })
+
+  it('parses COUNT=5 end condition', () => {
+    const s = parseRrule('FREQ=DAILY;COUNT=5')
+    expect(s.endMode).toBe('count')
+    expect(s.count).toBe(5)
+  })
+
+  it('parses UNTIL end condition', () => {
+    const s = parseRrule('FREQ=DAILY;UNTIL=20261231T000000Z')
+    expect(s.endMode).toBe('until')
+    expect(s.until).toBe('2026-12-31')
+  })
+})
+
+describe('buildRrule', () => {
+  it('returns null for none freq', () => {
+    expect(buildRrule({ freq: 'none', interval: 1, byday: [], monthlyMode: 'date', nthWeekday: 1, endMode: 'never', count: 1, until: '' })).toBeNull()
+  })
+
+  it('builds FREQ=DAILY;INTERVAL=2', () => {
+    expect(buildRrule({ freq: 'daily', interval: 2, byday: [], monthlyMode: 'date', nthWeekday: 1, endMode: 'never', count: 1, until: '' }))
+      .toBe('FREQ=DAILY;INTERVAL=2')
+  })
+
+  it('builds FREQ=WEEKLY;BYDAY=TU,TH', () => {
+    expect(buildRrule({ freq: 'weekly', interval: 1, byday: ['TU', 'TH'], monthlyMode: 'date', nthWeekday: 1, endMode: 'never', count: 1, until: '' }))
+      .toBe('FREQ=WEEKLY;BYDAY=TU,TH')
+  })
+
+  it('builds FREQ=MONTHLY;BYDAY=2WE', () => {
+    expect(buildRrule({ freq: 'monthly', interval: 1, byday: ['WE'], monthlyMode: 'byday', nthWeekday: 2, endMode: 'never', count: 1, until: '' }))
+      .toBe('FREQ=MONTHLY;BYDAY=2WE')
+  })
+
+  it('appends COUNT', () => {
+    const r = buildRrule({ freq: 'daily', interval: 1, byday: [], monthlyMode: 'date', nthWeekday: 1, endMode: 'count', count: 10, until: '' })
+    expect(r).toContain('COUNT=10')
+  })
+
+  it('appends UNTIL', () => {
+    const r = buildRrule({ freq: 'daily', interval: 1, byday: [], monthlyMode: 'date', nthWeekday: 1, endMode: 'until', count: 1, until: '2026-12-31' })
+    expect(r).toContain('UNTIL=20261231')
+  })
+})

--- a/frontend/src/composables/__tests__/useRruleParser.test.ts
+++ b/frontend/src/composables/__tests__/useRruleParser.test.ts
@@ -69,6 +69,11 @@ describe('buildRrule', () => {
     expect(r).toContain('COUNT=10')
   })
 
+  it('emits COUNT=1 (does not silently drop "after 1 occurrence")', () => {
+    const r = buildRrule({ freq: 'daily', interval: 1, byday: [], monthlyMode: 'date', nthWeekday: 1, endMode: 'count', count: 1, until: '' })
+    expect(r).toContain('COUNT=1')
+  })
+
   it('appends UNTIL', () => {
     const r = buildRrule({ freq: 'daily', interval: 1, byday: [], monthlyMode: 'date', nthWeekday: 1, endMode: 'until', count: 1, until: '2026-12-31' })
     expect(r).toContain('UNTIL=20261231')

--- a/frontend/src/composables/useColorResolver.ts
+++ b/frontend/src/composables/useColorResolver.ts
@@ -1,0 +1,37 @@
+import type { CalendarEvent } from '../types/events'
+import type { Milestone } from '../stores/milestones'
+import type { ContextNode } from '../stores/context'
+
+const DEFAULT_COLOR = '#6366f1'
+const GOOGLE_COLOR = '#4285f4'
+
+/**
+ * Resolve an event's display color following the hierarchy:
+ *   non-tether source → google blue
+ *   event.color → that
+ *   milestone owning the task → milestone.color
+ *   context node matching event.context_subject by name → node.color
+ *   else → default indigo
+ */
+export function resolveEventColor(
+  event: CalendarEvent,
+  milestones: Milestone[],
+  contextNodes: Record<string, ContextNode>,
+): string {
+  if (event.source !== 'tether') return GOOGLE_COLOR
+
+  if (event.color) return event.color
+
+  if (event.task_id) {
+    for (const m of milestones) {
+      if (m.task_ids.includes(event.task_id) && m.color) return m.color
+    }
+  }
+
+  if (event.context_subject) {
+    const node = Object.values(contextNodes).find(n => n.name === event.context_subject)
+    if (node?.color) return node.color
+  }
+
+  return DEFAULT_COLOR
+}

--- a/frontend/src/composables/useOverlapLayout.ts
+++ b/frontend/src/composables/useOverlapLayout.ts
@@ -43,18 +43,51 @@ export function computeOverlapLayout(events: LayoutEvent[]): Record<string, Even
     }
   }
 
+  // Group events by connected overlap component (transitive overlap).
+  // Column count = max lane index + 1 within that component, so chained
+  // overlaps (A∩B, B∩C, A!∩C) get a consistent 3-column layout instead of
+  // each event sizing itself by its own neighbor count.
+  const adj = new Map<string, string[]>()
+  for (const ev of sorted) adj.set(ev.id, [])
+  for (let i = 0; i < sorted.length; i++) {
+    const a = sorted[i]
+    const aStart = new Date(a.start_time).getTime()
+    const aEnd = new Date(a.end_time).getTime()
+    for (let j = i + 1; j < sorted.length; j++) {
+      const b = sorted[j]
+      const bStart = new Date(b.start_time).getTime()
+      const bEnd = new Date(b.end_time).getTime()
+      if (bStart < aEnd && bEnd > aStart) {
+        adj.get(a.id)!.push(b.id)
+        adj.get(b.id)!.push(a.id)
+      }
+    }
+  }
+
+  const componentColumns = new Map<string, number>()
+  const visited = new Set<string>()
+  for (const ev of sorted) {
+    if (visited.has(ev.id)) continue
+    const stack = [ev.id]
+    const component: string[] = []
+    while (stack.length) {
+      const id = stack.pop()!
+      if (visited.has(id)) continue
+      visited.add(id)
+      component.push(id)
+      for (const nb of adj.get(id) ?? []) if (!visited.has(nb)) stack.push(nb)
+    }
+    let maxLane = 0
+    for (const id of component) maxLane = Math.max(maxLane, eventLane.get(id) ?? 0)
+    const columns = maxLane + 1
+    for (const id of component) componentColumns.set(id, columns)
+  }
+
   const result: Record<string, EventLayout> = {}
   for (const ev of sorted) {
-    const evStart = new Date(ev.start_time).getTime()
-    const evEnd = new Date(ev.end_time).getTime()
-    const overlapping = sorted.filter(other => {
-      const s = new Date(other.start_time).getTime()
-      const e = new Date(other.end_time).getTime()
-      return s < evEnd && e > evStart
-    })
-    const groupSize = overlapping.length
     const lane = eventLane.get(ev.id) ?? 0
-    const widthPercent = 100 / groupSize
+    const columns = componentColumns.get(ev.id) ?? 1
+    const widthPercent = 100 / columns
     const leftPercent = lane * widthPercent
     result[ev.id] = { leftPercent, widthPercent }
   }

--- a/frontend/src/composables/useOverlapLayout.ts
+++ b/frontend/src/composables/useOverlapLayout.ts
@@ -1,0 +1,63 @@
+export interface LayoutEvent {
+  id: string
+  start_time: string
+  end_time: string
+}
+
+export interface EventLayout {
+  leftPercent: number
+  widthPercent: number
+}
+
+/**
+ * Compute side-by-side layout for events overlapping in time within a single day.
+ * Greedily assigns each event to the first lane where it doesn't overlap the lane's
+ * last event; group size is the count of all events overlapping with the target.
+ */
+export function computeOverlapLayout(events: LayoutEvent[]): Record<string, EventLayout> {
+  if (events.length === 0) return {}
+
+  const sorted = [...events].sort((a, b) =>
+    new Date(a.start_time).getTime() - new Date(b.start_time).getTime()
+  )
+
+  const lanes: LayoutEvent[][] = []
+  const eventLane = new Map<string, number>()
+
+  for (const ev of sorted) {
+    const evStart = new Date(ev.start_time).getTime()
+    let placed = false
+    for (let i = 0; i < lanes.length; i++) {
+      const lastInLane = lanes[i][lanes[i].length - 1]
+      const lastEnd = new Date(lastInLane.end_time).getTime()
+      if (evStart >= lastEnd) {
+        lanes[i].push(ev)
+        eventLane.set(ev.id, i)
+        placed = true
+        break
+      }
+    }
+    if (!placed) {
+      eventLane.set(ev.id, lanes.length)
+      lanes.push([ev])
+    }
+  }
+
+  const result: Record<string, EventLayout> = {}
+  for (const ev of sorted) {
+    const evStart = new Date(ev.start_time).getTime()
+    const evEnd = new Date(ev.end_time).getTime()
+    const overlapping = sorted.filter(other => {
+      const s = new Date(other.start_time).getTime()
+      const e = new Date(other.end_time).getTime()
+      return s < evEnd && e > evStart
+    })
+    const groupSize = overlapping.length
+    const lane = eventLane.get(ev.id) ?? 0
+    const widthPercent = 100 / groupSize
+    const leftPercent = lane * widthPercent
+    result[ev.id] = { leftPercent, widthPercent }
+  }
+
+  return result
+}

--- a/frontend/src/composables/useRruleParser.ts
+++ b/frontend/src/composables/useRruleParser.ts
@@ -1,0 +1,78 @@
+export interface RruleState {
+  freq: 'none' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'custom'
+  interval: number
+  byday: string[]
+  monthlyMode: 'date' | 'byday'
+  nthWeekday: number
+  endMode: 'never' | 'count' | 'until'
+  count: number
+  until: string
+}
+
+export const DOW_CODES = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'] as const
+export const DOW_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+export function parseRrule(rrule: string | null): RruleState {
+  const defaults: RruleState = {
+    freq: 'none', interval: 1, byday: [], monthlyMode: 'date',
+    nthWeekday: 1, endMode: 'never', count: 1, until: '',
+  }
+  if (!rrule) return defaults
+
+  const parts = Object.fromEntries(rrule.split(';').map(p => p.split('=')))
+  const freqStr = (parts['FREQ'] ?? '').toLowerCase()
+  const interval = parts['INTERVAL'] ? parseInt(parts['INTERVAL']) : 1
+  const countVal = parts['COUNT'] ? parseInt(parts['COUNT']) : 1
+  const untilVal = parts['UNTIL'] ?? ''
+
+  let endMode: RruleState['endMode'] = 'never'
+  let until = ''
+  if (parts['COUNT']) endMode = 'count'
+  else if (parts['UNTIL']) {
+    endMode = 'until'
+    const u = untilVal.replace(/T.*/, '')
+    until = `${u.slice(0, 4)}-${u.slice(4, 6)}-${u.slice(6, 8)}`
+  }
+
+  let byday: string[] = []
+  let monthlyMode: RruleState['monthlyMode'] = 'date'
+  let nthWeekday = 1
+  if (parts['BYDAY']) {
+    const raw = parts['BYDAY']
+    const nthMatch = raw.match(/^(-?\d)(SU|MO|TU|WE|TH|FR|SA)$/)
+    if (nthMatch) {
+      monthlyMode = 'byday'
+      nthWeekday = parseInt(nthMatch[1])
+      byday = [nthMatch[2]]
+    } else {
+      byday = raw.split(',')
+    }
+  }
+
+  const validFreq: RruleState['freq'][] = ['none', 'daily', 'weekly', 'monthly', 'yearly', 'custom']
+  const freq = (validFreq.includes(freqStr as RruleState['freq']) ? freqStr : 'custom') as RruleState['freq']
+
+  return { freq, interval, byday, monthlyMode, nthWeekday, endMode, count: countVal, until }
+}
+
+export function buildRrule(s: RruleState): string | null {
+  if (s.freq === 'none' || s.freq === 'custom') return null
+
+  const parts: string[] = [`FREQ=${s.freq.toUpperCase()}`]
+  if (s.interval > 1) parts.push(`INTERVAL=${s.interval}`)
+
+  if (s.freq === 'weekly' && s.byday.length > 0) {
+    parts.push(`BYDAY=${s.byday.join(',')}`)
+  } else if (s.freq === 'monthly' && s.monthlyMode === 'byday' && s.byday.length > 0) {
+    parts.push(`BYDAY=${s.nthWeekday}${s.byday[0]}`)
+  }
+
+  if (s.endMode === 'count' && s.count > 1) {
+    parts.push(`COUNT=${s.count}`)
+  } else if (s.endMode === 'until' && s.until) {
+    const d = s.until.replace(/-/g, '')
+    parts.push(`UNTIL=${d}T000000Z`)
+  }
+
+  return parts.join(';')
+}

--- a/frontend/src/composables/useRruleParser.ts
+++ b/frontend/src/composables/useRruleParser.ts
@@ -67,7 +67,7 @@ export function buildRrule(s: RruleState): string | null {
     parts.push(`BYDAY=${s.nthWeekday}${s.byday[0]}`)
   }
 
-  if (s.endMode === 'count' && s.count > 1) {
+  if (s.endMode === 'count') {
     parts.push(`COUNT=${s.count}`)
   } else if (s.endMode === 'until' && s.until) {
     const d = s.until.replace(/-/g, '')

--- a/frontend/src/stores/__tests__/events.test.ts
+++ b/frontend/src/stores/__tests__/events.test.ts
@@ -14,6 +14,7 @@ const BASE_EVENT_FIELDS = {
   is_recurring: false,
   is_occurrence: false,
   rrule: null,
+  context_subject: null,
 }
 
 describe('useEventStore', () => {

--- a/frontend/src/stores/events.ts
+++ b/frontend/src/stores/events.ts
@@ -57,6 +57,7 @@ export const useEventStore = defineStore('events', () => {
       is_recurring: false,
       is_occurrence: false,
       rrule: null,
+      context_subject: null,
     }
     events.value.push(optimistic)
     return optimistic

--- a/frontend/src/types/events.ts
+++ b/frontend/src/types/events.ts
@@ -28,4 +28,6 @@ export interface CalendarEvent {
   is_occurrence: boolean
   /** RRULE string (e.g. "FREQ=WEEKLY;BYDAY=MO"). Non-null only on master events (is_recurring === true). */
   rrule: string | null
+  /** context_subject of the linked task, if any. Populated by backend (get_events_for_range). */
+  context_subject: string | null
 }

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -344,10 +344,16 @@ const allowedTaskIds = computed<Set<string> | null>(() => {
     }
   }
   if (contextNodeIds.size > 0) {
+    // Map selected node ids → their names. event.context_subject matches by name,
+    // so duplicate-named nodes deliberately merge filter behavior (predictable
+    // rather than silently dropping one of the duplicates).
+    const allowedNames = new Set<string>()
+    for (const node of Object.values(contextStore.nodes)) {
+      if (contextNodeIds.has(node.id)) allowedNames.add(node.name)
+    }
     for (const ev of eventStore.events) {
-      if (ev.context_subject) {
-        const node = Object.values(contextStore.nodes).find(n => n.name === ev.context_subject)
-        if (node && contextNodeIds.has(node.id) && ev.task_id) ids.add(ev.task_id)
+      if (ev.context_subject && allowedNames.has(ev.context_subject) && ev.task_id) {
+        ids.add(ev.task_id)
       }
     }
   }

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -202,6 +202,7 @@ onMounted(() => {
   kanbanStore.fetchColumns()
   contextStore.fetchRootNodes().catch(() => {})
   document.addEventListener('click', onDocumentClick)
+  document.addEventListener('keydown', onDocumentKeydown)
   loadEvents()
 })
 
@@ -209,6 +210,7 @@ onUnmounted(() => {
   window.removeEventListener('mousemove', onWindowMousemove)
   window.removeEventListener('mouseup', onWindowMouseup)
   document.removeEventListener('click', onDocumentClick)
+  document.removeEventListener('keydown', onDocumentKeydown)
 })
 
 // ─── Week date range ──────────────────────────────────────────
@@ -368,6 +370,12 @@ function onDocumentClick(e: MouseEvent) {
   if (!panel?.contains(e.target as Node) && !button?.contains(e.target as Node)) {
     filterOpen.value = false
   }
+}
+
+// Escape closes the filter regardless of focus (the panel's own keydown
+// handler only fires when the panel is focused, which it isn't on open).
+function onDocumentKeydown(e: KeyboardEvent) {
+  if (filterOpen.value && e.key === 'Escape') filterOpen.value = false
 }
 
 // ─── Events mapped per day (with filter) ─────────────────────

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -333,8 +333,6 @@ const activeFilterCount = computed(() =>
   activeFilter.value.milestoneIds.size + activeFilter.value.contextNodeIds.size + activeFilter.value.kanbanColumnIds.size
 )
 
-function clearFilters() { activeFilter.value = emptyFilter() }
-
 // Tasks allowed by milestone/context filters (null = no filter active)
 const allowedTaskIds = computed<Set<string> | null>(() => {
   const { milestoneIds, contextNodeIds } = activeFilter.value

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -4,9 +4,14 @@ import { useAnchorStore } from '../stores/anchors'
 import { useEventStore } from '../stores/events'
 import { usePlanStore } from '../stores/plan'
 import { useMilestoneStore } from '../stores/milestones'
+import { useKanbanStore } from '../stores/kanban'
+import { useContextStore } from '../stores/context'
 import { useCalendarFocus } from '../composables/useCalendarFocus'
 import { useSlideOver } from '../composables/useSlideOver'
 import CalendarEventBlock from '../components/CalendarEventBlock.vue'
+import CalendarFilterPanel from '../components/CalendarFilterPanel.vue'
+import { resolveEventColor } from '../composables/useColorResolver'
+import { computeOverlapLayout, type EventLayout } from '../composables/useOverlapLayout'
 import type { CalendarEvent } from '../types/events'
 import type { Anchor } from '../stores/anchors'
 
@@ -14,6 +19,8 @@ const anchorStore = useAnchorStore()
 const eventStore = useEventStore()
 const planStore = usePlanStore()
 const milestoneStore = useMilestoneStore()
+const kanbanStore = useKanbanStore()
+const contextStore = useContextStore()
 const { focusedDay, setFocusedDay } = useCalendarFocus()
 const { push: pushPanel } = useSlideOver()
 
@@ -192,12 +199,16 @@ onMounted(() => {
   anchorStore.fetchAnchors()
   planStore.fetchPlan(focusedDay.value)
   milestoneStore.fetchAll()
+  kanbanStore.fetchColumns()
+  contextStore.fetchRootNodes().catch(() => {})
+  document.addEventListener('click', onDocumentClick)
   loadEvents()
 })
 
 onUnmounted(() => {
   window.removeEventListener('mousemove', onWindowMousemove)
   window.removeEventListener('mouseup', onWindowMouseup)
+  document.removeEventListener('click', onDocumentClick)
 })
 
 // ─── Week date range ──────────────────────────────────────────
@@ -313,34 +324,47 @@ const END_HOUR = 24
 
 const hours = Array.from({ length: END_HOUR - START_HOUR }, (_, i) => START_HOUR + i)
 
-// ─── Milestone filtering ──────────────────────────────────────
+// ─── Filter state ─────────────────────────────────────────────
 const filterOpen = ref(false)
-const selectedMilestoneIds = ref<Set<string>>(new Set())
+interface CalendarFilter { milestoneIds: Set<string>; contextNodeIds: Set<string>; kanbanColumnIds: Set<string> }
+const emptyFilter = (): CalendarFilter => ({ milestoneIds: new Set(), contextNodeIds: new Set(), kanbanColumnIds: new Set() })
+const activeFilter = ref<CalendarFilter>(emptyFilter())
+const activeFilterCount = computed(() =>
+  activeFilter.value.milestoneIds.size + activeFilter.value.contextNodeIds.size + activeFilter.value.kanbanColumnIds.size
+)
 
-function toggleMilestoneFilter(id: string) {
-  const s = new Set(selectedMilestoneIds.value)
-  if (s.has(id)) s.delete(id)
-  else s.add(id)
-  selectedMilestoneIds.value = s
-}
+function clearFilters() { activeFilter.value = emptyFilter() }
 
-function clearFilters() {
-  selectedMilestoneIds.value = new Set()
-}
-
-const activeFilterCount = computed(() => selectedMilestoneIds.value.size)
-
-// Tasks allowed by the filter (or all tasks if no filter active)
+// Tasks allowed by milestone/context filters (null = no filter active)
 const allowedTaskIds = computed<Set<string> | null>(() => {
-  if (selectedMilestoneIds.value.size === 0) return null
+  const { milestoneIds, contextNodeIds } = activeFilter.value
+  if (milestoneIds.size === 0 && contextNodeIds.size === 0) return null
   const ids = new Set<string>()
-  for (const m of milestoneStore.all) {
-    if (selectedMilestoneIds.value.has(m.id)) {
-      for (const tid of m.task_ids) ids.add(tid)
+  if (milestoneIds.size > 0) {
+    for (const m of milestoneStore.all) {
+      if (milestoneIds.has(m.id)) for (const tid of m.task_ids) ids.add(tid)
+    }
+  }
+  if (contextNodeIds.size > 0) {
+    for (const ev of eventStore.events) {
+      if (ev.context_subject) {
+        const node = Object.values(contextStore.nodes).find(n => n.name === ev.context_subject)
+        if (node && contextNodeIds.has(node.id) && ev.task_id) ids.add(ev.task_id)
+      }
     }
   }
   return ids
 })
+
+// ─── Click-away to close filter ───────────────────────────────
+function onDocumentClick(e: MouseEvent) {
+  if (!filterOpen.value) return
+  const panel = document.getElementById('calendar-filter-panel')
+  const button = document.getElementById('calendar-filter-button')
+  if (!panel?.contains(e.target as Node) && !button?.contains(e.target as Node)) {
+    filterOpen.value = false
+  }
+}
 
 // ─── Events mapped per day (with filter) ─────────────────────
 const filteredEventsByDay = computed(() => {
@@ -391,10 +415,18 @@ function eventHeightPx(event: CalendarEvent): number {
   return Math.max((minutes / 60) * HOUR_HEIGHT, 20)
 }
 
-function eventColor(event: CalendarEvent): string {
-  if (event.source !== 'tether') return '#4285f4' // Google blue for synced
-  return event.color ?? '#6366f1' // indigo default
+function resolveColor(event: CalendarEvent): string {
+  return resolveEventColor(event, milestoneStore.all, contextStore.nodes)
 }
+
+// ─── Overlap layout per day ───────────────────────────────────
+const overlapLayouts = computed<Record<string, Record<string, EventLayout>>>(() => {
+  const byDay: Record<string, Record<string, EventLayout>> = {}
+  for (const [dayKey, evs] of Object.entries(eventsByDay.value)) {
+    byDay[dayKey] = computeOverlapLayout(evs)
+  }
+  return byDay
+})
 
 // Creation drag selection rect (in px relative to day column)
 const createSelectionStyle = computed(() => {
@@ -590,52 +622,34 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
         <!-- Filter button -->
         <div class="relative">
           <button
+            id="calendar-filter-button"
             data-testid="filter-button"
             class="flex items-center gap-1 px-2 py-0.5 rounded text-xs border transition-colors"
             :class="activeFilterCount > 0
               ? 'text-indigo-300 border-indigo-500/40 bg-indigo-500/10 hover:bg-indigo-500/20'
               : 'text-white/50 border-white/10 hover:text-white hover:bg-white/10'"
-            @click="filterOpen = !filterOpen"
+            @click.stop="filterOpen = !filterOpen"
           >
             Filter
             <span v-if="activeFilterCount > 0" class="bg-indigo-500 text-white rounded-full text-[10px] px-1 leading-none py-0.5 font-bold">
               {{ activeFilterCount }}
             </span>
           </button>
-          <!-- Filter dropdown -->
           <Teleport to="body">
             <div
               v-if="filterOpen"
-              class="fixed z-50 bg-gray-800 border border-white/20 rounded-xl shadow-xl p-3 min-w-[200px] space-y-1"
+              id="calendar-filter-panel"
+              class="fixed z-50"
               style="top: 56px; right: 16px"
               @click.stop
             >
-              <div class="flex items-center justify-between mb-2">
-                <span class="text-xs text-white/50 font-medium uppercase tracking-wide">Milestones</span>
-                <button v-if="activeFilterCount > 0" @click="clearFilters" class="text-[10px] text-indigo-400 hover:text-indigo-300">
-                  Clear all
-                </button>
-              </div>
-              <div v-if="!milestoneStore.all.length" class="text-xs text-white/30 py-1">No milestones</div>
-              <button
-                v-for="m in milestoneStore.all"
-                :key="m.id"
-                class="flex items-center gap-2 w-full text-left px-2 py-1.5 rounded text-xs transition-colors"
-                :class="selectedMilestoneIds.has(m.id) ? 'bg-indigo-500/20 text-indigo-200' : 'text-white/60 hover:bg-white/5'"
-                @click="toggleMilestoneFilter(m.id)"
-              >
-                <span
-                  class="w-2 h-2 rounded-full flex-shrink-0"
-                  :style="m.color ? { backgroundColor: m.color } : { backgroundColor: '#6366f1' }"
-                />
-                {{ m.name }}
-              </button>
-              <button
-                class="mt-2 text-[10px] text-white/30 hover:text-white/60 w-full text-right"
-                @click="filterOpen = false"
-              >
-                Done
-              </button>
+              <CalendarFilterPanel
+                v-model="activeFilter"
+                :milestones="milestoneStore.all"
+                :context-nodes="Object.values(contextStore.nodes)"
+                :kanban-columns="kanbanStore.columns"
+                @close="filterOpen = false"
+              />
             </div>
           </Teleport>
         </div>
@@ -678,7 +692,7 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
                 v-for="ev in eventsForDay(date).slice(0, 3)"
                 :key="ev.id"
                 class="rounded text-[10px] px-1 py-0.5 truncate font-medium text-white leading-none"
-                :style="{ backgroundColor: eventColor(ev) }"
+                :style="{ backgroundColor: resolveColor(ev) }"
               >
                 {{ ev.title }}
               </div>
@@ -778,6 +792,9 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
                 :event="event"
                 :top-px="eventTopPx(event)"
                 :height-px="eventHeightPx(event)"
+                :left-percent="overlapLayouts[dayKeys[i]]?.[event.id]?.leftPercent ?? 0"
+                :width-percent="overlapLayouts[dayKeys[i]]?.[event.id]?.widthPercent ?? 100"
+                :resolved-color="resolveColor(event)"
                 :style="draggingEvent?.eventId === event.id ? { opacity: 0.5 } : {}"
                 data-event-block
                 @click="openEventPanel(event)"

--- a/frontend/src/views/__tests__/CalendarView.test.ts
+++ b/frontend/src/views/__tests__/CalendarView.test.ts
@@ -177,6 +177,7 @@ describe('CalendarView', () => {
         is_recurring: false,
         is_occurrence: false,
         rrule: null,
+        context_subject: null,
       },
       {
         id: 'ev-b',
@@ -191,6 +192,7 @@ describe('CalendarView', () => {
         is_recurring: false,
         is_occurrence: false,
         rrule: null,
+        context_subject: null,
       },
     )
     await nextTick()


### PR DESCRIPTION
## Summary

Implements four calendar UI improvements per plan `cc-context-store/tether/plans/frontend/2026-04-27-calendar-ui-improvements.md`:

1. **CalendarFilterPanel** — grouped, collapsible, searchable filter (milestones, context nodes, kanban columns) replacing the milestone-only dropdown.
2. **Overlap layout** — events overlapping in time now subdivide the day column side-by-side (greedy lane assignment).
3. **Color hierarchy** — `event.color → milestone.color → context node color → default indigo` (Google events stay blue). Adds `context_subject: string | null` to `CalendarEvent`.
4. **Expanded RecurrencePicker** — every-N-interval, monthly Nth-weekday, yearly, COUNT/UNTIL end conditions, custom RRULE fallback. Parser/builder extracted to `useRruleParser` composable.

## Test plan

- [x] `vitest run` — 182/182 passing
- [x] `vue-tsc --noEmit` — clean
- [ ] Manual: filter panel groups, search, collapse, click-away
- [ ] Manual: two events overlapping render side-by-side
- [ ] Manual: event colors follow hierarchy when milestone/context node set
- [ ] Manual: RecurrencePicker emits valid RRULE for each preset

## Caveats

- **`context_subject` matched by name** (not id) against root context nodes — relies on backend populating `event.context_subject` correctly.
- **Overlap algorithm is simple**: groupSize = count of events overlapping the focal event; not full clique-finding. Adequate for typical day grids.
- **Recurrence editing**: only the picker is expanded; UX for editing one-vs-all occurrences is deferred.