### PR TITLE
feat(db/api): calendar event management — anchor assignment, GCal cleanup, event delete, event demotion

### DIFF
--- a/api/routes/events.py
+++ b/api/routes/events.py
@@ -1,13 +1,14 @@
 import logging
 
 from typing import Literal
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 import asyncpg
 
 from db.pg_queries.tasks import (
     promote_task_to_event, get_events_for_range, update_event_time,
     patch_recurring_this, patch_recurring_this_and_future,
+    delete_event, delete_recurring_occurrence, delete_recurring_from,
 )
 from db.pool_middleware import get_db_conn
 from api.auth import auth_dependency
@@ -89,3 +90,41 @@ async def get_events(
 ):
     """Return all calendar events (promoted tasks) whose start_time falls in [start, end]."""
     return await get_events_for_range(conn, start, end)
+
+
+@router.delete("/events/{event_id}", status_code=204)
+async def delete_event_route(
+    event_id: str,
+    scope: Literal["all", "this", "this_and_future"] = Query(default="all"),
+    original_start_time: str | None = Query(default=None),
+    _auth=Depends(auth_dependency),
+    conn: asyncpg.Connection = Depends(get_db_conn),
+):
+    """Delete a calendar event or recurring occurrence.
+
+    scope=all (default): hard-delete the event/master + all orphan exceptions.
+    scope=this: append an EXDATE to suppress this occurrence only; master persists.
+    scope=this_and_future: set UNTIL on the master to truncate future occurrences.
+
+    original_start_time (ISO 8601) is required for scope=this and scope=this_and_future.
+    """
+    if scope != "all" and original_start_time is None:
+        raise HTTPException(
+            status_code=422,
+            detail="original_start_time is required when scope is not 'all'",
+        )
+
+    try:
+        if scope == "this":
+            found = await delete_recurring_occurrence(conn, event_id, original_start_time)
+        elif scope == "this_and_future":
+            found = await delete_recurring_from(conn, event_id, original_start_time)
+        else:
+            found = await delete_event(conn, event_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    if not found:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    logger.info("events: deleted event %s scope=%s", event_id, scope)

--- a/api/routes/integrations.py
+++ b/api/routes/integrations.py
@@ -23,6 +23,7 @@ import api.config as cfg
 from api.auth import auth_dependency
 from db.pg_queries.integrations import (
     delete_integration,
+    delete_tasks_by_source,
     get_integration,
     upsert_integration,
 )
@@ -193,7 +194,11 @@ async def google_disconnect(
     except Exception:
         logger.exception("Token revocation failed for user %s", user_id)
 
-    # Ensure deletion even if revoke had an error
+    # Delete all tasks synced from this integration before removing the row
+    deleted = await delete_tasks_by_source(conn, user_id, _PROVIDER)
+    logger.info("disconnect: deleted %d synced tasks for user %s", deleted, user_id)
+
+    # Ensure integration row deletion even if revoke had an error
     await delete_integration(conn, user_id, _PROVIDER)
     return {"ok": True}
 

--- a/db/migrations/versions/f1a2b3c4d5e6_is_all_day_preferred_timezones.py
+++ b/db/migrations/versions/f1a2b3c4d5e6_is_all_day_preferred_timezones.py
@@ -1,0 +1,43 @@
+"""Add is_all_day on tasks and preferred_timezones on users.
+
+is_all_day — flag for all-day events (GCal all-day or UI-created all-day);
+             these have no meaningful time component, only a date.
+             Frontend renders them in a separate "All day" band.
+
+preferred_timezones — up to 5 recently-used IANA timezone strings for the
+                      event scheduling timezone picker; appended to when the
+                      user schedules in a non-local timezone.
+
+Note: these are column additions, not new tables, so they satisfy the
+      cross-role constraint that prohibits new tables until Postgres
+      migration is complete.
+
+Revision ID: f1a2b3c4d5e6
+Revises: e1f2a3b4c5d6
+Create Date: 2026-04-27
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "f1a2b3c4d5e6"
+down_revision: Union[str, Sequence[str], None] = "e1f2a3b4c5d6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # All-day flag for calendar events — FALSE by default for all existing rows
+    op.execute(
+        "ALTER TABLE tasks ADD COLUMN is_all_day BOOLEAN NOT NULL DEFAULT FALSE"
+    )
+
+    # Preferred IANA timezone list per user — empty array by default
+    op.execute(
+        "ALTER TABLE users ADD COLUMN preferred_timezones TEXT[] NOT NULL DEFAULT '{}'"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE tasks DROP COLUMN IF EXISTS is_all_day")
+    op.execute("ALTER TABLE users DROP COLUMN IF EXISTS preferred_timezones")

--- a/db/pg_queries/integrations.py
+++ b/db/pg_queries/integrations.py
@@ -131,11 +131,33 @@ async def delete_tasks_by_source(
 
     Returns the number of tasks deleted.
     """
-    result = await conn.execute(
-        """
-        DELETE FROM tasks
-        WHERE user_id = $1::uuid AND source = $2
+    # task_id columns in child tables have no FK REFERENCES tasks(uuid) ON DELETE CASCADE —
+    # cleanup must be explicit. Use a subquery to batch-clean all child rows in one statement
+    # before deleting the tasks themselves.
+    task_id_subquery = "SELECT uuid::text FROM tasks WHERE user_id = $1::uuid AND source = $2"
+    await conn.execute(
+        f"DELETE FROM subtasks WHERE task_id IN ({task_id_subquery})", user_id, source
+    )
+    await conn.execute(
+        f"DELETE FROM links WHERE parent_type = 'tasks' AND parent_id IN ({task_id_subquery})",
+        user_id, source,
+    )
+    await conn.execute(
+        f"""
+        DELETE FROM dependencies
+        WHERE (blocker_type = 'task' AND blocker_id IN ({task_id_subquery}))
+           OR (blocked_type = 'task' AND blocked_id IN ({task_id_subquery}))
         """,
+        user_id, source, user_id, source,
+    )
+    await conn.execute(
+        f"DELETE FROM milestone_tasks WHERE task_id IN ({task_id_subquery})", user_id, source
+    )
+    await conn.execute(
+        f"DELETE FROM followup_state WHERE task_id IN ({task_id_subquery})", user_id, source
+    )
+    result = await conn.execute(
+        "DELETE FROM tasks WHERE user_id = $1::uuid AND source = $2",
         user_id, source,
     )
     # asyncpg returns "DELETE N" as the command tag

--- a/db/pg_queries/integrations.py
+++ b/db/pg_queries/integrations.py
@@ -119,6 +119,32 @@ async def upsert_sync_state(
     return _row(row)
 
 
+async def delete_tasks_by_source(
+    conn: asyncpg.Connection,
+    user_id: str,
+    source: str,
+) -> int:
+    """Hard-delete all tasks imported from a given source for this user.
+
+    Called when the user disconnects an integration (e.g. Google Calendar)
+    so that stale synced events don't persist in the calendar or plan view.
+
+    Returns the number of tasks deleted.
+    """
+    result = await conn.execute(
+        """
+        DELETE FROM tasks
+        WHERE user_id = $1::uuid AND source = $2
+        """,
+        user_id, source,
+    )
+    # asyncpg returns "DELETE N" as the command tag
+    try:
+        return int(result.split()[-1])
+    except (IndexError, ValueError):
+        return 0
+
+
 async def soft_delete_task_by_external_id(
     conn: asyncpg.Connection,
     user_id: str,

--- a/db/pg_queries/integrations.py
+++ b/db/pg_queries/integrations.py
@@ -148,7 +148,7 @@ async def delete_tasks_by_source(
         WHERE (blocker_type = 'task' AND blocker_id IN ({task_id_subquery}))
            OR (blocked_type = 'task' AND blocked_id IN ({task_id_subquery}))
         """,
-        user_id, source, user_id, source,
+        user_id, source,
     )
     await conn.execute(
         f"DELETE FROM milestone_tasks WHERE task_id IN ({task_id_subquery})", user_id, source

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -1122,11 +1122,44 @@ async def delete_event(
 
         external_id = master["external_id"]
         if external_id:
-            # Delete orphan exception rows first (FK-safe ordering)
+            # Collect exception UUIDs so child-table cleanup can reference them by text ID.
+            # task_id columns in subtasks/links/dependencies/milestone_tasks/followup_state
+            # have no FK REFERENCES tasks(uuid) ON DELETE CASCADE — cleanup must be explicit.
+            exc_uuids = await conn.fetch(
+                "SELECT uuid FROM tasks WHERE recurrence_id = $1",
+                str(external_id),
+            )
+            for row in exc_uuids:
+                exc_id = str(row["uuid"])
+                await conn.execute("DELETE FROM subtasks WHERE task_id = $1", exc_id)
+                await conn.execute(
+                    "DELETE FROM links WHERE parent_type = 'tasks' AND parent_id = $1", exc_id
+                )
+                await conn.execute(
+                    "DELETE FROM dependencies WHERE (blocker_type='task' AND blocker_id=$1)"
+                    " OR (blocked_type='task' AND blocked_id=$1)",
+                    exc_id,
+                )
+                await conn.execute("DELETE FROM milestone_tasks WHERE task_id = $1", exc_id)
+                await conn.execute("DELETE FROM followup_state WHERE task_id = $1", exc_id)
+
             await conn.execute(
                 "DELETE FROM tasks WHERE recurrence_id = $1",
                 str(external_id),
             )
+
+        # Clean child tables for the master row before deleting it
+        await conn.execute("DELETE FROM subtasks WHERE task_id = $1", event_uuid)
+        await conn.execute(
+            "DELETE FROM links WHERE parent_type = 'tasks' AND parent_id = $1", event_uuid
+        )
+        await conn.execute(
+            "DELETE FROM dependencies WHERE (blocker_type='task' AND blocker_id=$1)"
+            " OR (blocked_type='task' AND blocked_id=$1)",
+            event_uuid,
+        )
+        await conn.execute("DELETE FROM milestone_tasks WHERE task_id = $1", event_uuid)
+        await conn.execute("DELETE FROM followup_state WHERE task_id = $1", event_uuid)
 
         result = await conn.execute(
             "DELETE FROM tasks WHERE uuid = $1",

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -842,6 +842,114 @@ def expand_recurring(task: dict, window_start: _datetime, window_end: _datetime)
     return occurrences
 
 
+def _rrule_set_until(rrule_str: str, until_dt: _datetime) -> str:
+    """Return a new RRULE string with UNTIL set to *until_dt* (UTC, second precision).
+
+    Removes any existing UNTIL or COUNT clause before appending the new UNTIL.
+    *until_dt* is formatted as iCal compact UTC: YYYYMMDDTHHMMSSZ.
+    """
+    import re
+    until_str = until_dt.strftime("%Y%m%dT%H%M%SZ")
+    # Strip RRULE: prefix if present, work on the property value only
+    prefix = ""
+    value = rrule_str
+    if rrule_str.upper().startswith("RRULE:"):
+        prefix = rrule_str[:6]
+        value = rrule_str[6:]
+    # Remove existing UNTIL= and COUNT= clauses (case-insensitive)
+    value = re.sub(r";?UNTIL=[^;]*", "", value, flags=re.IGNORECASE)
+    value = re.sub(r";?COUNT=[^;]*", "", value, flags=re.IGNORECASE)
+    # Build the new value then strip stray leading/trailing semicolons.
+    # Prevents "RRULE:;UNTIL=..." when value is empty.
+    value = (value + ";UNTIL=" + until_str).strip(";")
+    return f"{prefix}{value}"
+
+
+def assign_event_anchor(
+    event: dict,
+    anchors: list[dict],
+    now_utc: "datetime",  # noqa: F821 — datetime imported at module level as _datetime
+) -> str | None:
+    """Return the anchor_id best matching an event for the dashboard now-view.
+
+    All time comparison is done in server-local (naive) time so anchor HH:MM
+    strings are directly comparable to event times.  now_utc is converted with
+    ``astimezone()`` which reads the system timezone (Pi local == user local).
+
+    Priority rules (evaluated in order):
+      1. Currently-active anchor (whose window contains now) overlaps event → return it.
+      2. No active-anchor overlap, but a future anchor will → return next upcoming.
+      3. Active anchor has moved past event end → return last overlapping anchor.
+      4. now is before all anchor windows → return first anchor.
+      5. No anchors overlap at all → return first anchor (fallback).
+
+    Returns None only when anchors is empty.
+    """
+    if not anchors:
+        return None
+
+    now_local = now_utc.astimezone().replace(tzinfo=None)
+    today = now_local.date()
+
+    def _anchor_window(a: dict) -> tuple["datetime", "datetime"]:  # noqa: F821
+        h, m = map(int, a["time"].split(":"))
+        start = _datetime(today.year, today.month, today.day, h, m)
+        return start, start + _timedelta(minutes=a.get("duration_minutes", 0))
+
+    def _event_times() -> tuple["datetime", "datetime"]:  # noqa: F821
+        raw_start = event.get("start_time") or ""
+        raw_end = event.get("end_time") or ""
+        # Parse UTC ISO → local naive
+        def _to_naive_local(s: str) -> "_datetime":  # noqa: F821
+            dt = _parse_ts(s)
+            return dt.astimezone().replace(tzinfo=None)
+        return _to_naive_local(raw_start), _to_naive_local(raw_end)
+
+    def _overlaps(a_start, a_end, e_start, e_end) -> bool:
+        return a_start < e_end and a_end > e_start
+
+    ev_start, ev_end = _event_times()
+
+    # Rule 4: before all anchors
+    first_window_start, _ = _anchor_window(anchors[0])
+    if now_local < first_window_start:
+        return anchors[0]["id"]
+
+    # Classify each anchor
+    active_anchor = None
+    overlapping: list[dict] = []
+    for a in anchors:
+        a_start, a_end = _anchor_window(a)
+        if a_start <= now_local < a_end:
+            active_anchor = a
+        if _overlaps(a_start, a_end, ev_start, ev_end):
+            overlapping.append(a)
+
+    # Rule 1: active anchor overlaps event
+    if active_anchor and any(a["id"] == active_anchor["id"] for a in overlapping):
+        return active_anchor["id"]
+
+    # Rule 3: active anchor moved past event end — find last overlapping
+    if active_anchor:
+        past_overlapping = [
+            a for a in overlapping
+            if _anchor_window(a)[1] <= now_local
+        ]
+        if past_overlapping:
+            return past_overlapping[-1]["id"]
+
+    # Rule 2: future anchor will overlap event
+    future_overlapping = [
+        a for a in overlapping
+        if _anchor_window(a)[0] > now_local
+    ]
+    if future_overlapping:
+        return future_overlapping[0]["id"]
+
+    # Rule 5: no anchors overlap at all — first anchor fallback
+    return anchors[0]["id"]
+
+
 async def promote_task_to_event(
     conn: asyncpg.Connection,
     task_uuid: str,
@@ -982,6 +1090,125 @@ async def get_events_for_range(
                 results.append(occ)
 
     return sorted(results, key=lambda e: e["start_time"] or "")
+
+
+async def delete_event(
+    conn: asyncpg.Connection,
+    event_uuid: str,
+) -> bool:
+    """Hard-delete a single event (or recurring master + its orphan exceptions).
+
+    For a recurring master (rrule IS NOT NULL), also deletes all exception rows
+    whose recurrence_id matches the master's external_id.
+
+    Returns True if a row was deleted, False if not found.
+    """
+    async with conn.transaction():
+        # Check if this is a recurring master with an external_id
+        master = await conn.fetchrow(
+            "SELECT external_id FROM tasks WHERE uuid = $1 AND start_time IS NOT NULL",
+            _uuid.UUID(event_uuid),
+        )
+        if master is None:
+            return False
+
+        external_id = master["external_id"]
+        if external_id:
+            # Delete orphan exception rows first (FK-safe ordering)
+            await conn.execute(
+                "DELETE FROM tasks WHERE recurrence_id = $1",
+                str(external_id),
+            )
+
+        result = await conn.execute(
+            "DELETE FROM tasks WHERE uuid = $1",
+            _uuid.UUID(event_uuid),
+        )
+        return result == "DELETE 1"
+
+
+async def delete_recurring_occurrence(
+    conn: asyncpg.Connection,
+    event_uuid: str,
+    original_start_time: str,
+) -> bool:
+    """Suppress a single occurrence of a recurring event by appending an EXDATE.
+
+    Mutates the master row's exdates array in place — does NOT delete any row.
+    The date token written is ISO compact (e.g. "20260511") for iCalendar compatibility.
+
+    Returns True if the master was found and updated, False if not found.
+    """
+    master = await conn.fetchrow(
+        """
+        SELECT uuid, exdates FROM tasks
+        WHERE uuid = $1 AND start_time IS NOT NULL
+        """,
+        _uuid.UUID(event_uuid),
+    )
+    if master is None:
+        return False
+
+    dt = _parse_ts(original_start_time)
+    # Write compact iCalendar EXDATE;VALUE=DATE token
+    exdate_token = f"EXDATE;VALUE=DATE:{dt.year:04d}{dt.month:02d}{dt.day:02d}"
+    existing = list(master["exdates"] or [])
+    existing.append(exdate_token)
+
+    await conn.execute(
+        "UPDATE tasks SET exdates = $1, version = version + 1 WHERE uuid = $2",
+        existing, _uuid.UUID(event_uuid),
+    )
+    return True
+
+
+async def delete_recurring_from(
+    conn: asyncpg.Connection,
+    event_uuid: str,
+    original_start_time: str,
+) -> bool:
+    """Truncate a recurring series by setting UNTIL one instant before original_start_time.
+
+    Mutates the master's rrule in place — does NOT create a new master.
+    Also hard-deletes any exception rows that fall on or after original_start_time.
+
+    Returns True if the master was found and updated, False if not found.
+    """
+    master = await conn.fetchrow(
+        """
+        SELECT uuid, rrule, external_id FROM tasks
+        WHERE uuid = $1 AND start_time IS NOT NULL
+        """,
+        _uuid.UUID(event_uuid),
+    )
+    if master is None:
+        return False
+
+    cutoff = _parse_ts(original_start_time)
+    # UNTIL is exclusive — set to one second before the first deleted occurrence
+    until_dt = cutoff - _timedelta(seconds=1)
+
+    new_rrule = _rrule_set_until(master["rrule"] or "", until_dt)
+
+    async with conn.transaction():
+        await conn.execute(
+            "UPDATE tasks SET rrule = $1, version = version + 1 WHERE uuid = $2",
+            new_rrule, _uuid.UUID(event_uuid),
+        )
+
+        # Remove exceptions on or after the cutoff date
+        external_id = master["external_id"]
+        if external_id:
+            await conn.execute(
+                """
+                DELETE FROM tasks
+                WHERE recurrence_id = $1
+                  AND original_start_time >= $2
+                """,
+                str(external_id), cutoff,
+            )
+
+    return True
 
 
 async def update_event_time(

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -1182,19 +1182,22 @@ async def delete_recurring_occurrence(
     """
     master = await conn.fetchrow(
         """
-        SELECT uuid, exdates FROM tasks
+        SELECT uuid, rrule, exdates FROM tasks
         WHERE uuid = $1 AND start_time IS NOT NULL
         """,
         _uuid.UUID(event_uuid),
     )
     if master is None:
         return False
+    if not master["rrule"]:
+        raise ValueError(f"Task {event_uuid} is not a recurring event")
 
     dt = _parse_ts(original_start_time)
     # Write compact iCalendar EXDATE;VALUE=DATE token
     exdate_token = f"EXDATE;VALUE=DATE:{dt.year:04d}{dt.month:02d}{dt.day:02d}"
     existing = list(master["exdates"] or [])
-    existing.append(exdate_token)
+    if exdate_token not in existing:
+        existing.append(exdate_token)
 
     await conn.execute(
         "UPDATE tasks SET exdates = $1, version = version + 1 WHERE uuid = $2",
@@ -1224,6 +1227,8 @@ async def delete_recurring_from(
     )
     if master is None:
         return False
+    if not master["rrule"]:
+        raise ValueError(f"Task {event_uuid} is not a recurring event")
 
     cutoff = _parse_ts(original_start_time)
     # UNTIL is exclusive — set to one second before the first deleted occurrence
@@ -1281,29 +1286,6 @@ async def update_event_time(
 # ---------------------------------------------------------------------------
 # Recurrence scope edit DB functions
 # ---------------------------------------------------------------------------
-
-def _rrule_set_until(rrule_str: str, until_dt: _datetime) -> str:
-    """Return a new RRULE string with UNTIL set to *until_dt* (UTC, second precision).
-
-    Removes any existing UNTIL or COUNT clause before appending the new UNTIL.
-    *until_dt* is formatted as iCal compact UTC: YYYYMMDDTHHMMSSZ.
-    """
-    import re
-    until_str = until_dt.strftime("%Y%m%dT%H%M%SZ")
-    # Strip RRULE: prefix if present, work on the property value only
-    prefix = ""
-    value = rrule_str
-    if rrule_str.upper().startswith("RRULE:"):
-        prefix = rrule_str[:6]
-        value = rrule_str[6:]
-    # Remove existing UNTIL= and COUNT= clauses (case-insensitive)
-    value = re.sub(r";?UNTIL=[^;]*", "", value, flags=re.IGNORECASE)
-    value = re.sub(r";?COUNT=[^;]*", "", value, flags=re.IGNORECASE)
-    # Build the new value then strip stray leading/trailing semicolons.
-    # Doing it this way prevents "RRULE:;UNTIL=..." when value is empty
-    # (e.g. the RRULE contained only a UNTIL or COUNT clause).
-    value = (value + ";UNTIL=" + until_str).strip(";")
-    return f"{prefix}{value}"
 
 
 async def patch_recurring_this(

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -155,6 +155,14 @@ async def patch_task_fields(
         val = fields["anchor_id"]
         params.append(_uuid.UUID(val) if val is not None else None)
         set_parts.append(f"anchor_id = ${len(params)}")
+    if "start_time" in fields:
+        val = fields["start_time"]
+        params.append(_parse_ts(val) if val is not None else None)
+        set_parts.append(f"start_time = ${len(params)}")
+    if "end_time" in fields:
+        val = fields["end_time"]
+        params.append(_parse_ts(val) if val is not None else None)
+        set_parts.append(f"end_time = ${len(params)}")
 
     if not set_parts:
         return None

--- a/tests/api/test_anchor_assignment.py
+++ b/tests/api/test_anchor_assignment.py
@@ -1,0 +1,166 @@
+"""Tests for assign_event_anchor() — pure function, no DB.
+
+Timezone model:
+  - now_utc is tz-aware UTC datetime (the caller's clock).
+  - Anchor times are HH:MM in server-local time (Pi local == user local).
+  - Event start_time/end_time are UTC ISO strings.
+
+Tests run under TZ=UTC so UTC == local, making time comparisons straightforward.
+The tz_utc autouse fixture enforces this so tests are portable regardless of
+the host machine's configured timezone.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+from db.pg_queries.tasks import assign_event_anchor
+
+
+@pytest.fixture(autouse=True)
+def tz_utc(monkeypatch):
+    """Force TZ=UTC so UTC event times equal local anchor window times."""
+    monkeypatch.setenv("TZ", "UTC")
+    # Reload the C-level timezone cache so astimezone() picks up TZ=UTC.
+    import time
+    time.tzset()
+    yield
+    time.tzset()  # restore after test
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _anchors():
+    return [
+        {"id": "morning", "time": "08:00", "duration_minutes": 60},
+        {"id": "midday",  "time": "10:00", "duration_minutes": 90},
+        {"id": "evening", "time": "17:00", "duration_minutes": 120},
+    ]
+
+
+def _event(start_h: int, start_m: int = 0, end_h: int = None, end_m: int = 0) -> dict:
+    if end_h is None:
+        end_h = start_h + 1
+    return {
+        "start_time": f"2026-05-01T{start_h:02d}:{start_m:02d}:00+00:00",
+        "end_time":   f"2026-05-01T{end_h:02d}:{end_m:02d}:00+00:00",
+    }
+
+
+def _now(h: int, m: int = 0) -> datetime:
+    return datetime(2026, 5, 1, h, m, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Rule 1 — currently active anchor overlaps event → return it
+# ---------------------------------------------------------------------------
+
+def test_rule1_active_anchor_overlaps_event():
+    """now=08:30 (inside Morning), event 08:15-08:45 → Morning."""
+    event = _event(8, 15, 8, 45)
+    result = assign_event_anchor(event, _anchors(), _now(8, 30))
+    assert result == "morning", f"Expected 'morning', got {result!r}"
+
+
+def test_rule1_active_anchor_overlaps_event_midday():
+    """now=10:45 (inside Midday), event 10:30-11:00 → Midday."""
+    event = _event(10, 30, 11, 0)
+    result = assign_event_anchor(event, _anchors(), _now(10, 45))
+    assert result == "midday", f"Expected 'midday', got {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# Rule 2 — no active anchor overlaps event, but future anchor will → next upcoming
+# ---------------------------------------------------------------------------
+
+def test_rule2_future_anchor_will_overlap():
+    """now=09:30 (gap, no active anchor), event 10:15-10:45 → Midday (upcoming)."""
+    event = _event(10, 15, 10, 45)
+    result = assign_event_anchor(event, _anchors(), _now(9, 30))
+    assert result == "midday", f"Expected 'midday', got {result!r}"
+
+
+def test_rule2_future_anchor_evening():
+    """now=11:45 (after Midday, before Evening), event 17:30-18:00 → Evening."""
+    event = _event(17, 30, 18, 0)
+    result = assign_event_anchor(event, _anchors(), _now(11, 45))
+    assert result == "evening", f"Expected 'evening', got {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# Rule 3 — active anchor has moved past event end → return last overlapping
+# ---------------------------------------------------------------------------
+
+def test_rule3_active_anchor_past_event_end():
+    """now=10:30 (Midday active), event ended at 08:45 → Morning (last overlapping)."""
+    event = _event(8, 15, 8, 45)
+    result = assign_event_anchor(event, _anchors(), _now(10, 30))
+    assert result == "morning", f"Expected 'morning', got {result!r}"
+
+
+def test_rule3_event_in_gap_all_past():
+    """now=17:00 (Evening starts), event was 09:15-09:45 (gap, no anchor overlap).
+    No anchor overlapped → fallback to first anchor."""
+    event = _event(9, 15, 9, 45)
+    result = assign_event_anchor(event, _anchors(), _now(17, 0))
+    # Gap event, no anchor overlaps — expect first anchor (rule 5 fallback)
+    assert result == "morning", f"Expected 'morning' (fallback), got {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# Rule 4 — before all anchors → return first anchor
+# ---------------------------------------------------------------------------
+
+def test_rule4_before_all_anchors():
+    """now=07:00 (before first anchor at 08:00) → first anchor 'morning'."""
+    event = _event(8, 15, 8, 45)
+    result = assign_event_anchor(event, _anchors(), _now(7, 0))
+    assert result == "morning", f"Expected 'morning', got {result!r}"
+
+
+def test_rule4_midnight():
+    """now=00:01 → first anchor."""
+    event = _event(8, 0, 9, 0)
+    result = assign_event_anchor(event, _anchors(), _now(0, 1))
+    assert result == "morning"
+
+
+# ---------------------------------------------------------------------------
+# Rule 5 — no anchors overlap event at all → first anchor fallback
+# ---------------------------------------------------------------------------
+
+def test_rule5_no_overlap_event_in_gap():
+    """Event 09:10-09:50 falls in gap between Morning [08-09) and Midday [10-11:30).
+    No anchor overlaps → return first anchor."""
+    event = _event(9, 10, 9, 50)
+    result = assign_event_anchor(event, _anchors(), _now(9, 15))
+    assert result == "morning", f"Expected 'morning' (fallback), got {result!r}"
+
+
+def test_rule5_no_overlap_late_event_no_future_anchor():
+    """Event 20:00-21:00 after all anchors end at 19:00.
+    No anchor overlaps, no future anchor → first anchor fallback."""
+    event = _event(20, 0, 21, 0)
+    result = assign_event_anchor(event, _anchors(), _now(22, 0))
+    assert result == "morning", f"Expected 'morning' (fallback), got {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+def test_empty_anchors_returns_none():
+    """No anchors → return None."""
+    result = assign_event_anchor(_event(9, 0), [], _now(9, 0))
+    assert result is None
+
+
+def test_single_anchor_always_returns_it():
+    """Single anchor → always returned regardless of overlap."""
+    anchors = [{"id": "only", "time": "09:00", "duration_minutes": 60}]
+    result = assign_event_anchor(_event(14, 0, 15, 0), anchors, _now(14, 0))
+    assert result == "only"

--- a/tests/api/test_events_routes.py
+++ b/tests/api/test_events_routes.py
@@ -306,3 +306,154 @@ async def test_patch_event_scope_all_context_subject_in_response(api_client, con
     assert data.get("context_subject") == "personal", (
         f"update_event_time must return context_subject, got: {data.get('context_subject')!r}"
     )
+
+
+# ─── DELETE /api/events/:id ──────────────────────────────────────────────────
+
+async def _insert_recurring_master(conn, rrule: str = "RRULE:FREQ=WEEKLY") -> str:
+    """Insert a recurring master task (promoted event) and return its UUID string."""
+    row = await conn.fetchrow(
+        """
+        INSERT INTO tasks (
+            uuid, user_id, text, status,
+            start_time, end_time,
+            source, external_id, rrule
+        )
+        VALUES (
+            gen_random_uuid(),
+            current_setting('app.current_user_id', true)::uuid,
+            'Weekly recurring event',
+            'pending',
+            '2026-05-04T09:00:00Z',
+            '2026-05-04T09:30:00Z',
+            'google_calendar',
+            'gcal-master-test',
+            $1
+        )
+        RETURNING uuid
+        """,
+        rrule,
+    )
+    return str(row["uuid"])
+
+
+async def test_delete_event_scope_all_removes_task(api_client, conn):
+    """DELETE scope=all removes the master task row entirely."""
+    task_id = await _insert_task(conn, "Non-recurring single event")
+    # Promote it to an event first
+    await api_client.post("/api/events", json={
+        "task_id": task_id,
+        "start_time": "2026-05-10T09:00:00Z",
+        "end_time": "2026-05-10T10:00:00Z",
+    })
+
+    resp = await api_client.delete(f"/api/events/{task_id}?scope=all")
+    assert resp.status_code == 204, resp.text
+
+    # Verify task is gone
+    row = await conn.fetchrow("SELECT uuid FROM tasks WHERE uuid = $1::uuid", task_id)
+    assert row is None, "scope=all must delete the task row"
+
+
+async def test_delete_event_scope_all_removes_recurring_master_and_exceptions(api_client, conn):
+    """DELETE scope=all on a recurring master also deletes orphan exception rows."""
+    import uuid
+    master_id = await _insert_recurring_master(conn)
+
+    # Insert an exception row linked to this master via recurrence_id
+    master_external_id = "gcal-master-test"
+    await conn.execute(
+        """
+        INSERT INTO tasks (uuid, user_id, text, status, source, external_id, recurrence_id,
+                           start_time, end_time, original_start_time)
+        VALUES (
+            $1, current_setting('app.current_user_id', true)::uuid,
+            'Moved exception', 'pending', 'google_calendar', 'gcal-exc-1',
+            $2, '2026-05-11T14:00:00Z', '2026-05-11T14:30:00Z', '2026-05-11T09:00:00Z'
+        )
+        """,
+        uuid.uuid4(), master_external_id,
+    )
+
+    resp = await api_client.delete(f"/api/events/{master_id}?scope=all")
+    assert resp.status_code == 204, resp.text
+
+    # Both master and exception must be gone
+    master_row = await conn.fetchrow("SELECT uuid FROM tasks WHERE uuid = $1::uuid", master_id)
+    assert master_row is None, "Master must be deleted"
+
+    exc_rows = await conn.fetch(
+        "SELECT uuid FROM tasks WHERE recurrence_id = $1", master_external_id
+    )
+    assert len(exc_rows) == 0, "Orphan exceptions must be deleted with master"
+
+
+async def test_delete_event_scope_this_adds_exdate(api_client, conn):
+    """DELETE scope=this adds an EXDATE to the master's rrule, suppressing that occurrence."""
+    master_id = await _insert_recurring_master(conn, "RRULE:FREQ=WEEKLY")
+    original_start = "2026-05-11T09:00:00Z"
+
+    resp = await api_client.delete(
+        f"/api/events/{master_id}?scope=this&original_start_time={original_start}"
+    )
+    assert resp.status_code == 204, resp.text
+
+    row = await conn.fetchrow("SELECT exdates FROM tasks WHERE uuid = $1::uuid", master_id)
+    assert row is not None, "Master task must still exist after scope=this delete"
+    exdates = row["exdates"] or []
+    assert any("20260511" in e or "2026-05-11" in e for e in exdates), (
+        f"EXDATE for 2026-05-11 must be appended; got: {exdates}"
+    )
+
+
+async def test_delete_event_scope_this_and_future_sets_until(api_client, conn):
+    """DELETE scope=this_and_future truncates the series by setting UNTIL on the rrule."""
+    master_id = await _insert_recurring_master(conn, "RRULE:FREQ=WEEKLY")
+    original_start = "2026-05-11T09:00:00Z"
+
+    resp = await api_client.delete(
+        f"/api/events/{master_id}?scope=this_and_future&original_start_time={original_start}"
+    )
+    assert resp.status_code == 204, resp.text
+
+    row = await conn.fetchrow("SELECT rrule FROM tasks WHERE uuid = $1::uuid", master_id)
+    assert row is not None, "Master task must still exist after scope=this_and_future delete"
+    assert "UNTIL=" in (row["rrule"] or ""), (
+        f"UNTIL must be set on rrule to truncate series; got: {row['rrule']!r}"
+    )
+
+
+async def test_delete_event_scope_this_requires_original_start_time(api_client, conn):
+    """DELETE scope=this without original_start_time returns 422."""
+    task_id = await _insert_task(conn, "Scope this requires original")
+    await api_client.post("/api/events", json={
+        "task_id": task_id,
+        "start_time": "2026-05-10T09:00:00Z",
+        "end_time": "2026-05-10T10:00:00Z",
+    })
+
+    resp = await api_client.delete(f"/api/events/{task_id}?scope=this")
+    assert resp.status_code == 422, (
+        f"scope=this without original_start_time should return 422, got {resp.status_code}"
+    )
+
+
+async def test_delete_event_404_unknown_id(api_client):
+    """DELETE unknown event ID returns 404."""
+    resp = await api_client.delete(
+        "/api/events/00000000-0000-0000-0000-000000000099?scope=all"
+    )
+    assert resp.status_code == 404
+
+
+async def test_delete_event_scope_all_default_when_omitted(api_client, conn):
+    """DELETE with no scope param defaults to scope=all."""
+    task_id = await _insert_task(conn, "Default scope delete")
+    await api_client.post("/api/events", json={
+        "task_id": task_id,
+        "start_time": "2026-05-10T09:00:00Z",
+        "end_time": "2026-05-10T10:00:00Z",
+    })
+
+    resp = await api_client.delete(f"/api/events/{task_id}")
+    assert resp.status_code == 204, resp.text

--- a/tests/api/test_events_routes.py
+++ b/tests/api/test_events_routes.py
@@ -457,3 +457,57 @@ async def test_delete_event_scope_all_default_when_omitted(api_client, conn):
 
     resp = await api_client.delete(f"/api/events/{task_id}")
     assert resp.status_code == 204, resp.text
+
+
+async def test_delete_scope_this_on_non_recurring_returns_400(api_client, conn):
+    """scope=this on a non-recurring event returns 400 — no rrule to append EXDATE to."""
+    task_id = await _insert_task(conn, "Non-recurring scope=this target")
+    await api_client.post("/api/events", json={
+        "task_id": task_id,
+        "start_time": "2026-05-10T09:00:00Z",
+        "end_time": "2026-05-10T10:00:00Z",
+    })
+
+    resp = await api_client.delete(
+        f"/api/events/{task_id}?scope=this&original_start_time=2026-05-10T09:00:00Z"
+    )
+    assert resp.status_code == 400, (
+        f"scope=this on a non-recurring event must return 400, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_delete_scope_this_and_future_on_non_recurring_returns_400(api_client, conn):
+    """scope=this_and_future on a non-recurring event returns 400 — no rrule to truncate."""
+    task_id = await _insert_task(conn, "Non-recurring scope=this_and_future target")
+    await api_client.post("/api/events", json={
+        "task_id": task_id,
+        "start_time": "2026-05-10T09:00:00Z",
+        "end_time": "2026-05-10T10:00:00Z",
+    })
+
+    resp = await api_client.delete(
+        f"/api/events/{task_id}?scope=this_and_future&original_start_time=2026-05-10T09:00:00Z"
+    )
+    assert resp.status_code == 400, (
+        f"scope=this_and_future on a non-recurring event must return 400, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_delete_scope_this_repeated_does_not_duplicate_exdate(api_client, conn):
+    """Deleting the same occurrence twice via scope=this does not produce duplicate EXDATEs."""
+    master_id = await _insert_recurring_master(conn, "RRULE:FREQ=WEEKLY")
+    original_start = "2026-05-11T09:00:00Z"
+
+    await api_client.delete(
+        f"/api/events/{master_id}?scope=this&original_start_time={original_start}"
+    )
+    await api_client.delete(
+        f"/api/events/{master_id}?scope=this&original_start_time={original_start}"
+    )
+
+    row = await conn.fetchrow("SELECT exdates FROM tasks WHERE uuid = $1::uuid", master_id)
+    exdates = row["exdates"] or []
+    matching = [e for e in exdates if "20260511" in e or "2026-05-11" in e]
+    assert len(matching) == 1, (
+        f"EXDATE for 2026-05-11 must appear exactly once, got: {exdates}"
+    )

--- a/tests/api/test_integrations.py
+++ b/tests/api/test_integrations.py
@@ -188,6 +188,54 @@ async def test_disconnect_no_integration_returns_ok(api_client):
     assert resp.status_code == 200
 
 
+@pytest.mark.asyncio
+async def test_disconnect_deletes_synced_tasks(api_client, conn):
+    """Disconnect hard-deletes all tasks imported from google_calendar.
+
+    Task C scenario 2: when the user unlinks GCal, all tasks created by
+    the sync worker (source='google_calendar') must be removed so stale
+    events don't appear in the calendar or plan.
+    """
+    from db.pg_queries.integrations import upsert_integration
+
+    await upsert_integration(
+        conn, TEST_USER_ID, "google_calendar",
+        access_token="tok", refresh_token="rt",
+    )
+
+    import uuid
+    # Insert two tasks that look like they were synced from GCal
+    for ext_id in ("gcal-evt-1", "gcal-evt-2"):
+        await conn.execute(
+            """
+            INSERT INTO tasks (uuid, user_id, text, status, source, external_id)
+            VALUES ($1, $2::uuid, $3, 'pending', 'google_calendar', $4)
+            """,
+            uuid.uuid4(), TEST_USER_ID, f"GCal event {ext_id}", ext_id,
+        )
+
+    # Verify they exist before disconnect
+    rows_before = await conn.fetch(
+        "SELECT uuid FROM tasks WHERE user_id = $1::uuid AND source = 'google_calendar'",
+        TEST_USER_ID,
+    )
+    assert len(rows_before) >= 2, "Precondition: synced tasks must exist before disconnect"
+
+    with patch("api.routes.integrations.GoogleCalendarAuth.revoke", new=AsyncMock()):
+        resp = await api_client.post("/api/integrations/google/disconnect")
+
+    assert resp.status_code == 200, resp.text
+
+    rows_after = await conn.fetch(
+        "SELECT uuid FROM tasks WHERE user_id = $1::uuid AND source = 'google_calendar'",
+        TEST_USER_ID,
+    )
+    assert len(rows_after) == 0, (
+        f"All google_calendar tasks must be deleted on disconnect, "
+        f"{len(rows_after)} remain"
+    )
+
+
 # ---------------------------------------------------------------------------
 # 4. POST /api/integrations/google/sync — manual sync via PG NOTIFY
 # ---------------------------------------------------------------------------

--- a/tests/db/test_pg_tasks.py
+++ b/tests/db/test_pg_tasks.py
@@ -115,3 +115,70 @@ async def test_subtasks(conn, task_uuid):
     await delete_subtask(conn, sid)
     subtasks = await get_subtasks(conn, task_uuid)
     assert not any(s["id"] == sid for s in subtasks)
+
+
+# ─── patch_task_fields: start_time / end_time null passthrough ────────────────
+
+@pytest.fixture
+async def event_task_uuid(conn, anchor_id):
+    """A task that has already been promoted to an event (has start_time/end_time)."""
+    await upsert_plan(conn, DATE)
+    # Insert directly so we can set start_time/end_time
+    row = await conn.fetchrow(
+        """
+        INSERT INTO tasks (uuid, user_id, text, status, start_time, end_time)
+        VALUES (
+            gen_random_uuid(),
+            current_setting('app.current_user_id', true)::uuid,
+            'Promoted event task',
+            'pending',
+            '2026-05-01T09:00:00Z',
+            '2026-05-01T10:00:00Z'
+        )
+        RETURNING uuid
+        """
+    )
+    return str(row["uuid"])
+
+
+@pytest.mark.asyncio
+async def test_patch_task_fields_sets_start_end_time(conn, event_task_uuid):
+    """patch_task_fields can set start_time and end_time to new values."""
+    result = await patch_task_fields(conn, event_task_uuid, {
+        "start_time": "2026-05-02T14:00:00Z",
+        "end_time": "2026-05-02T15:00:00Z",
+    })
+    # Verify via direct DB read since patch_task_fields SELECT may not return these cols
+    row = await conn.fetchrow(
+        "SELECT start_time, end_time FROM tasks WHERE uuid = $1::uuid",
+        event_task_uuid,
+    )
+    assert row["start_time"] is not None
+    assert "14" in str(row["start_time"]) or "14:00" in str(row["start_time"])
+
+
+@pytest.mark.asyncio
+async def test_patch_task_fields_clears_start_end_time_with_null(conn, event_task_uuid):
+    """patch_task_fields with start_time=None and end_time=None demotes event back to task."""
+    result = await patch_task_fields(conn, event_task_uuid, {
+        "start_time": None,
+        "end_time": None,
+    })
+    row = await conn.fetchrow(
+        "SELECT start_time, end_time FROM tasks WHERE uuid = $1::uuid",
+        event_task_uuid,
+    )
+    assert row["start_time"] is None, "start_time should be cleared to NULL"
+    assert row["end_time"] is None, "end_time should be cleared to NULL"
+
+
+@pytest.mark.asyncio
+async def test_patch_task_fields_omitting_start_time_does_not_clear_it(conn, event_task_uuid):
+    """Omitting start_time from the patch dict must NOT clear the existing value."""
+    # Patch only the status — start_time should remain
+    await patch_task_fields(conn, event_task_uuid, {"status": "in_progress"})
+    row = await conn.fetchrow(
+        "SELECT start_time FROM tasks WHERE uuid = $1::uuid",
+        event_task_uuid,
+    )
+    assert row["start_time"] is not None, "start_time must not be cleared when not in patch dict"


### PR DESCRIPTION
## Summary

- **Task B — `assign_event_anchor()`**: Pure function in `db/pg_queries/tasks.py` that assigns a calendar event to an anchor block using a 5-rule priority: active overlap → future overlap → last past-overlap → first anchor (before all) → first anchor (fallback). 12 tests in `tests/api/test_anchor_assignment.py`.

- **Task C — GCal disconnect cleanup**: `delete_tasks_by_source(conn, user_id, source)` in `db/pg_queries/integrations.py` hard-deletes all tasks imported from a given integration source, including explicit child-table cleanup (subtasks, links, dependencies, milestone_tasks, followup_state — no CASCADE on task FKs). Called in `google_disconnect` route so synced GCal tasks are removed on integration disconnect.

- **Task D — `DELETE /api/events/:id`**: Scoped event deletion endpoint with `scope=all|this|this_and_future` and `original_start_time` query params. `scope=all` hard-deletes master + orphan exceptions (with full FK child-table cleanup); `scope=this` appends EXDATE; `scope=this_and_future` sets UNTIL on rrule. 7 route tests in `tests/api/test_events_routes.py`.

- **Migrations** (`f1a2b3c4d5e6`): `is_all_day BOOLEAN NOT NULL DEFAULT FALSE` on tasks; `preferred_timezones TEXT[] NOT NULL DEFAULT '{}'` on users.

- **`patch_task_fields` null passthrough**: Added `start_time` and `end_time` to the SET clause builder. Explicit `null` now clears the fields (event→task demotion). Omitting the key leaves existing values intact. 3 tests in `tests/db/test_pg_tasks.py`.

- **FK cleanup**: Confirmed `task_id` columns in `subtasks`, `links`, `dependencies`, `milestone_tasks`, `followup_state` have no `REFERENCES tasks(uuid) ON DELETE CASCADE`. Both `delete_event` and `delete_tasks_by_source` now mirror the explicit cleanup pattern from `delete_task_by_uuid`.

## Test plan

- [ ] `tests/api/test_anchor_assignment.py` — 12 unit tests, all pass locally
- [ ] `tests/api/test_events_routes.py` — GET/POST/PATCH/DELETE route tests (DB integration, CI)
- [ ] `tests/db/test_pg_tasks.py` — `patch_task_fields` null passthrough (3 new tests, DB integration, CI)
- [ ] `tests/api/test_integrations.py` — GCal disconnect cleanup test (DB integration, CI)