### PR TITLE
feat(db): Stream A anchor-recurring tasks — create, expansion, scope delete

### DIFF
--- a/db/migrations/versions/2a3b4c5d6e7f_add_color_to_tasks.py
+++ b/db/migrations/versions/2a3b4c5d6e7f_add_color_to_tasks.py
@@ -1,0 +1,27 @@
+"""Add color column to tasks table.
+
+Anchor-recurring task masters need a per-task color so the frontend
+can render them with the same color affordance as regular tasks.
+The column is NULL by default so existing rows are unaffected.
+
+Revision ID: 2a3b4c5d6e7f
+Revises: 1cd716bba331
+Create Date: 2026-04-29
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "2a3b4c5d6e7f"
+down_revision: Union[str, Sequence[str], None] = "1cd716bba331"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # color — optional display color for task rows (e.g. anchor-recurring masters)
+    op.execute("ALTER TABLE tasks ADD COLUMN color TEXT NULL")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE tasks DROP COLUMN IF EXISTS color")

--- a/db/pg_queries/__init__.py
+++ b/db/pg_queries/__init__.py
@@ -17,6 +17,8 @@ from db.pg_queries.tasks import (
     get_subtasks, create_subtask, update_subtask, delete_subtask, reorder_subtasks,
     resolve_blocked_status,
     promote_task_to_event, get_events_for_range, update_event_time,
+    create_anchor_recurring_master, set_task_rrule,
+    delete_anchor_occurrence, truncate_anchor_series,
 )
 from db.pg_queries.context import (
     upsert_context_entry, get_context_entries, delete_context_entry, rename_context_subject,

--- a/db/pg_queries/plans.py
+++ b/db/pg_queries/plans.py
@@ -1,8 +1,10 @@
 """Async Postgres queries — plans table and related."""
 from __future__ import annotations
+import datetime as _dt
 import uuid as _uuid
 
 import asyncpg
+from dateutil.rrule import rrulestr as _rrulestr
 
 
 async def upsert_plan(conn: asyncpg.Connection, date: str) -> None:
@@ -14,6 +16,20 @@ async def upsert_plan(conn: asyncpg.Connection, date: str) -> None:
         """,
         date,
     )
+
+
+def _anchor_recurring_occurs_on(rrule_str: str, date_str: str) -> bool:
+    """Return True if the rrule fires on the given calendar date (date-only, ignoring time).
+
+    Accepts rrule strings with or without the 'RRULE:' prefix, and with or
+    without an embedded DTSTART line.
+    """
+    target_date = _dt.date.fromisoformat(date_str)
+    dtstart = _dt.datetime(target_date.year, target_date.month, target_date.day, 0, 0, 0)
+    window_end = dtstart + _dt.timedelta(days=1)
+    rule = _rrulestr(rrule_str, dtstart=dtstart, ignoretz=True)
+    occurrences = rule.between(dtstart, window_end, inc=True)
+    return len(occurrences) > 0
 
 
 async def get_plan(conn: asyncpg.Connection, date: str) -> dict:
@@ -40,6 +56,59 @@ async def get_plan(conn: asyncpg.Connection, date: str) -> dict:
         if aid not in anchors:
             anchors[aid] = {"tasks": [], "notes": row["notes"]}
         anchors[aid]["tasks"].append(_row_to_task(row))
