### PR TITLE
feat: anchor-recurring API endpoints (Stream B)

### DIFF
--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends, HTTPException, Request
+from typing import Literal
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
 import asyncpg
 from db.pg_queries import (
     patch_task_fields, move_task_atomic,
@@ -8,10 +10,15 @@ from db.pg_queries import (
     get_unscheduled_tasks, create_unscheduled_task, get_task_by_uuid, get_all_tasks,
     link_milestone_task, upsert_plan, delete_task_by_uuid, get_full_task_dependencies,
 )
+from db.pg_queries.tasks import set_task_rrule, delete_anchor_occurrence, truncate_anchor_series
 from db.pool_middleware import get_db_conn
 from api.auth import auth_dependency
 
 router = APIRouter()
+
+
+class TaskRruleBody(BaseModel):
+    rrule: str | None
 
 
 @router.get("/search")
@@ -83,12 +90,54 @@ async def patch_task(task_uuid: str, body: dict,
     return result
 
 
-@router.delete("/tasks/{task_uuid}")
-async def delete_task(task_uuid: str, _auth=Depends(auth_dependency),
-                      conn: asyncpg.Connection = Depends(get_db_conn)):
-    async with conn.transaction():
-        await delete_task_by_uuid(conn, task_uuid)
-    return {"ok": True}
+@router.patch("/tasks/{task_id}/rrule")
+async def patch_task_rrule(
+    task_id: str,
+    body: TaskRruleBody,
+    request: Request,
+    _auth=Depends(auth_dependency),
+    conn: asyncpg.Connection = Depends(get_db_conn),
+):
+    task = await get_task_by_uuid(conn, task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    if task.get("anchor_id") is None:
+        raise HTTPException(
+            status_code=400,
+            detail="rrule scheduling only supported for anchor tasks; use /api/events for time-scheduled recurrence",
+        )
+    await set_task_rrule(conn, task_id, body.rrule)
+    return await get_task_by_uuid(conn, task_id)
+
+
+@router.delete("/tasks/{task_uuid}", status_code=204)
+async def delete_task(
+    task_uuid: str,
+    request: Request,
+    scope: Literal["all", "this", "this_and_future"] = Query(default="all"),
+    original_date: str | None = Query(default=None),
+    _auth=Depends(auth_dependency),
+    conn: asyncpg.Connection = Depends(get_db_conn),
+):
+    task = await get_task_by_uuid(conn, task_uuid)
+    if task is None:
+        raise HTTPException(status_code=404)
+    if task.get("rrule") and task.get("anchor_id"):
+        # Anchor-recurring master — honour scope
+        if scope == "this":
+            if not original_date:
+                raise HTTPException(status_code=422, detail="original_date required for scope=this")
+            await delete_anchor_occurrence(conn, task_uuid, original_date)
+        elif scope == "this_and_future":
+            if not original_date:
+                raise HTTPException(status_code=422, detail="original_date required for scope=this_and_future")
+            await truncate_anchor_series(conn, task_uuid, original_date)
+        else:
+            async with conn.transaction():
+                await delete_task_by_uuid(conn, task_uuid)
+    else:
+        async with conn.transaction():
+            await delete_task_by_uuid(conn, task_uuid)
 
 
 @router.put("/tasks/{task_uuid}/move")

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -124,16 +124,16 @@ async def delete_task(
         raise HTTPException(status_code=404)
     if task.get("rrule") and task.get("anchor_id"):
         # Anchor-recurring master — honour scope
-        if scope == "this":
-            if not original_date:
-                raise HTTPException(status_code=422, detail="original_date required for scope=this")
-            await delete_anchor_occurrence(conn, task_uuid, original_date)
-        elif scope == "this_and_future":
-            if not original_date:
-                raise HTTPException(status_code=422, detail="original_date required for scope=this_and_future")
-            await truncate_anchor_series(conn, task_uuid, original_date)
-        else:
-            async with conn.transaction():
+        async with conn.transaction():
+            if scope == "this":
+                if not original_date:
+                    raise HTTPException(status_code=422, detail="original_date required for scope=this")
+                await delete_anchor_occurrence(conn, task_uuid, original_date)
+            elif scope == "this_and_future":
+                if not original_date:
+                    raise HTTPException(status_code=422, detail="original_date required for scope=this_and_future")
+                await truncate_anchor_series(conn, task_uuid, original_date)
+            else:
                 await delete_task_by_uuid(conn, task_uuid)
     else:
         async with conn.transaction():

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -1658,7 +1658,7 @@ async def create_anchor_recurring_master(
         """
         INSERT INTO tasks (uuid, user_id, anchor_id, text, rrule, notes, color,
                            plan_date, start_time, end_time, recurrence_id, status, position)
-        VALUES ($1, $2::uuid, $3::uuid, $4, $5, $6, $7,
+        VALUES ($1, $2::uuid, $3::uuid, $4, $5, COALESCE($6, ''), $7,
                 NULL, NULL, NULL, NULL, 'pending', 0)
         """,
         new_id, user_id, anchor_id, text, anchored_rrule, notes, color,

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -226,12 +226,18 @@ async def get_task_by_uuid(conn: asyncpg.Connection, task_uuid: str) -> dict | N
     row = await conn.fetchrow(
         """
         SELECT uuid, plan_date, anchor_id, text, status, position,
-               followup_config, description, context_subject, context_node_id, version
+               followup_config, description, context_subject, context_node_id, version,
+               rrule, exdates
         FROM tasks WHERE uuid = $1
         """,
         _uuid.UUID(task_uuid),
     )
-    return _row_to_task(row, include_schedule=True) if row else None
+    if row is None:
+        return None
+    result = _row_to_task(row, include_schedule=True)
+    result["rrule"] = row["rrule"]
+    result["exdates"] = list(row["exdates"]) if row["exdates"] else []
+    return result
 
 
 async def get_all_tasks(conn: asyncpg.Connection) -> list[dict]:
@@ -1687,7 +1693,7 @@ async def set_task_rrule(
             "SELECT plan_date FROM tasks WHERE uuid=$1::uuid", task_id
         )
         anchor_date = (
-            row["plan_date"].isoformat() if row and row["plan_date"] else
+            row["plan_date"] if row and row["plan_date"] else
             _datetime_mod.date.today().isoformat()
         )
         anchored_rrule = _ensure_anchor_dtstart(rrule, anchor_date)

--- a/tests/api/test_anchor_recurrence_api.py
+++ b/tests/api/test_anchor_recurrence_api.py
@@ -1,0 +1,111 @@
+"""API tests for anchor-recurring task endpoints (PATCH rrule, scope-aware DELETE)."""
+from __future__ import annotations
+import pytest
+from db.pg_queries import upsert_anchor
+from db.pg_queries.tasks import create_anchor_recurring_master
+
+ANCHOR_ID = "00000000-0000-0000-0000-000000000020"
+ANCHOR = {
+    "id": ANCHOR_ID, "name": "Morning Block", "time": "09:00",
+    "duration_minutes": 60, "flexibility": "locked",
+    "strictness": 4, "color": "#5c8ee0", "position": 0,
+}
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def anchor_id(conn):
+    await upsert_anchor(conn, ANCHOR)
+    return ANCHOR_ID
+
+
+@pytest.fixture
+async def task_id(conn, anchor_id):
+    """Plain anchor task (plan_date set, no rrule)."""
+    from tests.api.conftest import TEST_USER_ID
+    row = await conn.fetchrow(
+        """INSERT INTO tasks (uuid, user_id, anchor_id, plan_date, text, status, position)
+           VALUES (gen_random_uuid(), $1::uuid, $2::uuid, '2026-05-05', 'Stand-up', 'pending', 0)
+           RETURNING uuid""",
+        TEST_USER_ID, anchor_id,
+    )
+    return str(row["uuid"])
+
+
+@pytest.fixture
+async def non_anchor_task_id(conn):
+    """Task with no anchor_id."""
+    from tests.api.conftest import TEST_USER_ID
+    row = await conn.fetchrow(
+        """INSERT INTO tasks (uuid, user_id, plan_date, text, status, position)
+           VALUES (gen_random_uuid(), $1::uuid, '2026-05-05', 'Standalone', 'pending', 0)
+           RETURNING uuid""",
+        TEST_USER_ID,
+    )
+    return str(row["uuid"])
+
+
+@pytest.fixture
+async def master_task_id(conn, anchor_id):
+    """Anchor-recurring master (rrule set, plan_date=NULL)."""
+    from tests.api.conftest import TEST_USER_ID
+    return await create_anchor_recurring_master(
+        conn, TEST_USER_ID, anchor_id, "Daily stand-up", "RRULE:FREQ=DAILY"
+    )
+
+
+async def test_set_rrule_on_anchor_task(api_client, anchor_id, task_id):
+    resp = await api_client.patch(
+        f"/api/tasks/{task_id}/rrule",
+        json={"rrule": "RRULE:FREQ=WEEKLY;BYDAY=MO"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "FREQ=WEEKLY" in data["rrule"]
+
+
+async def test_clear_rrule_on_anchor_task(api_client, anchor_id, task_id):
+    await api_client.patch(f"/api/tasks/{task_id}/rrule", json={"rrule": "RRULE:FREQ=DAILY"})
+    resp = await api_client.patch(f"/api/tasks/{task_id}/rrule", json={"rrule": None})
+    assert resp.status_code == 200
+    assert resp.json()["rrule"] is None
+
+
+async def test_set_rrule_on_non_anchor_task_returns_400(api_client, non_anchor_task_id):
+    resp = await api_client.patch(
+        f"/api/tasks/{non_anchor_task_id}/rrule",
+        json={"rrule": "RRULE:FREQ=DAILY"},
+    )
+    assert resp.status_code == 400
+
+
+async def test_delete_anchor_task_scope_this(api_client, anchor_id, master_task_id):
+    resp = await api_client.delete(
+        f"/api/tasks/{master_task_id}",
+        params={"scope": "this", "original_date": "2026-05-05"},
+    )
+    assert resp.status_code == 204
+    # Master should still exist
+    check = await api_client.get(f"/api/tasks/{master_task_id}")
+    assert check.status_code == 200
+    # 2026-05-05 should be excluded
+    assert "2026-05-05" in (check.json().get("exdates") or [])
+
+
+async def test_delete_anchor_task_scope_this_missing_date_returns_422(api_client, anchor_id, master_task_id):
+    resp = await api_client.delete(
+        f"/api/tasks/{master_task_id}",
+        params={"scope": "this"},
+    )
+    assert resp.status_code == 422
+
+
+async def test_delete_anchor_task_scope_all_removes_task(api_client, anchor_id, master_task_id):
+    resp = await api_client.delete(
+        f"/api/tasks/{master_task_id}",
+        params={"scope": "all"},
+    )
+    assert resp.status_code == 204
+    check = await api_client.get(f"/api/tasks/{master_task_id}")
+    assert check.status_code == 404


### PR DESCRIPTION
## Summary

Stream B of the anchor-recurring tasks feature. Depends on PR #232 (Stream A, DB layer — already merged).

- `PATCH /api/tasks/{task_id}/rrule` — set or clear rrule on an anchor task. Validates anchor_id is present; 400 for non-anchor tasks. Calls `set_task_rrule` (clears plan_date on set, restores today on clear). Returns updated task.
- `DELETE /api/tasks/{task_uuid}` — extended with `scope` and `original_date` query params. Scope-aware behaviour for anchor-recurring masters: `scope=this` appends to exdates, `scope=this_and_future` truncates rrule UNTIL, `scope=all` (default) hard-deletes. Non-recurring tasks always hard-delete regardless of scope. Changed from 200 + `{"ok":True}` to 204 (verified no existing callers break).

Also includes three bug fixes in `db/pg_queries/tasks.py` found during TDD:
- `create_anchor_recurring_master`: `COALESCE(notes, '')` — notes column is NOT NULL
- `set_task_rrule`: removed stale `.isoformat()` call on TEXT plan_date field
- `get_task_by_uuid`: added `rrule` and `exdates` to SELECT (required for scope logic)

## Test plan

- [ ] 6 new tests in `tests/api/test_anchor_recurrence_api.py` — require DATABASE_URL (Pi CI)
- [ ] Full non-DB suite passes (535 tests, 0 regressions)
- [ ] `PATCH /api/tasks/{id}/rrule` with anchor task → 200 + rrule in response
- [ ] `PATCH /api/tasks/{id}/rrule` with non-anchor task → 400
- [ ] `DELETE` with `scope=this&original_date=2026-05-05` → 204, master still exists, exdates contains date
- [ ] `DELETE` with `scope=this` missing original_date → 422
- [ ] `DELETE` with `scope=all` → 204, task gone (404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)