### PR TITLE
fix: use pexpect PTY for claude setup-token OAuth flow

### DIFF
--- a/api/routes/integrations.py
+++ b/api/routes/integrations.py
@@ -27,8 +27,6 @@ import tempfile
 import time
 import urllib.parse
 
-import pexpect
-
 import asyncpg
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Request
@@ -135,6 +133,8 @@ def _start_pexpect_sync(temp_dir: str, env: dict) -> tuple:
     A wide PTY (220 cols) prevents the URL from line-wrapping, which would
     break the URL regex. Returns ``(None, None)`` on any failure.
     """
+    import pexpect  # lazy — keeps module importable when pexpect is not installed
+
     try:
         child = pexpect.spawn(
             "claude",
@@ -180,6 +180,8 @@ def _complete_pexpect_sync(child, code: str) -> str:
       ``"timeout"`` — process did not exit within 30 seconds
       ``"error"``   — unexpected error (e.g. sendline raised, process died early)
     """
+    import pexpect  # lazy — keeps module importable when pexpect is not installed
+
     try:
         child.sendline(code)
     except Exception:

--- a/api/routes/integrations.py
+++ b/api/routes/integrations.py
@@ -27,6 +27,8 @@ import tempfile
 import time
 import urllib.parse
 
+import pexpect
+
 import asyncpg
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Request
@@ -68,6 +70,10 @@ _start_locks: dict[str, asyncio.Lock] = {}
 
 _SETUP_TTL = 600  # seconds
 _ANTHROPIC_URL_RE = re.compile(r"https://\S+")
+# Strip ANSI CSI escape sequences emitted by TUI programs on a PTY.
+# Note: does not strip OSC8 hyperlinks (\x1b]8;;URL\x07...\x1b]8;;\x07) — if
+# claude setup-token ever uses them, extend this regex or post-process the URL.
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 _ANTHROPIC_URL_SCHEME = "https"
 _ANTHROPIC_URL_NETLOC = "console.anthropic.com"
 
@@ -103,22 +109,107 @@ class AnthropicCompleteBody(BaseModel):
 # Anthropic OAuth helpers
 # ---------------------------------------------------------------------------
 
-async def _reap_proc(proc) -> None:
-    """Kill a subprocess and await it to release transport/pipe FDs."""
+def _close_child_sync(child) -> None:
+    """Kill a pexpect child and close its PTY file descriptor."""
     try:
-        proc.kill()
+        child.close(force=True)
     except Exception:
         pass
+
+
+async def _reap_child(child) -> None:
+    """Async wrapper: close pexpect child in an executor to avoid blocking the event loop."""
+    loop = asyncio.get_running_loop()
     try:
-        await proc.wait()
+        await loop.run_in_executor(None, _close_child_sync, child)
     except Exception:
         pass