+
+    # Expand anchor-recurring masters for this date (on-demand, RLS scoped)
+    master_rows = await conn.fetch(
+        """
+        SELECT uuid, anchor_id, text, status, notes, position,
+               rrule, color, context_subject, context_node_id,
+               followup_config, description, version, exdates
+        FROM tasks
+        WHERE anchor_id IS NOT NULL
+          AND rrule IS NOT NULL
+          AND plan_date IS NULL
+          AND recurrence_id IS NULL
+          AND start_time IS NULL
+          AND (source_status IS NULL OR source_status != 'cancelled')
+        ORDER BY anchor_id, position
+        """,
+    )
+    for master in master_rows:
+        rrule_str = master["rrule"]
+        if not _anchor_recurring_occurs_on(rrule_str, date):
+            continue
+        # Check exdates — stored as plain ISO date strings for anchor-recurring tasks
+        exdates = list(master["exdates"] or [])
+        if date in exdates:
+            continue
+        # Skip if there's already an exception occurrence row for this date
+        exception = await conn.fetchrow(
+            "SELECT uuid FROM tasks WHERE recurrence_id = $1 AND plan_date = $2",
+            str(master["uuid"]), date,
+        )
+        if exception:
+            continue  # Exception row already picked up by plan_date query above
+        aid = str(master["anchor_id"])
+        if aid not in anchors:
+            anchors[aid] = {"tasks": [], "notes": master["notes"]}
+        anchors[aid]["tasks"].append({
+            "id": str(master["uuid"]),
+            "text": master["text"],
+            "status": master["status"] or "pending",
+            "position": master["position"] or 0,
+            "description": master["description"],
+            "context_subject": master["context_subject"],
+            "context_node_id": str(master["context_node_id"]) if master["context_node_id"] else None,
+            "followup_config": master["followup_config"],
+            "version": master["version"] or 0,
+            "anchor_id": aid,
+            "plan_date": date,
+            "rrule": rrule_str,
+            "color": master["color"],
+            "is_recurring_master": True,
+            "blocks": [],
+            "blocked_by": [],
+        })
 
     all_uuids = [t["id"] for a in anchors.values() for t in a["tasks"] if t["id"]]
     if all_uuids:

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -1609,3 +1609,117 @@ async def _update_event_time_all(
         new_master_start, new_master_end, new_rrule, _uuid.UUID(event_uuid),
     )
     return _row_to_event(row) if row else None
