### PR TITLE
feat: Plan view timeline column (right column day timeline)

### DIFF
--- a/frontend/src/components/AnchorBlock.vue
+++ b/frontend/src/components/AnchorBlock.vue
@@ -114,6 +114,7 @@ function onDragStart(evt: DragEvent, task: Task) {
   evt.dataTransfer!.effectAllowed = 'move'
   evt.dataTransfer!.setData('text/plain', JSON.stringify({
     taskId: task.id,
+    title: task.text,
     fromAnchorId: props.anchorId,
     fromDate: effectiveDate.value,
   }))

--- a/frontend/src/components/DayTimeline.vue
+++ b/frontend/src/components/DayTimeline.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, watch, onMounted, ref } from 'vue'
+import { computed, watch, onMounted, ref, nextTick } from 'vue'
 import { useEventStore } from '../stores/events'
 import { useAnchorStore } from '../stores/anchors'
 import CalendarEventBlock from './CalendarEventBlock.vue'
@@ -101,7 +101,8 @@ function onRecurrenceCancel() {
 
 // --- Drag-to-move (vertical) ---
 
-// draggingEvent tracks the event being dragged and the initial cursor offset
+// draggingEvent tracks the event being dragged and the initial cursor offset.
+// justDragged guards against the browser firing a trailing click after mouseup.
 const draggingEvent = ref<{
   event: CalendarEvent
   startY: number
@@ -110,6 +111,7 @@ const draggingEvent = ref<{
 } | null>(null)
 
 const dragOffsetY = ref(0)
+const justDragged = ref(false)
 
 function onEventMousedown(event: CalendarEvent, mouseEvent: MouseEvent) {
   const top = eventTopPx(event.start_time)
@@ -138,6 +140,9 @@ function onEventMousedown(event: CalendarEvent, mouseEvent: MouseEvent) {
       return
     }
 
+    // Set guard BEFORE clearing draggingEvent so the trailing click is blocked.
+    // Clear it after nextTick once the click event has been processed.
+    justDragged.value = true
     const origStart = new Date(draggingEvent.value.event.start_time)
     const origEnd = new Date(draggingEvent.value.event.end_time)
     const newStart = new Date(origStart.getTime() + deltaMin * 60_000)
@@ -146,6 +151,8 @@ function onEventMousedown(event: CalendarEvent, mouseEvent: MouseEvent) {
     const ev = draggingEvent.value.event
     draggingEvent.value = null
     await handleEventMove(ev, newStart.toISOString(), newEnd.toISOString())
+    await nextTick()
+    justDragged.value = false
   }
 
   window.addEventListener('mousemove', onMove)
@@ -155,7 +162,9 @@ function onEventMousedown(event: CalendarEvent, mouseEvent: MouseEvent) {
 // --- Click-to-create ---
 
 function onTimedAreaClick(e: MouseEvent) {
-  // Ignore if we were dragging
+  // Block click fired immediately after a drag-end (mouseup → click ordering)
+  if (justDragged.value) return
+  // Also block if we're mid-drag (shouldn't happen, but guard anyway)
   if (draggingEvent.value) return
 
   const target = e.currentTarget as HTMLElement
@@ -170,13 +179,19 @@ function onTimedAreaClick(e: MouseEvent) {
   d.setHours(AXIS_START_HOUR, 0, 0, 0)
   d.setMinutes(d.getMinutes() + snappedMin)
 
-  // Format as local ISO (no Z) to preserve intent
+  emit('create-at', toLocalIso(d))
+}
+
+// --- Time formatting helpers ---
+
+/** Format a Date as local-naive ISO (YYYY-MM-DDTHH:MM) — no timezone offset. */
+function toLocalIso(d: Date): string {
   const year = d.getFullYear()
   const mo = String(d.getMonth() + 1).padStart(2, '0')
   const day = String(d.getDate()).padStart(2, '0')
   const hh = String(d.getHours()).padStart(2, '0')
   const mm = String(d.getMinutes()).padStart(2, '0')
-  emit('create-at', `${year}-${mo}-${day}T${hh}:${mm}`)
+  return `${year}-${mo}-${day}T${hh}:${mm}`
 }
 
 // --- Drop from anchor block (task promotion) ---
@@ -192,11 +207,11 @@ async function onTimedAreaDrop(e: DragEvent) {
   if (!raw) return
   try {
     const data = JSON.parse(raw)
-    // AnchorBlock drag payload: { taskId, fromAnchorId, fromDate }
+    // AnchorBlock drag payload: { taskId, title, fromAnchorId, fromDate }
     // Check for taskId directly (AnchorBlock format) or type:'task' (application/json format)
     const isTask = data.taskId && (data.type === 'task' || data.fromAnchorId !== undefined)
     if (isTask) {
-      // Compute drop time from cursor position
+      // Compute drop time from cursor position — use local ISO to match click-create format
       const target = e.currentTarget as HTMLElement
       const rect = target.getBoundingClientRect()
       const offsetY = e.clientY - rect.top + target.scrollTop
@@ -206,11 +221,12 @@ async function onTimedAreaDrop(e: DragEvent) {
       const d = new Date(props.date + 'T00:00:00')
       d.setHours(AXIS_START_HOUR, 0, 0, 0)
       d.setMinutes(d.getMinutes() + snappedMin)
-      const startISO = d.toISOString()
-      const endISO = new Date(d.getTime() + 30 * 60_000).toISOString()
+      const startISO = toLocalIso(d)
+      const endD = new Date(d.getTime() + 30 * 60_000)
+      const endISO = toLocalIso(endD)
 
       // TODO: if task is recurring, show RecurrenceEditDialog with title "Edit recurring task: move to timeline?"
-      await eventStore.promoteTask(data.taskId, startISO, endISO, data.title ?? 'Task')
+      await eventStore.promoteTask(data.taskId, startISO, endISO, data.title ?? data.taskId)
     }
   } catch {
     // ignore malformed drag data
@@ -318,20 +334,36 @@ function timedEventStyle(event: CalendarEvent) {
           :style="{ top: `${(hour - AXIS_START_HOUR) * 60 * PX_PER_MINUTE}px` }"
         />
 
-        <!-- Timed events — draggable for vertical move and demote to anchor column -->
+        <!--
+          Timed event wrapper.
+          Layout: an absolute positioned container holds two children:
+            1. A narrow left-edge grip strip — has draggable="true" for HTML5 demote-to-sidebar drag.
+               HTML5 drag suppresses mousemove once started (Chromium/WebKit), so it lives on its
+               own element, separate from the mousedown-based vertical reposition.
+            2. CalendarEventBlock — handles mousedown (vertical reposition) and click (open panel).
+               No draggable attr here so the browser's drag threshold never cancels mousemove.
+        -->
         <div
           v-for="ev in timedEvents"
           :key="ev.id"
-          class="absolute"
+          class="absolute flex"
           :style="{
             top: `${eventTopPx(ev.start_time)}px`,
             left: timedEventStyle(ev).left,
             width: timedEventStyle(ev).width,
+            height: `${eventHeightPx(ev.start_time, ev.end_time)}px`,
           }"
-          draggable="true"
-          @dragstart="(de) => onEventDragstart(ev, de)"
         >
+          <!-- Drag grip (HTML5 demote drag) — narrow left strip -->
+          <div
+            class="flex-shrink-0 w-2 cursor-grab z-20 rounded-l opacity-0 hover:opacity-100 bg-white/20 transition-opacity"
+            :title="'Drag to anchor column to un-schedule'"
+            draggable="true"
+            @dragstart.stop="(de) => onEventDragstart(ev, de)"
+          />
+          <!-- Event block body — mousedown for vertical reposition only, no draggable -->
           <CalendarEventBlock
+            class="flex-1 min-w-0"
             :event="ev"
             :top-px="0"
             :height-px="eventHeightPx(ev.start_time, ev.end_time)"

--- a/frontend/src/components/DayTimeline.vue
+++ b/frontend/src/components/DayTimeline.vue
@@ -184,12 +184,19 @@ function onTimedAreaClick(e: MouseEvent) {
 
 async function onTimedAreaDrop(e: DragEvent) {
   e.preventDefault()
-  const raw = e.dataTransfer?.getData('application/json')
+  // AnchorBlock writes 'text/plain'; we also accept 'application/json' for future-proofing.
+  // Try application/json first, fall back to text/plain.
+  const rawJson = e.dataTransfer?.getData('application/json')
+  const rawText = e.dataTransfer?.getData('text/plain')
+  const raw = rawJson || rawText
   if (!raw) return
   try {
     const data = JSON.parse(raw)
-    if (data.type === 'task' && data.taskId) {
-      // Compute drop time
+    // AnchorBlock drag payload: { taskId, fromAnchorId, fromDate }
+    // Check for taskId directly (AnchorBlock format) or type:'task' (application/json format)
+    const isTask = data.taskId && (data.type === 'task' || data.fromAnchorId !== undefined)
+    if (isTask) {
+      // Compute drop time from cursor position
       const target = e.currentTarget as HTMLElement
       const rect = target.getBoundingClientRect()
       const offsetY = e.clientY - rect.top + target.scrollTop
@@ -208,6 +215,21 @@ async function onTimedAreaDrop(e: DragEvent) {
   } catch {
     // ignore malformed drag data
   }
+}
+
+// --- Drag event block (for demote: drag to left anchor column) ---
+
+function onEventDragstart(event: CalendarEvent, dragEvent: DragEvent) {
+  dragEvent.dataTransfer!.effectAllowed = 'move'
+  // Write as both formats: text/plain for broadest compatibility, application/json for type safety
+  const payload = JSON.stringify({
+    type: 'calendar-event',
+    eventId: event.id,
+    taskId: event.task_id,
+    title: event.title,
+  })
+  dragEvent.dataTransfer!.setData('application/json', payload)
+  dragEvent.dataTransfer!.setData('text/plain', payload)
 }
 
 function onDragover(e: DragEvent) {
@@ -296,17 +318,27 @@ function timedEventStyle(event: CalendarEvent) {
           :style="{ top: `${(hour - AXIS_START_HOUR) * 60 * PX_PER_MINUTE}px` }"
         />
 
-        <!-- Timed events -->
-        <CalendarEventBlock
+        <!-- Timed events — draggable for vertical move and demote to anchor column -->
+        <div
           v-for="ev in timedEvents"
           :key="ev.id"
-          :event="ev"
-          :top-px="eventTopPx(ev.start_time)"
-          :height-px="eventHeightPx(ev.start_time, ev.end_time)"
-          :style="timedEventStyle(ev)"
-          @click="emit('open-event', ev)"
-          @mousedown="(me) => onEventMousedown(ev, me)"
-        />
+          class="absolute"
+          :style="{
+            top: `${eventTopPx(ev.start_time)}px`,
+            left: timedEventStyle(ev).left,
+            width: timedEventStyle(ev).width,
+          }"
+          draggable="true"
+          @dragstart="(de) => onEventDragstart(ev, de)"
+        >
+          <CalendarEventBlock
+            :event="ev"
+            :top-px="0"
+            :height-px="eventHeightPx(ev.start_time, ev.end_time)"
+            @click="emit('open-event', ev)"
+            @mousedown="(me) => onEventMousedown(ev, me)"
+          />
+        </div>
       </div>
     </div>
 

--- a/frontend/src/components/DayTimeline.vue
+++ b/frontend/src/components/DayTimeline.vue
@@ -1,0 +1,321 @@
+<script setup lang="ts">
+import { computed, watch, onMounted, ref } from 'vue'
+import { useEventStore } from '../stores/events'
+import { useAnchorStore } from '../stores/anchors'
+import CalendarEventBlock from './CalendarEventBlock.vue'
+import RecurrenceEditDialog from './RecurrenceEditDialog.vue'
+import {
+  eventTopPx,
+  eventHeightPx,
+  anchorBandTopPx,
+  anchorBandHeightPx,
+  AXIS_START_HOUR,
+  AXIS_END_HOUR,
+  AXIS_TOTAL_PX,
+  PX_PER_MINUTE,
+} from '../composables/useDayTimeline'
+import { computeOverlapLayout } from '../composables/useOverlapLayout'
+import type { CalendarEvent } from '../types/events'
+import type { RecurrenceEditScope } from '../types/recurrence'
+
+const props = defineProps<{
+  date: string  // YYYY-MM-DD
+}>()
+
+const emit = defineEmits<{
+  (e: 'create-at', isoTime: string): void
+  (e: 'open-event', event: CalendarEvent): void
+}>()
+
+const eventStore = useEventStore()
+const anchorStore = useAnchorStore()
+
+// --- Date parsing ---
+
+const dateObj = computed(() => new Date(props.date + 'T12:00:00'))
+
+// --- Events split by type ---
+
+const allDayEvents = computed(() =>
+  eventStore.events.filter(ev => ev.is_all_day === true)
+)
+
+const timedEvents = computed(() =>
+  eventStore.events.filter(ev => ev.is_all_day !== true)
+)
+
+// --- Overlap layout for timed events ---
+
+const overlapLayout = computed(() => computeOverlapLayout(timedEvents.value))
+
+// --- Hour labels (6am..11pm) ---
+
+const hourLabels = computed(() => {
+  const labels: { hour: number; label: string }[] = []
+  for (let h = AXIS_START_HOUR; h < AXIS_END_HOUR; h++) {
+    const suffix = h < 12 ? 'am' : 'pm'
+    const display = h === 12 ? 12 : h > 12 ? h - 12 : h
+    labels.push({ hour: h, label: `${display}${suffix}` })
+  }
+  return labels
+})
+
+// --- Fetch events on mount and when date changes ---
+
+function fetchForDate(date: string) {
+  const start = date + 'T00:00:00'
+  const end = date + 'T23:59:59'
+  eventStore.fetchEvents(start, end)
+}
+
+onMounted(() => fetchForDate(props.date))
+watch(() => props.date, fetchForDate)
+
+// --- Drag / move state ---
+
+const showRecurrenceDialog = ref(false)
+const pendingMove = ref<{ event: CalendarEvent; newStart: string; newEnd: string } | null>(null)
+
+async function handleEventMove(event: CalendarEvent, newStart: string, newEnd: string) {
+  if (event.is_recurring || event.is_occurrence) {
+    pendingMove.value = { event, newStart, newEnd }
+    showRecurrenceDialog.value = true
+    return
+  }
+  await eventStore.moveEvent(event.id, newStart, newEnd)
+}
+
+async function onRecurrenceConfirm(_scope: RecurrenceEditScope) {
+  showRecurrenceDialog.value = false
+  if (!pendingMove.value) return
+  const { event, newStart, newEnd } = pendingMove.value
+  // TODO: pass scope to backend when backend supports it
+  await eventStore.moveEvent(event.id, newStart, newEnd)
+  pendingMove.value = null
+}
+
+function onRecurrenceCancel() {
+  showRecurrenceDialog.value = false
+  pendingMove.value = null
+}
+
+// --- Drag-to-move (vertical) ---
+
+// draggingEvent tracks the event being dragged and the initial cursor offset
+const draggingEvent = ref<{
+  event: CalendarEvent
+  startY: number
+  origTopPx: number
+  durationMin: number
+} | null>(null)
+
+const dragOffsetY = ref(0)
+
+function onEventMousedown(event: CalendarEvent, mouseEvent: MouseEvent) {
+  const top = eventTopPx(event.start_time)
+  const dur = (new Date(event.end_time).getTime() - new Date(event.start_time).getTime()) / 60_000
+  draggingEvent.value = {
+    event,
+    startY: mouseEvent.clientY,
+    origTopPx: top,
+    durationMin: dur,
+  }
+  dragOffsetY.value = 0
+
+  const onMove = (e: MouseEvent) => {
+    if (!draggingEvent.value) return
+    dragOffsetY.value = e.clientY - draggingEvent.value.startY
+  }
+
+  const onUp = async (e: MouseEvent) => {
+    window.removeEventListener('mousemove', onMove)
+    window.removeEventListener('mouseup', onUp)
+    if (!draggingEvent.value) return
+
+    const deltaMin = Math.round((e.clientY - draggingEvent.value.startY) / PX_PER_MINUTE / 15) * 15
+    if (deltaMin === 0) {
+      draggingEvent.value = null
+      return
+    }
+
+    const origStart = new Date(draggingEvent.value.event.start_time)
+    const origEnd = new Date(draggingEvent.value.event.end_time)
+    const newStart = new Date(origStart.getTime() + deltaMin * 60_000)
+    const newEnd = new Date(origEnd.getTime() + deltaMin * 60_000)
+
+    const ev = draggingEvent.value.event
+    draggingEvent.value = null
+    await handleEventMove(ev, newStart.toISOString(), newEnd.toISOString())
+  }
+
+  window.addEventListener('mousemove', onMove)
+  window.addEventListener('mouseup', onUp)
+}
+
+// --- Click-to-create ---
+
+function onTimedAreaClick(e: MouseEvent) {
+  // Ignore if we were dragging
+  if (draggingEvent.value) return
+
+  const target = e.currentTarget as HTMLElement
+  const rect = target.getBoundingClientRect()
+  const offsetY = e.clientY - rect.top + target.scrollTop
+
+  // Convert px offset to minutes from axis start, snap to 15 min
+  const rawMin = offsetY / PX_PER_MINUTE
+  const snappedMin = Math.round(rawMin / 15) * 15
+
+  const d = new Date(props.date + 'T00:00:00')
+  d.setHours(AXIS_START_HOUR, 0, 0, 0)
+  d.setMinutes(d.getMinutes() + snappedMin)
+
+  // Format as local ISO (no Z) to preserve intent
+  const year = d.getFullYear()
+  const mo = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mm = String(d.getMinutes()).padStart(2, '0')
+  emit('create-at', `${year}-${mo}-${day}T${hh}:${mm}`)
+}
+
+// --- Drop from anchor block (task promotion) ---
+// Note: drag of event block to LEFT column (demote) is handled by PlanView droptarget
+
+async function onTimedAreaDrop(e: DragEvent) {
+  e.preventDefault()
+  const raw = e.dataTransfer?.getData('application/json')
+  if (!raw) return
+  try {
+    const data = JSON.parse(raw)
+    if (data.type === 'task' && data.taskId) {
+      // Compute drop time
+      const target = e.currentTarget as HTMLElement
+      const rect = target.getBoundingClientRect()
+      const offsetY = e.clientY - rect.top + target.scrollTop
+      const rawMin = offsetY / PX_PER_MINUTE
+      const snappedMin = Math.round(rawMin / 15) * 15
+
+      const d = new Date(props.date + 'T00:00:00')
+      d.setHours(AXIS_START_HOUR, 0, 0, 0)
+      d.setMinutes(d.getMinutes() + snappedMin)
+      const startISO = d.toISOString()
+      const endISO = new Date(d.getTime() + 30 * 60_000).toISOString()
+
+      // TODO: if task is recurring, show RecurrenceEditDialog with title "Edit recurring task: move to timeline?"
+      await eventStore.promoteTask(data.taskId, startISO, endISO, data.title ?? 'Task')
+    }
+  } catch {
+    // ignore malformed drag data
+  }
+}
+
+function onDragover(e: DragEvent) {
+  e.preventDefault()
+}
+
+// --- Anchor color helper ---
+
+function anchorBandStyle(anchor: { color: string; id: string }) {
+  return {
+    backgroundColor: (anchor.color ?? '#6366f1') + '33',  // ~20% opacity
+    top: `${anchorBandTopPx(anchor as Parameters<typeof anchorBandTopPx>[0], dateObj.value)}px`,
+    height: `${anchorBandHeightPx(anchor as Parameters<typeof anchorBandHeightPx>[0], dateObj.value)}px`,
+  }
+}
+
+// --- Event block helpers ---
+
+function timedEventStyle(event: CalendarEvent) {
+  const layout = overlapLayout.value[event.id]
+  const leftPct = layout?.leftPercent ?? 0
+  const widthPct = layout?.widthPercent ?? 100
+  return {
+    left: `${leftPct}%`,
+    width: `calc(${widthPct}% - 4px)`,
+  }
+}
+</script>
+
+<template>
+  <div data-testid="day-timeline" class="flex flex-col bg-gray-900 border border-white/10 rounded-lg overflow-hidden select-none">
+    <!-- All-day events strip -->
+    <div
+      data-testid="allday-strip"
+      class="flex flex-col gap-0.5 px-2 py-1 border-b border-white/10 min-h-[28px]"
+    >
+      <div
+        v-for="ev in allDayEvents"
+        :key="ev.id"
+        class="text-xs px-1.5 py-0.5 rounded text-white truncate cursor-pointer"
+        :style="{ backgroundColor: ev.color ?? '#6366f1' }"
+        @click="emit('open-event', ev)"
+      >
+        {{ ev.title }}
+      </div>
+    </div>
+
+    <!-- Timed area -->
+    <div
+      data-testid="timed-area"
+      class="relative flex overflow-y-auto"
+      :style="{ height: '480px' }"
+      @click="onTimedAreaClick"
+      @dragover="onDragover"
+      @drop="onTimedAreaDrop"
+    >
+      <!-- Hour grid + labels -->
+      <div class="relative flex-shrink-0 w-10" :style="{ height: `${AXIS_TOTAL_PX}px` }">
+        <div
+          v-for="{ hour, label } in hourLabels"
+          :key="hour"
+          :data-testid="`time-label-${hour}`"
+          class="absolute right-1 text-[10px] text-white/30 leading-none"
+          :style="{ top: `${(hour - AXIS_START_HOUR) * 60 * PX_PER_MINUTE}px` }"
+        >
+          {{ label }}
+        </div>
+      </div>
+
+      <!-- Event + anchor band area -->
+      <div class="relative flex-1" :style="{ height: `${AXIS_TOTAL_PX}px` }">
+        <!-- Anchor background bands -->
+        <div
+          v-for="anchor in anchorStore.anchors"
+          :key="anchor.id"
+          :data-testid="`anchor-band-${anchor.id}`"
+          class="absolute inset-x-0 pointer-events-none rounded-sm"
+          :style="anchorBandStyle(anchor)"
+        />
+
+        <!-- Hour grid lines -->
+        <div
+          v-for="{ hour } in hourLabels"
+          :key="'line-' + hour"
+          class="absolute inset-x-0 border-t border-white/5 pointer-events-none"
+          :style="{ top: `${(hour - AXIS_START_HOUR) * 60 * PX_PER_MINUTE}px` }"
+        />
+
+        <!-- Timed events -->
+        <CalendarEventBlock
+          v-for="ev in timedEvents"
+          :key="ev.id"
+          :event="ev"
+          :top-px="eventTopPx(ev.start_time)"
+          :height-px="eventHeightPx(ev.start_time, ev.end_time)"
+          :style="timedEventStyle(ev)"
+          @click="emit('open-event', ev)"
+          @mousedown="(me) => onEventMousedown(ev, me)"
+        />
+      </div>
+    </div>
+
+    <!-- Recurrence edit dialog -->
+    <RecurrenceEditDialog
+      :open="showRecurrenceDialog"
+      title="Edit recurring event"
+      @confirm="onRecurrenceConfirm"
+      @cancel="onRecurrenceCancel"
+    />
+  </div>
+</template>

--- a/frontend/src/components/DayTimeline.vue
+++ b/frontend/src/components/DayTimeline.vue
@@ -237,12 +237,13 @@ async function onTimedAreaDrop(e: DragEvent) {
 
 function onEventDragstart(event: CalendarEvent, dragEvent: DragEvent) {
   dragEvent.dataTransfer!.effectAllowed = 'move'
-  // Write as both formats: text/plain for broadest compatibility, application/json for type safety
+  // Include anchor_id so the drop target can return the task to its original anchor
   const payload = JSON.stringify({
     type: 'calendar-event',
     eventId: event.id,
     taskId: event.task_id,
     title: event.title,
+    anchorId: event.anchor_id,
   })
   dragEvent.dataTransfer!.setData('application/json', payload)
   dragEvent.dataTransfer!.setData('text/plain', payload)
@@ -376,8 +377,9 @@ function timedEventStyle(event: CalendarEvent) {
 
     <!-- Recurrence edit dialog -->
     <RecurrenceEditDialog
-      :open="showRecurrenceDialog"
-      title="Edit recurring event"
+      :visible="showRecurrenceDialog"
+      mode="event"
+      action="move"
       @confirm="onRecurrenceConfirm"
       @cancel="onRecurrenceCancel"
     />

--- a/frontend/src/components/__tests__/DayTimeline.test.ts
+++ b/frontend/src/components/__tests__/DayTimeline.test.ts
@@ -8,6 +8,7 @@ import {
   anchorBandTopPx,
   anchorBandHeightPx,
   AXIS_START_HOUR,
+  AXIS_END_HOUR,
   PX_PER_MINUTE,
 } from '../../composables/useDayTimeline'
 import type { Anchor } from '../../stores/anchors'
@@ -163,6 +164,31 @@ describe('eventHeightPx', () => {
     // 1-minute event would be 1.5px without clamping
     expect(eventHeightPx('2024-06-10T09:00:00', '2024-06-10T09:01:00')).toBe(20)
   })
+
+  it('clips start to axis start for events beginning before 6am', () => {
+    // Event 5am–7am: only 60min visible (6–7am), not 120min
+    const d5am = new Date('2024-06-10T00:00:00')
+    d5am.setHours(AXIS_START_HOUR - 1, 0, 0, 0)
+    const d7am = new Date('2024-06-10T00:00:00')
+    d7am.setHours(AXIS_START_HOUR + 1, 0, 0, 0)
+    const to5 = `${d5am.getFullYear()}-${String(d5am.getMonth()+1).padStart(2,'0')}-${String(d5am.getDate()).padStart(2,'0')}T${String(d5am.getHours()).padStart(2,'0')}:00:00`
+    const to7 = `${d7am.getFullYear()}-${String(d7am.getMonth()+1).padStart(2,'0')}-${String(d7am.getDate()).padStart(2,'0')}T${String(d7am.getHours()).padStart(2,'0')}:00:00`
+    expect(eventHeightPx(to5, to7)).toBe(60 * PX_PER_MINUTE)
+  })
+
+  it('clips end to axis end for events ending past midnight', () => {
+    // Build times relative to AXIS_END_HOUR (midnight = 24)
+    // 23:00 – 25:00 (conceptually); we use AXIS_END_HOUR - 1 to AXIS_END_HOUR + 1
+    const d23 = new Date('2024-06-10T00:00:00')
+    d23.setHours(AXIS_END_HOUR - 1, 0, 0, 0)
+    // Simulate a time past axis end by adding 2 hours of ms after the end boundary
+    const pastMidnight = new Date(d23.getTime() + 2 * 60 * 60_000)
+    const to23 = `${d23.getFullYear()}-${String(d23.getMonth()+1).padStart(2,'0')}-${String(d23.getDate()).padStart(2,'0')}T${String(d23.getHours()).padStart(2,'0')}:00:00`
+    // past midnight ISO from Date object
+    const toPast = pastMidnight.toISOString()
+    // Only 60 visible minutes (23:00–24:00)
+    expect(eventHeightPx(to23, toPast)).toBe(60 * PX_PER_MINUTE)
+  })
 })
 
 describe('anchorBandTopPx', () => {
@@ -275,11 +301,28 @@ describe('DayTimeline component', () => {
     await expect(timedArea.trigger('drop')).resolves.not.toThrow()
   })
 
-  it('event blocks are draggable (have draggable attribute)', async () => {
+  it('grip strip has draggable attribute; CalendarEventBlock body does not', async () => {
     const { default: DayTimeline } = await import('../DayTimeline.vue')
     const wrapper = mount(DayTimeline, { props: { date: '2024-06-10' } })
-    // The timed event wrapper should have draggable="true"
-    const draggableBlocks = wrapper.findAll('[draggable="true"]')
-    expect(draggableBlocks.length).toBeGreaterThan(0)
+    // The grip element (left-edge strip) should have draggable="true"
+    const draggableGrips = wrapper.findAll('[draggable="true"]')
+    expect(draggableGrips.length).toBeGreaterThan(0)
+    // But the CalendarEventBlock rendered inside the event container should NOT be the draggable element
+    // (draggable is on the grip, not on the CalendarEventBlock absolute div)
+    for (const grip of draggableGrips) {
+      // Each grip is the narrow left-strip, it should not contain the event title text directly
+      expect(grip.text()).not.toContain('Team standup')
+    }
+  })
+
+  it('create-at emit uses local ISO format (no Z suffix)', async () => {
+    const { default: DayTimeline } = await import('../DayTimeline.vue')
+    const wrapper = mount(DayTimeline, { props: { date: '2024-06-10' } })
+    const timedArea = wrapper.find('[data-testid="timed-area"]')
+    await timedArea.trigger('click', { offsetY: 0 })
+    const emitted = wrapper.emitted('create-at')
+    expect(emitted).toBeTruthy()
+    // Should be local-naive: YYYY-MM-DDTHH:MM (no Z, no +offset)
+    expect(emitted![0][0]).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/)
   })
 })

--- a/frontend/src/components/__tests__/DayTimeline.test.ts
+++ b/frontend/src/components/__tests__/DayTimeline.test.ts
@@ -57,6 +57,7 @@ const mockEvents: CalendarEvent[] = [
     is_occurrence: false,
     rrule: null,
     is_all_day: false,
+    context_subject: null,
   },
   {
     id: 'ev-allday',
@@ -72,6 +73,7 @@ const mockEvents: CalendarEvent[] = [
     is_occurrence: false,
     rrule: null,
     is_all_day: true,
+    context_subject: null,
   },
 ]
 

--- a/frontend/src/components/__tests__/DayTimeline.test.ts
+++ b/frontend/src/components/__tests__/DayTimeline.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import {
+  anchorWindow,
+  eventTopPx,
+  eventHeightPx,
+  anchorBandTopPx,
+  anchorBandHeightPx,
+  AXIS_START_HOUR,
+  PX_PER_MINUTE,
+} from '../../composables/useDayTimeline'
+import type { Anchor } from '../../stores/anchors'
+import type { CalendarEvent } from '../../types/events'
+
+// --- Mocks ---
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ path: '/plan/day', query: {} }),
+  RouterLink: { template: '<a><slot /></a>' },
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: true, json: async () => [] })),
+}))
+
+// Mock stores so we can control their output
+const mockAnchors: Anchor[] = [
+  {
+    id: 'a1',
+    name: 'Morning',
+    time: '08:00',
+    duration_minutes: 120,
+    flexibility: 'moderate',
+    strictness: 2,
+    color: '#6366f1',
+    position: 1,
+    followup_config: null,
+  },
+]
+
+const mockEvents: CalendarEvent[] = [
+  {
+    id: 'ev-timed',
+    title: 'Team standup',
+    // Use local-time strings (no Z suffix) to avoid TZ ambiguity
+    start_time: '2024-06-10T09:00:00',
+    end_time: '2024-06-10T09:30:00',
+    source: 'tether',
+    external_id: null,
+    task_id: null,
+    anchor_id: null,
+    color: null,
+    is_recurring: false,
+    is_occurrence: false,
+    rrule: null,
+    is_all_day: false,
+  },
+  {
+    id: 'ev-allday',
+    title: 'Holiday',
+    start_time: '2024-06-10T00:00:00',
+    end_time: '2024-06-10T23:59:59',
+    source: 'tether',
+    external_id: null,
+    task_id: null,
+    anchor_id: null,
+    color: null,
+    is_recurring: false,
+    is_occurrence: false,
+    rrule: null,
+    is_all_day: true,
+  },
+]
+
+vi.mock('../../stores/anchors', () => ({
+  useAnchorStore: () => ({
+    anchors: mockAnchors,
+    fetchAnchors: vi.fn(),
+  }),
+}))
+
+vi.mock('../../stores/events', () => ({
+  useEventStore: () => ({
+    events: mockEvents,
+    loading: false,
+    fetchEvents: vi.fn(),
+    moveEvent: vi.fn(),
+    promoteTask: vi.fn(),
+    demoteEvent: vi.fn(),
+    createTaskAndPromote: vi.fn(),
+  }),
+}))
+
+// --- Pure function tests ---
+
+const testAnchor: Anchor = {
+  id: 'anc-1',
+  name: 'Morning',
+  time: '09:00',
+  duration_minutes: 60,
+  flexibility: 'moderate',
+  strictness: 2,
+  color: '#6366f1',
+  position: 1,
+  followup_config: null,
+}
+
+const testDate = new Date('2024-06-10T12:00:00')
+
+describe('anchorWindow', () => {
+  it('returns start time matching anchor.time on the given date', () => {
+    const { start } = anchorWindow(testAnchor, testDate)
+    expect(start.getHours()).toBe(9)
+    expect(start.getMinutes()).toBe(0)
+  })
+
+  it('returns end time = start + duration_minutes', () => {
+    const { start, end } = anchorWindow(testAnchor, testDate)
+    const diffMin = (end.getTime() - start.getTime()) / 60_000
+    expect(diffMin).toBe(60)
+  })
+
+  it('preserves the date from the passed date arg', () => {
+    const { start } = anchorWindow(testAnchor, testDate)
+    expect(start.getFullYear()).toBe(2024)
+    expect(start.getMonth()).toBe(5) // June = 5 (0-indexed)
+    expect(start.getDate()).toBe(10)
+  })
+})
+
+describe('eventTopPx', () => {
+  it('returns 0 for a time at the axis start hour', () => {
+    // Build a date at AXIS_START_HOUR local time
+    const d = new Date('2024-06-10T00:00:00')
+    d.setHours(AXIS_START_HOUR, 0, 0, 0)
+    const isoLocal = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}T${String(d.getHours()).padStart(2,'0')}:00:00`
+    expect(eventTopPx(isoLocal)).toBe(0)
+  })
+
+  it('returns correct px for an event 60 minutes after axis start', () => {
+    const d = new Date('2024-06-10T00:00:00')
+    d.setHours(AXIS_START_HOUR + 1, 0, 0, 0)
+    const isoLocal = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}T${String(d.getHours()).padStart(2,'0')}:00:00`
+    expect(eventTopPx(isoLocal)).toBe(60 * PX_PER_MINUTE)
+  })
+
+  it('clamps to 0 for times before axis start', () => {
+    const d = new Date('2024-06-10T00:00:00')
+    d.setHours(AXIS_START_HOUR - 1, 0, 0, 0)
+    const isoLocal = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}T${String(d.getHours()).padStart(2,'0')}:00:00`
+    expect(eventTopPx(isoLocal)).toBe(0)
+  })
+})
+
+describe('eventHeightPx', () => {
+  it('returns duration * PX_PER_MINUTE for a 30-min event', () => {
+    expect(eventHeightPx('2024-06-10T09:00:00', '2024-06-10T09:30:00')).toBe(30 * PX_PER_MINUTE)
+  })
+
+  it('enforces minimum height of 20px', () => {
+    // 1-minute event would be 1.5px without clamping
+    expect(eventHeightPx('2024-06-10T09:00:00', '2024-06-10T09:01:00')).toBe(20)
+  })
+})
+
+describe('anchorBandTopPx', () => {
+  it('returns correct px for an anchor starting at 8am when axis starts at 6am', () => {
+    const anchor8am: Anchor = { ...testAnchor, time: '08:00' }
+    const result = anchorBandTopPx(anchor8am, testDate)
+    // 8am = 120 minutes after 6am axis start
+    expect(result).toBe(120 * PX_PER_MINUTE)
+  })
+})
+
+describe('anchorBandHeightPx', () => {
+  it('returns duration * PX_PER_MINUTE for the anchor band', () => {
+    // testAnchor is 60 minutes
+    const result = anchorBandHeightPx(testAnchor, testDate)
+    expect(result).toBe(60 * PX_PER_MINUTE)
+  })
+})
+
+// --- DayTimeline component tests ---
+
+describe('DayTimeline component', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('mounts and renders day-timeline root element', async () => {
+    const { default: DayTimeline } = await import('../DayTimeline.vue')
+    const wrapper = mount(DayTimeline, {
+      props: { date: '2024-06-10' },
+    })
+    expect(wrapper.find('[data-testid="day-timeline"]').exists()).toBe(true)
+  })
+
+  it('renders time labels for each hour from 6am to 11pm', async () => {
+    const { default: DayTimeline } = await import('../DayTimeline.vue')
+    const wrapper = mount(DayTimeline, {
+      props: { date: '2024-06-10' },
+    })
+    // Hours 6..23 => 18 labels
+    for (const hour of [6, 7, 8, 9, 10, 11, 12, 13, 23]) {
+      expect(wrapper.find(`[data-testid="time-label-${hour}"]`).exists()).toBe(true)
+    }
+  })
+
+  it('renders anchor bands with correct data-testids', async () => {
+    const { default: DayTimeline } = await import('../DayTimeline.vue')
+    const wrapper = mount(DayTimeline, {
+      props: { date: '2024-06-10' },
+    })
+    expect(wrapper.find('[data-testid="anchor-band-a1"]').exists()).toBe(true)
+  })
+
+  it('renders the timed-area container', async () => {
+    const { default: DayTimeline } = await import('../DayTimeline.vue')
+    const wrapper = mount(DayTimeline, {
+      props: { date: '2024-06-10' },
+    })
+    expect(wrapper.find('[data-testid="timed-area"]').exists()).toBe(true)
+  })
+
+  it('renders the allday-strip container', async () => {
+    const { default: DayTimeline } = await import('../DayTimeline.vue')
+    const wrapper = mount(DayTimeline, {
+      props: { date: '2024-06-10' },
+    })
+    expect(wrapper.find('[data-testid="allday-strip"]').exists()).toBe(true)
+  })
+
+  it('renders timed event titles in the timed area', async () => {
+    const { default: DayTimeline } = await import('../DayTimeline.vue')
+    const wrapper = mount(DayTimeline, {
+      props: { date: '2024-06-10' },
+    })
+    const timedArea = wrapper.find('[data-testid="timed-area"]')
+    expect(timedArea.text()).toContain('Team standup')
+  })
+
+  it('renders all-day event titles in the allday-strip, not the timed area', async () => {
+    const { default: DayTimeline } = await import('../DayTimeline.vue')
+    const wrapper = mount(DayTimeline, {
+      props: { date: '2024-06-10' },
+    })
+    const alldayStrip = wrapper.find('[data-testid="allday-strip"]')
+    const timedArea = wrapper.find('[data-testid="timed-area"]')
+    expect(alldayStrip.text()).toContain('Holiday')
+    expect(timedArea.text()).not.toContain('Holiday')
+  })
+
+  it('emits create-at with an ISO time string when empty area is clicked', async () => {
+    const { default: DayTimeline } = await import('../DayTimeline.vue')
+    const wrapper = mount(DayTimeline, {
+      props: { date: '2024-06-10' },
+    })
+    const timedArea = wrapper.find('[data-testid="timed-area"]')
+    // Simulate click with offsetY
+    await timedArea.trigger('click', { offsetY: 0 })
+    const emitted = wrapper.emitted('create-at')
+    expect(emitted).toBeTruthy()
+    expect(emitted![0][0]).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/)
+  })
+})

--- a/frontend/src/components/__tests__/DayTimeline.test.ts
+++ b/frontend/src/components/__tests__/DayTimeline.test.ts
@@ -264,4 +264,22 @@ describe('DayTimeline component', () => {
     expect(emitted).toBeTruthy()
     expect(emitted![0][0]).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/)
   })
+
+  it('timed area has drop handler (wired for promote from AnchorBlock)', async () => {
+    // Verifies that the timed area is set up to accept drops.
+    // Full integration of DragEvent.dataTransfer is limited in jsdom; this tests the wiring.
+    const { default: DayTimeline } = await import('../DayTimeline.vue')
+    const wrapper = mount(DayTimeline, { props: { date: '2024-06-10' } })
+    const timedArea = wrapper.find('[data-testid="timed-area"]')
+    // Drop should not throw even with no dataTransfer payload
+    await expect(timedArea.trigger('drop')).resolves.not.toThrow()
+  })
+
+  it('event blocks are draggable (have draggable attribute)', async () => {
+    const { default: DayTimeline } = await import('../DayTimeline.vue')
+    const wrapper = mount(DayTimeline, { props: { date: '2024-06-10' } })
+    // The timed event wrapper should have draggable="true"
+    const draggableBlocks = wrapper.findAll('[draggable="true"]')
+    expect(draggableBlocks.length).toBeGreaterThan(0)
+  })
 })

--- a/frontend/src/composables/useDayTimeline.ts
+++ b/frontend/src/composables/useDayTimeline.ts
@@ -1,0 +1,43 @@
+import type { Anchor } from '../stores/anchors'
+
+// Configurable axis
+export const AXIS_START_HOUR = 6   // 6am
+export const AXIS_END_HOUR   = 24  // midnight
+export const PX_PER_MINUTE   = 1.5 // tune to taste
+
+export interface TimeWindow { start: Date; end: Date }
+
+export function anchorWindow(anchor: Anchor, date: Date): TimeWindow {
+  const [h, m] = anchor.time.split(':').map(Number)
+  const start = new Date(date)
+  start.setHours(h, m, 0, 0)
+  const end = new Date(start.getTime() + anchor.duration_minutes * 60_000)
+  return { start, end }
+}
+
+export function minutesFromAxisStart(dt: Date): number {
+  return (dt.getHours() - AXIS_START_HOUR) * 60 + dt.getMinutes()
+}
+
+export function eventTopPx(startTime: string): number {
+  const dt = new Date(startTime)
+  return Math.max(0, minutesFromAxisStart(dt)) * PX_PER_MINUTE
+}
+
+export function eventHeightPx(startTime: string, endTime: string): number {
+  const durationMin = (new Date(endTime).getTime() - new Date(startTime).getTime()) / 60_000
+  return Math.max(20, durationMin * PX_PER_MINUTE)
+}
+
+export function anchorBandTopPx(anchor: Anchor, date: Date): number {
+  const { start } = anchorWindow(anchor, date)
+  return Math.max(0, minutesFromAxisStart(start)) * PX_PER_MINUTE
+}
+
+export function anchorBandHeightPx(anchor: Anchor, date: Date): number {
+  const { start, end } = anchorWindow(anchor, date)
+  const durationMin = (end.getTime() - start.getTime()) / 60_000
+  return durationMin * PX_PER_MINUTE
+}
+
+export const AXIS_TOTAL_PX = (AXIS_END_HOUR - AXIS_START_HOUR) * 60 * PX_PER_MINUTE

--- a/frontend/src/composables/useDayTimeline.ts
+++ b/frontend/src/composables/useDayTimeline.ts
@@ -24,9 +24,23 @@ export function eventTopPx(startTime: string): number {
   return Math.max(0, minutesFromAxisStart(dt)) * PX_PER_MINUTE
 }
 
+/**
+ * Height of an event block in pixels, clipped to the visible axis window.
+ * Uses raw start position + duration (not end getHours()) so that events
+ * crossing midnight (e.g. 11pm–1am) compute correctly when AXIS_END_HOUR=24.
+ */
 export function eventHeightPx(startTime: string, endTime: string): number {
+  const axisStartMin = 0
+  const axisEndMin = (AXIS_END_HOUR - AXIS_START_HOUR) * 60
+
+  const rawStartMin = minutesFromAxisStart(new Date(startTime))
   const durationMin = (new Date(endTime).getTime() - new Date(startTime).getTime()) / 60_000
-  return Math.max(20, durationMin * PX_PER_MINUTE)
+
+  const clampedStartMin = Math.max(axisStartMin, rawStartMin)
+  // Compute end as start+duration so it works even when endTime wraps past midnight
+  const clampedEndMin = Math.min(axisEndMin, rawStartMin + durationMin)
+  const visibleMin = Math.max(0, clampedEndMin - clampedStartMin)
+  return Math.max(20, visibleMin * PX_PER_MINUTE)
 }
 
 export function anchorBandTopPx(anchor: Anchor, date: Date): number {

--- a/frontend/src/views/PlanView.vue
+++ b/frontend/src/views/PlanView.vue
@@ -94,7 +94,9 @@ async function onAnchorColumnDrop(e: DragEvent) {
   try {
     const data = JSON.parse(raw)
     if (data.type === 'calendar-event' && data.eventId) {
-      await eventStore.demoteEvent(data.eventId)
+      // Use the event's original anchor if available; fall back to first anchor
+      const anchorId = data.anchorId ?? anchorStore.anchors[0]?.id ?? ''
+      await eventStore.demoteEvent(data.eventId, anchorId, activeDate.value)
       // Refresh plan so the demoted task appears in anchor blocks
       await planStore.fetchPlan(activeDate.value)
     }

--- a/frontend/src/views/PlanView.vue
+++ b/frontend/src/views/PlanView.vue
@@ -86,13 +86,17 @@ function onOpenEvent(event: CalendarEvent) {
 
 /** Handle drop of a calendar event onto the anchor column — demotes it back to a plain task. */
 async function onAnchorColumnDrop(e: DragEvent) {
-  const raw = e.dataTransfer?.getData('application/json')
+  // DayTimeline writes both application/json and text/plain; prefer application/json
+  const rawJson = e.dataTransfer?.getData('application/json')
+  const rawText = e.dataTransfer?.getData('text/plain')
+  const raw = rawJson || rawText
   if (!raw) return
   try {
     const data = JSON.parse(raw)
     if (data.type === 'calendar-event' && data.eventId) {
       await eventStore.demoteEvent(data.eventId)
-      // planStore will refresh on next fetch; tasks will appear in anchor blocks
+      // Refresh plan so the demoted task appears in anchor blocks
+      await planStore.fetchPlan(activeDate.value)
     }
   } catch {
     // ignore malformed drag data

--- a/frontend/src/views/PlanView.vue
+++ b/frontend/src/views/PlanView.vue
@@ -157,7 +157,7 @@ async function onAnchorColumnDrop(e: DragEvent) {
     <template v-else>
       <div v-if="planStore.loading" class="text-white/40">Loading...</div>
       <!-- Two-column: anchor blocks left, day timeline right -->
-      <div v-else class="grid grid-cols-[1fr,320px] gap-4 items-start">
+      <div v-else class="grid grid-cols-[1fr_320px] gap-4 items-start">
         <!-- Left: anchor blocks -->
         <div
           class="flex flex-col gap-2"

--- a/frontend/src/views/PlanView.vue
+++ b/frontend/src/views/PlanView.vue
@@ -4,15 +4,21 @@ import { useRouter } from 'vue-router'
 import { usePlanStore } from '../stores/plan'
 import { useAnchorStore } from '../stores/anchors'
 import { useMilestoneStore } from '../stores/milestones'
+import { useEventStore } from '../stores/events'
+import { useSlideOver } from '../composables/useSlideOver'
 import AnchorBlock from '../components/AnchorBlock.vue'
 import WeekView from '../components/WeekView.vue'
 import MonthView from '../components/MonthView.vue'
+import DayTimeline from '../components/DayTimeline.vue'
+import type { CalendarEvent } from '../types/events'
 
 const props = defineProps<{ view: string; date?: string }>()
 const router = useRouter()
 const planStore = usePlanStore()
 const anchorStore = useAnchorStore()
 const milestoneStore = useMilestoneStore()
+const eventStore = useEventStore()
+const { push: pushPanel } = useSlideOver()
 
 // Resolve date from route or default to today
 const activeDate = computed(() => (props.date as string) || planStore.today)
@@ -61,6 +67,36 @@ function nextDay() {
 
 function goToday() {
   goToDate(planStore.today)
+}
+
+async function onCreateAt(isoTime: string) {
+  // Create a new task then promote it to a calendar event at the chosen time
+  const endTime = new Date(new Date(isoTime).getTime() + 30 * 60_000).toISOString()
+  const taskId = await eventStore.createTaskAndPromote(isoTime, endTime)
+  if (taskId) {
+    pushPanel({ kind: 'task', entityId: taskId })
+  }
+}
+
+function onOpenEvent(event: CalendarEvent) {
+  if (event.task_id) {
+    pushPanel({ kind: 'task', entityId: event.task_id })
+  }
+}
+
+/** Handle drop of a calendar event onto the anchor column — demotes it back to a plain task. */
+async function onAnchorColumnDrop(e: DragEvent) {
+  const raw = e.dataTransfer?.getData('application/json')
+  if (!raw) return
+  try {
+    const data = JSON.parse(raw)
+    if (data.type === 'calendar-event' && data.eventId) {
+      await eventStore.demoteEvent(data.eventId)
+      // planStore will refresh on next fetch; tasks will appear in anchor blocks
+    }
+  } catch {
+    // ignore malformed drag data
+  }
 }
 </script>
 
@@ -113,17 +149,31 @@ function goToday() {
     <!-- Month view -->
     <MonthView v-else-if="props.view === 'month'" />
 
-    <!-- Day view -->
+    <!-- Day view: two-column layout -->
     <template v-else>
       <div v-if="planStore.loading" class="text-white/40">Loading...</div>
-      <div v-else class="flex flex-col gap-2">
-        <AnchorBlock
-          v-for="anchor in anchorStore.anchors"
-          :key="anchor.id"
-          :anchor-id="anchor.id"
-          :anchor-name="anchor.name"
-          :time="anchor.time"
-          :color="anchor.color" />
+      <!-- Two-column: anchor blocks left, day timeline right -->
+      <div v-else class="grid grid-cols-[1fr,320px] gap-4 items-start">
+        <!-- Left: anchor blocks -->
+        <div
+          class="flex flex-col gap-2"
+          @dragover.prevent
+          @drop="onAnchorColumnDrop"
+        >
+          <AnchorBlock
+            v-for="anchor in anchorStore.anchors"
+            :key="anchor.id"
+            :anchor-id="anchor.id"
+            :anchor-name="anchor.name"
+            :time="anchor.time"
+            :color="anchor.color" />
+        </div>
+        <!-- Right: day timeline -->
+        <DayTimeline
+          :date="activeDate"
+          @create-at="onCreateAt"
+          @open-event="onOpenEvent"
+        />
       </div>
     </template>
 


### PR DESCRIPTION
## Summary

Adds a right-column day timeline to the Plan tab day view. The existing anchor-block column is unchanged; the new timeline sits to its right.

**DayTimeline.vue**
- Vertical time axis from 6 am to midnight with hour labels and grid lines
- Anchor periods rendered as low-opacity color bands behind the grid
- All-day events shown in a horizontal strip above the timed area
- Timed events positioned by start/end time with side-by-side overlap layout (computeOverlapLayout)
- Click empty area to create a new event at that time
- Drag event block vertically to move it; shows RecurrenceEditDialog for recurring events
- Narrow left-edge grip handle for dragging an event back to the anchor column (demote)
- Drag a task card from the anchor column onto the timeline to promote it to a timed event

**PlanView.vue**
- Day view layout changed from single column to two-column grid (anchor blocks left, timeline right)
- Drop handler on anchor column demotes calendar events back to plain tasks

**useDayTimeline.ts**
- Pure composable: anchorWindow, eventTopPx, eventHeightPx, anchorBandTopPx/HeightPx, axis constants
- eventHeightPx clips to the visible axis window so events before 6 am or past midnight do not overflow

**Other**
- RecurrenceEditDialog.vue — scope selection modal (this, this-and-future, all) for recurring event edits
- types/recurrence.ts — RecurrenceEditScope type
- CalendarEvent gains is_all_day field; context_subject already present from main

## Test plan

- 207 tests passing
- Zero TypeScript errors
- Manual: day view renders two columns
- Manual: anchor bands show at correct positions with anchor color
- Manual: timed events render at correct vertical position
- Manual: all-day events appear in strip above timed area, not inside it
- Manual: clicking empty area emits create-at with local ISO time
- Manual: dragging a recurring event opens RecurrenceEditDialog before moving