+
+
+def _start_pexpect_sync(temp_dir: str, env: dict) -> tuple:
+    """Spawn ``claude setup-token`` in a PTY, wait for the auth URL, return ``(child, url)``.
+
+    The child process stays alive after this returns, waiting for the user to
+    paste the OAuth code via :func:`_complete_pexpect_sync`.
+
+    A wide PTY (220 cols) prevents the URL from line-wrapping, which would
+    break the URL regex. Returns ``(None, None)`` on any failure.
+    """
+    try:
+        child = pexpect.spawn(
+            "claude",
+            args=["setup-token"],
+            env=env,
+            dimensions=(24, 220),
+            timeout=15,
+        )
+    except Exception:
+        logger.exception("pexpect.spawn failed for claude setup-token")
+        return None, None
+
+    buf = ""
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        try:
+            chunk = child.read_nonblocking(4096, timeout=1)
+            # Accumulate raw bytes first, then strip ANSI from the full buffer
+            # so CSI sequences that straddle read boundaries are handled correctly.
+            buf += chunk.decode(errors="replace")
+            clean = _ANSI_ESCAPE_RE.sub("", buf)
+            url = _extract_anthropic_url(clean)
+            if url:
+                return child, url
+        except pexpect.TIMEOUT:
+            continue
+        except pexpect.EOF:
+            # Process exited before showing a URL.
+            break
+        except Exception:
+            logger.exception("Unexpected error reading pexpect child output")
+            break
+
+    _close_child_sync(child)
+    return None, None
+
+
+def _complete_pexpect_sync(child, code: str) -> str:
+    """Send the OAuth code to the waiting pexpect child and wait for it to exit.
+
+    Returns:
+      ``"ok"``      — process exited with code 0 (credentials written)
+      ``"failed"``  — process exited with non-zero code (setup rejected the code)
+      ``"timeout"`` — process did not exit within 30 seconds
+      ``"error"``   — unexpected error (e.g. sendline raised, process died early)
+    """
+    try:
+        child.sendline(code)
+    except Exception:
+        logger.exception("pexpect sendline failed — child likely already exited")
+        return "error"
+
+    try:
+        child.expect(pexpect.EOF, timeout=30)
+    except pexpect.TIMEOUT:
+        return "timeout"
+    except Exception:
+        logger.exception("pexpect expect(EOF) failed")
+        return "error"
+
+    # Reap the process so that exitstatus is populated.
+    try:
+        child.close()
+    except Exception:
+        pass
+
+    if child.exitstatus not in (0, None):
+        return "failed"
+    return "ok"
 
 
 async def _sweep_expired_setups() -> None:
     """Kill and remove any pending setups older than _SETUP_TTL seconds.
 
-    Each killed process is reaped via an asyncio task so pipe FDs are released
+    Each killed child is reaped via an asyncio task so PTY FDs are released
     without blocking the current request.
     """
     now = time.time()
@@ -128,9 +219,9 @@ async def _sweep_expired_setups() -> None:
     ]
     for uid in expired_users:
         entry = _pending_setups.pop(uid)
-        proc = entry.get("proc")
-        if proc is not None:
-            asyncio.create_task(_reap_proc(proc))
+        child = entry.get("child")
+        if child is not None:
+            asyncio.create_task(_reap_child(child))
         temp_dir = entry.get("temp_dir")
         if temp_dir:
             shutil.rmtree(temp_dir, ignore_errors=True)
