### PR TITLE
feat: Anthropic account integration tile with OAuth connect/disconnect

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -89,40 +89,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
@@ -131,6 +97,7 @@
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -147,6 +114,7 @@
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -163,6 +131,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -179,6 +148,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -195,6 +165,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -211,6 +182,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -227,6 +199,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -243,6 +216,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -259,6 +233,7 @@
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -275,6 +250,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -291,6 +267,7 @@
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -307,6 +284,7 @@
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -323,6 +301,7 @@
         "mips64el"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -339,6 +318,7 @@
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -355,6 +335,7 @@
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -371,6 +352,7 @@
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -387,6 +369,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -396,9 +379,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
       "cpu": [
         "arm64"
       ],
@@ -408,7 +391,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -421,6 +403,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -430,9 +413,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
       "cpu": [
         "arm64"
       ],
@@ -442,7 +425,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -455,6 +437,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -464,9 +447,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
       "cpu": [
         "arm64"
       ],
@@ -476,7 +459,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -489,6 +471,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -505,6 +488,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -521,6 +505,7 @@
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -537,6 +522,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -601,25 +587,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -665,16 +632,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@oxc-project/types": {
-      "version": "0.126.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
-      "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -685,270 +642,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
-      "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
-      "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
-      "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
-      "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
-      "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
-      "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
-      "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
@@ -1307,17 +1000,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1415,16 +1097,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1432,10 +1114,47 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1446,13 +1165,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1460,14 +1179,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1476,9 +1195,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1486,13 +1205,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1530,53 +1249,53 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
-      "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
+      "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@vue/shared": "3.5.32",
+        "@vue/shared": "3.5.33",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
-      "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
+      "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-core": "3.5.33",
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz",
-      "integrity": "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
+      "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@vue/compiler-core": "3.5.32",
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/compiler-ssr": "3.5.32",
-        "@vue/shared": "3.5.32",
+        "@vue/compiler-core": "3.5.33",
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/compiler-ssr": "3.5.33",
+        "@vue/shared": "3.5.33",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.8",
+        "postcss": "^8.5.10",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz",
-      "integrity": "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
+      "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/compiler-vue2": {
@@ -1649,64 +1368,74 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.32.tgz",
-      "integrity": "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
+      "integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.32"
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.32.tgz",
-      "integrity": "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
+      "integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/reactivity": "3.5.33",
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz",
-      "integrity": "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
+      "integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.32",
-        "@vue/runtime-core": "3.5.32",
-        "@vue/shared": "3.5.32",
+        "@vue/reactivity": "3.5.33",
+        "@vue/runtime-core": "3.5.33",
+        "@vue/shared": "3.5.33",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.32.tgz",
-      "integrity": "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
+      "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-ssr": "3.5.33",
+        "@vue/shared": "3.5.33"
       },
       "peerDependencies": {
-        "vue": "3.5.32"
+        "vue": "3.5.33"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
-      "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
+      "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
       "license": "MIT"
     },
     "node_modules/@vue/test-utils": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.6.tgz",
-      "integrity": "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.9.tgz",
+      "integrity": "sha512-YwgowiO1mPleZqpgAGfxvWu/A5A8nkLrbyH2SqiQRkyzCIaDzzo27/2uS/F1g7fRLvl8BUY0+Sr1eC+6+IHfrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-beautify": "^1.14.9",
-        "vue-component-type-helpers": "^2.0.0"
+        "vue-component-type-helpers": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-dom": "3.x",
+        "@vue/server-renderer": "3.x",
+        "vue": "3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/server-renderer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vueuse/core": {
@@ -1873,9 +1602,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.20",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
-      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
+      "version": "2.10.24",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1975,9 +1704,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001788",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "dev": true,
       "funding": [
         {
@@ -2147,16 +1876,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -2172,9 +1891,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -2207,9 +1926,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.340",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
-      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "dev": true,
       "license": "ISC"
     },
@@ -2243,9 +1962,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2255,6 +1974,7 @@
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2288,54 +2008,6 @@
         "@esbuild/win32-arm64": "0.25.12",
         "@esbuild/win32-ia32": "0.25.12",
         "@esbuild/win32-x64": "0.25.12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/escalade": {
@@ -2711,267 +2383,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -3114,9 +2525,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3299,9 +2710,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -3549,40 +2960,6 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
-    },
-    "node_modules/rolldown": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oxc-project/types": "=0.126.0",
-        "@rolldown/pluginutils": "1.0.0-rc.16"
-      },
-      "bin": {
-        "rolldown": "bin/cli.mjs"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
-      }
     },
     "node_modules/rollup": {
       "version": "4.60.2",
@@ -4059,14 +3436,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/typescript": {
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
@@ -4131,6 +3500,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4205,6 +3575,7 @@
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
       },
@@ -4222,6 +3593,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -4230,19 +3602,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4270,12 +3642,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4319,501 +3691,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.1.4",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
-      }
-    },
-    "node_modules/vitest/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/vitest/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -4827,84 +3704,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/vitest/node_modules/vite": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
-      "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.16",
-        "tinyglobby": "^0.2.16"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0 || ^0.28.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -4913,16 +3712,16 @@
       "license": "MIT"
     },
     "node_modules/vue": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