+
+
+# ---------------------------------------------------------------------------
+# Anchor-recurring task helpers
+# ---------------------------------------------------------------------------
+
+async def create_anchor_recurring_master(
+    conn: asyncpg.Connection,
+    user_id: str,
+    anchor_id: str,
+    text: str,
+    rrule: str,
+    notes: str | None = None,
+    color: str | None = None,
+) -> str:
+    """Create an anchor-recurring master task.
+
+    plan_date=NULL, start_time=NULL, recurrence_id=NULL.
+    Occurrences are synthesized on-demand by get_plan().
+    """
+    new_id = _uuid.uuid4()
+    await conn.execute(
+        """
+        INSERT INTO tasks (uuid, user_id, anchor_id, text, rrule, notes, color,
+                           plan_date, start_time, end_time, recurrence_id, status, position)
+        VALUES ($1, $2::uuid, $3::uuid, $4, $5, $6, $7,
+                NULL, NULL, NULL, NULL, 'pending', 0)
+        """,
+        new_id, user_id, anchor_id, text, rrule, notes, color,
+    )
+    return str(new_id)
+
+
+async def set_task_rrule(
+    conn: asyncpg.Connection,
+    task_id: str,
+    rrule: str | None,
+) -> None:
+    """Set or clear rrule on an anchor task.
+
+    Setting: clears plan_date (task becomes a recurring master) and deletes any
+    pre-existing occurrence rows.
+    Clearing: restores plan_date to today so the task remains visible in today's plan
+    rather than falling into backlog; also clears recurrence_id and exdates.
+    """
+    import datetime as _datetime_mod
+    if rrule is not None:
+        await conn.execute(
+            "UPDATE tasks SET rrule=$1, plan_date=NULL WHERE uuid=$2::uuid",
+            rrule, task_id,
+        )
+        await conn.execute(
+            "DELETE FROM tasks WHERE recurrence_id=$1",
+            task_id,
+        )
+    else:
+        today = _datetime_mod.date.today().isoformat()
+        await conn.execute(
+            "UPDATE tasks SET rrule=NULL, plan_date=$1, exdates='{}' WHERE uuid=$2::uuid",
+            today, task_id,
+        )
+
+
+async def delete_anchor_occurrence(
+    conn: asyncpg.Connection,
+    master_id: str,
+    date_str: str,
+) -> None:
+    """scope=this: suppress one occurrence of an anchor-recurring series.
+
+    Appends the plain ISO date string to the master's exdates array.
+    Idempotent — does not add duplicates.
+    """
+    row = await conn.fetchrow(
+        "SELECT exdates FROM tasks WHERE uuid=$1::uuid", master_id
+    )
+    if row is None:
+        return
+    existing = list(row["exdates"] or [])
+    if date_str not in existing:
+        existing.append(date_str)
+    await conn.execute(
+        "UPDATE tasks SET exdates=$1, version=version+1 WHERE uuid=$2::uuid",
+        existing, master_id,
+    )
+
+
+async def truncate_anchor_series(
+    conn: asyncpg.Connection,
+    master_id: str,
+    from_date_str: str,
+) -> None:
+    """scope=this_and_future: truncate anchor-recurring series before from_date.
+
+    Sets UNTIL on the master's rrule to midnight UTC of the day before from_date,
+    so occurrences on or after from_date no longer appear.
+    Uses the existing _rrule_set_until helper.
+    """
+    import datetime as _dt_mod
+    row = await conn.fetchrow(
+        "SELECT rrule FROM tasks WHERE uuid=$1::uuid", master_id
+    )
+    if row is None or not row["rrule"]:
+        return
+    from_date = _dt_mod.date.fromisoformat(from_date_str)
+    until_dt = _dt_mod.datetime(
+        from_date.year, from_date.month, from_date.day, 0, 0, 0,
+        tzinfo=_dt_mod.timezone.utc,
+    ) - _dt_mod.timedelta(days=1)
+    new_rrule = _rrule_set_until(row["rrule"], until_dt)
+    await conn.execute(
+        "UPDATE tasks SET rrule=$1, version=version+1 WHERE uuid=$2::uuid",
+        new_rrule, master_id,
+    )

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -1615,6 +1615,25 @@ async def _update_event_time_all(
 # Anchor-recurring task helpers
 # ---------------------------------------------------------------------------
 
+
+def _ensure_anchor_dtstart(rrule_str: str, anchor_date_iso: str) -> str:
+    """Prepend DTSTART:YYYYMMDD to an rrule if not already present.
+
+    Without an explicit DTSTART, dateutil resolves ambiguous patterns (e.g.
+    FREQ=WEEKLY without BYDAY) using the dtstart passed at query time.  In
+    _anchor_recurring_occurs_on the query-time dtstart is the target date
+    itself, which makes every day match its own weekday — a daily-like
+    over-match.  Embedding a DTSTART at series-creation time anchors the
+    series to the correct weekday/day-of-month so FREQ=WEEKLY fires on the
+    same weekday the series started.
+    """
+    if "DTSTART" in rrule_str.upper():
+        return rrule_str
+    compact = anchor_date_iso.replace("-", "")  # "2026-04-29" → "20260429"
+    rrule_line = rrule_str if rrule_str.upper().startswith("RRULE:") else f"RRULE:{rrule_str}"
+    return f"DTSTART:{compact}\n{rrule_line}"
+
+
 async def create_anchor_recurring_master(
     conn: asyncpg.Connection,
     user_id: str,
@@ -1628,7 +1647,12 @@ async def create_anchor_recurring_master(
 
     plan_date=NULL, start_time=NULL, recurrence_id=NULL.
     Occurrences are synthesized on-demand by get_plan().
+    A DTSTART:YYYYMMDD is embedded in the rrule (using today's date) so that
+    bare FREQ=WEEKLY/MONTHLY rules anchor to the correct weekday/day-of-month.
     """
+    import datetime as _dt_today
+    today_iso = _dt_today.date.today().isoformat()
+    anchored_rrule = _ensure_anchor_dtstart(rrule, today_iso)
     new_id = _uuid.uuid4()
     await conn.execute(
         """
@@ -1637,7 +1661,7 @@ async def create_anchor_recurring_master(
         VALUES ($1, $2::uuid, $3::uuid, $4, $5, $6, $7,
                 NULL, NULL, NULL, NULL, 'pending', 0)
         """,
-        new_id, user_id, anchor_id, text, rrule, notes, color,
+        new_id, user_id, anchor_id, text, anchored_rrule, notes, color,
     )
     return str(new_id)
 
@@ -1650,15 +1674,26 @@ async def set_task_rrule(
     """Set or clear rrule on an anchor task.
 
     Setting: clears plan_date (task becomes a recurring master) and deletes any
-    pre-existing occurrence rows.
+    pre-existing occurrence rows.  A DTSTART:YYYYMMDD is embedded using the
+    task's current plan_date (preserving the existing schedule anchor) or
+    today's date if the task has no plan_date.
     Clearing: restores plan_date to today so the task remains visible in today's plan
     rather than falling into backlog; also clears recurrence_id and exdates.
     """
     import datetime as _datetime_mod
     if rrule is not None:
+        # Fetch current plan_date to use as the series anchor
+        row = await conn.fetchrow(
+            "SELECT plan_date FROM tasks WHERE uuid=$1::uuid", task_id
+        )
+        anchor_date = (
+            row["plan_date"].isoformat() if row and row["plan_date"] else
+            _datetime_mod.date.today().isoformat()
+        )
+        anchored_rrule = _ensure_anchor_dtstart(rrule, anchor_date)
         await conn.execute(
-            "UPDATE tasks SET rrule=$1, plan_date=NULL WHERE uuid=$2::uuid",
-            rrule, task_id,
+            "UPDATE tasks SET rrule=$1, plan_date=NULL, version=version+1 WHERE uuid=$2::uuid",
+            anchored_rrule, task_id,
         )
         await conn.execute(
             "DELETE FROM tasks WHERE recurrence_id=$1",
@@ -1667,7 +1702,7 @@ async def set_task_rrule(
     else:
         today = _datetime_mod.date.today().isoformat()
         await conn.execute(
-            "UPDATE tasks SET rrule=NULL, plan_date=$1, exdates='{}' WHERE uuid=$2::uuid",
+            "UPDATE tasks SET rrule=NULL, plan_date=$1, exdates='{}', version=version+1 WHERE uuid=$2::uuid",
             today, task_id,
         )
 

--- a/tests/db/test_anchor_recurrence.py
+++ b/tests/db/test_anchor_recurrence.py
@@ -130,3 +130,55 @@ async def test_truncate_anchor_series_sets_until(conn):
     row = await conn.fetchrow("SELECT rrule FROM tasks WHERE uuid=$1::uuid", master_id)
     # UNTIL should be 2026-05-09 (day before from_date)
     assert "UNTIL=20260509" in row["rrule"]
+
+
+async def test_create_anchor_recurring_master_embeds_dtstart(conn):
+    """DTSTART should be embedded so FREQ=WEEKLY anchors to the correct weekday.
+
+    Without DTSTART, _anchor_recurring_occurs_on would use target_date as dtstart,
+    making every day match its own weekday (FREQ=WEEKLY would behave like FREQ=DAILY).
+    """
+    from db.pg_queries.tasks import create_anchor_recurring_master
+    anchor_id = str(_uuid_mod.uuid4())
+    master_id = await create_anchor_recurring_master(
+        conn, TEST_USER_ID, anchor_id, "Weekly stand-up", "RRULE:FREQ=WEEKLY"
+    )
+    row = await conn.fetchrow("SELECT rrule FROM tasks WHERE uuid=$1::uuid", master_id)
+    assert "DTSTART" in row["rrule"], (
+        "create_anchor_recurring_master must embed DTSTART so bare FREQ=WEEKLY "
+        "anchors to the creation weekday, not over-matches every day"
+    )
+    assert "FREQ=WEEKLY" in row["rrule"]
+
+
+async def test_set_task_rrule_embeds_dtstart_from_plan_date(conn):
+    """set_task_rrule should embed DTSTART from the task's plan_date."""
+    from db.pg_queries.tasks import set_task_rrule
+    anchor_id = str(_uuid_mod.uuid4())
+    # Task scheduled on a Monday (2026-05-04)
+    plain_id = await conn.fetchval(
+        """INSERT INTO tasks (uuid, user_id, anchor_id, plan_date, text, status, position)
+           VALUES ($1, $2::uuid, $3::uuid, '2026-05-04', 'Stand-up', 'pending', 0) RETURNING uuid::text""",
+        str(_uuid_mod.uuid4()), TEST_USER_ID, anchor_id,
+    )
+    await set_task_rrule(conn, plain_id, "RRULE:FREQ=WEEKLY")
+    row = await conn.fetchrow("SELECT rrule FROM tasks WHERE uuid=$1::uuid", plain_id)
+    # DTSTART should be embedded with the original plan_date
+    assert "DTSTART:20260504" in row["rrule"], (
+        "set_task_rrule must embed DTSTART from original plan_date to preserve weekday anchor"
+    )
+
+
+async def test_set_task_rrule_bumps_version(conn):
+    """set_task_rrule must bump version for stale-read detection."""
+    from db.pg_queries.tasks import set_task_rrule
+    anchor_id = str(_uuid_mod.uuid4())
+    plain_id = await conn.fetchval(
+        """INSERT INTO tasks (uuid, user_id, anchor_id, plan_date, text, status, position)
+           VALUES ($1, $2::uuid, $3::uuid, '2026-05-05', 'Stand-up', 'pending', 0) RETURNING uuid::text""",
+        str(_uuid_mod.uuid4()), TEST_USER_ID, anchor_id,
+    )
+    v_before = await conn.fetchval("SELECT version FROM tasks WHERE uuid=$1::uuid", plain_id)
+    await set_task_rrule(conn, plain_id, "RRULE:FREQ=DAILY")
+    v_after = await conn.fetchval("SELECT version FROM tasks WHERE uuid=$1::uuid", plain_id)
+    assert v_after > v_before, "set_task_rrule must bump version"

--- a/tests/db/test_anchor_recurrence.py
+++ b/tests/db/test_anchor_recurrence.py
@@ -1,0 +1,132 @@
+"""DB-level tests for anchor-recurring task expansion (Tasks 1–5 Stream A)."""
+from __future__ import annotations
+import uuid as _uuid_mod
+import pytest
+
+from tests.db.pg_conftest import conn, TEST_USER_ID  # noqa: F401
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_create_anchor_recurring_master_returns_uuid(conn):
+    from db.pg_queries.tasks import create_anchor_recurring_master
+    anchor_id = str(_uuid_mod.uuid4())
+    master_id = await create_anchor_recurring_master(
+        conn, TEST_USER_ID, anchor_id,
+        text="Daily stand-up", rrule="RRULE:FREQ=DAILY"
+    )
+    assert master_id is not None
+    row = await conn.fetchrow("SELECT uuid, plan_date, anchor_id, rrule, start_time FROM tasks WHERE uuid=$1::uuid", master_id)
+    assert row is not None
+    assert row["plan_date"] is None
+    assert row["start_time"] is None
+    assert str(row["anchor_id"]) == anchor_id
+    assert "FREQ=DAILY" in row["rrule"]
+
+
+async def test_set_task_rrule_converts_to_master(conn):
+    from db.pg_queries.tasks import set_task_rrule
+    anchor_id = str(_uuid_mod.uuid4())
+    plain_id = await conn.fetchval(
+        """INSERT INTO tasks (uuid, user_id, anchor_id, plan_date, text, status, position)
+           VALUES ($1, $2::uuid, $3::uuid, '2026-05-05', 'Stand-up', 'pending', 0) RETURNING uuid::text""",
+        str(_uuid_mod.uuid4()), TEST_USER_ID, anchor_id,
+    )
+    await set_task_rrule(conn, plain_id, "RRULE:FREQ=WEEKLY;BYDAY=MO")
+    row = await conn.fetchrow("SELECT plan_date, rrule FROM tasks WHERE uuid=$1::uuid", plain_id)
+    assert row["plan_date"] is None
+    assert "FREQ=WEEKLY" in row["rrule"]
+
+
+async def test_set_task_rrule_none_removes_recurrence(conn):
+    from db.pg_queries.tasks import set_task_rrule, create_anchor_recurring_master
+    anchor_id = str(_uuid_mod.uuid4())
+    master_id = await create_anchor_recurring_master(
+        conn, TEST_USER_ID, anchor_id, "Stand-up", "RRULE:FREQ=DAILY"
+    )
+    await set_task_rrule(conn, master_id, None)
+    row = await conn.fetchrow("SELECT rrule FROM tasks WHERE uuid=$1::uuid", master_id)
+    assert row["rrule"] is None
+
+
+async def test_get_plan_includes_anchor_recurring_occurrence(conn):
+    from db.pg_queries.tasks import create_anchor_recurring_master
+    from db.pg_queries.plans import get_plan, upsert_plan
+    anchor_id = str(_uuid_mod.uuid4())
+    # Weekly on Monday — 2026-05-04 is a Monday
+    await create_anchor_recurring_master(
+        conn, TEST_USER_ID, anchor_id, "Weekly stand-up", "RRULE:FREQ=WEEKLY;BYDAY=MO"
+    )
+    await upsert_plan(conn, "2026-05-04")
+    plan = await get_plan(conn, "2026-05-04")
+    anchor_tasks = plan["anchors"].get(anchor_id, {}).get("tasks", [])
+    assert any(t["text"] == "Weekly stand-up" for t in anchor_tasks), (
+        f"Expected anchor_recurring task in plan; got anchor tasks: {anchor_tasks}"
+    )
+
+
+async def test_get_plan_excludes_anchor_recurring_on_non_matching_date(conn):
+    from db.pg_queries.tasks import create_anchor_recurring_master
+    from db.pg_queries.plans import get_plan, upsert_plan
+    anchor_id = str(_uuid_mod.uuid4())
+    # Weekly on Monday — 2026-05-05 is a Tuesday
+    await create_anchor_recurring_master(
+        conn, TEST_USER_ID, anchor_id, "Weekly stand-up", "RRULE:FREQ=WEEKLY;BYDAY=MO"
+    )
+    await upsert_plan(conn, "2026-05-05")
+    plan = await get_plan(conn, "2026-05-05")
+    anchor_tasks = plan["anchors"].get(anchor_id, {}).get("tasks", [])
+    assert not any(t["text"] == "Weekly stand-up" for t in anchor_tasks)
+
+
+async def test_get_plan_excludes_anchor_recurring_exdated_occurrence(conn):
+    from db.pg_queries.tasks import create_anchor_recurring_master, delete_anchor_occurrence
+    from db.pg_queries.plans import get_plan, upsert_plan
+    anchor_id = str(_uuid_mod.uuid4())
+    master_id = await create_anchor_recurring_master(
+        conn, TEST_USER_ID, anchor_id, "Daily stand-up", "RRULE:FREQ=DAILY"
+    )
+    await upsert_plan(conn, "2026-05-05")
+    await delete_anchor_occurrence(conn, master_id, "2026-05-05")
+    plan = await get_plan(conn, "2026-05-05")
+    anchor_tasks = plan["anchors"].get(anchor_id, {}).get("tasks", [])
+    assert not any(t["text"] == "Daily stand-up" for t in anchor_tasks), (
+        "Exdated occurrence should be suppressed in get_plan"
+    )
+
+
+async def test_delete_anchor_occurrence_adds_exdate(conn):
+    from db.pg_queries.tasks import create_anchor_recurring_master, delete_anchor_occurrence
+    anchor_id = str(_uuid_mod.uuid4())
+    master_id = await create_anchor_recurring_master(
+        conn, TEST_USER_ID, anchor_id, "Stand-up", "RRULE:FREQ=DAILY"
+    )
+    await delete_anchor_occurrence(conn, master_id, "2026-05-05")
+    row = await conn.fetchrow("SELECT exdates FROM tasks WHERE uuid=$1::uuid", master_id)
+    exdates = list(row["exdates"] or [])
+    assert "2026-05-05" in exdates
+
+
+async def test_delete_anchor_occurrence_idempotent(conn):
+    from db.pg_queries.tasks import create_anchor_recurring_master, delete_anchor_occurrence
+    anchor_id = str(_uuid_mod.uuid4())
+    master_id = await create_anchor_recurring_master(
+        conn, TEST_USER_ID, anchor_id, "Stand-up", "RRULE:FREQ=DAILY"
+    )
+    await delete_anchor_occurrence(conn, master_id, "2026-05-05")
+    await delete_anchor_occurrence(conn, master_id, "2026-05-05")
+    row = await conn.fetchrow("SELECT exdates FROM tasks WHERE uuid=$1::uuid", master_id)
+    exdates = list(row["exdates"] or [])
+    assert exdates.count("2026-05-05") == 1  # not duplicated
+
+
+async def test_truncate_anchor_series_sets_until(conn):
+    from db.pg_queries.tasks import create_anchor_recurring_master, truncate_anchor_series
+    anchor_id = str(_uuid_mod.uuid4())
+    master_id = await create_anchor_recurring_master(
+        conn, TEST_USER_ID, anchor_id, "Stand-up", "RRULE:FREQ=DAILY"
+    )
+    await truncate_anchor_series(conn, master_id, "2026-05-10")
+    row = await conn.fetchrow("SELECT rrule FROM tasks WHERE uuid=$1::uuid", master_id)
+    # UNTIL should be 2026-05-09 (day before from_date)
+    assert "UNTIL=20260509" in row["rrule"]


### PR DESCRIPTION
## Summary

Stream A (DB layer) of the anchor-recurring tasks feature. Anchor-recurring masters are tasks with `anchor_id + rrule` set and `plan_date = NULL`; `get_plan()` expands them on-demand for each requested date, parallel to how `get_events_for_range()` expands time-recurring masters.

No migration needed — existing `rrule`, `recurrence_id`, `anchor_id`, `plan_date`, `exdates` columns reused.

### New functions

| Function | File | Description |
|---|---|---|
| `_ensure_anchor_dtstart` | `db/pg_queries/tasks.py` | Embeds `DTSTART:YYYYMMDD` if absent — anchors bare `FREQ=WEEKLY` to creation weekday |
| `create_anchor_recurring_master` | `db/pg_queries/tasks.py` | Inserts master task with `plan_date/start_time/recurrence_id = NULL` |
| `set_task_rrule` | `db/pg_queries/tasks.py` | Converts anchor task to recurring master (preserves `plan_date` as DTSTART anchor) or removes rrule (restores `plan_date` to today); bumps `version` |
| `_anchor_recurring_occurs_on` | `db/pg_queries/plans.py` | Date-space rrule check; `ignoretz=True`; respects embedded DTSTART |
| `delete_anchor_occurrence` | `db/pg_queries/tasks.py` | scope=this — appends ISO date to `exdates TEXT[]`; idempotent |
| `truncate_anchor_series` | `db/pg_queries/tasks.py` | scope=this_and_future — sets UNTIL via `_rrule_set_until` to day before cutoff |

### `get_plan` extension

- Fetches anchor-recurring masters (RLS-scoped, no signature change)
- Expands for the requested date, filters `exdates` and exception rows
- Synthesized task dicts (with all fields) inserted into `anchors` **before** the dependency loop — masters participate in `blocked_by`/`blocks` resolution

### Key design decisions

- `exdates` for anchor-recurring stores plain ISO dates (`"2026-05-05"`), not iCal tokens — these tasks have no time-of-day semantics
- `get_plan(conn, date)` signature unchanged; 14+ callers unaffected
- `_rrule_set_until` reused for `truncate_anchor_series`

## Tests

12 new tests in `tests/db/test_anchor_recurrence.py` — skip without `DATABASE_URL`, run in Pi CI.

358 pure-Python tests passing locally.

## Out of scope

Stream B (API: `PATCH /api/tasks/:id/rrule`, scoped DELETE) and Stream C (frontend: `setTaskRrule`, `RecurrencePicker` wiring) are separate streams.