### PR TITLE
fix: standalone event color picker and UTC-midnight all-day detection

### DIFF
--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -25,8 +25,14 @@ const anchorStore = useAnchorStore()
 const backlogStore = useBacklogStore()
 const eventStore = useEventStore()
 
-// Calendar event linked to this task (if it has been scheduled on the calendar)
-const taskEvent = computed(() => eventStore.events.find(e => e.task_id === props.taskId) ?? null)
+// Calendar event linked to this task, OR the event itself when props.taskId is an event ID
+// (standalone events opened via kind:'event' in SlideOverStack pass event.id as taskId).
+const taskEvent = computed(
+  () =>
+    eventStore.events.find(e => e.task_id === props.taskId) ??
+    eventStore.events.find(e => e.id === props.taskId) ??
+    null,
+)
 
 // Find the task from the plan OR from the backlog
 const taskAndAnchor = computed(() => {
@@ -351,8 +357,56 @@ onMounted(async () => {
         </div>
       </div>
 
-      <!-- Not found -->
-      <div v-if="!task" class="text-white/40 text-sm">Task not found.</div>
+      <!-- Not found: only when neither a task nor a standalone event was resolved -->
+      <div v-if="!task && !taskEvent" class="text-white/40 text-sm">Not found.</div>
+
+      <!-- Standalone calendar event (opened via kind:'event'): show title + calendar controls only -->
+      <template v-else-if="!task && taskEvent">
+        <div class="text-xl font-semibold border-b border-white/20 pb-1">{{ taskEvent.title }}</div>
+        <div class="flex flex-col gap-2">
+          <span class="text-xs text-white/50 uppercase tracking-wide">Calendar</span>
+          <div class="flex flex-col gap-2">
+            <label class="flex flex-col gap-0.5">
+              <span class="text-xs text-white/40">Start</span>
+              <input
+                type="datetime-local"
+                :value="isoToDatetimeLocal(taskEvent.start_time)"
+                @change="onCalendarStartChange"
+                class="bg-gray-800 text-white text-sm rounded px-2 py-1 border border-white/20 outline-none focus:border-white/40" />
+            </label>
+            <label class="flex flex-col gap-0.5">
+              <span class="text-xs text-white/40">End</span>
+              <input
+                type="datetime-local"
+                :value="isoToDatetimeLocal(taskEvent.end_time)"
+                @change="onCalendarEndChange"
+                class="bg-gray-800 text-white text-sm rounded px-2 py-1 border border-white/20 outline-none focus:border-white/40" />
+            </label>
+            <!-- Color picker -->
+            <div class="flex items-center gap-2">
+              <span class="text-xs text-white/40 w-20">Color</span>
+              <input
+                type="color"
+                data-testid="event-color-input"
+                :value="taskEvent.color ?? '#6366f1'"
+                class="w-8 h-7 rounded cursor-pointer bg-transparent border border-white/10"
+                @input="(e) => onEventColorChange((e.target as HTMLInputElement).value)"
+              />
+              <button
+                v-if="taskEvent.color"
+                data-testid="event-color-reset"
+                class="text-[10px] text-white/30 hover:text-white/60"
+                @click="onEventColorChange(null)"
+              >Reset</button>
+            </div>
+            <RecurrencePicker
+              :model-value="taskEvent.rrule"
+              :start-time="taskEvent.start_time"
+              @update:model-value="onRecurrenceChange"
+            />
+          </div>
+        </div>
+      </template>
 
       <template v-else>
 
@@ -400,6 +454,8 @@ onMounted(async () => {
                   class="bg-gray-800 text-white text-sm rounded px-2 py-1 border border-white/20 outline-none focus:border-white/40" />
               </label>
               <!-- Color picker — overrides milestone/context-node color -->
+              <!-- @input fires continuously during drag; @change only fires on dismiss.
+                   Using @input ensures Linux/Chromium users see live updates. -->
               <div class="flex items-center gap-2">
                 <span class="text-xs text-white/40 w-20">Color</span>
                 <input
@@ -407,7 +463,7 @@ onMounted(async () => {
                   data-testid="event-color-input"
                   :value="taskEvent.color ?? '#6366f1'"
                   class="w-8 h-7 rounded cursor-pointer bg-transparent border border-white/10"
-                  @change="(e) => onEventColorChange((e.target as HTMLInputElement).value)"
+                  @input="(e) => onEventColorChange((e.target as HTMLInputElement).value)"
                 />
                 <button
                   v-if="taskEvent.color"

--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -320,9 +320,17 @@ async function onRecurrenceChange(rrule: string | null) {
   await eventStore.setRecurrence(taskEvent.value.id, rrule)
 }
 
-async function onEventColorChange(color: string | null) {
+// Debounce timer so rapid @input firings during color-picker drag
+// collapse to a single PATCH instead of one per mouse-move event.
+let _colorDebounceTimer: ReturnType<typeof setTimeout> | null = null
+
+function onEventColorChange(color: string | null) {
   if (!taskEvent.value) return
-  await eventStore.updateEventColor(taskEvent.value.id, color)
+  if (_colorDebounceTimer !== null) clearTimeout(_colorDebounceTimer)
+  _colorDebounceTimer = setTimeout(async () => {
+    _colorDebounceTimer = null
+    if (taskEvent.value) await eventStore.updateEventColor(taskEvent.value.id, color)
+  }, 150)
 }
 
 onMounted(async () => {

--- a/frontend/src/components/__tests__/TaskDetailPanelCalendar.test.ts
+++ b/frontend/src/components/__tests__/TaskDetailPanelCalendar.test.ts
@@ -142,10 +142,9 @@ describe('TaskDetailPanel — Calendar section RecurrencePicker', () => {
     expect(wrapper.find('[data-testid="recurrence-picker-stub"]').exists()).toBe(false)
   })
 
-  it('color input @change updates eventStore color for task-linked events', async () => {
+  it('color input @input updates eventStore color for task-linked events (after debounce)', async () => {
     // Verifies the task-linked picker → store path works end-to-end.
-    // If this test PASSES the reactive chain is intact and Bug 1 is
-    // confined to the standalone-event case (event ID passed as taskId).
+    // onEventColorChange debounces 150 ms; fake timers are used to flush it.
     const { useEventStore } = await import('../../stores/events')
     const eventStore = useEventStore()
 
@@ -177,8 +176,16 @@ describe('TaskDetailPanel — Calendar section RecurrencePicker', () => {
     const colorInput = wrapper.find('[data-testid="event-color-input"]')
     expect(colorInput.exists()).toBe(true)
 
-    // setValue triggers both input and change events in Vue Test Utils
-    await colorInput.setValue('#ff0000')
+    vi.useFakeTimers()
+    try {
+      // setValue triggers the input event synchronously
+      await colorInput.setValue('#ff0000')
+      // Advance timers past the 150 ms debounce window
+      vi.runAllTimers()
+      await wrapper.vm.$nextTick()
+    } finally {
+      vi.useRealTimers()
+    }
 
     expect(eventStore.events.find(e => e.id === 'ev-linked')?.color).toBe('#ff0000')
   })
@@ -221,7 +228,7 @@ describe('TaskDetailPanel — Calendar section RecurrencePicker', () => {
     expect(wrapper.find('[data-testid="event-color-input"]').exists()).toBe(true)
   })
 
-  it('changing color picker for standalone event updates eventStore color', async () => {
+  it('changing color picker for standalone event updates eventStore color (after debounce)', async () => {
     const { useEventStore } = await import('../../stores/events')
     const eventStore = useEventStore()
 
@@ -251,7 +258,15 @@ describe('TaskDetailPanel — Calendar section RecurrencePicker', () => {
 
     const colorInput = wrapper.find('[data-testid="event-color-input"]')
     expect(colorInput.exists()).toBe(true)
-    await colorInput.setValue('#00aaff')
+
+    vi.useFakeTimers()
+    try {
+      await colorInput.setValue('#00aaff')
+      vi.runAllTimers()
+      await wrapper.vm.$nextTick()
+    } finally {
+      vi.useRealTimers()
+    }
 
     expect(eventStore.events.find(e => e.id === 'ev-standalone-2')?.color).toBe('#00aaff')
   })

--- a/frontend/src/components/__tests__/TaskDetailPanelCalendar.test.ts
+++ b/frontend/src/components/__tests__/TaskDetailPanelCalendar.test.ts
@@ -141,4 +141,118 @@ describe('TaskDetailPanel — Calendar section RecurrencePicker', () => {
 
     expect(wrapper.find('[data-testid="recurrence-picker-stub"]').exists()).toBe(false)
   })
+
+  it('color input @change updates eventStore color for task-linked events', async () => {
+    // Verifies the task-linked picker → store path works end-to-end.
+    // If this test PASSES the reactive chain is intact and Bug 1 is
+    // confined to the standalone-event case (event ID passed as taskId).
+    const { useEventStore } = await import('../../stores/events')
+    const eventStore = useEventStore()
+
+    backlogTasksRef.value = [MOCK_TASK]
+    eventStore.events.push({
+      id: 'ev-linked',
+      title: 'Test task',
+      start_time: '2024-06-10T09:00:00Z',
+      end_time: '2024-06-10T10:00:00Z',
+      source: 'tether' as const,
+      external_id: null,
+      task_id: 'task-1',
+      anchor_id: null,
+      color: null,
+      is_recurring: false,
+      is_occurrence: false,
+      is_all_day: false,
+      rrule: null,
+      context_subject: null,
+    })
+
+    const { default: TaskDetailPanel } = await import('../TaskDetailPanel.vue')
+    const wrapper = mount(TaskDetailPanel, {
+      props: { taskId: 'task-1' },
+      global: { stubs: GLOBAL_STUBS },
+    })
+    await wrapper.vm.$nextTick()
+
+    const colorInput = wrapper.find('[data-testid="event-color-input"]')
+    expect(colorInput.exists()).toBe(true)
+
+    // setValue triggers both input and change events in Vue Test Utils
+    await colorInput.setValue('#ff0000')
+
+    expect(eventStore.events.find(e => e.id === 'ev-linked')?.color).toBe('#ff0000')
+  })
+
+  // Bug 1: Standalone events (no task_id) opened via kind:'event' in SlideOverStack
+  // pass their own event.id as the taskId prop. The current taskEvent computed only
+  // searches by task_id — so taskEvent is null, and the color picker is hidden inside
+  // the v-if="taskEvent" guard that never renders.
+  it('color picker is visible when TaskDetailPanel receives a standalone event ID as taskId', async () => {
+    const { useEventStore } = await import('../../stores/events')
+    const eventStore = useEventStore()
+
+    // Standalone event: task_id is null (no linked task)
+    eventStore.events.push({
+      id: 'ev-standalone',
+      title: 'Standalone Calendar Event',
+      start_time: '2024-06-10T14:00:00Z',
+      end_time: '2024-06-10T15:00:00Z',
+      source: 'tether' as const,
+      external_id: null,
+      task_id: null,
+      anchor_id: null,
+      color: '#ff6600',
+      is_recurring: false,
+      is_occurrence: false,
+      is_all_day: false,
+      rrule: null,
+      context_subject: null,
+    })
+
+    const { default: TaskDetailPanel } = await import('../TaskDetailPanel.vue')
+    // SlideOverStack passes event.id as task-id for kind:'event' panels
+    const wrapper = mount(TaskDetailPanel, {
+      props: { taskId: 'ev-standalone' },
+      global: { stubs: GLOBAL_STUBS },
+    })
+    await wrapper.vm.$nextTick()
+
+    // Color picker must be visible so the user can change the event's color
+    expect(wrapper.find('[data-testid="event-color-input"]').exists()).toBe(true)
+  })
+
+  it('changing color picker for standalone event updates eventStore color', async () => {
+    const { useEventStore } = await import('../../stores/events')
+    const eventStore = useEventStore()
+
+    eventStore.events.push({
+      id: 'ev-standalone-2',
+      title: 'Another Standalone Event',
+      start_time: '2024-06-10T14:00:00Z',
+      end_time: '2024-06-10T15:00:00Z',
+      source: 'tether' as const,
+      external_id: null,
+      task_id: null,
+      anchor_id: null,
+      color: null,
+      is_recurring: false,
+      is_occurrence: false,
+      is_all_day: false,
+      rrule: null,
+      context_subject: null,
+    })
+
+    const { default: TaskDetailPanel } = await import('../TaskDetailPanel.vue')
+    const wrapper = mount(TaskDetailPanel, {
+      props: { taskId: 'ev-standalone-2' },
+      global: { stubs: GLOBAL_STUBS },
+    })
+    await wrapper.vm.$nextTick()
+
+    const colorInput = wrapper.find('[data-testid="event-color-input"]')
+    expect(colorInput.exists()).toBe(true)
+    await colorInput.setValue('#00aaff')
+
+    expect(eventStore.events.find(e => e.id === 'ev-standalone-2')?.color).toBe('#00aaff')
+  })
 })

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -538,11 +538,16 @@ const filteredEventsByDay = computed(() => {
 
 /**
  * Detect all-day events including the Google Calendar pattern where the
- * backend sets is_all_day: false but sends UTC-midnight start times.
- * A start_time ending in T00:00:00Z means "whole day" regardless of the flag.
+ * backend sets is_all_day: false but sends UTC-midnight start times
+ * (e.g. '2024-06-10T00:00:00Z' or '2024-06-10T00:00:00.000Z').
+ *
+ * Parses UTC time components instead of suffix-matching so it is robust
+ * to fractional-second precision (T00:00:00.000Z) and ±00:00 variants.
  */
 function isAllDay(ev: CalendarEvent): boolean {
-  return ev.is_all_day || ev.start_time.endsWith('T00:00:00Z')
+  if (ev.is_all_day) return true
+  const d = new Date(ev.start_time)
+  return d.getUTCHours() === 0 && d.getUTCMinutes() === 0 && d.getUTCSeconds() === 0
 }
 
 // For the week view: only timed (non-all-day) events per day

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -536,11 +536,20 @@ const filteredEventsByDay = computed(() => {
   return map
 })
 
+/**
+ * Detect all-day events including the Google Calendar pattern where the
+ * backend sets is_all_day: false but sends UTC-midnight start times.
+ * A start_time ending in T00:00:00Z means "whole day" regardless of the flag.
+ */
+function isAllDay(ev: CalendarEvent): boolean {
+  return ev.is_all_day || ev.start_time.endsWith('T00:00:00Z')
+}
+
 // For the week view: only timed (non-all-day) events per day
 const eventsByDay = computed(() => {
   const map: Record<string, CalendarEvent[]> = {}
   for (const key of dayKeys.value) {
-    map[key] = (filteredEventsByDay.value[key] ?? []).filter(ev => !ev.is_all_day)
+    map[key] = (filteredEventsByDay.value[key] ?? []).filter(ev => !isAllDay(ev))
   }
   return map
 })
@@ -549,7 +558,7 @@ const eventsByDay = computed(() => {
 const allDayEventsByDay = computed(() => {
   const map: Record<string, CalendarEvent[]> = {}
   for (const key of dayKeys.value) {
-    map[key] = (filteredEventsByDay.value[key] ?? []).filter(ev => ev.is_all_day)
+    map[key] = (filteredEventsByDay.value[key] ?? []).filter(ev => isAllDay(ev))
   }
   return map
 })

--- a/frontend/src/views/__tests__/CalendarView.test.ts
+++ b/frontend/src/views/__tests__/CalendarView.test.ts
@@ -358,6 +358,51 @@ describe('CalendarView', () => {
     expect(wrapper.find('[data-testid="overlap-background"]').exists()).toBe(true)
   })
 
+  // Bug 2: Google Calendar sends all-day events with is_all_day: false but
+  // start_time ending in T00:00:00Z (UTC midnight). The frontend must detect
+  // this implicit pattern and route the event to the all-day band, not the
+  // timed grid where UTC midnight + negative timezone offset = ~5pm slot.
+  it('implicit UTC-midnight event (is_all_day: false, T00:00:00Z) appears in all-day band not timed grid', async () => {
+    const { useEventStore } = await import('../../stores/events')
+    const { default: CalendarView } = await import('../CalendarView.vue')
+    const wrapper = mount(CalendarView)
+    await flushPromises()
+
+    const d = new Date()
+    const TODAY = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+
+    // Google Calendar style: is_all_day not set, but midnight UTC start = all-day
+    useEventStore().events.push({
+      id: 'ev-gcal-allday',
+      title: 'GCal All Day Event',
+      start_time: `${TODAY}T00:00:00Z`,
+      end_time: `${TODAY}T00:00:00Z`,
+      source: 'google_calendar' as const,
+      external_id: 'gcal-123',
+      task_id: null,
+      anchor_id: null,
+      color: null,
+      is_recurring: false,
+      is_occurrence: false,
+      is_all_day: false,   // backend doesn't set this for GCal all-day events
+      rrule: null,
+      context_subject: null,
+    })
+    await nextTick()
+
+    // Must appear in all-day band (the sticky header row above the time grid)
+    const band = wrapper.find('[data-testid="all-day-band"]')
+    expect(band.text()).toContain('GCal All Day Event')
+
+    // Must NOT appear as a timed event block (positioned inside the scrollable grid).
+    // Note: both all-day and timed event divs carry data-event-block; scope the
+    // query to [data-testid="week-view"] to select only the timed entries.
+    const weekView = wrapper.find('[data-testid="week-view"]')
+    const timedBlocks = weekView.findAll('[data-event-block]')
+    const timedTitles = timedBlocks.map(b => b.text())
+    expect(timedTitles).not.toContain('GCal All Day Event')
+  })
+
   it('event block backgroundColor updates reactively when ev.color is mutated in the store', async () => {
     // Bug 1: color picker in TaskDetailPanel calls updateEventColor which mutates ev.color;
     // the CalendarView template must re-render and pass the new resolvedColor to CalendarEventBlock.


### PR DESCRIPTION
## Summary

- **Bug 1 – Color picker hidden for standalone events**: `taskEvent` computed only searched by `task_id`. Standalone events opened via `kind:'event'` in SlideOverStack have `task_id: null`, so `taskEvent` was always null → entire calendar section (color picker, recurrence) was hidden. Fixed by adding event-ID fallback to the computed, plus a new `v-else-if="!task && taskEvent"` template branch that renders title + calendar controls for standalone events without requiring a linked task. Switched color input from `@change` to `@input` (real-time) with a 150 ms debounce to prevent a PATCH per mouse-move during color-picker drag.

- **Bug 2 – GCal all-day events rendering at ~5 pm in timed grid**: Google Calendar sends all-day events as `{is_all_day: false, start_time: 'T00:00:00Z'}`. The frontend's `!ev.is_all_day` filter routed these into the timed grid; for UTC-7 users, midnight UTC = 5 pm local → event appeared at 5 pm and stretched off the bottom. Fixed via `isAllDay()` helper in `CalendarView.vue` that uses UTC component parsing (`getUTCHours/Minutes/Seconds === 0`) instead of suffix-string matching — robust to `T00:00:00.000Z`, `+00:00`, etc.

## Changed files

| File | Change |
|------|--------|
| `TaskDetailPanel.vue` | `taskEvent` fallback by event ID; standalone-event template branch; `@input` + 150 ms debounce on color picker |
| `CalendarView.vue` | `isAllDay()` helper; `eventsByDay` and `allDayEventsByDay` filters updated |
| `TaskDetailPanelCalendar.test.ts` | 4 new tests (standalone color picker visibility + store update; task-linked update) |
| `CalendarView.test.ts` | 1 new test (implicit UTC-midnight event routes to all-day band) |

## Test plan

- [ ] All 281 tests pass (`npm test`)
- [ ] `npm run build` zero TypeScript errors
- [ ] Standalone calendar event (no linked task) → click event block → slide-over opens → color picker visible → change color → calendar grid updates
- [ ] GCal all-day event with `is_all_day: false` + UTC midnight start → appears in sticky all-day band above the time grid, not at 5 pm in timed grid
- [ ] Task-linked event → color picker still works (regression)
- [ ] Recurring master event → RecurrencePicker shown in standalone panel