-      "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
+      "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/compiler-sfc": "3.5.32",
-        "@vue/runtime-dom": "3.5.32",
-        "@vue/server-renderer": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/compiler-sfc": "3.5.33",
+        "@vue/runtime-dom": "3.5.33",
+        "@vue/server-renderer": "3.5.33",
+        "@vue/shared": "3.5.33"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -4934,9 +3733,9 @@
       }
     },
     "node_modules/vue-component-type-helpers": {
-      "version": "2.2.12",
-      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz",
-      "integrity": "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.2.7.tgz",
+      "integrity": "sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/src/components/AnthropicAccountSection.vue
+++ b/frontend/src/components/AnthropicAccountSection.vue
@@ -1,0 +1,249 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useIntegrationsStore } from '../stores/integrations'
+
+const store = useIntegrationsStore()
+
+onMounted(() => {
+  store.fetchAnthropicStatus()
+})
+
+// Modal state machine: idle | starting | awaiting_code | completing | error
+type ModalPhase = 'idle' | 'starting' | 'awaiting_code' | 'completing' | 'error'
+const modalPhase = ref<ModalPhase>('idle')
+const codeInput = ref('')
+const showConfirmDisconnect = ref(false)
+const copied = ref(false)
+let copiedTimer: ReturnType<typeof setTimeout> | null = null
+
+async function handleConnect() {
+  modalPhase.value = 'starting'
+  const url = await store.startAnthropicConnect()
+  if (url) {
+    modalPhase.value = 'awaiting_code'
+  } else {
+    modalPhase.value = 'error'
+  }
+}
+
+async function handleSubmit() {
+  if (!codeInput.value.trim()) return
+  modalPhase.value = 'completing'
+  await store.completeAnthropicConnect(codeInput.value.trim())
+  if (store.anthropicConnected) {
+    // Success — close modal
+    modalPhase.value = 'idle'
+    codeInput.value = ''
+  } else {
+    // Failed — return to awaiting_code phase (error shown inline)
+    modalPhase.value = 'awaiting_code'
+  }
+}
+
+function handleCancel() {
+  modalPhase.value = 'idle'
+  codeInput.value = ''
+}
+
+function handleDisconnectClick() {
+  showConfirmDisconnect.value = true
+}
+
+function handleDisconnectCancel() {
+  showConfirmDisconnect.value = false
+}
+
+async function handleDisconnectConfirm() {
+  await store.disconnectAnthropic()
+  showConfirmDisconnect.value = false
+}
+
+async function copyUrl() {
+  if (!store.anthropicAuthUrl) return
+  try {
+    await navigator.clipboard.writeText(store.anthropicAuthUrl)
+    copied.value = true
+    if (copiedTimer) clearTimeout(copiedTimer)
+    copiedTimer = setTimeout(() => {
+      copied.value = false
+    }, 2000)
+  } catch {
+    // clipboard not available in test env, ignore
+  }
+}
+</script>
+
+<template>
+  <section class="mb-8">
+    <h2 class="text-sm font-semibold text-white/50 uppercase tracking-wider mb-3">Anthropic Account</h2>
+    <div class="bg-gray-800 rounded-xl p-4">
+      <!-- Status row -->
+      <div class="flex items-center justify-between mb-4">
+        <div class="flex items-center gap-2">
+          <!-- Anthropic "A" logo mark -->
+          <div class="w-5 h-5 flex-shrink-0 flex items-center justify-center bg-orange-500 rounded text-white font-bold text-xs" aria-hidden="true">
+            A
+          </div>
+          <div>
+            <div class="text-sm font-medium text-white">Anthropic Account</div>
+            <div v-if="store.anthropicConnected" class="text-xs text-green-400 flex items-center gap-1">
+              <span>&#10003;</span>
+              <span>Connected</span>
+            </div>
+            <div v-else class="text-xs text-white/40">Not connected</div>
+          </div>
+        </div>
+
+        <!-- Action buttons -->
+        <div v-if="store.anthropicConnected">
+          <template v-if="showConfirmDisconnect">
+            <div class="flex items-center gap-2 flex-wrap">
+              <span class="text-xs text-white/60">Are you sure? You'll need to re-connect.</span>
+              <button
+                data-testid="anthropic-disconnect-confirm"
+                :disabled="store.anthropicLoading"
+                @click="handleDisconnectConfirm"
+                class="text-sm text-red-400 hover:text-red-300 disabled:opacity-50 border border-red-400/30 hover:border-red-300/50 rounded-lg px-3 py-1.5 transition-colors"
+              >
+                {{ store.anthropicLoading ? '…' : 'Confirm Disconnect' }}
+              </button>
+              <button
+                @click="handleDisconnectCancel"
+                class="text-sm text-white/50 hover:text-white border border-white/20 hover:border-white/40 rounded-lg px-2.5 py-1.5 transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </template>
+          <button
+            v-else
+            data-testid="anthropic-disconnect"
+            :disabled="store.anthropicLoading"
+            @click="handleDisconnectClick"
+            class="text-sm text-red-400 hover:text-red-300 disabled:opacity-50 border border-red-400/30 hover:border-red-300/50 rounded-lg px-3 py-1.5 transition-colors"
+          >
+            {{ store.anthropicLoading ? '…' : 'Disconnect' }}
+          </button>
+        </div>
+        <button
+          v-else
+          data-testid="anthropic-connect"
+          :disabled="store.anthropicLoading || modalPhase === 'starting'"
+          @click="handleConnect"
+          class="text-sm bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white font-medium rounded-lg px-3 py-1.5 transition-colors"
+        >
+          {{ (store.anthropicLoading || modalPhase === 'starting') ? '…' : 'Connect' }}
+        </button>
+      </div>
+
+      <!-- Info text when not connected and modal not open -->
+      <p v-if="!store.anthropicConnected && modalPhase === 'idle'" class="text-xs text-white/40">
+        Connect your Anthropic account to use Claude-powered features in Tether.
+      </p>
+
+      <!-- Error from store when not in modal context -->
+      <p v-if="store.anthropicError && modalPhase === 'idle'" class="text-xs text-red-400 mt-2">
+        {{ store.anthropicError }}
+      </p>
+
+      <!-- Connect Modal (inline overlay inside tile) -->
+      <div
+        v-if="modalPhase !== 'idle'"
+        class="mt-4 border border-white/10 rounded-xl p-4 bg-gray-900/60 space-y-3"
+      >
+        <h3 class="text-sm font-semibold text-white">Connect your Anthropic account</h3>
+
+        <!-- Starting spinner -->
+        <div v-if="modalPhase === 'starting'" class="flex items-center gap-2 text-sm text-white/50">
+          <span class="inline-block w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"></span>
+          <span>Starting connection...</span>
+        </div>
+
+        <!-- Awaiting code phase -->
+        <template v-if="modalPhase === 'awaiting_code' || modalPhase === 'completing'">
+          <ol class="text-xs text-white/60 space-y-1 list-decimal list-inside">
+            <li>Click the link below to authorize on Anthropic's site.</li>
+            <li>Copy the code shown on that page.</li>
+            <li>Paste it here to complete the connection.</li>
+          </ol>
+
+          <!-- Auth URL + Copy button -->
+          <div v-if="store.anthropicAuthUrl" class="flex items-center gap-2 flex-wrap">
+            <a
+              data-testid="anthropic-auth-url"
+              :href="store.anthropicAuthUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xs text-indigo-400 hover:text-indigo-300 underline truncate max-w-xs"
+            >
+              {{ store.anthropicAuthUrl }}
+            </a>
+            <button
+              data-testid="anthropic-copy-url"
+              @click="copyUrl"
+              class="text-xs text-white/50 hover:text-white border border-white/20 hover:border-white/40 rounded px-2 py-1 transition-colors flex-shrink-0"
+            >
+              {{ copied ? 'Copied!' : 'Copy URL' }}
+            </button>
+          </div>
+
+          <!-- Error from store (inline, shown in awaiting_code) -->
+          <p v-if="store.anthropicError" class="text-xs text-red-400">
+            {{ store.anthropicError }}
+          </p>
+
+          <!-- Code input + Submit -->
+          <div class="flex items-center gap-2">
+            <input
+              data-testid="anthropic-code-input"
+              v-model="codeInput"
+              type="text"
+              placeholder="Paste code here"
+              :disabled="modalPhase === 'completing'"
+              class="flex-1 bg-gray-700 text-white rounded-lg px-3 py-2 text-sm border border-gray-600 focus:outline-none focus:border-indigo-500 placeholder-gray-500 disabled:opacity-50"
+              @keydown.enter="handleSubmit"
+            />
+            <button
+              data-testid="anthropic-submit"
+              :disabled="!codeInput.trim() || modalPhase === 'completing'"
+              @click="handleSubmit"
+              class="text-sm bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white font-medium rounded-lg px-3 py-2 transition-colors flex-shrink-0"
+            >
+              {{ modalPhase === 'completing' ? '…' : 'Submit' }}
+            </button>
+          </div>
+
+          <!-- Cancel -->
+          <button
+            @click="handleCancel"
+            :disabled="modalPhase === 'completing'"
+            class="text-xs text-white/40 hover:text-white/70 disabled:opacity-50 transition-colors"
+          >
+            Cancel
+          </button>
+        </template>
+
+        <!-- Error phase (start failed) -->
+        <template v-if="modalPhase === 'error'">
+          <p class="text-xs text-red-400">
+            {{ store.anthropicError ?? 'Failed to start connection. Please try again.' }}
+          </p>
+          <div class="flex gap-2">
+            <button
+              @click="handleConnect"
+              class="text-xs bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg px-3 py-1.5 transition-colors"
+            >
+              Retry
+            </button>
+            <button
+              @click="handleCancel"
+              class="text-xs text-white/40 hover:text-white/70 transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </template>
+      </div>
+    </div>
+  </section>
+</template>