@@ -470,50 +561,36 @@ async def anthropic_start(
 
 
 async def _anthropic_start_locked(request: Request, user_id: str) -> dict:
-    """Inner /start logic — called while holding the per-user _start_locks entry."""
+    """Inner /start logic — called while holding the per-user _start_locks entry.
+
+    Spawns ``claude setup-token`` in a PTY via :func:`_start_pexpect_sync` (run
+    in a thread-pool executor so the event loop is not blocked). The pexpect child
+    stays alive waiting for the user to paste their OAuth code.
+    """
     if user_id in _pending_setups:
         old = _pending_setups.pop(user_id)
-        asyncio.create_task(_reap_proc(old["proc"]))
+        asyncio.create_task(_reap_child(old["child"]))
         shutil.rmtree(old.get("temp_dir", ""), ignore_errors=True)
 
     temp_dir = tempfile.mkdtemp()
     env_override = {**os.environ, "CLAUDE_CONFIG_DIR": temp_dir}
 
+    loop = asyncio.get_running_loop()
     try:
-        proc = await asyncio.create_subprocess_exec(
-            "claude", "setup-token",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            stdin=asyncio.subprocess.PIPE,
-            env=env_override,
+        child, url = await loop.run_in_executor(
+            None, _start_pexpect_sync, temp_dir, env_override
         )
     except Exception as exc:
         shutil.rmtree(temp_dir, ignore_errors=True)
-        logger.exception("Failed to spawn claude setup-token: %s", exc)
+        logger.exception("Unexpected error from _start_pexpect_sync: %s", exc)
         raise HTTPException(status_code=502, detail="Failed to spawn setup process")
 
-    async def _read_stream(stream):
-        try:
-            return await asyncio.wait_for(stream.read(65536), timeout=10.0)
-        except asyncio.TimeoutError:
-            return b""
-
-    stdout_bytes, stderr_bytes = await asyncio.gather(
-        _read_stream(proc.stdout),
-        _read_stream(proc.stderr),
-    )
-
-    combined = stdout_bytes.decode(errors="replace") + stderr_bytes.decode(errors="replace")
-    url = _extract_anthropic_url(combined)
-
     if url is None:
-        proc.kill()
-        await proc.wait()
         shutil.rmtree(temp_dir, ignore_errors=True)
         raise HTTPException(status_code=502, detail="Auth URL not found in claude output")
 
     _pending_setups[user_id] = {
-        "proc": proc,
+        "child": child,
         "temp_dir": temp_dir,
         "started_at": time.time(),
     }
@@ -531,43 +608,41 @@ async def anthropic_complete(
     body: AnthropicCompleteBody,
     _auth: dict = Depends(auth_dependency),
 ):
-    """Submit the OAuth code to the waiting subprocess and persist credentials."""
+    """Submit the OAuth code to the waiting pexpect child and persist credentials."""
     user_id = request.state.user_id
 
     entry = _pending_setups.get(user_id)
     if entry is None:
         raise HTTPException(status_code=404, detail="No pending Anthropic setup for this user")
 
-    proc = entry["proc"]
+    child = entry["child"]
     temp_dir = entry["temp_dir"]
 
-    # Write code to subprocess stdin — guard against broken pipe if process already exited.
-    try:
-        proc.stdin.write((body.code + "\n").encode())
-        await asyncio.wait_for(proc.stdin.drain(), timeout=5.0)
-    except (BrokenPipeError, ConnectionResetError, asyncio.TimeoutError, OSError) as exc:
+    loop = asyncio.get_running_loop()
+    result = await loop.run_in_executor(None, _complete_pexpect_sync, child, body.code)
+
+    if result == "error":
         _pending_setups.pop(user_id, None)
-        asyncio.create_task(_reap_proc(proc))
+        asyncio.create_task(_reap_child(child))
         shutil.rmtree(temp_dir, ignore_errors=True)
-        logger.warning("anthropic_complete: stdin write failed (%s)", exc)
         raise HTTPException(status_code=502, detail="Setup process closed unexpectedly")
 
-    try:
-        await asyncio.wait_for(proc.wait(), timeout=30.0)
-    except asyncio.TimeoutError:
+    if result == "timeout":
         _pending_setups.pop(user_id, None)
-        asyncio.create_task(_reap_proc(proc))
+        asyncio.create_task(_reap_child(child))
         shutil.rmtree(temp_dir, ignore_errors=True)
         raise HTTPException(status_code=504, detail="Setup process timed out")
 
-    if proc.returncode != 0:
-        _pending_setups.pop(user_id, None)
+    # "ok" or "failed" — child already reaped by _complete_pexpect_sync.
+    _pending_setups.pop(user_id, None)
+
+    if result == "failed":
         shutil.rmtree(temp_dir, ignore_errors=True)
         return {"ok": False, "error": "setup failed"}
 
+    # result == "ok"
     creds_file = pathlib.Path(temp_dir) / ".credentials.json"
     if not creds_file.exists():
-        _pending_setups.pop(user_id, None)
         shutil.rmtree(temp_dir, ignore_errors=True)
         return {"ok": False, "error": "credentials file not found"}
 
@@ -577,7 +652,6 @@ async def anthropic_complete(
     if vault is not None:
         await vault.store_initial(user_id, blob_dict)
 
-    _pending_setups.pop(user_id, None)
     shutil.rmtree(temp_dir, ignore_errors=True)
 
     return {"ok": True}

--- a/api/routes/integrations.py
+++ b/api/routes/integrations.py
@@ -141,14 +141,13 @@ def _start_pexpect_sync(temp_dir: str, env: dict) -> tuple:
             args=["setup-token"],
             env=env,
             dimensions=(24, 220),
-            timeout=15,
         )
     except Exception:
         logger.exception("pexpect.spawn failed for claude setup-token")
         return None, None
 
     buf = ""
-    deadline = time.time() + 15
+    deadline = time.time() + 30
     while time.time() < deadline:
         try:
             chunk = child.read_nonblocking(4096, timeout=1)
@@ -201,9 +200,9 @@ def _complete_pexpect_sync(child, code: str) -> str:
     except Exception:
         pass
 
-    if child.exitstatus not in (0, None):
-        return "failed"
-    return "ok"
+    # exitstatus is None when the process was killed by a signal — treat that as
+    # failure, not success.  Only exitstatus == 0 means the setup succeeded.
+    return "ok" if child.exitstatus == 0 else "failed"
 
 
 async def _sweep_expired_setups() -> None:
@@ -611,7 +610,9 @@ async def anthropic_complete(
     """Submit the OAuth code to the waiting pexpect child and persist credentials."""
     user_id = request.state.user_id
 
-    entry = _pending_setups.get(user_id)
+    # Pop atomically: prevents two concurrent /complete calls from racing on the
+    # same child process or temp dir.
+    entry = _pending_setups.pop(user_id, None)
     if entry is None:
         raise HTTPException(status_code=404, detail="No pending Anthropic setup for this user")
 
@@ -622,20 +623,16 @@ async def anthropic_complete(
     result = await loop.run_in_executor(None, _complete_pexpect_sync, child, body.code)
 
     if result == "error":
-        _pending_setups.pop(user_id, None)
         asyncio.create_task(_reap_child(child))
         shutil.rmtree(temp_dir, ignore_errors=True)
         raise HTTPException(status_code=502, detail="Setup process closed unexpectedly")
 
     if result == "timeout":
-        _pending_setups.pop(user_id, None)
         asyncio.create_task(_reap_child(child))
         shutil.rmtree(temp_dir, ignore_errors=True)
         raise HTTPException(status_code=504, detail="Setup process timed out")
 
     # "ok" or "failed" — child already reaped by _complete_pexpect_sync.
-    _pending_setups.pop(user_id, None)
-
     if result == "failed":
         shutil.rmtree(temp_dir, ignore_errors=True)
         return {"ok": False, "error": "setup failed"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ python-dateutil>=2.9
 slowapi>=0.1.9
 werkzeug>=3.0
 websockets>=12.0
+pexpect>=4.8

--- a/tests/api/test_anthropic_integrations.py
+++ b/tests/api/test_anthropic_integrations.py
@@ -64,23 +64,15 @@ def clear_pending_setups():
 
 @pytest.mark.asyncio
 async def test_start_returns_url(auth_app_client):
-    """Mock subprocess that outputs a URL on stdout; response contains url + expires_in."""
+    """Mock _start_pexpect_sync returning a URL; response contains url + expires_in."""
     client, mock_vault, app = auth_app_client
 
-    url_line = b"Visit https://console.anthropic.com/oauth/authorize?code=abc123 to authorize\n"
-
-    mock_proc = AsyncMock()
-    mock_proc.stdout = AsyncMock()
-    mock_proc.stderr = AsyncMock()
-    mock_proc.stdout.read = AsyncMock(return_value=url_line)
-    mock_proc.stderr.read = AsyncMock(return_value=b"")
-    mock_proc.pid = 12345
-    mock_proc.kill = MagicMock()
-    mock_proc.wait = AsyncMock(return_value=None)
+    mock_child = MagicMock()
+    expected_url = "https://console.anthropic.com/oauth/authorize?code=abc123"
 
     with patch(
-        "api.routes.integrations.asyncio.create_subprocess_exec",
-        return_value=mock_proc,
+        "api.routes.integrations._start_pexpect_sync",
+        return_value=(mock_child, expected_url),
     ):
         resp = await client.post("/api/integrations/anthropic/start")
 
@@ -101,21 +93,12 @@ async def test_start_returns_url(auth_app_client):
 
 @pytest.mark.asyncio
 async def test_start_no_url_returns_502(auth_app_client):
-    """When subprocess returns no URL, endpoint returns 502."""
+    """When _start_pexpect_sync finds no URL, endpoint returns 502."""
     client, mock_vault, app = auth_app_client
 
-    mock_proc = AsyncMock()
-    mock_proc.stdout = AsyncMock()
-    mock_proc.stderr = AsyncMock()
-    mock_proc.stdout.read = AsyncMock(return_value=b"some garbage output no url here\n")
-    mock_proc.stderr.read = AsyncMock(return_value=b"error: something went wrong\n")
-    mock_proc.pid = 12346
-    mock_proc.kill = MagicMock()
-    mock_proc.wait = AsyncMock(return_value=None)
-
     with patch(
-        "api.routes.integrations.asyncio.create_subprocess_exec",
-        return_value=mock_proc,
+        "api.routes.integrations._start_pexpect_sync",
+        return_value=(None, None),
     ):
         resp = await client.post("/api/integrations/anthropic/start")
 
@@ -137,24 +120,23 @@ async def test_complete_success(auth_app_client, tmp_path):
     creds_file = tmp_path / ".credentials.json"
     creds_file.write_text(json.dumps(creds_data))
 
-    mock_proc = AsyncMock()
-    mock_proc.stdin = AsyncMock()
-    mock_proc.stdin.write = MagicMock()
-    mock_proc.stdin.drain = AsyncMock()
-    mock_proc.wait = AsyncMock(return_value=0)
-    mock_proc.returncode = 0
+    mock_child = MagicMock()
 
     # Stash fake pending entry for TEST_USER_ID
     ant_routes._pending_setups[TEST_USER_ID] = {
-        "proc": mock_proc,
+        "child": mock_child,
         "temp_dir": str(tmp_path),
         "started_at": time.time(),
     }
 
-    resp = await client.post(
-        "/api/integrations/anthropic/complete",
-        json={"code": "auth_code_123"},
-    )
+    with patch(
+        "api.routes.integrations._complete_pexpect_sync",
+        return_value="ok",
+    ):
+        resp = await client.post(
+            "/api/integrations/anthropic/complete",
+            json={"code": "auth_code_123"},
+        )
 
     assert resp.status_code == 200
     data = resp.json()
@@ -185,29 +167,22 @@ async def test_complete_no_pending_returns_404(auth_app_client):
 
 @pytest.mark.asyncio
 async def test_complete_process_timeout_returns_504(auth_app_client, tmp_path):
-    """If asyncio.wait_for times out on proc.wait(), endpoint returns 504."""
+    """If _complete_pexpect_sync returns 'timeout', endpoint returns 504."""
     import api.routes.integrations as ant_routes
     client, mock_vault, app = auth_app_client
 
-    mock_proc = AsyncMock()
-    mock_proc.stdin = AsyncMock()
-    mock_proc.stdin.write = MagicMock()
-    mock_proc.stdin.drain = AsyncMock()
-    # wait() returns 0 immediately; asyncio.wait_for is patched below to raise TimeoutError
-    # so the direct await proc.wait() after kill() won't hang
-    mock_proc.wait = AsyncMock(return_value=0)
-    mock_proc.kill = MagicMock()
+    mock_child = MagicMock()
 
     ant_routes._pending_setups[TEST_USER_ID] = {
-        "proc": mock_proc,
+        "child": mock_child,
         "temp_dir": str(tmp_path),
         "started_at": time.time(),
     }
 
-    # wait_for is called twice: once for stdin.drain (should succeed → None),
-    # once for proc.wait (should timeout). Use a side_effect list.
-    mock_wait_for = AsyncMock(side_effect=[None, asyncio.TimeoutError()])
-    with patch("api.routes.integrations.asyncio.wait_for", mock_wait_for):
+    with patch(
+        "api.routes.integrations._complete_pexpect_sync",
+        return_value="timeout",
+    ):
         resp = await client.post(
             "/api/integrations/anthropic/complete",
             json={"code": "code"},
@@ -300,27 +275,26 @@ async def test_start_requires_auth():
 
 @pytest.mark.asyncio
 async def test_complete_broken_pipe_returns_502(auth_app_client, tmp_path):
-    """If stdin.drain raises BrokenPipeError (process already exited), return 502."""
+    """If _complete_pexpect_sync returns 'error' (e.g. sendline failed), return 502."""
     import api.routes.integrations as routes
     client, mock_vault, app = auth_app_client
 
-    mock_proc = AsyncMock()
-    mock_proc.stdin = AsyncMock()
-    mock_proc.stdin.write = MagicMock()
-    mock_proc.stdin.drain = AsyncMock(side_effect=BrokenPipeError("pipe broken"))
-    mock_proc.kill = MagicMock()
-    mock_proc.wait = AsyncMock(return_value=None)
+    mock_child = MagicMock()
 
     routes._pending_setups[TEST_USER_ID] = {
-        "proc": mock_proc,
+        "child": mock_child,
         "temp_dir": str(tmp_path),
         "started_at": time.time(),
     }
 
-    resp = await client.post(
-        "/api/integrations/anthropic/complete",
-        json={"code": "code"},
-    )
+    with patch(
+        "api.routes.integrations._complete_pexpect_sync",
+        return_value="error",
+    ):
+        resp = await client.post(
+            "/api/integrations/anthropic/complete",
+            json={"code": "code"},
+        )
 
     assert resp.status_code == 502
     # Entry should be cleaned up


### PR DESCRIPTION
## Problem

`POST /api/integrations/anthropic/start` was silently hanging in production. `claude setup-token` is a TUI binary that checks `isatty()` — when connected to a pipe (what `asyncio.create_subprocess_exec` with `PIPE` gives), it suppresses the OAuth URL and blocks indefinitely.

## Fix

Rewrites the Anthropic OAuth helpers to use `pexpect.spawn`, which allocates a real PTY via `pty.openpty()`, making `isatty()` return `True`. The child process then emits the URL as expected.

Key design decisions:
- **220-col PTY** (`dimensions=(24, 220)`) prevents the URL from line-wrapping, which would break the regex
- **ANSI stripping on accumulated buffer** (`_ANSI_ESCAPE_RE.sub("", buf)`) handles CSI sequences that straddle read boundaries; documented limitation re: OSC8 hyperlinks
- **`run_in_executor`** wraps all blocking pexpect calls so the FastAPI event loop is not blocked
- **Atomic pop** in `/complete` prevents concurrent calls racing on the same child + temp dir
- **`exitstatus == 0`** check (not `not in (0, None)`) correctly treats signal-killed processes as failure
- **30s URL-extraction deadline** (up from 15s) — more headroom on a Pi under load

## Changes

- `api/routes/integrations.py` — replace asyncio subprocess approach with pexpect helpers (`_start_pexpect_sync`, `_complete_pexpect_sync`, `_close_child_sync`, `_reap_child`); pending registry uses `"child"` key instead of `"proc"`
- `requirements.txt` — add `pexpect>=4.8`
- `tests/api/test_anthropic_integrations.py` — update mocks to patch sync helpers (`MagicMock`, not `AsyncMock`) and use `"child"` key in pending setup stubs

## Test plan

- [ ] All 12 `test_anthropic_integrations.py` tests pass ✅
- [ ] Full suite (493 tests) passes ✅
- [ ] Smoke test: `POST /api/integrations/anthropic/start` on Pi emits URL from `claude setup-token`

🤖 Generated with [Claude Code](https://claude.com/claude-code)