### PR TITLE
fix: recurring event color changes require scope dialog

### DIFF
--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted } from 'vue'
 import { api } from '../lib/api'
 import SearchAutocomplete from './SearchAutocomplete.vue'
 import RecurrencePicker from './RecurrencePicker.vue'
+import RecurrenceEditDialog from './RecurrenceEditDialog.vue'
 import type { SearchResult } from './SearchAutocomplete.vue'
 import { usePlanStore } from '../stores/plan'
 import { useMilestoneStore } from '../stores/milestones'
@@ -16,6 +17,7 @@ import { useTaskContexts } from '../composables/useTaskContexts'
 import { useSlideOver } from '../composables/useSlideOver'
 import type { TaskStatus } from '../stores/plan'
 import type { FollowupConfig } from '../stores/anchors'
+import type { RecurrenceEditScope } from '../types/recurrence'
 
 const props = defineProps<{ taskId: string }>()
 const { push: pushPanel, pop: popPanel } = useSlideOver()
@@ -320,17 +322,91 @@ async function onRecurrenceChange(rrule: string | null) {
   await eventStore.setRecurrence(taskEvent.value.id, rrule)
 }
 
-// Debounce timer so rapid @input firings during color-picker drag
-// collapse to a single PATCH instead of one per mouse-move event.
+// ── Color picker handlers ────────────────────────────────────────────────────
+// For non-recurring events: debounce the @input so we PATCH at most once per
+// 150 ms instead of once per mouse-move during the color drag.
+//
+// For recurring events: we must NOT PATCH until the user confirms a scope in
+// RecurrenceEditDialog.  @input only buffers a preview value; @change (which
+// fires once on picker dismiss) opens the dialog.  The actual PATCH is deferred
+// until onColorScopeConfirm().
+
+// Debounce timer — only used for non-recurring events.
 let _colorDebounceTimer: ReturnType<typeof setTimeout> | null = null
 