--- a/frontend/src/components/AnthropicAccountSection.vue
+++ b/frontend/src/components/AnthropicAccountSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import { useIntegrationsStore } from '../stores/integrations'
 
 const store = useIntegrationsStore()
@@ -17,6 +17,8 @@ const copied = ref(false)
 let copiedTimer: ReturnType<typeof setTimeout> | null = null
 
 async function handleConnect() {
+  if (modalPhase.value !== 'idle') return
+  store.clearAnthropicFlowState()
   modalPhase.value = 'starting'
   const url = await store.startAnthropicConnect()
   if (url) {
@@ -27,11 +29,13 @@ async function handleConnect() {
 }
 
 async function handleSubmit() {
+  if (modalPhase.value === 'completing') return
   if (!codeInput.value.trim()) return
   modalPhase.value = 'completing'
   await store.completeAnthropicConnect(codeInput.value.trim())
   if (store.anthropicConnected) {
     // Success — close modal
+    store.clearAnthropicFlowState()
     modalPhase.value = 'idle'
     codeInput.value = ''
   } else {
@@ -41,6 +45,7 @@ async function handleSubmit() {
 }
 
 function handleCancel() {
+  store.clearAnthropicFlowState()
   modalPhase.value = 'idle'
   codeInput.value = ''
 }
@@ -55,8 +60,14 @@ function handleDisconnectCancel() {
 
 async function handleDisconnectConfirm() {
   await store.disconnectAnthropic()
-  showConfirmDisconnect.value = false
+  if (!store.anthropicError) {
+    showConfirmDisconnect.value = false
+  }
 }
+
+onUnmounted(() => {
+  if (copiedTimer) clearTimeout(copiedTimer)
+})
 
 async function copyUrl() {
   if (!store.anthropicAuthUrl) return
@@ -136,6 +147,9 @@ async function copyUrl() {
         </button>
       </div>
 
+      <!-- Error shown in connected view (e.g. disconnect failure) -->
+      <p v-if="store.anthropicConnected && store.anthropicError" class="text-xs text-red-400 mt-2">{{ store.anthropicError }}</p>
+
       <!-- Info text when not connected and modal not open -->
       <p v-if="!store.anthropicConnected && modalPhase === 'idle'" class="text-xs text-white/40">
         Connect your Anthropic account to use Claude-powered features in Tether.
@@ -157,6 +171,7 @@ async function copyUrl() {
         <div v-if="modalPhase === 'starting'" class="flex items-center gap-2 text-sm text-white/50">
           <span class="inline-block w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"></span>
           <span>Starting connection...</span>
+          <button @click="handleCancel" class="ml-auto text-xs text-white/40 hover:text-white/70 transition-colors" data-testid="anthropic-cancel-starting">Cancel</button>
         </div>
 
         <!-- Awaiting code phase -->
@@ -230,6 +245,7 @@ async function copyUrl() {
           </p>
           <div class="flex gap-2">
             <button
+              data-testid="anthropic-retry"
               @click="handleConnect"
               class="text-xs bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg px-3 py-1.5 transition-colors"
             >

--- a/frontend/src/components/__tests__/AnthropicAccountSection.test.ts
+++ b/frontend/src/components/__tests__/AnthropicAccountSection.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ path: '/settings' }),
+}))
+
+// Mock the integrations store module
+vi.mock('../../stores/integrations', () => ({
+  useIntegrationsStore: vi.fn(),
+}))
+
+import { useIntegrationsStore } from '../../stores/integrations'
+
+function makeStore(overrides: Partial<{
+  anthropicConnected: boolean
+  anthropicLoading: boolean
+  anthropicError: string | null
+  anthropicAuthUrl: string | null
+  fetchAnthropicStatus: () => Promise<void>
+  startAnthropicConnect: () => Promise<string | null>
+  completeAnthropicConnect: (code: string) => Promise<void>
+  disconnectAnthropic: () => Promise<void>
+}> = {}) {
+  return {
+    anthropicConnected: false,
+    anthropicLoading: false,
+    anthropicError: null,
+    anthropicAuthUrl: null,
+    fetchAnthropicStatus: vi.fn().mockResolvedValue(undefined),
+    startAnthropicConnect: vi.fn().mockResolvedValue('https://auth.anthropic.com/oauth'),
+    completeAnthropicConnect: vi.fn().mockResolvedValue(undefined),
+    disconnectAnthropic: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+describe('AnthropicAccountSection', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(useIntegrationsStore).mockReturnValue(makeStore() as any)
+  })
+
+  it('mounts without error', async () => {
+    const { default: AnthropicAccountSection } = await import('../AnthropicAccountSection.vue')
+    const wrapper = mount(AnthropicAccountSection)
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('shows Connect button when anthropicConnected is false', async () => {
+    vi.mocked(useIntegrationsStore).mockReturnValue(makeStore({ anthropicConnected: false }) as any)
+    const { default: AnthropicAccountSection } = await import('../AnthropicAccountSection.vue')
+    const wrapper = mount(AnthropicAccountSection)
+    const btn = wrapper.find('[data-testid="anthropic-connect"]')
+    expect(btn.exists()).toBe(true)
+    expect(btn.text()).toContain('Connect')
+  })
+
+  it('shows Connected badge and Disconnect button when anthropicConnected is true', async () => {
+    vi.mocked(useIntegrationsStore).mockReturnValue(makeStore({ anthropicConnected: true }) as any)
+    const { default: AnthropicAccountSection } = await import('../AnthropicAccountSection.vue')
+    const wrapper = mount(AnthropicAccountSection)
+    expect(wrapper.text()).toContain('Connected')
+    const disconnectBtn = wrapper.find('[data-testid="anthropic-disconnect"]')
+    expect(disconnectBtn.exists()).toBe(true)
+  })
+
+  it('clicking Connect calls store.startAnthropicConnect and shows modal', async () => {
+    const startAnthropicConnect = vi.fn().mockResolvedValue('https://auth.anthropic.com/oauth')
+    vi.mocked(useIntegrationsStore).mockReturnValue(
+      makeStore({ anthropicConnected: false, startAnthropicConnect }) as any
+    )
+    const { default: AnthropicAccountSection } = await import('../AnthropicAccountSection.vue')
+    const wrapper = mount(AnthropicAccountSection)
+    await wrapper.find('[data-testid="anthropic-connect"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(startAnthropicConnect).toHaveBeenCalledOnce()
+    // Modal should appear — look for heading text
+    expect(wrapper.text()).toContain('Connect your Anthropic account')
+  })
+
+  it('Disconnect button shows inline confirmation on click', async () => {
+    vi.mocked(useIntegrationsStore).mockReturnValue(makeStore({ anthropicConnected: true }) as any)
+    const { default: AnthropicAccountSection } = await import('../AnthropicAccountSection.vue')
+    const wrapper = mount(AnthropicAccountSection)
+    await wrapper.find('[data-testid="anthropic-disconnect"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-testid="anthropic-disconnect-confirm"]').exists()).toBe(true)
+  })
+
+  it('clicking Confirm calls store.disconnectAnthropic', async () => {
+    const disconnectAnthropic = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(useIntegrationsStore).mockReturnValue(
+      makeStore({ anthropicConnected: true, disconnectAnthropic }) as any
+    )
+    const { default: AnthropicAccountSection } = await import('../AnthropicAccountSection.vue')
+    const wrapper = mount(AnthropicAccountSection)
+    // Show the confirmation first
+    await wrapper.find('[data-testid="anthropic-disconnect"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    await wrapper.find('[data-testid="anthropic-disconnect-confirm"]').trigger('click')
+    expect(disconnectAnthropic).toHaveBeenCalledOnce()
+  })
+
+  it('modal shows URL with copy button when anthropicAuthUrl is set', async () => {
+    const startAnthropicConnect = vi.fn().mockImplementation(async () => {
+      return 'https://auth.anthropic.com/oauth'
+    })
+    vi.mocked(useIntegrationsStore).mockReturnValue(
+      makeStore({
+        anthropicConnected: false,
+        anthropicAuthUrl: 'https://auth.anthropic.com/oauth',
+        startAnthropicConnect,
+      }) as any
+    )
+    const { default: AnthropicAccountSection } = await import('../AnthropicAccountSection.vue')
+    const wrapper = mount(AnthropicAccountSection)
+    await wrapper.find('[data-testid="anthropic-connect"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    // Should show the auth URL link
+    const link = wrapper.find('[data-testid="anthropic-auth-url"]')
+    expect(link.exists()).toBe(true)
+    // Should show copy button
+    const copyBtn = wrapper.find('[data-testid="anthropic-copy-url"]')
+    expect(copyBtn.exists()).toBe(true)
+  })
+
+  it('Submit calls store.completeAnthropicConnect with input value', async () => {
+    const completeAnthropicConnect = vi.fn().mockResolvedValue(undefined)
+    const startAnthropicConnect = vi.fn().mockResolvedValue('https://auth.anthropic.com/oauth')
+    vi.mocked(useIntegrationsStore).mockReturnValue(
+      makeStore({
+        anthropicConnected: false,
+        anthropicAuthUrl: 'https://auth.anthropic.com/oauth',
+        startAnthropicConnect,
+        completeAnthropicConnect,
+      }) as any
+    )
+    const { default: AnthropicAccountSection } = await import('../AnthropicAccountSection.vue')
+    const wrapper = mount(AnthropicAccountSection)
+    // Open the modal
+    await wrapper.find('[data-testid="anthropic-connect"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    // Enter code
+    const codeInput = wrapper.find('[data-testid="anthropic-code-input"]')
+    await codeInput.setValue('mycode123')
+    // Submit
+    await wrapper.find('[data-testid="anthropic-submit"]').trigger('click')
+    expect(completeAnthropicConnect).toHaveBeenCalledWith('mycode123')
+  })
+
+  it('modal error shown when store.anthropicError is set', async () => {
+    const startAnthropicConnect = vi.fn().mockResolvedValue('https://auth.anthropic.com/oauth')
+    vi.mocked(useIntegrationsStore).mockReturnValue(
+      makeStore({
+        anthropicConnected: false,
+        anthropicAuthUrl: 'https://auth.anthropic.com/oauth',
+        anthropicError: 'Invalid code',
+        startAnthropicConnect,
+      }) as any
+    )
+    const { default: AnthropicAccountSection } = await import('../AnthropicAccountSection.vue')
+    const wrapper = mount(AnthropicAccountSection)
+    // Open the modal
+    await wrapper.find('[data-testid="anthropic-connect"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    // Error should appear in the modal
+    expect(wrapper.text()).toContain('Invalid code')
+  })
+
+  it('calls fetchAnthropicStatus on mount', async () => {
+    const fetchAnthropicStatus = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(useIntegrationsStore).mockReturnValue(makeStore({ fetchAnthropicStatus }) as any)
+    const { default: AnthropicAccountSection } = await import('../AnthropicAccountSection.vue')
+    mount(AnthropicAccountSection)
+    expect(fetchAnthropicStatus).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/__tests__/AnthropicAccountSection.test.ts
+++ b/frontend/src/components/__tests__/AnthropicAccountSection.test.ts
@@ -23,6 +23,7 @@ function makeStore(overrides: Partial<{
   startAnthropicConnect: () => Promise<string | null>
   completeAnthropicConnect: (code: string) => Promise<void>
   disconnectAnthropic: () => Promise<void>
+  clearAnthropicFlowState: () => void
 }> = {}) {
   return {
     anthropicConnected: false,
@@ -33,6 +34,7 @@ function makeStore(overrides: Partial<{
     startAnthropicConnect: vi.fn().mockResolvedValue('https://auth.anthropic.com/oauth'),
     completeAnthropicConnect: vi.fn().mockResolvedValue(undefined),
     disconnectAnthropic: vi.fn().mockResolvedValue(undefined),
+    clearAnthropicFlowState: vi.fn(),
     ...overrides,
   }
 }
@@ -168,6 +170,145 @@ describe('AnthropicAccountSection', () => {
     await wrapper.vm.$nextTick()
     // Error should appear in the modal
     expect(wrapper.text()).toContain('Invalid code')
+  })
+
+  it('handleCancel clears codeInput, closes modal, and calls clearAnthropicFlowState', async () => {
+    const clearAnthropicFlowState = vi.fn()
+    const startAnthropicConnect = vi.fn().mockResolvedValue('https://auth.anthropic.com/oauth')
+    vi.mocked(useIntegrationsStore).mockReturnValue(
+      makeStore({ anthropicConnected: false, anthropicAuthUrl: 'https://auth.anthropic.com/oauth', startAnthropicConnect, clearAnthropicFlowState }) as any
+    )
+    const { default: AnthropicAccountSection } = await import('../AnthropicAccountSection.vue')
+    const wrapper = mount(AnthropicAccountSection)
+    // Open the modal
+    await wrapper.find('[data-testid="anthropic-connect"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    // Set some code
+    await wrapper.find('[data-testid="anthropic-code-input"]').setValue('somecode')
+    // Cancel
+    const cancelBtn = wrapper.findAll('button').find(b => b.text() === 'Cancel')
+    await cancelBtn!.trigger('click')
+    await wrapper.vm.$nextTick()
+    // Modal should be gone
+    expect(wrapper.find('[data-testid="anthropic-code-input"]').exists()).toBe(false)
+    // clearAnthropicFlowState should have been called
+    expect(clearAnthropicFlowState).toHaveBeenCalled()
+  })
+
+  it('handleConnect no-ops if already in non-idle phase (double-click guard)', async () => {
+    const startAnthropicConnect = vi.fn().mockResolvedValue('https://auth.anthropic.com/oauth')
+    vi.mocked(useIntegrationsStore).mockReturnValue(
+      makeStore({ anthropicConnected: false, startAnthropicConnect }) as any
+    )
+    const { default: AnthropicAccountSection } = await import('../AnthropicAccountSection.vue')
+    const wrapper = mount(AnthropicAccountSection)
+    const btn = wrapper.find('[data-testid="anthropic-connect"]')
+    // Fire two clicks without awaiting between them
+    btn.trigger('click')
+    btn.trigger('click')
+    await new Promise(r => setTimeout(r, 50))
+    await wrapper.vm.$nextTick()
+    expect(startAnthropicConnect).toHaveBeenCalledOnce()
+  })
+
+  it('modal closes on successful submit', async () => {
+    let connected = false
+    const completeAnthropicConnect = vi.fn().mockImplementation(async () => {
+      connected = true
+    })
+    const storeObj = makeStore({
+      anthropicConnected: false,
+      anthropicAuthUrl: 'https://auth.anthropic.com/oauth',
+      startAnthropicConnect: vi.fn().mockResolvedValue('https://auth.anthropic.com/oauth'),
+      completeAnthropicConnect,
+    })
+    // Make anthropicConnected reactive via getter
+    Object.defineProperty(storeObj, 'anthropicConnected', {
+      get: () => connected,
+      set: (v) => { connected = v },
+      configurable: true,
+      enumerable: true,
+    })
+    vi.mocked(useIntegrationsStore).mockReturnValue(storeObj as any)
+    const { default: AnthropicAccountSection } = await import('../AnthropicAccountSection.vue')
+    const wrapper = mount(AnthropicAccountSection)
+    // Open modal
+    await wrapper.find('[data-testid="anthropic-connect"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    // Enter code
+    await wrapper.find('[data-testid="anthropic-code-input"]').setValue('validcode')
+    // Submit
+    await wrapper.find('[data-testid="anthropic-submit"]').trigger('click')
+    await new Promise(r => setTimeout(r, 20))
+    await wrapper.vm.$nextTick()
+    // Modal should be gone (no code input visible)
+    expect(wrapper.find('[data-testid="anthropic-code-input"]').exists()).toBe(false)
+  })
+
+  it('modal stays open (awaiting_code) on failed submit', async () => {
+    const completeAnthropicConnect = vi.fn().mockImplementation(async () => {
+      // leaves anthropicError set, anthropicConnected false
+    })
+    const storeObj = makeStore({
+      anthropicConnected: false,
+      anthropicAuthUrl: 'https://auth.anthropic.com/oauth',
+      anthropicError: null,
+      startAnthropicConnect: vi.fn().mockResolvedValue('https://auth.anthropic.com/oauth'),
+      completeAnthropicConnect,
+    })
+    vi.mocked(useIntegrationsStore).mockReturnValue(storeObj as any)
+    const { default: AnthropicAccountSection } = await import('../AnthropicAccountSection.vue')
+    const wrapper = mount(AnthropicAccountSection)
+    // Open modal
+    await wrapper.find('[data-testid="anthropic-connect"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    await wrapper.find('[data-testid="anthropic-code-input"]').setValue('badcode')
+    await wrapper.find('[data-testid="anthropic-submit"]').trigger('click')
+    await new Promise(r => setTimeout(r, 20))
+    await wrapper.vm.$nextTick()
+    // Code input should still be visible (modal in awaiting_code)
+    expect(wrapper.find('[data-testid="anthropic-code-input"]').exists()).toBe(true)
+  })
+
+  it('error phase shown when startAnthropicConnect returns null', async () => {
+    const startAnthropicConnect = vi.fn().mockResolvedValue(null)
+    vi.mocked(useIntegrationsStore).mockReturnValue(
+      makeStore({ anthropicConnected: false, anthropicError: 'Failed to start connection. Please try again.', startAnthropicConnect }) as any
+    )
+    const { default: AnthropicAccountSection } = await import('../AnthropicAccountSection.vue')
+    const wrapper = mount(AnthropicAccountSection)
+    await wrapper.find('[data-testid="anthropic-connect"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    // Retry button should be visible
+    expect(wrapper.find('[data-testid="anthropic-retry"]').exists()).toBe(true)
+  })
+
+  it('disconnect confirm stays visible on disconnect error', async () => {
+    let errorState: string | null = null
+    const disconnectAnthropic = vi.fn().mockImplementation(async () => {
+      errorState = 'Failed to disconnect. Please try again.'
+    })
+    const storeObj = makeStore({
+      anthropicConnected: true,
+      disconnectAnthropic,
+    })
+    Object.defineProperty(storeObj, 'anthropicError', {
+      get: () => errorState,
+      configurable: true,
+      enumerable: true,
+    })
+    vi.mocked(useIntegrationsStore).mockReturnValue(storeObj as any)
+    const { default: AnthropicAccountSection } = await import('../AnthropicAccountSection.vue')
+    const wrapper = mount(AnthropicAccountSection)
+    // Click disconnect to show confirm row
+    await wrapper.find('[data-testid="anthropic-disconnect"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    // Click confirm
+    await wrapper.find('[data-testid="anthropic-disconnect-confirm"]').trigger('click')
+    await new Promise(r => setTimeout(r, 20))
+    await wrapper.vm.$nextTick()
+    // Confirm row should still be visible because disconnect failed
+    expect(wrapper.find('[data-testid="anthropic-disconnect-confirm"]').exists()).toBe(true)
   })
 
   it('calls fetchAnthropicStatus on mount', async () => {

--- a/frontend/src/stores/__tests__/integrations.test.ts
+++ b/frontend/src/stores/__tests__/integrations.test.ts
@@ -207,4 +207,236 @@ describe('useIntegrationsStore', () => {
       expect(window.location.href).toContain('/api/integrations/google/connect')
     })
   })
+
+  describe('fetchAnthropicStatus', () => {
+    it('sets anthropicConnected to true when GET returns { connected: true }', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ connected: true }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.fetchAnthropicStatus()
+
+      expect(store.anthropicConnected).toBe(true)
+    })
+
+    it('sets anthropicConnected to false when GET returns non-200', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.fetchAnthropicStatus()
+
+      expect(store.anthropicConnected).toBe(false)
+    })
+
+    it('sets anthropicLoading to false after fetch completes', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ connected: false }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.fetchAnthropicStatus()
+
+      expect(store.anthropicLoading).toBe(false)
+    })
+  })
+
+  describe('startAnthropicConnect', () => {
+    it('calls POST /api/integrations/anthropic/start', async () => {
+      const { api } = await import('../../lib/api')
+      const mockApi = vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ url: 'https://auth.example.com/oauth', expires_in: 300 }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.startAnthropicConnect()
+
+      expect(mockApi).toHaveBeenCalledWith(
+        '/api/integrations/anthropic/start',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+
+    it('sets anthropicAuthUrl to the returned url', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ url: 'https://auth.example.com/oauth', expires_in: 300 }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.startAnthropicConnect()
+
+      expect(store.anthropicAuthUrl).toBe('https://auth.example.com/oauth')
+    })
+
+    it('sets anthropicLoading to false after completing', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ url: 'https://auth.example.com/oauth', expires_in: 300 }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.startAnthropicConnect()
+
+      expect(store.anthropicLoading).toBe(false)
+    })
+
+    it('sets anthropicError on network failure', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockRejectedValueOnce(new Error('Network error'))
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.startAnthropicConnect()
+
+      expect(store.anthropicError).toBeTruthy()
+      expect(store.anthropicLoading).toBe(false)
+    })
+  })
+
+  describe('completeAnthropicConnect', () => {
+    it('calls POST /api/integrations/anthropic/complete with the code', async () => {
+      const { api } = await import('../../lib/api')
+      const mockApi = vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.completeAnthropicConnect('abc123')
+
+      expect(mockApi).toHaveBeenCalledWith(
+        '/api/integrations/anthropic/complete',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ code: 'abc123' }),
+        }),
+      )
+    })
+
+    it('sets anthropicConnected to true on { ok: true }', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.completeAnthropicConnect('mycode')
+
+      expect(store.anthropicConnected).toBe(true)
+    })
+
+    it('sets anthropicError on { ok: false, error: "..." }', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: false, error: 'Invalid code' }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.completeAnthropicConnect('badcode')
+
+      expect(store.anthropicError).toBe('Invalid code')
+      expect(store.anthropicConnected).toBe(false)
+    })
+
+    it('clears anthropicAuthUrl on success', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      store.anthropicAuthUrl = 'https://auth.example.com/oauth'
+      await store.completeAnthropicConnect('mycode')
+
+      expect(store.anthropicAuthUrl).toBeNull()
+    })
+  })
+
+  describe('disconnectAnthropic', () => {
+    it('calls DELETE /api/integrations/anthropic', async () => {
+      const { api } = await import('../../lib/api')
+      const mockApi = vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+        json: async () => ({}),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.disconnectAnthropic()
+
+      expect(mockApi).toHaveBeenCalledWith(
+        '/api/integrations/anthropic',
+        expect.objectContaining({ method: 'DELETE' }),
+      )
+    })
+
+    it('sets anthropicConnected to false on 204', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+        json: async () => ({}),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      store.anthropicConnected = true
+      await store.disconnectAnthropic()
+
+      expect(store.anthropicConnected).toBe(false)
+    })
+
+    it('keeps anthropicConnected true and sets anthropicError on failure', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({ detail: 'Server error' }),
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      store.anthropicConnected = true
+      await store.disconnectAnthropic()
+
+      expect(store.anthropicConnected).toBe(true)
+      expect(store.anthropicError).toBeTruthy()
+    })
+  })
 })

--- a/frontend/src/stores/__tests__/integrations.test.ts
+++ b/frontend/src/stores/__tests__/integrations.test.ts
@@ -370,6 +370,23 @@ describe('useIntegrationsStore', () => {
       expect(store.anthropicConnected).toBe(false)
     })
 
+    it('handles non-JSON 5xx response gracefully', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        json: async () => { throw new Error('not json') },
+      } as any)
+
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      await store.completeAnthropicConnect('mycode')
+
+      expect(store.anthropicError).toBe('Connection failed.')
+      expect(store.anthropicLoading).toBe(false)
+      expect(store.anthropicConnected).toBe(false)
+    })
+
     it('clears anthropicAuthUrl on success', async () => {
       const { api } = await import('../../lib/api')
       vi.mocked(api).mockResolvedValueOnce({
@@ -383,6 +400,18 @@ describe('useIntegrationsStore', () => {
       store.anthropicAuthUrl = 'https://auth.example.com/oauth'
       await store.completeAnthropicConnect('mycode')
 
+      expect(store.anthropicAuthUrl).toBeNull()
+    })
+  })
+
+  describe('clearAnthropicFlowState', () => {
+    it('clears both anthropicError and anthropicAuthUrl to null', async () => {
+      const { useIntegrationsStore } = await import('../integrations')
+      const store = useIntegrationsStore()
+      store.anthropicError = 'Some previous error'
+      store.anthropicAuthUrl = 'https://auth.example.com/oauth'
+      store.clearAnthropicFlowState()
+      expect(store.anthropicError).toBeNull()
       expect(store.anthropicAuthUrl).toBeNull()
     })
   })

--- a/frontend/src/stores/integrations.ts
+++ b/frontend/src/stores/integrations.ts
@@ -8,6 +8,12 @@ export const useIntegrationsStore = defineStore('integrations', () => {
   const error = ref<string | null>(null)
   const lastSyncedAt = ref<string | null>(null)
 
+  // Anthropic Account state
+  const anthropicConnected = ref(false)
+  const anthropicLoading = ref(false)
+  const anthropicError = ref<string | null>(null)
+  const anthropicAuthUrl = ref<string | null>(null)
+
   /**
    * Check Google Calendar connection status.
    * Uses GET /api/integrations/google/calendars as a proxy:
@@ -76,6 +82,102 @@ export const useIntegrationsStore = defineStore('integrations', () => {
     }
   }
 
+  /**
+   * Check Anthropic account connection status.
+   * GET /api/integrations/anthropic → { connected: boolean }
+   */
+  async function fetchAnthropicStatus() {
+    anthropicLoading.value = true
+    anthropicError.value = null
+    try {
+      const resp = await api('/api/integrations/anthropic')
+      if (resp.ok) {
+        const data = await resp.json()
+        anthropicConnected.value = data.connected === true
+      } else {
+        anthropicConnected.value = false
+      }
+    } catch {
+      anthropicConnected.value = false
+      anthropicError.value = 'Could not reach server. Check your connection.'
+    } finally {
+      anthropicLoading.value = false
+    }
+  }
+
+  /**
+   * Start Anthropic OAuth flow.
+   * POST /api/integrations/anthropic/start → { url: string, expires_in: number }
+   */
+  async function startAnthropicConnect(): Promise<string | null> {
+    anthropicLoading.value = true
+    anthropicError.value = null
+    try {
+      const resp = await api('/api/integrations/anthropic/start', { method: 'POST' })
+      if (resp.ok) {
+        const data = await resp.json()
+        anthropicAuthUrl.value = data.url
+        return data.url
+      } else {
+        anthropicError.value = 'Failed to start connection. Please try again.'
+        return null
+      }
+    } catch {
+      anthropicError.value = 'Could not reach server. Check your connection.'
+      return null
+    } finally {
+      anthropicLoading.value = false
+    }
+  }
+
+  /**
+   * Complete Anthropic OAuth flow with code.
+   * POST /api/integrations/anthropic/complete { code } → { ok: true } | { ok: false, error: string }
+   */
+  async function completeAnthropicConnect(code: string) {
+    anthropicLoading.value = true
+    anthropicError.value = null
+    try {
+      const resp = await api('/api/integrations/anthropic/complete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code }),
+      })
+      const data = await resp.json()
+      if (data.ok) {
+        anthropicConnected.value = true
+        anthropicAuthUrl.value = null
+      } else {
+        anthropicError.value = data.error ?? 'Connection failed.'
+      }
+    } catch {
+      anthropicError.value = 'Could not reach server. Check your connection.'
+    } finally {
+      anthropicLoading.value = false
+    }
+  }
+
+  /**
+   * Disconnect Anthropic account.
+   * DELETE /api/integrations/anthropic → 204
+   */
+  async function disconnectAnthropic() {
+    anthropicLoading.value = true
+    anthropicError.value = null
+    try {
+      const resp = await api('/api/integrations/anthropic', { method: 'DELETE' })
+      if (resp.ok) {
+        anthropicConnected.value = false
+      } else {
+        anthropicError.value = 'Failed to disconnect. Please try again.'
+      }
+    } catch {
+      anthropicError.value = 'Failed to disconnect. Please try again.'
+    } finally {
+      anthropicLoading.value = false
+    }
+  }
+
   return {
     gcalConnected,
     loading,
@@ -85,5 +187,13 @@ export const useIntegrationsStore = defineStore('integrations', () => {
     connectGCal,
     disconnectGCal,
     syncNow,
+    anthropicConnected,
+    anthropicLoading,
+    anthropicError,
+    anthropicAuthUrl,
+    fetchAnthropicStatus,
+    startAnthropicConnect,
+    completeAnthropicConnect,
+    disconnectAnthropic,
   }
 })

--- a/frontend/src/stores/integrations.ts
+++ b/frontend/src/stores/integrations.ts
@@ -83,6 +83,15 @@ export const useIntegrationsStore = defineStore('integrations', () => {
   }
 
   /**
+   * Clear transient Anthropic flow state (error and auth URL).
+   * Call before starting a new flow, on cancel, and after modal closes on success.
+   */
+  function clearAnthropicFlowState() {
+    anthropicError.value = null
+    anthropicAuthUrl.value = null
+  }
+
+  /**
    * Check Anthropic account connection status.
    * GET /api/integrations/anthropic → { connected: boolean }
    */
@@ -114,10 +123,10 @@ export const useIntegrationsStore = defineStore('integrations', () => {
     anthropicError.value = null
     try {
       const resp = await api('/api/integrations/anthropic/start', { method: 'POST' })
-      if (resp.ok) {
-        const data = await resp.json()
+      const data = await resp.json().catch(() => ({}))
+      if (resp.ok && data.url) {
         anthropicAuthUrl.value = data.url
-        return data.url
+        return data.url as string
       } else {
         anthropicError.value = 'Failed to start connection. Please try again.'
         return null
@@ -143,6 +152,11 @@ export const useIntegrationsStore = defineStore('integrations', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ code }),
       })
+      if (!resp.ok) {
+        const errData = await resp.json().catch(() => ({}))
+        anthropicError.value = errData.detail ?? errData.error ?? 'Connection failed.'
+        return
+      }
       const data = await resp.json()
       if (data.ok) {
         anthropicConnected.value = true
@@ -191,6 +205,7 @@ export const useIntegrationsStore = defineStore('integrations', () => {
     anthropicLoading,
     anthropicError,
     anthropicAuthUrl,
+    clearAnthropicFlowState,
     fetchAnthropicStatus,
     startAnthropicConnect,
     completeAnthropicConnect,

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from 'vue'
 import { useAuthStore } from '../stores/auth'
 import { api } from '../lib/api'
 import GoogleCalendarSection from '../components/GoogleCalendarSection.vue'
+import AnthropicAccountSection from '../components/AnthropicAccountSection.vue'
 import ConnectionsSection from '../components/ConnectionsSection.vue'
 
 const auth = useAuthStore()
@@ -265,6 +266,9 @@ async function linkTelegram() {
 
       <!-- Google Calendar Integration -->
       <GoogleCalendarSection />
+
+      <!-- Anthropic Account Integration -->
+      <AnthropicAccountSection />
 
       <!-- OAuth Connections -->
       <section class="mb-8">


### PR DESCRIPTION
## Summary

- Adds **Anthropic Account** tile to the Settings / Integrations section, mounted alongside Google Calendar
- Implements a two-phase connect modal: Phase 1 spawns the auth URL from `POST /api/integrations/anthropic/start` and displays it with a copy button; Phase 2 accepts the user-pasted code and calls `POST /api/integrations/anthropic/complete`
- Inline disconnect with confirmation step calls `DELETE /api/integrations/anthropic`
- Extends `useIntegrationsStore` with Anthropic-specific state (`anthropicConnected`, `anthropicLoading`, `anthropicError`, `anthropicAuthUrl`) and four actions — GCal state untouched

## Endpoint contracts expected from api-teammate
```
GET  /api/integrations/anthropic          → { connected: boolean }
POST /api/integrations/anthropic/start    → { url: string, expires_in: number }
POST /api/integrations/anthropic/complete body: { code: string } → { ok: true } | { ok: false, error: string }
DELETE /api/integrations/anthropic        → 204
```

## Test plan
- [x] 174/174 Vitest tests pass (`npm test`)
- [x] `npm run build` — zero type errors
- [x] Store tests: `fetchAnthropicStatus`, `startAnthropicConnect`, `completeAnthropicConnect`, `disconnectAnthropic` — all edge cases covered
- [x] Component tests: tile state, connect button, modal phases, disconnect confirmation, copy URL button