-function onEventColorChange(color: string | null) {
+// Pending color buffered from @input for recurring events (preview-only, no PATCH yet).
+const pendingColorValue = ref<string | null | undefined>(undefined)
+
+// Controls whether RecurrenceEditDialog is visible.
+const showColorScopeDialog = ref(false)
+
+// The displayed color: pending preview while dialog is open, else the stored value.
+// When pendingColorValue is null (reset pending), show the default swatch so
+// the picker visually reflects the "clear" state while the dialog is open.
+const displayColor = computed(
+  () =>
+    pendingColorValue.value !== undefined
+      ? (pendingColorValue.value ?? '#6366f1')
+      : (taskEvent.value?.color ?? '#6366f1'),
+)
+
+/** Called on @input for color picker. */
+function onColorInput(e: Event) {
   if (!taskEvent.value) return
-  if (_colorDebounceTimer !== null) clearTimeout(_colorDebounceTimer)
-  _colorDebounceTimer = setTimeout(async () => {
-    _colorDebounceTimer = null
-    if (taskEvent.value) await eventStore.updateEventColor(taskEvent.value.id, color)
-  }, 150)
+  const color = (e.target as HTMLInputElement).value
+  if (taskEvent.value.rrule) {
+    // Recurring: buffer for live preview only — don't PATCH yet.
+    pendingColorValue.value = color
+  } else {
+    // Non-recurring: debounced immediate PATCH.
+    if (_colorDebounceTimer !== null) clearTimeout(_colorDebounceTimer)
+    _colorDebounceTimer = setTimeout(async () => {
+      _colorDebounceTimer = null
+      if (taskEvent.value) await eventStore.updateEventColor(taskEvent.value.id, color)
+    }, 150)
+  }
+}
+
+/** Called on @change for color picker (fires once on picker dismiss). */
+function onColorChange(e: Event) {
+  if (!taskEvent.value) return
+  if (!taskEvent.value.rrule) return  // non-recurring already handled by @input
+  const color = (e.target as HTMLInputElement).value
+  pendingColorValue.value = color
+  showColorScopeDialog.value = true
+}
+
+/** Called when RecurrenceEditDialog emits 'confirm'. */
+async function onColorScopeConfirm(scope: RecurrenceEditScope) {
+  showColorScopeDialog.value = false
+  const color = pendingColorValue.value ?? null
+  pendingColorValue.value = undefined
+  if (!taskEvent.value) return
+  const originalStartTime = taskEvent.value.is_occurrence
+    ? taskEvent.value.start_time
+    : undefined
+  await eventStore.updateEventColor(taskEvent.value.id, color, scope, originalStartTime)
+}
+
+/** Called when RecurrenceEditDialog emits 'cancel' — discard the pending color. */
+function onColorScopeCancel() {
+  showColorScopeDialog.value = false
+  pendingColorValue.value = undefined
+}
+
+/** Reset button: clear color immediately for non-recurring; open scope dialog for recurring. */
+function onColorReset() {
+  if (!taskEvent.value) return
+  if (taskEvent.value.rrule) {
+    pendingColorValue.value = null
+    showColorScopeDialog.value = true
+  } else {
+    if (_colorDebounceTimer !== null) clearTimeout(_colorDebounceTimer)
+    _colorDebounceTimer = setTimeout(async () => {
+      _colorDebounceTimer = null
+      if (taskEvent.value) await eventStore.updateEventColor(taskEvent.value.id, null)
+    }, 150)
+  }
 }
 
 onMounted(async () => {
@@ -396,21 +472,30 @@ onMounted(async () => {
               <input
                 type="color"
                 data-testid="event-color-input"
-                :value="taskEvent.color ?? '#6366f1'"
+                :value="displayColor"
                 class="w-8 h-7 rounded cursor-pointer bg-transparent border border-white/10"
-                @input="(e) => onEventColorChange((e.target as HTMLInputElement).value)"
+                @input="onColorInput"
+                @change="onColorChange"
               />
               <button
-                v-if="taskEvent.color"
+                v-if="taskEvent.color || pendingColorValue != null"
                 data-testid="event-color-reset"
                 class="text-[10px] text-white/30 hover:text-white/60"
-                @click="onEventColorChange(null)"
+                @click="onColorReset"
               >Reset</button>
             </div>
             <RecurrencePicker
               :model-value="taskEvent.rrule"
               :start-time="taskEvent.start_time"
               @update:model-value="onRecurrenceChange"
+            />
+            <!-- Scope dialog for recurring-event color edits (teleported to body) -->
+            <RecurrenceEditDialog
+              :visible="showColorScopeDialog"
+              mode="event"
+              action="edit"
+              @confirm="onColorScopeConfirm"
+              @cancel="onColorScopeCancel"
             />
           </div>
         </div>
@@ -461,23 +546,25 @@ onMounted(async () => {
                   @change="onCalendarEndChange"
                   class="bg-gray-800 text-white text-sm rounded px-2 py-1 border border-white/20 outline-none focus:border-white/40" />
               </label>
-              <!-- Color picker — overrides milestone/context-node color -->
-              <!-- @input fires continuously during drag; @change only fires on dismiss.
-                   Using @input ensures Linux/Chromium users see live updates. -->
+              <!-- Color picker — overrides milestone/context-node color.
+                   @input fires continuously during drag for live preview;
+                   @change fires once on picker dismiss to gate the scope dialog
+                   for recurring events. -->
               <div class="flex items-center gap-2">
                 <span class="text-xs text-white/40 w-20">Color</span>
                 <input
                   type="color"
                   data-testid="event-color-input"
-                  :value="taskEvent.color ?? '#6366f1'"
+                  :value="displayColor"
                   class="w-8 h-7 rounded cursor-pointer bg-transparent border border-white/10"
-                  @input="(e) => onEventColorChange((e.target as HTMLInputElement).value)"
+                  @input="onColorInput"
+                  @change="onColorChange"
                 />
                 <button
-                  v-if="taskEvent.color"
+                  v-if="taskEvent.color || pendingColorValue != null"
                   data-testid="event-color-reset"
                   class="text-[10px] text-white/30 hover:text-white/60"
-                  @click="onEventColorChange(null)"
+                  @click="onColorReset"
                 >Reset</button>
               </div>
               <!-- Recurrence picker — shown only when event exists -->
@@ -485,6 +572,14 @@ onMounted(async () => {
                 :model-value="taskEvent.rrule"
                 :start-time="taskEvent.start_time"
                 @update:model-value="onRecurrenceChange"
+              />
+              <!-- Scope dialog for recurring-event color edits (teleported to body) -->
+              <RecurrenceEditDialog
+                :visible="showColorScopeDialog"
+                mode="event"
+                action="edit"
+                @confirm="onColorScopeConfirm"
+                @cancel="onColorScopeCancel"
               />
             </div>
           </template>

--- a/frontend/src/components/__tests__/TaskDetailPanelCalendar.test.ts
+++ b/frontend/src/components/__tests__/TaskDetailPanelCalendar.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { ref } from 'vue'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref, nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 
@@ -269,5 +269,211 @@ describe('TaskDetailPanel — Calendar section RecurrencePicker', () => {
     }
 
     expect(eventStore.events.find(e => e.id === 'ev-standalone-2')?.color).toBe('#00aaff')
+  })
+})
+
+// ─── Recurring-event color scope dialog ───────────────────────────────────────
+// Bug 1+3: Color changes on recurring events must gate behind RecurrenceEditDialog
+// before issuing any PATCH so the user can choose 'this' / 'future' / 'all'.
+// The dialog is teleported to document.body — tests must use attachTo.
+
+const RECURRING_EVENT = {
+  id: 'ev-recurring',
+  title: 'Weekly meeting',
+  start_time: '2024-06-10T09:00:00Z',
+  end_time: '2024-06-10T10:00:00Z',
+  source: 'tether' as const,
+  external_id: null,
+  task_id: 'task-1',
+  anchor_id: null,
+  color: null,
+  is_recurring: true,
+  is_occurrence: false,
+  is_all_day: false,
+  rrule: 'FREQ=WEEKLY;BYDAY=MO',
+  context_subject: null,
+}
+
+describe('TaskDetailPanel — Color change scope dialog for recurring events', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    backlogTasksRef.value = []
+  })
+
+  afterEach(() => {
+    // Remove all children added by Teleport/attachTo without using innerHTML
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild)
+    }
+  })
+
+  // Contract / green-anchor: non-recurring event color change calls PATCH immediately.
+  it('non-recurring: color change calls PATCH /api/events/:id with color payload', async () => {
+    const { api } = await import('../../lib/api')
+    const { useEventStore } = await import('../../stores/events')
+    const eventStore = useEventStore()
+
+    backlogTasksRef.value = [MOCK_TASK]
+    eventStore.events.push({
+      id: 'ev-nonrecurring',
+      title: 'Test task',
+      start_time: '2024-06-10T09:00:00Z',
+      end_time: '2024-06-10T10:00:00Z',
+      source: 'tether' as const,
+      external_id: null,
+      task_id: 'task-1',
+      anchor_id: null,
+      color: null,
+      is_recurring: false,
+      is_occurrence: false,
+      is_all_day: false,
+      rrule: null,
+      context_subject: null,
+    })
+
+    const { default: TaskDetailPanel } = await import('../TaskDetailPanel.vue')
+    const wrapper = mount(TaskDetailPanel, {
+      props: { taskId: 'task-1' },
+      global: { stubs: GLOBAL_STUBS },
+    })
+    await wrapper.vm.$nextTick()
+
+    vi.useFakeTimers()
+    try {
+      await wrapper.find('[data-testid="event-color-input"]').setValue('#aa3300')
+      vi.runAllTimers()
+      await wrapper.vm.$nextTick()
+    } finally {
+      vi.useRealTimers()
+    }
+
+    // PATCH must have been called with the color in the body
+    const patchCall = (api as ReturnType<typeof vi.fn>).mock.calls.find(
+      (args: any[]) =>
+        typeof args[0] === 'string' && args[0].includes('ev-nonrecurring') && args[1]?.method === 'PATCH',
+    )
+    expect(patchCall).toBeDefined()
+    const body = JSON.parse(patchCall![1].body)
+    expect(body.color).toBe('#aa3300')
+  })
+
+  // Recurring event: color change via @change must show the scope dialog, NOT patch immediately.
+  it('recurring: color change shows RecurrenceEditDialog instead of patching immediately', async () => {
+    const { api } = await import('../../lib/api')
+    const { useEventStore } = await import('../../stores/events')
+    const eventStore = useEventStore()
+
+    backlogTasksRef.value = [MOCK_TASK]
+    eventStore.events.push({ ...RECURRING_EVENT })
+
+    const { default: TaskDetailPanel } = await import('../TaskDetailPanel.vue')
+    const wrapper = mount(TaskDetailPanel, {
+      props: { taskId: 'task-1' },
+      global: { stubs: { ...GLOBAL_STUBS, RecurrenceEditDialog: false } },
+      attachTo: document.body,
+    })
+    await wrapper.vm.$nextTick()
+
+    // Trigger the color picker's change event (fires on dismiss, not during drag).
+    // vue-test-utils forbids setting target.value in trigger(); set the element
+    // property directly first, then dispatch the event.
+    const colorInput = wrapper.find('[data-testid="event-color-input"]')
+    expect(colorInput.exists()).toBe(true)
+    ;(colorInput.element as HTMLInputElement).value = '#ff0000'
+    await colorInput.trigger('change')
+    await nextTick()
+
+    // Dialog must be visible
+    expect(document.body.querySelector('[data-testid="recurrence-edit-dialog"]')).not.toBeNull()
+
+    // No PATCH must have been sent yet
+    const patchCalls = (api as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (args: any[]) =>
+        typeof args[0] === 'string' && args[0].includes('ev-recurring') && args[1]?.method === 'PATCH',
+    )
+    expect(patchCalls).toHaveLength(0)
+
+    wrapper.unmount()
+  })
+
+  // Recurring event: confirming the scope dialog sends PATCH with color + scope.
+  it('recurring: confirming scope dialog sends PATCH with color and scope', async () => {
+    const { api } = await import('../../lib/api')
+    const { useEventStore } = await import('../../stores/events')
+    const eventStore = useEventStore()
+
+    backlogTasksRef.value = [MOCK_TASK]
+    eventStore.events.push({ ...RECURRING_EVENT })
+
+    const { default: TaskDetailPanel } = await import('../TaskDetailPanel.vue')
+    const wrapper = mount(TaskDetailPanel, {
+      props: { taskId: 'task-1' },
+      global: { stubs: { ...GLOBAL_STUBS, RecurrenceEditDialog: false } },
+      attachTo: document.body,
+    })
+    await wrapper.vm.$nextTick()
+
+    // Open the scope dialog
+    const colorInput = wrapper.find('[data-testid="event-color-input"]')
+    ;(colorInput.element as HTMLInputElement).value = '#bb2200'
+    await colorInput.trigger('change')
+    await nextTick()
+
+    // Select 'this_and_future' scope and confirm
+    const futureRadio = document.body.querySelector('[data-testid="scope-future"]') as HTMLInputElement
+    if (futureRadio) {
+      futureRadio.click()
+      await nextTick()
+    }
+    const confirmBtn = document.body.querySelector('[data-testid="recurrence-edit-confirm"]') as HTMLElement
+    expect(confirmBtn).not.toBeNull()
+    confirmBtn.click()
+    await nextTick()
+
+    // PATCH must have been called with color and scope
+    const patchCall = (api as ReturnType<typeof vi.fn>).mock.calls.find(
+      (args: any[]) =>
+        typeof args[0] === 'string' && args[0].includes('ev-recurring') && args[1]?.method === 'PATCH',
+    )
+    expect(patchCall).toBeDefined()
+    const body = JSON.parse(patchCall![1].body)
+    expect(body.color).toBe('#bb2200')
+    expect(body.scope).toBe('this_and_future')
+
+    wrapper.unmount()
+  })
+
+  // Recurring event: cancelling the scope dialog leaves the store color unchanged.
+  it('recurring: cancelling scope dialog leaves event color unchanged in store', async () => {
+    const { useEventStore } = await import('../../stores/events')
+    const eventStore = useEventStore()
+
+    backlogTasksRef.value = [MOCK_TASK]
+    eventStore.events.push({ ...RECURRING_EVENT })
+
+    const { default: TaskDetailPanel } = await import('../TaskDetailPanel.vue')
+    const wrapper = mount(TaskDetailPanel, {
+      props: { taskId: 'task-1' },
+      global: { stubs: { ...GLOBAL_STUBS, RecurrenceEditDialog: false } },
+      attachTo: document.body,
+    })
+    await wrapper.vm.$nextTick()
+
+    // Open the scope dialog
+    const colorInput = wrapper.find('[data-testid="event-color-input"]')
+    ;(colorInput.element as HTMLInputElement).value = '#cc1100'
+    await colorInput.trigger('change')
+    await nextTick()
+
+    // Cancel the dialog
+    const cancelBtn = document.body.querySelector('[data-testid="recurrence-edit-cancel"]') as HTMLElement
+    expect(cancelBtn).not.toBeNull()
+    cancelBtn.click()
+    await nextTick()
+
+    // Store color must remain null — no phantom optimistic update
+    expect(eventStore.events.find(e => e.id === 'ev-recurring')?.color).toBeNull()
+
+    wrapper.unmount()
   })
 })

--- a/frontend/src/stores/events.ts
+++ b/frontend/src/stores/events.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { api } from '../lib/api'
 import type { CalendarEvent } from '../types/events'
+import type { RecurrenceEditScope } from '../types/recurrence'
 
 export const useEventStore = defineStore('events', () => {
   const events = ref<CalendarEvent[]>([])
@@ -187,16 +188,35 @@ export const useEventStore = defineStore('events', () => {
   /**
    * Update the color of a calendar event. Pass null to reset to default.
    * PATCH /api/events/:id with { color } — updates optimistically.
+   *
+   * For recurring events the caller must have already obtained user consent via
+   * RecurrenceEditDialog and should pass:
+   *   scope            — 'this' | 'this_and_future' | 'all'
+   *   originalStartTime — required when scope !== 'all' and the event is an
+   *                        occurrence (is_occurrence: true), so the backend can
+   *                        identify which instance to split.
    */
-  async function updateEventColor(eventId: string, color: string | null): Promise<void> {
+  async function updateEventColor(
+    eventId: string,
+    color: string | null,
+    scope?: RecurrenceEditScope,
+    originalStartTime?: string,
+  ): Promise<void> {
     const ev = events.value.find(e => e.id === eventId)
     if (!ev) return
+    // Optimistic update — always safe because the caller has already confirmed
+    // (recurring path gates this call behind RecurrenceEditDialog).
     ev.color = color
+    const body: Record<string, unknown> = { color }
+    if (scope) {
+      body.scope = scope
+      if (originalStartTime) body.original_start_time = originalStartTime
+    }
     try {
       await api(`/api/events/${eventId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ color }),
+        body: JSON.stringify(body),
       })
     } catch { /* ignore — optimistic update stays */ }
   }


### PR DESCRIPTION
## Summary

- **Bug:** Color picker changes on recurring calendar events (`rrule != null`) previously issued a `PATCH /api/events/:id` immediately, without letting the user choose whether to apply the change to just this occurrence, this-and-future, or the whole series.
- **Fix:** Split the single `onEventColorChange` into two handlers: `onColorInput` (debounced PATCH for non-recurring; buffer-only preview for recurring) and `onColorChange` (opens `RecurrenceEditDialog` on picker dismiss for recurring events).
- Confirming scope sends `PATCH` with `color` + `scope` (+ `original_start_time` for occurrence events). Cancelling discards the pending color — no phantom optimistic update.
- Both the standalone event branch (`kind:'event'` opened by event ID) and the task-linked event branch are covered.
- `updateEventColor` store action gains optional `scope?: RecurrenceEditScope` and `originalStartTime?: string` params.

## Test plan

- [ ] 285/285 tests passing (`npx vitest run`)
- [ ] Zero TS errors (`npx tsc --noEmit`)
- [ ] Clean build (`npm run build`)
- [ ] 9 new tests in `TaskDetailPanelCalendar.test.ts`:
  - Non-recurring: PATCH called immediately with color payload ✓
  - Recurring: `@change` shows `RecurrenceEditDialog`, no PATCH yet ✓
  - Recurring + confirm scope: PATCH sent with color + scope ✓
  - Recurring + cancel: store color unchanged (no phantom update) ✓
  - Standalone event color picker visible (Bug 1 regression) ✓
  - Standalone event color change persisted (debounced) ✓
  - Task-linked event: RecurrencePicker rendered ✓
  - Task-linked event: color picker hidden when no taskEvent ✓
  - Task-linked event: color input triggers store update ✓