### PR TITLE
feat: design system theme picker and motif CSS tokens

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,12 +1,27 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { useAuthStore } from './stores/auth'
 import { useRouter } from 'vue-router'
+import { loadPremiumThemes } from './composables/usePremiumThemes'
 import BotChat from './components/BotChat.vue'
 import SlideOverStack from './components/SlideOverStack.vue'
 
 const authStore = useAuthStore()
 const router = useRouter()
+
+// Load premium theme CSS once the user is known to be authenticated.
+// isPaid is always false today; this fires when backend adds the field.
+watch(
+  () => authStore.user,
+  (user) => {
+    if (user && (user as any).is_paid) {
+      // token not available client-side via cookie auth — pass empty string;
+      // the endpoint will use session cookie instead when implemented
+      loadPremiumThemes('')
+    }
+  },
+  { immediate: true },
+)
 const chatOpen = ref(false)
 
 async function logout() {
@@ -16,7 +31,7 @@ async function logout() {
 </script>
 
 <template>
-  <div class="min-h-screen bg-gray-900 text-white">
+  <div class="min-h-screen bg-gray-900 text-white crt" style="position: relative">
     <!-- Navigation bar (shown when authenticated) -->
     <nav v-if="authStore.isAuthenticated"
          class="flex items-center justify-between px-6 py-3 border-b border-white/10 bg-gray-900/80 backdrop-blur-sm sticky top-0 z-10">

--- a/frontend/src/assets/motifs.css
+++ b/frontend/src/assets/motifs.css
@@ -1,0 +1,773 @@
+/* =========================================================================
+   Tether — Motif Palettes
+   --------------------------------------------------------------------------
+   Each theme defines 8 named "motif slots" — semantic color roles that
+   anchors, tasks, and events are tagged with. The slot name is the same
+   across themes (e.g. anchor.motif = 'focus'); the hue is theme-defined.
+
+   This is what lets a user change themes without their schedule devolving
+   into clashing colors: Deep Work tagged `focus` is coral in Tether,
+   rust in Horizon, cyan in Terminal — but always semantically "focus".
+
+   Slots:
+     1. anchor   — the brand accent (matches --accent for that theme)
+     2. focus    — sharp, attention-demanding work
+     3. calm     — low-stim, restful
+     4. energy   — bright, active
+     5. care     — warm, body/health
+     6. flow     — cool, liquid, creative
+     7. dusk     — end-of-day, soft
+     8. quiet    — neutral fallback
+
+   Per slot, every theme MUST define:
+     --motif-{slot}        — the solid color (used on lines, text, ticks)
+     --motif-{slot}-band   — the calendar band fill (canvas-tinted)
+     --motif-{slot}-veil   — softer than band, for hovers / pill bg
+     --motif-{slot}-fg     — readable text on top of solid -motif
+
+   The "band" is the most important: it's the wide vertical stripe that
+   colors each anchor's time-segment in the calendar. It needs to be
+   *distinctly different from the canvas* but *quiet enough* not to fight
+   the content sitting on top.
+
+   Rules of construction (followed for every theme below):
+     - bands are always 6–10% alpha over canvas, tuned by hand per hue
+     - veils are 14–22% alpha (used on hovers, pill backgrounds)
+     - solids are 1.0 alpha; should pass 4.5:1 against canvas
+     - fg is canvas color (dark themes) or near-black (light themes)
+   ========================================================================= */
+
+
+/* =========================================================================
+   1. TETHER  (dark indigo / brand default)
+   ========================================================================= */
+:root,
+[data-theme="tether"][data-mode="dark"],
+[data-theme="tether"]:not([data-mode]) {
+  --motif-anchor:        #7C8AFF;  /* indigo — matches --accent */
+  --motif-anchor-band:   rgba(124, 138, 255, 0.08);
+  --motif-anchor-veil:   rgba(124, 138, 255, 0.18);
+  --motif-anchor-fg:     #0E1117;
+
+  --motif-focus:         #FF8B6E;  /* coral */
+  --motif-focus-band:    rgba(255, 139, 110, 0.07);
+  --motif-focus-veil:    rgba(255, 139, 110, 0.16);
+  --motif-focus-fg:      #0E1117;
+
+  --motif-calm:          #6BA8C4;  /* slate-blue */
+  --motif-calm-band:     rgba(107, 168, 196, 0.07);
+  --motif-calm-veil:     rgba(107, 168, 196, 0.16);
+  --motif-calm-fg:       #0E1117;
+
+  --motif-energy:        #C8E060;  /* yellow-green */
+  --motif-energy-band:   rgba(200, 224, 96, 0.07);
+  --motif-energy-veil:   rgba(200, 224, 96, 0.16);
+  --motif-energy-fg:     #0E1117;
+
+  --motif-care:          #F299B7;  /* warm pink */
+  --motif-care-band:     rgba(242, 153, 183, 0.07);
+  --motif-care-veil:     rgba(242, 153, 183, 0.16);
+  --motif-care-fg:       #0E1117;
+
+  --motif-flow:          #5FE3D5;  /* cyan */
+  --motif-flow-band:     rgba(95, 227, 213, 0.07);
+  --motif-flow-veil:     rgba(95, 227, 213, 0.16);
+  --motif-flow-fg:       #0E1117;
+
+  --motif-dusk:          #C09BE5;  /* plum */
+  --motif-dusk-band:     rgba(192, 155, 229, 0.07);
+  --motif-dusk-veil:     rgba(192, 155, 229, 0.16);
+  --motif-dusk-fg:       #0E1117;
+
+  --motif-quiet:         #9CA3B0;  /* slate gray */
+  --motif-quiet-band:    rgba(156, 163, 176, 0.06);
+  --motif-quiet-veil:    rgba(156, 163, 176, 0.14);
+  --motif-quiet-fg:      #0E1117;
+}
+
+[data-theme="tether"][data-mode="light"] {
+  --motif-anchor:        #4F58D9;
+  --motif-anchor-band:   rgba(79, 88, 217, 0.06);
+  --motif-anchor-veil:   rgba(79, 88, 217, 0.14);
+  --motif-anchor-fg:     #FFFFFF;
+
+  --motif-focus:         #D9522A;
+  --motif-focus-band:    rgba(217, 82, 42, 0.06);
+  --motif-focus-veil:    rgba(217, 82, 42, 0.14);
+  --motif-focus-fg:      #FFFFFF;
+
+  --motif-calm:          #3F7FA8;
+  --motif-calm-band:     rgba(63, 127, 168, 0.06);
+  --motif-calm-veil:     rgba(63, 127, 168, 0.14);
+  --motif-calm-fg:       #FFFFFF;
+
+  --motif-energy:        #5E8E1E;
+  --motif-energy-band:   rgba(94, 142, 30, 0.07);
+  --motif-energy-veil:   rgba(94, 142, 30, 0.16);
+  --motif-energy-fg:     #FFFFFF;
+
+  --motif-care:          #B85775;
+  --motif-care-band:     rgba(184, 87, 117, 0.06);
+  --motif-care-veil:     rgba(184, 87, 117, 0.14);
+  --motif-care-fg:       #FFFFFF;
+
+  --motif-flow:          #1F9B8E;
+  --motif-flow-band:     rgba(31, 155, 142, 0.07);
+  --motif-flow-veil:     rgba(31, 155, 142, 0.15);
+  --motif-flow-fg:       #FFFFFF;
+
+  --motif-dusk:          #7A5BAE;
+  --motif-dusk-band:     rgba(122, 91, 174, 0.06);
+  --motif-dusk-veil:     rgba(122, 91, 174, 0.14);
+  --motif-dusk-fg:       #FFFFFF;
+
+  --motif-quiet:         #6E7280;
+  --motif-quiet-band:    rgba(110, 114, 128, 0.05);
+  --motif-quiet-veil:    rgba(110, 114, 128, 0.12);
+  --motif-quiet-fg:      #FFFFFF;
+}
+
+
+/* =========================================================================
+   2. HORIZON  (warm dark / paper at night)
+   ========================================================================= */
+[data-theme="horizon"][data-mode="dark"],
+[data-theme="horizon"]:not([data-mode]) {
+  --motif-anchor:        #D4A85F;  /* amber — matches --accent */
+  --motif-anchor-band:   rgba(212, 168, 95, 0.08);
+  --motif-anchor-veil:   rgba(212, 168, 95, 0.18);
+  --motif-anchor-fg:     #161512;
+
+  --motif-focus:         #C46A3B;  /* rust */
+  --motif-focus-band:    rgba(196, 106, 59, 0.08);
+  --motif-focus-veil:    rgba(196, 106, 59, 0.18);
+  --motif-focus-fg:      #161512;
+
+  --motif-calm:          #A8B488;  /* sage */
+  --motif-calm-band:     rgba(168, 180, 136, 0.07);
+  --motif-calm-veil:     rgba(168, 180, 136, 0.16);
+  --motif-calm-fg:       #161512;
+
+  --motif-energy:        #B8A435;  /* olive */
+  --motif-energy-band:   rgba(184, 164, 53, 0.08);
+  --motif-energy-veil:   rgba(184, 164, 53, 0.18);
+  --motif-energy-fg:     #161512;
+
+  --motif-care:          #C2554E;  /* brick red */
+  --motif-care-band:     rgba(194, 85, 78, 0.08);
+  --motif-care-veil:     rgba(194, 85, 78, 0.18);
+  --motif-care-fg:       #161512;
+
+  --motif-flow:          #6BB0A8;  /* teal */
+  --motif-flow-band:     rgba(107, 176, 168, 0.07);
+  --motif-flow-veil:     rgba(107, 176, 168, 0.16);
+  --motif-flow-fg:       #161512;
+
+  --motif-dusk:          #B58AAB;  /* mauve */
+  --motif-dusk-band:     rgba(181, 138, 171, 0.07);
+  --motif-dusk-veil:     rgba(181, 138, 171, 0.16);
+  --motif-dusk-fg:       #161512;
+
+  --motif-quiet:         #978B72;  /* sand */
+  --motif-quiet-band:    rgba(151, 139, 114, 0.06);
+  --motif-quiet-veil:    rgba(151, 139, 114, 0.14);
+  --motif-quiet-fg:      #161512;
+}
+
+[data-theme="horizon"][data-mode="light"] {
+  --motif-anchor:        #A87330;
+  --motif-anchor-band:   rgba(168, 115, 48, 0.07);
+  --motif-anchor-veil:   rgba(168, 115, 48, 0.16);
+  --motif-anchor-fg:     #FBF6E8;
+
+  --motif-focus:         #9C4520;
+  --motif-focus-band:    rgba(156, 69, 32, 0.07);
+  --motif-focus-veil:    rgba(156, 69, 32, 0.16);
+  --motif-focus-fg:      #FBF6E8;
+
+  --motif-calm:          #6B8050;
+  --motif-calm-band:     rgba(107, 128, 80, 0.07);
+  --motif-calm-veil:     rgba(107, 128, 80, 0.16);
+  --motif-calm-fg:       #FBF6E8;
+
+  --motif-energy:        #8C7720;
+  --motif-energy-band:   rgba(140, 119, 32, 0.08);
+  --motif-energy-veil:   rgba(140, 119, 32, 0.18);
+  --motif-energy-fg:     #FBF6E8;
+
+  --motif-care:          #8E2E2A;
+  --motif-care-band:     rgba(142, 46, 42, 0.07);
+  --motif-care-veil:     rgba(142, 46, 42, 0.16);
+  --motif-care-fg:       #FBF6E8;
+
+  --motif-flow:          #2F8276;
+  --motif-flow-band:     rgba(47, 130, 118, 0.07);
+  --motif-flow-veil:     rgba(47, 130, 118, 0.16);
+  --motif-flow-fg:       #FBF6E8;
+
+  --motif-dusk:          #7A487B;
+  --motif-dusk-band:     rgba(122, 72, 123, 0.07);
+  --motif-dusk-veil:     rgba(122, 72, 123, 0.16);
+  --motif-dusk-fg:       #FBF6E8;
+
+  --motif-quiet:         #6A604D;
+  --motif-quiet-band:    rgba(106, 96, 77, 0.05);
+  --motif-quiet-veil:    rgba(106, 96, 77, 0.12);
+  --motif-quiet-fg:      #FBF6E8;
+}
+
+
+/* =========================================================================
+   3. CONTRAST  (WCAG AAA — strong fully-saturated bands)
+   ========================================================================= */
+[data-theme="contrast"][data-mode="dark"],
+[data-theme="contrast"]:not([data-mode]) {
+  --motif-anchor:        #FFD43B;  /* yellow — accent */
+  --motif-anchor-band:   #1F1A00;
+  --motif-anchor-veil:   #4A3A00;
+  --motif-anchor-fg:     #000000;
+
+  --motif-focus:         #FF6B6B;  /* red */
+  --motif-focus-band:    #1F0808;
+  --motif-focus-veil:    #4A1414;
+  --motif-focus-fg:      #000000;
+
+  --motif-calm:          #6FC0FF;  /* blue */
+  --motif-calm-band:     #001A2A;
+  --motif-calm-veil:     #00355A;
+  --motif-calm-fg:       #000000;
+
+  --motif-energy:        #6FE38B;  /* green */
+  --motif-energy-band:   #062810;
+  --motif-energy-veil:   #0E4A1F;
+  --motif-energy-fg:     #000000;
+
+  --motif-care:          #FF8FB1;  /* pink */
+  --motif-care-band:     #1F080F;
+  --motif-care-veil:     #4A1428;
+  --motif-care-fg:       #000000;
+
+  --motif-flow:          #5FF7E0;  /* cyan */
+  --motif-flow-band:     #002A26;
+  --motif-flow-veil:     #00524A;
+  --motif-flow-fg:       #000000;
+
+  --motif-dusk:          #C99CFF;  /* purple */
+  --motif-dusk-band:     #1A0A2A;
+  --motif-dusk-veil:     #361A55;
+  --motif-dusk-fg:       #000000;
+
+  --motif-quiet:         #B0B0B0;
+  --motif-quiet-band:    #1A1A1A;
+  --motif-quiet-veil:    #2A2A2A;
+  --motif-quiet-fg:      #000000;
+}
+
+[data-theme="contrast"][data-mode="light"] {
+  --motif-anchor:        #0030B0;
+  --motif-anchor-band:   #E8ECF8;
+  --motif-anchor-veil:   #D6DDF5;
+  --motif-anchor-fg:     #FFFFFF;
+
+  --motif-focus:         #B30000;
+  --motif-focus-band:    #FAEAEA;
+  --motif-focus-veil:    #F5D5D5;
+  --motif-focus-fg:      #FFFFFF;
+
+  --motif-calm:          #00538C;
+  --motif-calm-band:     #E2EFFA;
+  --motif-calm-veil:     #C8E0F5;
+  --motif-calm-fg:       #FFFFFF;
+
+  --motif-energy:        #1A6E1A;
+  --motif-energy-band:   #E0F0E0;
+  --motif-energy-veil:   #C0E5C0;
+  --motif-energy-fg:     #FFFFFF;
+
+  --motif-care:          #A02060;
+  --motif-care-band:     #FAE5EE;
+  --motif-care-veil:     #F2D0E0;
+  --motif-care-fg:       #FFFFFF;
+
+  --motif-flow:          #007570;
+  --motif-flow-band:     #DFF0EE;
+  --motif-flow-veil:     #BFE2DE;
+  --motif-flow-fg:       #FFFFFF;
+
+  --motif-dusk:          #5C2D8F;
+  --motif-dusk-band:     #ECE2F5;
+  --motif-dusk-veil:     #D8C5EB;
+  --motif-dusk-fg:       #FFFFFF;
+
+  --motif-quiet:         #555555;
+  --motif-quiet-band:    #EAEAEA;
+  --motif-quiet-veil:    #DADADA;
+  --motif-quiet-fg:      #FFFFFF;
+}
+
+
+/* =========================================================================
+   4. TERMINAL  (phosphor — dark and day modes)
+   ========================================================================= */
+[data-theme="terminal"][data-mode="dark"],
+[data-theme="terminal"]:not([data-mode]) {
+  --motif-anchor:        #50FA7B;  /* phosphor green — accent */
+  --motif-anchor-band:   rgba(80, 250, 123, 0.06);
+  --motif-anchor-veil:   rgba(80, 250, 123, 0.14);
+  --motif-anchor-fg:     #0A0E0A;
+
+  --motif-focus:         #8BE9FD;  /* cyan */
+  --motif-focus-band:    rgba(139, 233, 253, 0.05);
+  --motif-focus-veil:    rgba(139, 233, 253, 0.13);
+  --motif-focus-fg:      #0A0E0A;
+
+  --motif-calm:          #6FCF97;  /* dim green */
+  --motif-calm-band:     rgba(111, 207, 151, 0.05);
+  --motif-calm-veil:     rgba(111, 207, 151, 0.13);
+  --motif-calm-fg:       #0A0E0A;
+
+  --motif-energy:        #F1FA8C;  /* yellow */
+  --motif-energy-band:   rgba(241, 250, 140, 0.06);
+  --motif-energy-veil:   rgba(241, 250, 140, 0.14);
+  --motif-energy-fg:     #0A0E0A;
+
+  --motif-care:          #FF79C6;  /* magenta */
+  --motif-care-band:     rgba(255, 121, 198, 0.05);
+  --motif-care-veil:     rgba(255, 121, 198, 0.13);
+  --motif-care-fg:       #0A0E0A;
+
+  --motif-flow:          #A8E0FF;  /* sky cyan */
+  --motif-flow-band:     rgba(168, 224, 255, 0.05);
+  --motif-flow-veil:     rgba(168, 224, 255, 0.13);
+  --motif-flow-fg:       #0A0E0A;
+
+  --motif-dusk:          #BD93F9;  /* purple */
+  --motif-dusk-band:     rgba(189, 147, 249, 0.05);
+  --motif-dusk-veil:     rgba(189, 147, 249, 0.13);
+  --motif-dusk-fg:       #0A0E0A;
+
+  --motif-quiet:         #5A9A5A;
+  --motif-quiet-band:    rgba(90, 154, 90, 0.04);
+  --motif-quiet-veil:    rgba(90, 154, 90, 0.10);
+  --motif-quiet-fg:      #0A0E0A;
+}
+
+[data-theme="terminal"][data-mode="light"] {
+  --motif-anchor:        #1A6E1A;  /* dark forest green */
+  --motif-anchor-band:   rgba(26, 110, 26, 0.06);
+  --motif-anchor-veil:   rgba(26, 110, 26, 0.14);
+  --motif-anchor-fg:     #F2F1E8;
+
+  --motif-focus:         #006B7A;  /* deep cyan */
+  --motif-focus-band:    rgba(0, 107, 122, 0.05);
+  --motif-focus-veil:    rgba(0, 107, 122, 0.13);
+  --motif-focus-fg:      #F2F1E8;
+
+  --motif-calm:          #2D8552;  /* moss */
+  --motif-calm-band:     rgba(45, 133, 82, 0.05);
+  --motif-calm-veil:     rgba(45, 133, 82, 0.13);
+  --motif-calm-fg:       #F2F1E8;
+
+  --motif-energy:        #8C6E00;  /* mustard */
+  --motif-energy-band:   rgba(140, 110, 0, 0.06);
+  --motif-energy-veil:   rgba(140, 110, 0, 0.15);
+  --motif-energy-fg:     #F2F1E8;
+
+  --motif-care:          #A52A6E;  /* deep magenta */
+  --motif-care-band:     rgba(165, 42, 110, 0.05);
+  --motif-care-veil:     rgba(165, 42, 110, 0.13);
+  --motif-care-fg:       #F2F1E8;
+
+  --motif-flow:          #1F6E96;  /* slate cyan */
+  --motif-flow-band:     rgba(31, 110, 150, 0.05);
+  --motif-flow-veil:     rgba(31, 110, 150, 0.13);
+  --motif-flow-fg:       #F2F1E8;
+
+  --motif-dusk:          #5E3A8C;  /* aubergine */
+  --motif-dusk-band:     rgba(94, 58, 140, 0.05);
+  --motif-dusk-veil:     rgba(94, 58, 140, 0.13);
+  --motif-dusk-fg:       #F2F1E8;
+
+  --motif-quiet:         #4A5A4A;
+  --motif-quiet-band:    rgba(74, 90, 74, 0.04);
+  --motif-quiet-veil:    rgba(74, 90, 74, 0.10);
+  --motif-quiet-fg:      #F2F1E8;
+}
+
+
+/* =========================================================================
+   5. SOLSTICE  (cool glacial)
+   ========================================================================= */
+[data-theme="solstice"][data-mode="dark"],
+[data-theme="solstice"]:not([data-mode]) {
+  --motif-anchor:        #5FC8E6;
+  --motif-anchor-band:   rgba(95, 200, 230, 0.07);
+  --motif-anchor-veil:   rgba(95, 200, 230, 0.16);
+  --motif-anchor-fg:     #0B1418;
+
+  --motif-focus:         #FF9F7A;
+  --motif-focus-band:    rgba(255, 159, 122, 0.06);
+  --motif-focus-veil:    rgba(255, 159, 122, 0.15);
+  --motif-focus-fg:      #0B1418;
+
+  --motif-calm:          #88C4D0;
+  --motif-calm-band:     rgba(136, 196, 208, 0.06);
+  --motif-calm-veil:     rgba(136, 196, 208, 0.14);
+  --motif-calm-fg:       #0B1418;
+
+  --motif-energy:        #DCE872;
+  --motif-energy-band:   rgba(220, 232, 114, 0.07);
+  --motif-energy-veil:   rgba(220, 232, 114, 0.16);
+  --motif-energy-fg:     #0B1418;
+
+  --motif-care:          #F2A8C0;
+  --motif-care-band:     rgba(242, 168, 192, 0.06);
+  --motif-care-veil:     rgba(242, 168, 192, 0.15);
+  --motif-care-fg:       #0B1418;
+
+  --motif-flow:          #7DDFD1;
+  --motif-flow-band:     rgba(125, 223, 209, 0.07);
+  --motif-flow-veil:     rgba(125, 223, 209, 0.16);
+  --motif-flow-fg:       #0B1418;
+
+  --motif-dusk:          #BFA6E5;
+  --motif-dusk-band:     rgba(191, 166, 229, 0.06);
+  --motif-dusk-veil:     rgba(191, 166, 229, 0.15);
+  --motif-dusk-fg:       #0B1418;
+
+  --motif-quiet:         #92A8B0;
+  --motif-quiet-band:    rgba(146, 168, 176, 0.05);
+  --motif-quiet-veil:    rgba(146, 168, 176, 0.12);
+  --motif-quiet-fg:      #0B1418;
+}
+
+
+/* =========================================================================
+   6. DRACULA·TETHER  (vivid dev classic — distinctive 6-color palette)
+   ========================================================================= */
+[data-theme="dracula"][data-mode="dark"],
+[data-theme="dracula"]:not([data-mode]) {
+  --motif-anchor:        #BD93F9;  /* purple */
+  --motif-anchor-band:   rgba(189, 147, 249, 0.08);
+  --motif-anchor-veil:   rgba(189, 147, 249, 0.18);
+  --motif-anchor-fg:     #282A36;
+
+  --motif-focus:         #FF5555;  /* red */
+  --motif-focus-band:    rgba(255, 85, 85, 0.07);
+  --motif-focus-veil:    rgba(255, 85, 85, 0.16);
+  --motif-focus-fg:      #282A36;
+
+  --motif-calm:          #6272A4;  /* comment blue */
+  --motif-calm-band:     rgba(98, 114, 164, 0.10);
+  --motif-calm-veil:     rgba(98, 114, 164, 0.22);
+  --motif-calm-fg:       #F8F8F2;
+
+  --motif-energy:        #F1FA8C;  /* yellow */
+  --motif-energy-band:   rgba(241, 250, 140, 0.07);
+  --motif-energy-veil:   rgba(241, 250, 140, 0.16);
+  --motif-energy-fg:     #282A36;
+
+  --motif-care:          #FF79C6;  /* pink */
+  --motif-care-band:     rgba(255, 121, 198, 0.07);
+  --motif-care-veil:     rgba(255, 121, 198, 0.16);
+  --motif-care-fg:       #282A36;
+
+  --motif-flow:          #8BE9FD;  /* cyan */
+  --motif-flow-band:     rgba(139, 233, 253, 0.07);
+  --motif-flow-veil:     rgba(139, 233, 253, 0.16);
+  --motif-flow-fg:       #282A36;
+
+  --motif-dusk:          #FFB86C;  /* orange */
+  --motif-dusk-band:     rgba(255, 184, 108, 0.07);
+  --motif-dusk-veil:     rgba(255, 184, 108, 0.16);
+  --motif-dusk-fg:       #282A36;
+
+  --motif-quiet:         #50FA7B;  /* green — used as quiet because it's the "tether" anchor */
+  --motif-quiet-band:    rgba(80, 250, 123, 0.05);
+  --motif-quiet-veil:    rgba(80, 250, 123, 0.12);
+  --motif-quiet-fg:      #282A36;
+}
+
+
+/* =========================================================================
+   7. PAPER  (light monochrome — bands rely on warmth gradient, not hue)
+   ========================================================================= */
+[data-theme="paper"][data-mode="light"],
+[data-theme="paper"]:not([data-mode]) {
+  --motif-anchor:        #1C1C1A;  /* black — accent */
+  --motif-anchor-band:   rgba(28, 28, 26, 0.05);
+  --motif-anchor-veil:   rgba(28, 28, 26, 0.12);
+  --motif-anchor-fg:     #FAFAF7;
+
+  --motif-focus:         #5F4030;  /* warm sienna */
+  --motif-focus-band:    rgba(95, 64, 48, 0.06);
+  --motif-focus-veil:    rgba(95, 64, 48, 0.14);
+  --motif-focus-fg:      #FAFAF7;
+
+  --motif-calm:          #5A5A5A;  /* warm gray */
+  --motif-calm-band:     rgba(90, 90, 90, 0.05);
+  --motif-calm-veil:     rgba(90, 90, 90, 0.12);
+  --motif-calm-fg:       #FAFAF7;
+
+  --motif-energy:        #8A2020;  /* brick */
+  --motif-energy-band:   rgba(138, 32, 32, 0.06);
+  --motif-energy-veil:   rgba(138, 32, 32, 0.14);
+  --motif-energy-fg:     #FAFAF7;
+
+  --motif-care:          #6B3030;  /* dark sepia */
+  --motif-care-band:     rgba(107, 48, 48, 0.06);
+  --motif-care-veil:     rgba(107, 48, 48, 0.14);
+  --motif-care-fg:       #FAFAF7;
+
+  --motif-flow:          #2A4A5A;  /* steel blue */
+  --motif-flow-band:     rgba(42, 74, 90, 0.06);
+  --motif-flow-veil:     rgba(42, 74, 90, 0.14);
+  --motif-flow-fg:       #FAFAF7;
+
+  --motif-dusk:          #4A2A5A;  /* aubergine */
+  --motif-dusk-band:     rgba(74, 42, 90, 0.06);
+  --motif-dusk-veil:     rgba(74, 42, 90, 0.14);
+  --motif-dusk-fg:       #FAFAF7;
+
+  --motif-quiet:         #6A6A66;
+  --motif-quiet-band:    rgba(106, 106, 102, 0.04);
+  --motif-quiet-veil:    rgba(106, 106, 102, 0.10);
+  --motif-quiet-fg:      #FAFAF7;
+}
+
+
+/* =========================================================================
+   USAGE
+   --------------------------------------------------------------------------
+   Tag any element with [data-motif="<slot>"]. Components read the slot's
+   solid + band + veil values via local var() aliasing:
+
+       [data-motif="anchor"]  { --m: var(--motif-anchor);  --m-band: var(--motif-anchor-band); }
+       [data-motif="focus"]   { --m: var(--motif-focus);   --m-band: var(--motif-focus-band);  }
+       …etc
+
+   Then components reference --m / --m-band / --m-veil instead of --accent.
+
+   The block below sets up that aliasing once, so components don't repeat it.
+   ========================================================================= */
+/* Each motif slot publishes:
+   --m / --m-accent  the solid identity color (borders, dots, key strokes)
+   --m-band          soft tinted background (fills, day-bands, cards)
+   --m-line          mid-weight tint (separators, subtle borders)
+   --m-veil          very faint hint of color (hover states)
+   --m-fg            legible text-on-band color */
+/* =========================================================================
+   ADDITIONAL SLOTS — task / event / milestone colours
+   These extend the anchor palette for granular item colouring.
+   They don't need to represent an entire anchor's mood — they work at the
+   task / event / milestone level so users can mark individual items as
+   urgent, a launch milestone, or a sync/meeting without that colour
+   bleeding into the whole anchor block.
+
+   urgent  — critical, time-sensitive, overdue-adjacent
+   launch  — releases, milestones, ship moments
+   sync    — meetings, calendar events, collaboration
+   ========================================================================= */
+
+/* Tether dark */
+:root,
+[data-theme="tether"][data-mode="dark"],
+[data-theme="tether"]:not([data-mode]) {
+  --motif-urgent:        #FF5C5C;
+  --motif-urgent-band:   rgba(255, 92, 92, 0.08);
+  --motif-urgent-veil:   rgba(255, 92, 92, 0.18);
+  --motif-urgent-fg:     #0E1117;
+
+  --motif-launch:        #F5E642;
+  --motif-launch-band:   rgba(245, 230, 66, 0.07);
+  --motif-launch-veil:   rgba(245, 230, 66, 0.16);
+  --motif-launch-fg:     #0E1117;
+
+  --motif-sync:          #A78BFA;
+  --motif-sync-band:     rgba(167, 139, 250, 0.08);
+  --motif-sync-veil:     rgba(167, 139, 250, 0.18);
+  --motif-sync-fg:       #0E1117;
+}
+[data-theme="tether"][data-mode="light"] {
+  --motif-urgent:        #C0392B;
+  --motif-urgent-band:   rgba(192, 57, 43, 0.07);
+  --motif-urgent-veil:   rgba(192, 57, 43, 0.15);
+  --motif-urgent-fg:     #FFFFFF;
+
+  --motif-launch:        #A08800;
+  --motif-launch-band:   rgba(160, 136, 0, 0.07);
+  --motif-launch-veil:   rgba(160, 136, 0, 0.16);
+  --motif-launch-fg:     #FFFFFF;
+
+  --motif-sync:          #6D4ED8;
+  --motif-sync-band:     rgba(109, 78, 216, 0.07);
+  --motif-sync-veil:     rgba(109, 78, 216, 0.16);
+  --motif-sync-fg:       #FFFFFF;
+}
+
+/* Horizon dark */
+[data-theme="horizon"][data-mode="dark"],
+[data-theme="horizon"]:not([data-mode]) {
+  --motif-urgent:        #E05252;
+  --motif-urgent-band:   rgba(224, 82, 82, 0.08);
+  --motif-urgent-veil:   rgba(224, 82, 82, 0.18);
+  --motif-urgent-fg:     #161512;
+
+  --motif-launch:        #C8A820;
+  --motif-launch-band:   rgba(200, 168, 32, 0.08);
+  --motif-launch-veil:   rgba(200, 168, 32, 0.18);
+  --motif-launch-fg:     #161512;
+
+  --motif-sync:          #9B7ECC;
+  --motif-sync-band:     rgba(155, 126, 204, 0.08);
+  --motif-sync-veil:     rgba(155, 126, 204, 0.18);
+  --motif-sync-fg:       #161512;
+}
+[data-theme="horizon"][data-mode="light"] {
+  --motif-urgent:        #9C2A1A;
+  --motif-urgent-band:   rgba(156, 42, 26, 0.07);
+  --motif-urgent-veil:   rgba(156, 42, 26, 0.16);
+  --motif-urgent-fg:     #FBF6E8;
+
+  --motif-launch:        #7A5E00;
+  --motif-launch-band:   rgba(122, 94, 0, 0.07);
+  --motif-launch-veil:   rgba(122, 94, 0, 0.16);
+  --motif-launch-fg:     #FBF6E8;
+
+  --motif-sync:          #5A3A9C;
+  --motif-sync-band:     rgba(90, 58, 156, 0.07);
+  --motif-sync-veil:     rgba(90, 58, 156, 0.16);
+  --motif-sync-fg:       #FBF6E8;
+}
+
+/* Contrast dark */
+[data-theme="contrast"][data-mode="dark"],
+[data-theme="contrast"]:not([data-mode]) {
+  --motif-urgent:        #FF4444;
+  --motif-urgent-band:   #2A0000;
+  --motif-urgent-veil:   #4A0000;
+  --motif-urgent-fg:     #000000;
+
+  --motif-launch:        #FFEE44;
+  --motif-launch-band:   #2A2600;
+  --motif-launch-veil:   #4A4200;
+  --motif-launch-fg:     #000000;
+
+  --motif-sync:          #CC88FF;
+  --motif-sync-band:     #1A0A2A;
+  --motif-sync-veil:     #2E1450;
+  --motif-sync-fg:       #000000;
+}
+[data-theme="contrast"][data-mode="light"] {
+  --motif-urgent:        #AA0000;
+  --motif-urgent-band:   #F9DDDD;
+  --motif-urgent-veil:   #F0C0C0;
+  --motif-urgent-fg:     #FFFFFF;
+
+  --motif-launch:        #886600;
+  --motif-launch-band:   #F8F0CC;
+  --motif-launch-veil:   #EFE0A0;
+  --motif-launch-fg:     #FFFFFF;
+
+  --motif-sync:          #550099;
+  --motif-sync-band:     #EEE0FF;
+  --motif-sync-veil:     #DDC0FF;
+  --motif-sync-fg:       #FFFFFF;
+}
+
+/* Terminal dark */
+[data-theme="terminal"][data-mode="dark"],
+[data-theme="terminal"]:not([data-mode]) {
+  --motif-urgent:        #FF5555;
+  --motif-urgent-band:   rgba(255, 85, 85, 0.08);
+  --motif-urgent-veil:   rgba(255, 85, 85, 0.16);
+  --motif-urgent-fg:     #0A0E0A;
+
+  --motif-launch:        #F1FA8C;
+  --motif-launch-band:   rgba(241, 250, 140, 0.07);
+  --motif-launch-veil:   rgba(241, 250, 140, 0.15);
+  --motif-launch-fg:     #0A0E0A;
+
+  --motif-sync:          #BD93F9;
+  --motif-sync-band:     rgba(189, 147, 249, 0.08);
+  --motif-sync-veil:     rgba(189, 147, 249, 0.16);
+  --motif-sync-fg:       #0A0E0A;
+}
+[data-theme="terminal"][data-mode="light"] {
+  --motif-urgent:        #AA1E1E;
+  --motif-urgent-band:   rgba(170, 30, 30, 0.07);
+  --motif-urgent-veil:   rgba(170, 30, 30, 0.15);
+  --motif-urgent-fg:     #F2F1E8;
+
+  --motif-launch:        #8C7000;
+  --motif-launch-band:   rgba(140, 112, 0, 0.07);
+  --motif-launch-veil:   rgba(140, 112, 0, 0.15);
+  --motif-launch-fg:     #F2F1E8;
+
+  --motif-sync:          #6040B8;
+  --motif-sync-band:     rgba(96, 64, 184, 0.07);
+  --motif-sync-veil:     rgba(96, 64, 184, 0.15);
+  --motif-sync-fg:       #F2F1E8;
+}
+
+/* Solstice, Dracula, Paper — inherit from Tether/Terminal/Paper as reasonable defaults */
+[data-theme="solstice"] {
+  --motif-urgent:        #FF7A6B;
+  --motif-urgent-band:   rgba(255, 122, 107, 0.07);
+  --motif-urgent-veil:   rgba(255, 122, 107, 0.16);
+  --motif-urgent-fg:     #0B1418;
+
+  --motif-launch:        #DCE872;
+  --motif-launch-band:   rgba(220, 232, 114, 0.07);
+  --motif-launch-veil:   rgba(220, 232, 114, 0.16);
+  --motif-launch-fg:     #0B1418;
+
+  --motif-sync:          #BFA6E5;
+  --motif-sync-band:     rgba(191, 166, 229, 0.07);
+  --motif-sync-veil:     rgba(191, 166, 229, 0.16);
+  --motif-sync-fg:       #0B1418;
+}
+[data-theme="dracula"] {
+  --motif-urgent:        #FF5555;
+  --motif-urgent-band:   rgba(255, 85, 85, 0.08);
+  --motif-urgent-veil:   rgba(255, 85, 85, 0.18);
+  --motif-urgent-fg:     #282A36;
+
+  --motif-launch:        #F1FA8C;
+  --motif-launch-band:   rgba(241, 250, 140, 0.08);
+  --motif-launch-veil:   rgba(241, 250, 140, 0.18);
+  --motif-launch-fg:     #282A36;
+
+  --motif-sync:          #BD93F9;
+  --motif-sync-band:     rgba(189, 147, 249, 0.08);
+  --motif-sync-veil:     rgba(189, 147, 249, 0.18);
+  --motif-sync-fg:       #282A36;
+}
+[data-theme="paper"] {
+  --motif-urgent:        #8A1818;
+  --motif-urgent-band:   rgba(138, 24, 24, 0.07);
+  --motif-urgent-veil:   rgba(138, 24, 24, 0.14);
+  --motif-urgent-fg:     #FAFAF7;
+
+  --motif-launch:        #7A6200;
+  --motif-launch-band:   rgba(122, 98, 0, 0.07);
+  --motif-launch-veil:   rgba(122, 98, 0, 0.14);
+  --motif-launch-fg:     #FAFAF7;
+
+  --motif-sync:          #4A2A7A;
+  --motif-sync-band:     rgba(74, 42, 122, 0.07);
+  --motif-sync-veil:     rgba(74, 42, 122, 0.14);
+  --motif-sync-fg:       #FAFAF7;
+}
+
+[data-motif="anchor"] { --m: var(--motif-anchor); --m-accent: var(--motif-anchor); --m-band: var(--motif-anchor-band); --m-line: var(--motif-anchor-veil); --m-veil: var(--motif-anchor-veil); --m-fg: var(--motif-anchor-fg); }
+[data-motif="focus"]  { --m: var(--motif-focus);  --m-accent: var(--motif-focus);  --m-band: var(--motif-focus-band);  --m-line: var(--motif-focus-veil);  --m-veil: var(--motif-focus-veil);  --m-fg: var(--motif-focus-fg); }
+[data-motif="calm"]   { --m: var(--motif-calm);   --m-accent: var(--motif-calm);   --m-band: var(--motif-calm-band);   --m-line: var(--motif-calm-veil);   --m-veil: var(--motif-calm-veil);   --m-fg: var(--motif-calm-fg); }
+[data-motif="energy"] { --m: var(--motif-energy); --m-accent: var(--motif-energy); --m-band: var(--motif-energy-band); --m-line: var(--motif-energy-veil); --m-veil: var(--motif-energy-veil); --m-fg: var(--motif-energy-fg); }
+[data-motif="care"]   { --m: var(--motif-care);   --m-accent: var(--motif-care);   --m-band: var(--motif-care-band);   --m-line: var(--motif-care-veil);   --m-veil: var(--motif-care-veil);   --m-fg: var(--motif-care-fg); }
+[data-motif="flow"]   { --m: var(--motif-flow);   --m-accent: var(--motif-flow);   --m-band: var(--motif-flow-band);   --m-line: var(--motif-flow-veil);   --m-veil: var(--motif-flow-veil);   --m-fg: var(--motif-flow-fg); }
+[data-motif="dusk"]   { --m: var(--motif-dusk);   --m-accent: var(--motif-dusk);   --m-band: var(--motif-dusk-band);   --m-line: var(--motif-dusk-veil);   --m-veil: var(--motif-dusk-veil);   --m-fg: var(--motif-dusk-fg); }
+[data-motif="quiet"]  { --m: var(--motif-quiet);  --m-accent: var(--motif-quiet);  --m-band: var(--motif-quiet-band);  --m-line: var(--motif-quiet-veil);  --m-veil: var(--motif-quiet-veil);  --m-fg: var(--motif-quiet-fg); }
+[data-motif="urgent"] { --m: var(--motif-urgent); --m-accent: var(--motif-urgent); --m-band: var(--motif-urgent-band); --m-line: var(--motif-urgent-veil); --m-veil: var(--motif-urgent-veil); --m-fg: var(--motif-urgent-fg); }
+[data-motif="launch"] { --m: var(--motif-launch); --m-accent: var(--motif-launch); --m-band: var(--motif-launch-band); --m-line: var(--motif-launch-veil); --m-veil: var(--motif-launch-veil); --m-fg: var(--motif-launch-fg); }
+[data-motif="sync"]   { --m: var(--motif-sync);   --m-accent: var(--motif-sync);   --m-band: var(--motif-sync-band);   --m-line: var(--motif-sync-veil);   --m-veil: var(--motif-sync-veil);   --m-fg: var(--motif-sync-fg); }

--- a/frontend/src/assets/theme-distinctives.css
+++ b/frontend/src/assets/theme-distinctives.css
@@ -1,0 +1,226 @@
+/* =========================================================================
+   Theme Distinctives — visual treatments that go beyond color tokens.
+   --------------------------------------------------------------------------
+   Color tokens (themes.css) and motif slots (motifs.css) handle most of
+   what makes themes look different. But some themes earn their character
+   through *structural* details — scanlines, drop caps, ornament dividers.
+   Those live here.
+
+   This file is loaded AFTER themes.css and motifs.css, BEFORE component
+   stylesheets, so component rules can still override individual properties.
+
+   Conventions:
+     - Every selector is scoped to a [data-theme="..."] root.
+     - Where possible we hook into [data-type-voice] so future themes that
+       opt into "editorial" or "terminal" voice get the treatment for free.
+   ========================================================================= */
+
+
+/* =========================================================================
+   TERMINAL — CRT phosphor + scanlines + box-drawing
+   ========================================================================= */
+
+/* CRT scanline overlay on the canvas root.
+   Pseudo-element on body so it sits above all content but below nothing. */
+[data-theme="terminal"] .crt,
+[data-theme="terminal"].crt {
+  position: relative;
+  isolation: isolate;
+}
+[data-theme="terminal"] .crt::after,
+[data-theme="terminal"].crt::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 99;
+  background-image: repeating-linear-gradient(
+    180deg,
+    transparent 0,
+    transparent 1px,
+    rgba(0, 0, 0, 0.16) 1px,
+    rgba(0, 0, 0, 0.16) 2px
+  );
+  mix-blend-mode: multiply;
+  opacity: 0.55;
+}
+/* Terminal day mode: NO background scanlines — too much of a line-printer effect.
+   Scanlines only on interactive elements (buttons) in day mode. */
+[data-theme="terminal"][data-mode="light"] .crt::after,
+[data-theme="terminal"][data-mode="light"].crt::after {
+  display: none;
+}
+
+/* Day-terminal buttons get a subtle horizontal line texture instead */
+[data-theme="terminal"][data-mode="light"] .pa-btn::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  background-image: repeating-linear-gradient(
+    180deg,
+    transparent 0,
+    transparent 2px,
+    rgba(100, 120, 100, 0.10) 2px,
+    rgba(100, 120, 100, 0.10) 3px
+  );
+  mix-blend-mode: multiply;
+}
+[data-theme="terminal"][data-mode="light"] .pa-btn {
+  position: relative;
+  overflow: hidden;
+}
+
+/* Phosphor glow on accent text.
+   Applied to titles, the brand name, anything that should "burn" into the
+   tube. Use class .glow OR rely on h1/h2/h3 inside [data-type-voice="terminal"]. */
+[data-theme="terminal"][data-mode="dark"] .glow,
+[data-theme="terminal"][data-mode="dark"] [data-type-voice="terminal"] h1,
+[data-theme="terminal"][data-mode="dark"] [data-type-voice="terminal"] h2,
+[data-theme="terminal"][data-mode="dark"] .pa-anchor__title,
+[data-theme="terminal"][data-mode="dark"] .pa-login__brand,
+[data-theme="terminal"][data-mode="dark"] .pa-chat__name {
+  text-shadow:
+    0 0 1px var(--accent),
+    0 0 6px rgba(80, 250, 123, 0.45),
+    0 0 14px rgba(80, 250, 123, 0.25);
+  color: var(--accent);
+}
+/* Day-mode terminal — no glow, but the same titles get a heavier weight + ink color */
+[data-theme="terminal"][data-mode="light"] .pa-anchor__title,
+[data-theme="terminal"][data-mode="light"] .pa-login__brand,
+[data-theme="terminal"][data-mode="light"] .pa-chat__name {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+/* Replace card/panel borders with box-drawing characters.
+   Done via background-image with the corner glyphs as foreground letters. */
+[data-theme="terminal"] .pa-chat,
+[data-theme="terminal"] .pa-cal {
+  border: 1px solid var(--border-1);
+  border-radius: 0;
+  position: relative;
+}
+[data-theme="terminal"] .pa-chat::before,
+[data-theme="terminal"] .pa-chat::after,
+[data-theme="terminal"] .pa-cal::before,
+[data-theme="terminal"] .pa-cal::after {
+  position: absolute;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  line-height: 1;
+  color: var(--border-2);
+  background: var(--bg-canvas);
+  padding: 0 2px;
+  pointer-events: none;
+}
+[data-theme="terminal"] .pa-chat::before { content: "┌"; top: -8px; left: -1px; }
+[data-theme="terminal"] .pa-chat::after  { content: "┘"; bottom: -8px; right: -1px; }
+[data-theme="terminal"] .pa-cal::before  { content: "┌"; top: -8px; left: -1px; }
+[data-theme="terminal"] .pa-cal::after   { content: "┘"; bottom: -8px; right: -1px; }
+
+/* Tab/PgDn/Esc hint strip on chat bottom (decorative). */
+[data-theme="terminal"] .pa-chat__compose {
+  position: relative;
+}
+[data-theme="terminal"] .pa-chat__compose::before {
+  content: "[Enter] send  [Esc] close  [↑] history";
+  position: absolute;
+  bottom: -16px;
+  left: 0;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--fg-5);
+  letter-spacing: 0.05em;
+}
+
+/* Blinking block cursor inside the chat input */
+[data-theme="terminal"] .pa-chat__input {
+  caret-color: var(--accent);
+}
+[data-theme="terminal"] .pa-chat__input:focus {
+  background: var(--bg-canvas) !important;
+}
+
+/* Field labels get a leading "│ " glyph */
+[data-theme="terminal"] .pa-field__lbl::before { content: "│ "; color: var(--accent); }
+
+
+/* =========================================================================
+   HORIZON — drop caps, oldstyle figures, ornament dividers
+   ========================================================================= */
+
+/* Subtle warm-paper noise on the canvas.
+   Achieved by a faint repeating gradient — no asset needed. */
+[data-theme="horizon"] .crt,
+[data-theme="horizon"].crt {
+  position: relative;
+  background-image:
+    radial-gradient(circle at 25% 30%, rgba(212, 168, 95, 0.025) 0%, transparent 40%),
+    radial-gradient(circle at 75% 70%, rgba(212, 168, 95, 0.02) 0%, transparent 50%);
+}
+
+/* Drop cap on the first letter of bot quotes (italic + serif). */
+[data-theme="horizon"] [data-type-voice="editorial"] .pa-chat__msg--bot:first-child .pa-chat__bubble::first-letter {
+  font-family: var(--font-display);
+  font-size: 2.6em;
+  line-height: 0.85;
+  float: left;
+  margin: 0.05em 0.08em -0.05em 0;
+  font-weight: 400;
+  font-style: normal;
+  color: var(--accent);
+}
+
+/* Section divider ornament (horizontal rule with center glyph).
+   Use class .pa-ornament between sections. */
+[data-theme="horizon"] .pa-ornament {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  color: var(--fg-5);
+  font-family: var(--font-display);
+  font-size: 16px;
+  margin: 16px 0;
+}
+[data-theme="horizon"] .pa-ornament::before,
+[data-theme="horizon"] .pa-ornament::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border-soft);
+}
+[data-theme="horizon"] .pa-ornament-glyph::before { content: "❦"; color: var(--accent); }
+
+/* Time labels in oldstyle figures — fake it with small caps + spacing.
+   Source Serif Pro variants ship with oldstyle nums via font-feature-settings. */
+[data-theme="horizon"] .pa-anchor__time,
+[data-theme="horizon"] .pa-cal__hour,
+[data-theme="horizon"] .pa-cal__evt-time {
+  font-feature-settings: "onum" 1, "tnum" 0;
+  font-variant-numeric: oldstyle-nums proportional-nums;
+}
+
+/* Anchor titles in Horizon get a tiny § ornament before the now-pill */
+[data-theme="horizon"] .pa-anchor__head .pa-anchor__title::after { content: ''; }
+[data-theme="horizon"] .pa-anchor--now .pa-anchor__title::before {
+  content: "§ ";
+  color: var(--accent);
+  font-style: italic;
+  font-weight: 400;
+}
+
+
+/* =========================================================================
+   PAPER — minimal serif, hairline rules
+   ========================================================================= */
+[data-theme="paper"] .pa-anchor__time,
+[data-theme="paper"] .pa-cal__hour,
+[data-theme="paper"] .pa-cal__evt-time {
+  font-feature-settings: "onum" 1;
+  font-variant-numeric: oldstyle-nums proportional-nums;
+  font-style: italic;
+}
+[data-theme="paper"] .pa-anchor__title { font-style: italic; }

--- a/frontend/src/assets/themes.css
+++ b/frontend/src/assets/themes.css
@@ -1,0 +1,858 @@
+/* =========================================================================
+   Tether — Theme Architecture
+   --------------------------------------------------------------------------
+   Every theme is a complete set of semantic tokens. Themes are applied by
+   setting [data-theme="..."] (and optionally [data-mode="light"|"dark"])
+   on <html> or any subtree. All component CSS reads from these tokens —
+   no theme writes to component styles directly.
+
+   FREE THEMES (4): tether (default), horizon, contrast, terminal
+   FREE FEATURE:    day/night auto (data-mode toggles in user's local TZ,
+                    optionally synced to "wind down" / "morning" anchors)
+
+   PAID THEMES (3 at launch): solstice, dracula-tether, paper
+   PAID FEATURES:   custom accent, custom canvas, font swap, per-anchor
+                    theme transitions, custom image upload, seasonal drops
+
+   SPLIT:
+     - All theme tokens live in OSS (this file ships in the public repo).
+     - Cloud paywall is enforced server-side by a userTier check that
+       gates the "Apply theme" action; tokens are visible & previewable.
+     - Self-hosters get every theme by definition (AGPL3).
+     - tether-premium repo: seasonal delivery mechanism, custom image
+       pipeline, advanced gating. No visual tokens — only services.
+   ========================================================================= */
+
+
+/* =========================================================================
+   1. SEMANTIC TOKEN CONTRACT
+   --------------------------------------------------------------------------
+   Every theme MUST define every token in this list. Components only ever
+   reference these names, never raw hex values.
+   ========================================================================= */
+
+/*
+
+  CANVAS LAYERS  (the dark/light floor + stacked surfaces)
+  ─────────────────────────────────────────────────────────
+  --bg-canvas        the floor
+  --bg-canvas-veil   sticky-nav fill (canvas at 80% + backdrop-blur)
+  --bg-elev-1        cards, kanban columns, day timeline
+  --bg-elev-2        anchor blocks, dashboard tiles, inputs
+  --bg-elev-3        hover states, active row
+  --bg-elev-4        active route pill, selected
+  --bg-popover       dropdowns, status pickers, command palette
+  --bg-input         text inputs (auth screens)
+
+  FOREGROUND  (text on canvas)
+  ────────────────────────────
+  --fg-1 ... --fg-7   primary → faintest hint (7 stops)
+
+  BORDERS
+  ───────
+  --border-1         default 1px border
+  --border-2         hover/focused border
+  --border-soft      nested group containers
+  --border-input     auth input border
+
+  ACCENT  (the brand line — in default theme this is "the tether")
+  ──────────────────────────────────────────────────────────────────
+  --accent           primary accent (CTAs, focus rings, anchor color)
+  --accent-soft      ~20% alpha tint
+  --accent-veil      ~12% alpha (anchor block backgrounds)
+  --accent-fg        text color on top of solid --accent
+
+  THE LINE  (Tether's signature motif)
+  ────────────────────────────────────
+  --line-color       the vertical thread color
+  --line-glow        glow color around "now" node
+  --line-strength    1=hairline, 2=visible, 3=bold (sets stroke width)
+  --node-fill        the node background
+  --node-now         the "now" node fill
+  --node-done        the "done" node fill
+
+  STATUS  (5 states, every theme defines)
+  ───────────────────────────────────────
+  --status-todo-{bg,fg}
+  --status-doing-{bg,fg,card}
+  --status-done-{bg,fg,card}
+  --status-skip-{bg,fg,card}
+  --status-block-{bg,fg,card}
+
+  TYPE
+  ────
+  --font-display     display/headings
+  --font-sans        body
+  --font-mono        timestamps, status, code
+  --font-serif       (optional, only Horizon uses it; falls back to sans)
+  --type-voice       'sharp' | 'editorial' | 'terminal' (sets default tracking/casing rules)
+
+  RADII
+  ─────
+  --radius-sharp     0–2px (Tether default, rooted/grounded)
+  --radius-soft      6–10px (friendly themes)
+  --radius-pill      9999px
+
+  SHADOWS
+  ───────
+  --shadow-pop       popovers (status picker, dropdowns)
+  --shadow-event     calendar event blocks
+  --shadow-focus     focus ring shadow
+
+  TRANSITIONS
+  ───────────
+  --motion-fast      150ms (hover/state)
+  --motion-mid       300ms (theme swap, drawer)
+  --motion-slow      900ms (day/night auto crossfade)
+
+*/
+
+
+/* =========================================================================
+   2. SHARED TOKENS  (every theme inherits these unless overridden)
+   ========================================================================= */
+:root {
+  /* fonts — themes override --type-voice and may override --font-display */
+  --font-sans:    "Inter Tight", "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono:    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --font-serif:   "Source Serif Pro", "GT Sectra", Georgia, serif;
+  --font-display: var(--font-sans);
+
+  /* type voice (informs tracking, casing, capitalisation rules in components) */
+  --type-voice:   sharp;
+
+  /* radii — themes override */
+  --radius-sharp: 1px;
+  --radius-soft:  8px;
+  --radius-pill:  9999px;
+
+  /* line motif strength (themes override) */
+  --line-strength: 2px;
+
+  /* motion */
+  --motion-fast:  150ms;
+  --motion-mid:   300ms;
+  --motion-slow:  900ms;
+}
+
+
+/* =========================================================================
+   3. FREE TIER · DEFAULT — "TETHER"  (dark mode)
+   --------------------------------------------------------------------------
+   The line is the brand. Indigo-leaning dark. This is the fallback when no
+   data-theme is set.
+   ========================================================================= */
+:root,
+[data-theme="tether"],
+[data-theme="tether"][data-mode="dark"] {
+  /* canvas */
+  --bg-canvas:       #0E1117;
+  --bg-canvas-veil:  rgba(14, 17, 23, 0.80);
+  --bg-elev-1:       rgba(255, 255, 255, 0.03);
+  --bg-elev-2:       rgba(255, 255, 255, 0.05);
+  --bg-elev-3:       rgba(255, 255, 255, 0.10);
+  --bg-elev-4:       rgba(255, 255, 255, 0.18);
+  --bg-popover:      #161B25;
+  --bg-input:        #161B25;
+
+  /* foreground */
+  --fg-1: #E8E8E5;
+  --fg-2: rgba(232, 232, 229, 0.90);
+  --fg-3: rgba(232, 232, 229, 0.70);
+  --fg-4: rgba(232, 232, 229, 0.55);
+  --fg-5: rgba(232, 232, 229, 0.40);
+  --fg-6: rgba(232, 232, 229, 0.28);
+  --fg-7: rgba(232, 232, 229, 0.16);
+
+  /* borders */
+  --border-1:     rgba(255, 255, 255, 0.10);
+  --border-2:     rgba(255, 255, 255, 0.20);
+  --border-soft:  rgba(255, 255, 255, 0.06);
+  --border-input: #2A313D;
+
+  /* accent — indigo, but tightened */
+  --accent:       #7C8AFF;
+  --accent-soft:  rgba(124, 138, 255, 0.20);
+  --accent-veil:  rgba(124, 138, 255, 0.12);
+  --accent-fg:    #0E1117;
+
+  /* the line */
+  --line-color:    #3A4150;
+  --line-glow:     rgba(124, 138, 255, 0.35);
+  --line-strength: 1.5px;
+  --node-fill:     #0E1117;
+  --node-now:      #E8E8E5;
+  --node-done:     #3A4150;
+
+  /* status */
+  --status-todo-bg:    rgba(255, 255, 255, 0.08);
+  --status-todo-fg:    rgba(232, 232, 229, 0.55);
+  --status-doing-bg:   rgba(124, 138, 255, 0.16);
+  --status-doing-fg:   #B6C0FF;
+  --status-doing-card: #1A1F31;
+  --status-done-bg:    rgba(94, 200, 138, 0.14);
+  --status-done-fg:    #92D8AB;
+  --status-done-card:  #16201C;
+  --status-skip-bg:    rgba(245, 158, 11, 0.14);
+  --status-skip-fg:    #F0BB66;
+  --status-skip-card:  #1F1B16;
+  --status-block-bg:   rgba(244, 99, 99, 0.16);
+  --status-block-fg:   #F1A6A6;
+  --status-block-card: #211618;
+
+  /* radii — sharp/grounded */
+  --radius-sharp: 2px;
+  --radius-soft:  6px;
+
+  /* type voice */
+  --type-voice:   sharp;
+  --font-display: "Inter Tight", system-ui, sans-serif;
+
+  /* shadows */
+  --shadow-pop:    0 12px 32px -8px rgba(0, 0, 0, 0.55), 0 2px 6px rgba(0, 0, 0, 0.35);
+  --shadow-event:  0 2px 8px -2px rgba(0, 0, 0, 0.40);
+  --shadow-focus:  0 0 0 3px rgba(124, 138, 255, 0.32);
+}
+
+/* TETHER · LIGHT MODE  (day mode of the default — same brand, light canvas) */
+[data-theme="tether"][data-mode="light"] {
+  --bg-canvas:       #F7F5F0;
+  --bg-canvas-veil:  rgba(247, 245, 240, 0.85);
+  --bg-elev-1:       rgba(20, 24, 32, 0.025);
+  --bg-elev-2:       rgba(20, 24, 32, 0.045);
+  --bg-elev-3:       rgba(20, 24, 32, 0.08);
+  --bg-elev-4:       rgba(20, 24, 32, 0.14);
+  --bg-popover:      #FFFFFF;
+  --bg-input:        #FFFFFF;
+
+  --fg-1: #14181F;
+  --fg-2: rgba(20, 24, 32, 0.88);
+  --fg-3: rgba(20, 24, 32, 0.68);
+  --fg-4: rgba(20, 24, 32, 0.52);
+  --fg-5: rgba(20, 24, 32, 0.38);
+  --fg-6: rgba(20, 24, 32, 0.26);
+  --fg-7: rgba(20, 24, 32, 0.14);
+
+  --border-1:     rgba(20, 24, 32, 0.10);
+  --border-2:     rgba(20, 24, 32, 0.22);
+  --border-soft:  rgba(20, 24, 32, 0.06);
+  --border-input: rgba(20, 24, 32, 0.18);
+
+  --accent:       #4F58D9;
+  --accent-soft:  rgba(79, 88, 217, 0.16);
+  --accent-veil:  rgba(79, 88, 217, 0.08);
+  --accent-fg:    #FFFFFF;
+
+  --line-color:    #C8C2B5;
+  --line-glow:     rgba(79, 88, 217, 0.28);
+  --node-fill:     #F7F5F0;
+  --node-now:      #14181F;
+  --node-done:     #C8C2B5;
+
+  --status-todo-bg:    rgba(20, 24, 32, 0.06);
+  --status-todo-fg:    rgba(20, 24, 32, 0.55);
+  --status-doing-bg:   rgba(79, 88, 217, 0.14);
+  --status-doing-fg:   #2D3CB8;
+  --status-doing-card: #EEF0FB;
+  --status-done-bg:    rgba(94, 168, 113, 0.16);
+  --status-done-fg:    #2D7A4A;
+  --status-done-card:  #ECF4EE;
+  --status-skip-bg:    rgba(214, 138, 24, 0.16);
+  --status-skip-fg:    #8C5A0E;
+  --status-skip-card:  #F6EFE2;
+  --status-block-bg:   rgba(200, 60, 60, 0.14);
+  --status-block-fg:   #9C2828;
+  --status-block-card: #F6E9E9;
+}
+
+
+/* =========================================================================
+   4. FREE TIER · "HORIZON"  (warm, editorial)
+   --------------------------------------------------------------------------
+   Warm near-black canvas with amber accent. Serif headings for the
+   "editorial" type voice. Bot quotes set in italic. Same line motif but
+   warmer (amber-tinted thread).
+   ========================================================================= */
+[data-theme="horizon"],
+[data-theme="horizon"][data-mode="dark"] {
+  --bg-canvas:       #161512;
+  --bg-canvas-veil:  rgba(22, 21, 18, 0.85);
+  --bg-elev-1:       rgba(237, 231, 218, 0.03);
+  --bg-elev-2:       rgba(237, 231, 218, 0.06);
+  --bg-elev-3:       rgba(237, 231, 218, 0.10);
+  --bg-elev-4:       rgba(237, 231, 218, 0.18);
+  --bg-popover:      #1E1C18;
+  --bg-input:        #1E1C18;
+
+  --fg-1: #EDE7DA;
+  --fg-2: rgba(237, 231, 218, 0.88);
+  --fg-3: rgba(237, 231, 218, 0.68);
+  --fg-4: rgba(237, 231, 218, 0.52);
+  --fg-5: rgba(237, 231, 218, 0.40);
+  --fg-6: rgba(237, 231, 218, 0.28);
+  --fg-7: rgba(237, 231, 218, 0.16);
+
+  --border-1:     rgba(237, 231, 218, 0.10);
+  --border-2:     rgba(237, 231, 218, 0.22);
+  --border-soft:  rgba(237, 231, 218, 0.06);
+  --border-input: #3A352A;
+
+  --accent:       #D4A85F;
+  --accent-soft:  rgba(212, 168, 95, 0.20);
+  --accent-veil:  rgba(212, 168, 95, 0.10);
+  --accent-fg:    #161512;
+
+  --line-color:    #3A352A;
+  --line-glow:     rgba(212, 168, 95, 0.40);
+  --line-strength: 1px;
+  --node-fill:     #161512;
+  --node-now:      #D4A85F;
+  --node-done:     #3A352A;
+
+  --status-todo-bg:    rgba(237, 231, 218, 0.08);
+  --status-todo-fg:    rgba(237, 231, 218, 0.55);
+  --status-doing-bg:   rgba(212, 168, 95, 0.18);
+  --status-doing-fg:   #E8C485;
+  --status-doing-card: #2A2418;
+  --status-done-bg:    rgba(140, 168, 105, 0.16);
+  --status-done-fg:    #B8C893;
+  --status-done-card:  #1E2018;
+  --status-skip-bg:    rgba(214, 138, 56, 0.18);
+  --status-skip-fg:    #E0A968;
+  --status-skip-card:  #241D14;
+  --status-block-bg:   rgba(192, 88, 76, 0.18);
+  --status-block-fg:   #DD9888;
+  --status-block-card: #241814;
+
+  --radius-sharp: 1px;
+  --radius-soft:  4px;
+
+  --type-voice:   editorial;
+  --font-display: "Source Serif Pro", "GT Sectra", Georgia, serif;
+  --font-sans:    "Inter", system-ui, sans-serif;
+
+  --shadow-pop:    0 16px 40px -10px rgba(0, 0, 0, 0.60), 0 2px 8px rgba(0, 0, 0, 0.40);
+  --shadow-event:  0 2px 10px -2px rgba(0, 0, 0, 0.50);
+  --shadow-focus:  0 0 0 3px rgba(212, 168, 95, 0.35);
+}
+
+/* HORIZON · LIGHT — paper at noon */
+[data-theme="horizon"][data-mode="light"] {
+  --bg-canvas:       #F4EDDC;
+  --bg-canvas-veil:  rgba(244, 237, 220, 0.85);
+  --bg-elev-1:       rgba(60, 48, 28, 0.04);
+  --bg-elev-2:       rgba(60, 48, 28, 0.07);
+  --bg-elev-3:       rgba(60, 48, 28, 0.11);
+  --bg-elev-4:       rgba(60, 48, 28, 0.18);
+  --bg-popover:      #FBF6E8;
+  --bg-input:        #FBF6E8;
+
+  --fg-1: #2A2418;
+  --fg-2: rgba(42, 36, 24, 0.90);
+  --fg-3: rgba(42, 36, 24, 0.70);
+  --fg-4: rgba(42, 36, 24, 0.55);
+  --fg-5: rgba(42, 36, 24, 0.40);
+  --fg-6: rgba(42, 36, 24, 0.28);
+  --fg-7: rgba(42, 36, 24, 0.15);
+
+  --border-1:     rgba(42, 36, 24, 0.12);
+  --border-2:     rgba(42, 36, 24, 0.24);
+  --border-soft:  rgba(42, 36, 24, 0.07);
+  --border-input: rgba(42, 36, 24, 0.20);
+
+  --accent:       #A87330;
+  --accent-soft:  rgba(168, 115, 48, 0.16);
+  --accent-veil:  rgba(168, 115, 48, 0.08);
+  --accent-fg:    #FBF6E8;
+
+  --line-color:    #C9B98E;
+  --line-glow:     rgba(168, 115, 48, 0.32);
+  --node-fill:     #F4EDDC;
+  --node-now:      #A87330;
+  --node-done:     #C9B98E;
+
+  --status-todo-bg:    rgba(42, 36, 24, 0.07);
+  --status-todo-fg:    rgba(42, 36, 24, 0.58);
+  --status-doing-bg:   rgba(168, 115, 48, 0.16);
+  --status-doing-fg:   #6F4A14;
+  --status-doing-card: #F0E4C8;
+  --status-done-bg:    rgba(99, 130, 65, 0.16);
+  --status-done-fg:    #3F5C25;
+  --status-done-card:  #ECEAD2;
+  --status-skip-bg:    rgba(192, 122, 36, 0.18);
+  --status-skip-fg:    #804F12;
+  --status-skip-card:  #F2E2C8;
+  --status-block-bg:   rgba(168, 64, 56, 0.16);
+  --status-block-fg:   #87291F;
+  --status-block-card: #F1D9D2;
+}
+
+
+/* =========================================================================
+   5. FREE TIER · "CONTRAST"  (accessibility — pure black/white, sharp)
+   --------------------------------------------------------------------------
+   For users who need maximum contrast. WCAG AAA-compliant for body text.
+   Line motif present but at full opacity. No alpha-stacked surfaces; uses
+   solid colors only. Ships with both light and dark modes.
+   ========================================================================= */
+[data-theme="contrast"],
+[data-theme="contrast"][data-mode="dark"] {
+  --bg-canvas:       #000000;
+  --bg-canvas-veil:  rgba(0, 0, 0, 0.95);
+  --bg-elev-1:       #0C0C0C;
+  --bg-elev-2:       #161616;
+  --bg-elev-3:       #242424;
+  --bg-elev-4:       #383838;
+  --bg-popover:      #1A1A1A;
+  --bg-input:        #1A1A1A;
+
+  --fg-1: #FFFFFF;
+  --fg-2: #F5F5F5;
+  --fg-3: #D8D8D8;
+  --fg-4: #B0B0B0;
+  --fg-5: #888888;
+  --fg-6: #666666;
+  --fg-7: #4A4A4A;
+
+  --border-1:     #4A4A4A;
+  --border-2:     #FFFFFF;
+  --border-soft:  #2A2A2A;
+  --border-input: #888888;
+
+  --accent:       #FFD43B;
+  --accent-soft:  #4A3A00;
+  --accent-veil:  #2A2200;
+  --accent-fg:    #000000;
+
+  --line-color:    #888888;
+  --line-glow:     #FFD43B;
+  --line-strength: 2px;
+  --node-fill:     #000000;
+  --node-now:      #FFD43B;
+  --node-done:     #888888;
+
+  --status-todo-bg:    #2A2A2A;
+  --status-todo-fg:    #D8D8D8;
+  --status-doing-bg:   #00355A;
+  --status-doing-fg:   #6FC0FF;
+  --status-doing-card: #001E33;
+  --status-done-bg:    #0E4A1F;
+  --status-done-fg:    #6FE38B;
+  --status-done-card:  #062810;
+  --status-skip-bg:    #4A3000;
+  --status-skip-fg:    #FFC04A;
+  --status-skip-card:  #2A1B00;
+  --status-block-bg:   #5A0000;
+  --status-block-fg:   #FF8888;
+  --status-block-card: #2D0000;
+
+  --radius-sharp: 0px;
+  --radius-soft:  2px;
+
+  --type-voice:   sharp;
+
+  --shadow-pop:    0 0 0 1px #FFFFFF, 0 8px 24px rgba(0, 0, 0, 0.80);
+  --shadow-event:  0 0 0 1px #FFFFFF;
+  --shadow-focus:  0 0 0 3px #FFD43B;
+}
+
+[data-theme="contrast"][data-mode="light"] {
+  --bg-canvas:       #FFFFFF;
+  --bg-canvas-veil:  rgba(255, 255, 255, 0.95);
+  --bg-elev-1:       #F5F5F5;
+  --bg-elev-2:       #EAEAEA;
+  --bg-elev-3:       #DADADA;
+  --bg-elev-4:       #C0C0C0;
+  --bg-popover:      #FFFFFF;
+  --bg-input:        #FFFFFF;
+
+  --fg-1: #000000;
+  --fg-2: #1A1A1A;
+  --fg-3: #333333;
+  --fg-4: #555555;
+  --fg-5: #777777;
+  --fg-6: #999999;
+  --fg-7: #BBBBBB;
+
+  --border-1:     #999999;
+  --border-2:     #000000;
+  --border-soft:  #DADADA;
+  --border-input: #555555;
+
+  --accent:       #0030B0;
+  --accent-soft:  #D6DDF5;
+  --accent-veil:  #E8ECF8;
+  --accent-fg:    #FFFFFF;
+
+  --line-color:    #555555;
+  --line-glow:     #0030B0;
+  --node-fill:     #FFFFFF;
+  --node-now:      #0030B0;
+  --node-done:     #555555;
+
+  --status-todo-bg:    #DADADA;
+  --status-todo-fg:    #333333;
+  --status-doing-bg:   #CFE3F8;
+  --status-doing-fg:   #003E8C;
+  --status-doing-card: #E8F0FA;
+  --status-done-bg:    #C8EAD3;
+  --status-done-fg:    #1A5A2E;
+  --status-done-card:  #E2F2E8;
+  --status-skip-bg:    #FAE2B0;
+  --status-skip-fg:    #6B4400;
+  --status-skip-card:  #F8EDD0;
+  --status-block-bg:   #FACECE;
+  --status-block-fg:   #8A0000;
+  --status-block-card: #F8E2E2;
+}
+
+
+/* =========================================================================
+   5b. FREE TIER · "TERMINAL"  (phosphor green on near-black, mono everywhere)
+   --------------------------------------------------------------------------
+   The dev-aesthetic theme. Monospace for everything (display + body).
+   Replaces the line motif with ASCII tree characters (├─, └─) — handled in
+   components by checking [data-type-voice="terminal"]. Bracketed status
+   pills like [DOING] [DONE]. Cursor-block "now" indicator instead of a node
+   with glow. Carries the line as a subtle vertical pipe character only.
+   ========================================================================= */
+[data-theme="terminal"],
+[data-theme="terminal"][data-mode="dark"] {
+  --bg-canvas:       #0A0E0A;
+  --bg-canvas-veil:  rgba(10, 14, 10, 0.92);
+  --bg-elev-1:       #0E140E;
+  --bg-elev-2:       #131B13;
+  --bg-elev-3:       #1A241A;
+  --bg-elev-4:       #243224;
+  --bg-popover:      #0E140E;
+  --bg-input:        #0A0E0A;
+
+  --fg-1: #C9F2C9;          /* phosphor green-white */
+  --fg-2: #A8E0A8;
+  --fg-3: #7BC57B;
+  --fg-4: #5A9A5A;
+  --fg-5: #3D703D;
+  --fg-6: #2A4F2A;
+  --fg-7: #1F3A1F;
+
+  --border-1:     #1F3A1F;
+  --border-2:     #3D703D;
+  --border-soft:  #142014;
+  --border-input: #3D703D;
+
+  --accent:       #50FA7B;       /* the cursor green */
+  --accent-soft:  rgba(80, 250, 123, 0.16);
+  --accent-veil:  rgba(80, 250, 123, 0.08);
+  --accent-fg:    #0A0E0A;
+
+  --line-color:    #2A4F2A;       /* subtle — tree chars do the work */
+  --line-glow:     rgba(80, 250, 123, 0.50);
+  --line-strength: 1px;
+  --node-fill:     #0A0E0A;
+  --node-now:      #50FA7B;
+  --node-done:     #2A4F2A;
+
+  --status-todo-bg:    transparent;
+  --status-todo-fg:    #5A9A5A;
+  --status-doing-bg:   rgba(80, 250, 123, 0.18);
+  --status-doing-fg:   #50FA7B;
+  --status-doing-card: #0E1A10;
+  --status-done-bg:    rgba(80, 250, 123, 0.10);
+  --status-done-fg:    #3D703D;
+  --status-done-card:  #0C140C;
+  --status-skip-bg:    rgba(241, 196, 15, 0.14);
+  --status-skip-fg:    #F1C40F;
+  --status-skip-card:  #14140A;
+  --status-block-bg:   rgba(255, 85, 85, 0.16);
+  --status-block-fg:   #FF6B6B;
+  --status-block-card: #1A0E0E;
+
+  --radius-sharp: 0px;
+  --radius-soft:  0px;
+  --radius-pill:  0px;
+
+  --type-voice:   terminal;
+  --font-display: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-sans:    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-mono:    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --shadow-pop:    0 0 0 1px #3D703D, 0 8px 24px rgba(0, 0, 0, 0.80);
+  --shadow-event:  0 0 0 1px #2A4F2A;
+  --shadow-focus:  0 0 0 2px #50FA7B;
+}
+
+/* TERMINAL · DAYLIGHT — paper-white canvas, dark forest green text.
+   Like a 1970s line-printer printout. Same scanlines but inverted (cream
+   stripes on warm-white). */
+[data-theme="terminal"][data-mode="light"] {
+  --bg-canvas:       #F2F1E8;
+  --bg-canvas-veil:  rgba(242, 241, 232, 0.92);
+  --bg-elev-1:       #EDEBDF;
+  --bg-elev-2:       #E5E2D2;
+  --bg-elev-3:       #D8D4C0;
+  --bg-elev-4:       #C8C2A8;
+  --bg-popover:      #FFFEF5;
+  --bg-input:        #FFFEF5;
+
+  --fg-1: #1A3A1A;          /* dark forest green */
+  --fg-2: #234423;
+  --fg-3: #3A5A3A;
+  --fg-4: #5A7A5A;
+  --fg-5: #7A957A;
+  --fg-6: #95AA95;
+  --fg-7: #B8C5B8;
+
+  --border-1:     #95AA95;
+  --border-2:     #1A3A1A;
+  --border-soft:  #C0CEC0;
+  --border-input: #5A7A5A;
+
+  --accent:       #1A6E1A;       /* deep printer green */
+  --accent-soft:  rgba(26, 110, 26, 0.16);
+  --accent-veil:  rgba(26, 110, 26, 0.08);
+  --accent-fg:    #F2F1E8;
+
+  --line-color:    #95AA95;
+  --line-glow:     rgba(26, 110, 26, 0.32);
+  --line-strength: 1px;
+  --node-fill:     #F2F1E8;
+  --node-now:      #1A6E1A;
+  --node-done:     #95AA95;
+
+  --status-todo-bg:    transparent;
+  --status-todo-fg:    #5A7A5A;
+  --status-doing-bg:   rgba(26, 110, 26, 0.16);
+  --status-doing-fg:   #1A6E1A;
+  --status-doing-card: #E8EDDF;
+  --status-done-bg:    rgba(26, 110, 26, 0.08);
+  --status-done-fg:    #5A7A5A;
+  --status-done-card:  #ECECDC;
+  --status-skip-bg:    rgba(140, 110, 0, 0.16);
+  --status-skip-fg:    #8C6E00;
+  --status-skip-card:  #EFE8C8;
+  --status-block-bg:   rgba(165, 30, 30, 0.16);
+  --status-block-fg:   #A51E1E;
+  --status-block-card: #F2DCDC;
+}
+
+
+/* =========================================================================
+   6. FREE FEATURE · "DAYLIGHT"  — auto light-mode flip for any theme
+   --------------------------------------------------------------------------
+   Not a separate theme; it's a *mode*. Any theme + data-mode="light" gets
+   that theme's daylight variant. By default, the app sets data-mode based
+   on local time (light 07:00–19:00, dark otherwise) OR — better — based on
+   the user's "Wind Down" / "Morning" anchors. See README.
+   ========================================================================= */
+
+
+/* =========================================================================
+   7. PAID TIER · CURATED THEMES (3 at launch)
+   --------------------------------------------------------------------------
+   These are visually previewable to free users (the picker shows them
+   recoloring a sample), but applying them is gated by tier=='paid'.
+   ========================================================================= */
+
+/* SOLSTICE — cool, glacial, ultra-low-stim. Like a winter morning. */
+[data-theme="solstice"],
+[data-theme="solstice"][data-mode="dark"] {
+  --bg-canvas:       #0B1418;
+  --bg-canvas-veil:  rgba(11, 20, 24, 0.85);
+  --bg-elev-1:       rgba(174, 220, 235, 0.04);
+  --bg-elev-2:       rgba(174, 220, 235, 0.07);
+  --bg-elev-3:       rgba(174, 220, 235, 0.12);
+  --bg-elev-4:       rgba(174, 220, 235, 0.20);
+  --bg-popover:      #122026;
+  --bg-input:        #122026;
+
+  --fg-1: #DCEBF0;
+  --fg-2: rgba(220, 235, 240, 0.88);
+  --fg-3: rgba(220, 235, 240, 0.66);
+  --fg-4: rgba(220, 235, 240, 0.50);
+  --fg-5: rgba(220, 235, 240, 0.36);
+  --fg-6: rgba(220, 235, 240, 0.24);
+  --fg-7: rgba(220, 235, 240, 0.14);
+
+  --border-1:     rgba(174, 220, 235, 0.12);
+  --border-2:     rgba(174, 220, 235, 0.26);
+  --border-soft:  rgba(174, 220, 235, 0.06);
+  --border-input: #244048;
+
+  --accent:       #5FC8E6;
+  --accent-soft:  rgba(95, 200, 230, 0.18);
+  --accent-veil:  rgba(95, 200, 230, 0.10);
+  --accent-fg:    #0B1418;
+
+  --line-color:    #244048;
+  --line-glow:     rgba(95, 200, 230, 0.45);
+  --line-strength: 1.5px;
+  --node-fill:     #0B1418;
+  --node-now:      #5FC8E6;
+  --node-done:     #244048;
+
+  --status-todo-bg:    rgba(220, 235, 240, 0.08);
+  --status-todo-fg:    rgba(220, 235, 240, 0.55);
+  --status-doing-bg:   rgba(95, 200, 230, 0.18);
+  --status-doing-fg:   #98DEEE;
+  --status-doing-card: #102429;
+  --status-done-bg:    rgba(120, 200, 160, 0.16);
+  --status-done-fg:    #A8DDC0;
+  --status-done-card:  #0F2422;
+  --status-skip-bg:    rgba(220, 165, 90, 0.18);
+  --status-skip-fg:    #DEB079;
+  --status-skip-card:  #1E1B16;
+  --status-block-bg:   rgba(232, 116, 116, 0.18);
+  --status-block-fg:   #F0A2A2;
+  --status-block-card: #211618;
+
+  --radius-sharp: 3px;
+  --radius-soft:  10px;
+  --type-voice:   sharp;
+}
+
+/* DRACULA-TETHER — homage to Dracula, with the Tether line. Devs love this. */
+[data-theme="dracula"],
+[data-theme="dracula"][data-mode="dark"] {
+  --bg-canvas:       #282A36;
+  --bg-canvas-veil:  rgba(40, 42, 54, 0.85);
+  --bg-elev-1:       #2E3140;
+  --bg-elev-2:       #353748;
+  --bg-elev-3:       #3F4254;
+  --bg-elev-4:       #4A4D62;
+  --bg-popover:      #21222C;
+  --bg-input:        #21222C;
+
+  --fg-1: #F8F8F2;
+  --fg-2: rgba(248, 248, 242, 0.88);
+  --fg-3: rgba(248, 248, 242, 0.68);
+  --fg-4: rgba(248, 248, 242, 0.52);
+  --fg-5: rgba(248, 248, 242, 0.38);
+  --fg-6: rgba(248, 248, 242, 0.26);
+  --fg-7: rgba(248, 248, 242, 0.14);
+
+  --border-1:     rgba(248, 248, 242, 0.10);
+  --border-2:     rgba(248, 248, 242, 0.22);
+  --border-soft:  rgba(248, 248, 242, 0.05);
+  --border-input: #44475A;
+
+  --accent:       #BD93F9;
+  --accent-soft:  rgba(189, 147, 249, 0.20);
+  --accent-veil:  rgba(189, 147, 249, 0.10);
+  --accent-fg:    #282A36;
+
+  --line-color:    #44475A;
+  --line-glow:     rgba(189, 147, 249, 0.40);
+  --node-fill:     #282A36;
+  --node-now:      #BD93F9;
+  --node-done:     #44475A;
+
+  --status-todo-bg:    rgba(248, 248, 242, 0.08);
+  --status-todo-fg:    rgba(248, 248, 242, 0.55);
+  --status-doing-bg:   rgba(139, 233, 253, 0.16);  /* cyan */
+  --status-doing-fg:   #8BE9FD;
+  --status-doing-card: #1F2A36;
+  --status-done-bg:    rgba(80, 250, 123, 0.14);   /* green */
+  --status-done-fg:    #50FA7B;
+  --status-done-card:  #1A2E20;
+  --status-skip-bg:    rgba(241, 250, 140, 0.14);  /* yellow */
+  --status-skip-fg:    #F1FA8C;
+  --status-skip-card:  #2A2A1F;
+  --status-block-bg:   rgba(255, 85, 85, 0.16);    /* red */
+  --status-block-fg:   #FF5555;
+  --status-block-card: #2E1B1F;
+
+  --radius-sharp: 3px;
+  --radius-soft:  8px;
+  --type-voice:   terminal;
+  --font-display: "JetBrains Mono", ui-monospace, monospace;
+  --font-sans:    "Inter", system-ui, sans-serif;
+}
+
+/* PAPER — pure light theme, low chroma, almost monochrome. Like printing. */
+[data-theme="paper"],
+[data-theme="paper"][data-mode="light"] {
+  --bg-canvas:       #FAFAF7;
+  --bg-canvas-veil:  rgba(250, 250, 247, 0.85);
+  --bg-elev-1:       #F2F2EE;
+  --bg-elev-2:       #EAEAE5;
+  --bg-elev-3:       #DEDED8;
+  --bg-elev-4:       #C8C8C2;
+  --bg-popover:      #FFFFFF;
+  --bg-input:        #FFFFFF;
+
+  --fg-1: #1C1C1A;
+  --fg-2: rgba(28, 28, 26, 0.88);
+  --fg-3: rgba(28, 28, 26, 0.68);
+  --fg-4: rgba(28, 28, 26, 0.52);
+  --fg-5: rgba(28, 28, 26, 0.38);
+  --fg-6: rgba(28, 28, 26, 0.26);
+  --fg-7: rgba(28, 28, 26, 0.14);
+
+  --border-1:     rgba(28, 28, 26, 0.14);
+  --border-2:     rgba(28, 28, 26, 0.28);
+  --border-soft:  rgba(28, 28, 26, 0.08);
+  --border-input: rgba(28, 28, 26, 0.22);
+
+  --accent:       #1C1C1A;       /* monochrome — accent is just darker fg */
+  --accent-soft:  rgba(28, 28, 26, 0.12);
+  --accent-veil:  rgba(28, 28, 26, 0.05);
+  --accent-fg:    #FAFAF7;
+
+  --line-color:    rgba(28, 28, 26, 0.30);
+  --line-glow:     rgba(28, 28, 26, 0.50);
+  --line-strength: 1px;
+  --node-fill:     #FAFAF7;
+  --node-now:      #1C1C1A;
+  --node-done:     rgba(28, 28, 26, 0.30);
+
+  --status-todo-bg:    rgba(28, 28, 26, 0.06);
+  --status-todo-fg:    rgba(28, 28, 26, 0.58);
+  --status-doing-bg:   rgba(28, 28, 26, 0.85);
+  --status-doing-fg:   #FAFAF7;
+  --status-doing-card: #EFEFEB;
+  --status-done-bg:    rgba(28, 28, 26, 0.10);
+  --status-done-fg:    rgba(28, 28, 26, 0.55);
+  --status-done-card:  #EAEAE5;
+  --status-skip-bg:    rgba(28, 28, 26, 0.05);
+  --status-skip-fg:    rgba(28, 28, 26, 0.45);
+  --status-skip-card:  #F0F0EB;
+  --status-block-bg:   rgba(160, 30, 30, 0.10);
+  --status-block-fg:   #8A2020;
+  --status-block-card: #F0E2E0;
+
+  --radius-sharp: 0px;
+  --radius-soft:  1px;
+  --type-voice:   editorial;
+  --font-display: "Source Serif Pro", Georgia, serif;
+  --font-sans:    "Inter", system-ui, sans-serif;
+}
+
+
+/* =========================================================================
+   8. THEME-SWAP MOTION
+   --------------------------------------------------------------------------
+   When swapping themes (especially day/night auto-flips), animate the
+   color tokens themselves so the change feels like a transition, not a
+   strobe. Only animate at the document root; child components inherit.
+   ========================================================================= */
+html {
+  transition:
+    background-color var(--motion-slow) ease,
+    color var(--motion-slow) ease;
+}
+html * {
+  transition:
+    background-color var(--motion-slow) ease,
+    color var(--motion-slow) ease,
+    border-color var(--motion-slow) ease,
+    fill var(--motion-slow) ease,
+    stroke var(--motion-slow) ease;
+}
+/* Disable transition during interactive theme swap (set [data-theme-swap] briefly) */
+html[data-theme-swap="instant"], html[data-theme-swap="instant"] * {
+  transition: none !important;
+}
+/* Respect reduced-motion */
+@media (prefers-reduced-motion: reduce) {
+  html, html * { transition: none !important; }
+}

--- a/frontend/src/composables/__tests__/usePremiumThemes.test.ts
+++ b/frontend/src/composables/__tests__/usePremiumThemes.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+
+describe('loadPremiumThemes', () => {
+  const fakeToken = 'fake-token'
+
+  beforeEach(() => {
+    // Remove any existing premium-themes style element
+    const el = document.getElementById('premium-themes')
+    if (el) el.remove()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('injects a <style id="premium-themes"> element when API responds ok', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          themes: [
+            { id: 'terminal', name: 'Terminal', css: ':root[data-theme="terminal"] { --canvas: #0A0E0A; }' },
+          ],
+        }),
+      } as Response),
+    )
+
+    const { loadPremiumThemes } = await import('../usePremiumThemes')
+    await loadPremiumThemes(fakeToken)
+
+    const el = document.getElementById('premium-themes')
+    expect(el).not.toBeNull()
+    expect(el?.tagName).toBe('STYLE')
+    expect(el?.textContent).toContain('--canvas: #0A0E0A')
+  })
+
+  it('replaces existing <style id="premium-themes"> content on second call', async () => {
+    const existing = document.createElement('style')
+    existing.id = 'premium-themes'
+    existing.textContent = 'old-css {}'
+    document.head.appendChild(existing)
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          themes: [{ id: 'dracula', name: 'Dracula', css: '.new-css {}' }],
+        }),
+      } as Response),
+    )
+
+    const { loadPremiumThemes } = await import('../usePremiumThemes')
+    await loadPremiumThemes(fakeToken)
+
+    const all = document.querySelectorAll('#premium-themes')
+    expect(all).toHaveLength(1)
+    expect(all[0].textContent).toBe('.new-css {}')
+  })
+
+  it('does nothing when API returns non-ok response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({}),
+      } as Response),
+    )
+
+    const { loadPremiumThemes } = await import('../usePremiumThemes')
+    await loadPremiumThemes(fakeToken)
+
+    expect(document.getElementById('premium-themes')).toBeNull()
+  })
+
+  it('sends Authorization header with bearer token', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ themes: [] }),
+    } as Response)
+    vi.stubGlobal('fetch', mockFetch)
+
+    const { loadPremiumThemes } = await import('../usePremiumThemes')
+    await loadPremiumThemes(fakeToken)
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/premium/themes',
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${fakeToken}` },
+      }),
+    )
+  })
+})

--- a/frontend/src/composables/__tests__/useTheme.test.ts
+++ b/frontend/src/composables/__tests__/useTheme.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+// Mock the auth store — hoisted to top level by vitest
+vi.mock('../../stores/auth', () => ({
+  useAuthStore: () => ({ user: null }),
+}))
+
+describe('useTheme', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    // Reset document attributes
+    delete document.documentElement.dataset.theme
+    delete document.documentElement.dataset.mode
+    delete document.documentElement.dataset.typeVoice
+    delete document.documentElement.dataset.themeSwap
+    localStorage.clear()
+    vi.resetModules()
+  })
+
+  it('applyTheme sets data-theme on documentElement', async () => {
+    const { useTheme } = await import('../useTheme')
+    const { applyTheme } = useTheme()
+    applyTheme('tether')
+    expect(document.documentElement.dataset.theme).toBe('tether')
+  })
+
+  it('applyTheme persists to localStorage', async () => {
+    const { useTheme } = await import('../useTheme')
+    const { applyTheme } = useTheme()
+    applyTheme('horizon')
+    expect(localStorage.getItem('tether-theme')).toBe('horizon')
+  })
+
+  it('applyTheme sets data-type-voice based on theme', async () => {
+    const { useTheme } = await import('../useTheme')
+    const { applyTheme } = useTheme()
+    applyTheme('horizon')
+    expect(document.documentElement.dataset.typeVoice).toBe('editorial')
+  })
+
+  it('applyTheme does not apply locked themes for free user', async () => {
+    const { useTheme } = await import('../useTheme')
+    const { applyTheme } = useTheme()
+    // Start on tether
+    applyTheme('tether')
+    expect(document.documentElement.dataset.theme).toBe('tether')
+    // Try to switch to paid-oss theme (should be blocked for free user)
+    applyTheme('terminal')
+    // Should remain on tether
+    expect(document.documentElement.dataset.theme).toBe('tether')
+  })
+
+  it('isThemeUnlocked returns true for free tier themes', async () => {
+    const { useTheme, THEMES } = await import('../useTheme')
+    const { isThemeUnlocked } = useTheme()
+    const freeTheme = THEMES.find(t => t.id === 'tether')!
+    expect(isThemeUnlocked(freeTheme)).toBe(true)
+  })
+
+  it('isThemeUnlocked returns false for paid-oss themes when not paid', async () => {
+    const { useTheme, THEMES } = await import('../useTheme')
+    const { isThemeUnlocked } = useTheme()
+    const paidOssTheme = THEMES.find(t => t.id === 'terminal')!
+    expect(isThemeUnlocked(paidOssTheme)).toBe(false)
+  })
+
+  it('setMode updates data-mode and localStorage', async () => {
+    const { useTheme } = await import('../useTheme')
+    const { setMode } = useTheme()
+    setMode('light')
+    expect(document.documentElement.dataset.mode).toBe('light')
+    expect(localStorage.getItem('tether-mode')).toBe('light')
+
+    setMode('dark')
+    expect(document.documentElement.dataset.mode).toBe('dark')
+    expect(localStorage.getItem('tether-mode')).toBe('dark')
+  })
+
+  it('THEMES list has expected themes', async () => {
+    const { THEMES } = await import('../useTheme')
+    const ids = THEMES.map(t => t.id)
+    expect(ids).toContain('tether')
+    expect(ids).toContain('horizon')
+    expect(ids).toContain('contrast')
+    expect(ids).toContain('terminal')
+    expect(ids).toContain('solstice')
+    expect(ids).toContain('dracula')
+    expect(ids).toContain('paper')
+  })
+
+  it('previewTheme sets data-theme even for locked (paid-oss) theme', async () => {
+    const { useTheme } = await import('../useTheme')
+    const { previewTheme } = useTheme()
+    previewTheme('terminal')
+    expect(document.documentElement.dataset.theme).toBe('terminal')
+  })
+
+  it('previewTheme does NOT persist to localStorage', async () => {
+    const { useTheme } = await import('../useTheme')
+    const { previewTheme } = useTheme()
+    previewTheme('terminal')
+    expect(localStorage.getItem('tether-theme')).toBeNull()
+  })
+
+  it('previewTheme sets data-type-voice without persistence', async () => {
+    const { useTheme } = await import('../useTheme')
+    const { previewTheme } = useTheme()
+    previewTheme('terminal')
+    expect(document.documentElement.dataset.typeVoice).toBe('terminal')
+  })
+})
+
+describe('useTheme - community edition', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    delete document.documentElement.dataset.theme
+    delete document.documentElement.dataset.mode
+    delete document.documentElement.dataset.typeVoice
+    localStorage.clear()
+    vi.resetModules()
+  })
+
+  it('isThemeUnlocked returns true for paid-oss when community edition', async () => {
+    // Set the global before module import to simulate community edition build
+    ;(globalThis as any).__TETHER_EDITION__ = 'community'
+    const { useTheme, THEMES } = await import('../useTheme')
+    const { isThemeUnlocked } = useTheme()
+    const terminalTheme = THEMES.find(t => t.id === 'terminal')!
+    expect(isThemeUnlocked(terminalTheme)).toBe(true)
+    delete (globalThis as any).__TETHER_EDITION__
+  })
+})

--- a/frontend/src/composables/usePremiumThemes.ts
+++ b/frontend/src/composables/usePremiumThemes.ts
@@ -1,0 +1,17 @@
+/** Fetches server-side premium theme CSS and injects it into the document.
+ *  Called on boot when the user is known to be premium. The endpoint does not
+ *  exist yet — the call is a no-op until the backend ships it. */
+export async function loadPremiumThemes(token: string): Promise<void> {
+  const res = await fetch('/api/premium/themes', {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) return
+  const { themes } = await res.json() as { themes: { id: string; name: string; css: string }[] }
+  let el = document.getElementById('premium-themes') as HTMLStyleElement | null
+  if (!el) {
+    el = document.createElement('style')
+    el.id = 'premium-themes'
+    document.head.appendChild(el)
+  }
+  el.textContent = themes.map(t => t.css).join('\n')
+}

--- a/frontend/src/composables/useTheme.ts
+++ b/frontend/src/composables/useTheme.ts
@@ -1,0 +1,89 @@
+// frontend/src/composables/useTheme.ts
+import { ref, computed } from 'vue'
+import { useAuthStore } from '../stores/auth'
+
+export type ThemeTier = 'free' | 'paid-oss' | 'paid' | 'premium'
+export type MotifSlot = 'anchor' | 'focus' | 'calm' | 'energy' | 'care' | 'flow' | 'dusk' | 'quiet'
+export type TypeVoice = 'sharp' | 'editorial' | 'terminal'
+
+export interface ThemeDef {
+  id: string
+  name: string
+  tier: ThemeTier
+  canvas: string
+  accent: string
+}
+
+export const THEMES: ThemeDef[] = [
+  { id: 'tether',   name: 'The Tether',    tier: 'free',     canvas: '#0E1117', accent: '#7C8AFF' },
+  { id: 'horizon',  name: 'Horizon',       tier: 'free',     canvas: '#161512', accent: '#D4A85F' },
+  { id: 'contrast', name: 'High Contrast', tier: 'free',     canvas: '#000000', accent: '#FFD43B' },
+  { id: 'terminal', name: 'Terminal',      tier: 'paid-oss', canvas: '#0A0E0A', accent: '#50FA7B' },
+  { id: 'solstice', name: 'Solstice',      tier: 'paid-oss', canvas: '#0B1418', accent: '#5FC8E6' },
+  { id: 'dracula',  name: 'Dracula·Tether',tier: 'paid-oss', canvas: '#282A36', accent: '#BD93F9' },
+  { id: 'paper',    name: 'Paper',         tier: 'paid-oss', canvas: '#FAFAF7', accent: '#1C1C1A' },
+]
+
+const VOICE: Record<string, TypeVoice> = {
+  tether: 'sharp', horizon: 'editorial', contrast: 'sharp',
+  terminal: 'terminal', solstice: 'sharp', dracula: 'terminal', paper: 'editorial',
+}
+
+// Check if running as community edition (self-hosted, all OSS themes unlocked)
+// TODO: wire TETHER_EDITION into vite.config.ts define block
+declare const __TETHER_EDITION__: string | undefined
+const isCommunityEdition = (() => {
+  try { return typeof __TETHER_EDITION__ !== 'undefined' && __TETHER_EDITION__ === 'community' }
+  catch { return false }
+})()
+
+export function useTheme() {
+  useAuthStore() // reserved for future isPaid check — do not remove
+  // TODO: add is_paid to user type in stores/auth.ts when backend adds the field
+  const isPaid = computed(() => false)
+
+  const activeTheme = ref(localStorage.getItem('tether-theme') ?? 'tether')
+  const activeMode = ref<'light' | 'dark'>(
+    (localStorage.getItem('tether-mode') as 'light' | 'dark') ??
+    (new Date().getHours() >= 7 && new Date().getHours() < 19 ? 'light' : 'dark')
+  )
+
+  function isThemeUnlocked(theme: ThemeDef): boolean {
+    if (theme.tier === 'free') return true
+    if (theme.tier === 'paid-oss' && isCommunityEdition) return true
+    if (theme.tier === 'paid-oss' || theme.tier === 'paid') return isPaid.value
+    return false // premium tier always gated
+  }
+
+  function applyTheme(themeId: string) {
+    const theme = THEMES.find(t => t.id === themeId)
+    if (!theme || !isThemeUnlocked(theme)) return
+    activeTheme.value = themeId
+    localStorage.setItem('tether-theme', themeId)
+    document.documentElement.dataset.theme = themeId
+    document.documentElement.dataset.typeVoice = VOICE[themeId] ?? 'sharp'
+    // Instant swap: briefly suppress the slow crossfade so user-triggered swaps feel crisp
+    document.documentElement.dataset.themeSwap = 'instant'
+    requestAnimationFrame(() => { delete document.documentElement.dataset.themeSwap })
+  }
+
+  /** Applies a theme to the DOM for live preview without persisting to localStorage.
+   *  Bypasses the tier lock so any user can see how a theme looks before upgrading. */
+  function previewTheme(themeId: string) {
+    document.documentElement.dataset.theme = themeId
+    document.documentElement.dataset.typeVoice = VOICE[themeId] ?? 'sharp'
+  }
+
+  function setMode(mode: 'light' | 'dark') {
+    activeMode.value = mode
+    localStorage.setItem('tether-mode', mode)
+    document.documentElement.dataset.mode = mode
+  }
+
+  function autoMode() {
+    const h = new Date().getHours()
+    return h >= 7 && h < 19 ? 'light' : 'dark'
+  }
+
+  return { THEMES, activeTheme, activeMode, isPaid, isThemeUnlocked, applyTheme, previewTheme, setMode, autoMode, isCommunityEdition }
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,6 +2,22 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
+import './assets/themes.css'
+import './assets/motifs.css'
+import './assets/theme-distinctives.css'
 import './style.css'
+
+// Boot: apply saved theme + mode before Vue mounts (prevents flash)
+const savedTheme = localStorage.getItem('tether-theme') ?? 'tether'
+const savedMode = localStorage.getItem('tether-mode') ?? (new Date().getHours() >= 7 && new Date().getHours() < 19 ? 'light' : 'dark')
+document.documentElement.dataset.theme = savedTheme
+document.documentElement.dataset.mode = savedMode as 'light' | 'dark'
+
+// Also set type-voice to match theme
+const VOICE: Record<string, string> = {
+  tether: 'sharp', horizon: 'editorial', contrast: 'sharp',
+  terminal: 'terminal', solstice: 'sharp', dracula: 'terminal', paper: 'editorial',
+}
+document.documentElement.dataset.typeVoice = VOICE[savedTheme] ?? 'sharp'
 
 createApp(App).use(createPinia()).use(router).mount('#app')

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1,12 +1,48 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useAuthStore } from '../stores/auth'
+import { useTheme } from '../composables/useTheme'
 import { api } from '../lib/api'
 import GoogleCalendarSection from '../components/GoogleCalendarSection.vue'
 import AnthropicAccountSection from '../components/AnthropicAccountSection.vue'
 import ConnectionsSection from '../components/ConnectionsSection.vue'
 
 const auth = useAuthStore()
+
+// ---------------------------------------------------------------------------
+// Appearance / Theme
+// ---------------------------------------------------------------------------
+
+const { THEMES, activeTheme, isThemeUnlocked, applyTheme, previewTheme } = useTheme()
+const showUpgradeNudge = ref(false)
+const upgradeNudgeTheme = ref('')
+
+function onPreviewTheme(themeId: string) {
+  previewTheme(themeId)
+}
+
+function onSelectTheme(themeId: string) {
+  const theme = THEMES.find(t => t.id === themeId)
+  if (!theme) return
+
+  // Always apply locally for immediate visual feedback
+  previewTheme(themeId)
+
+  if (isThemeUnlocked(theme)) {
+    // Persist permanently for unlocked themes
+    applyTheme(themeId)
+    showUpgradeNudge.value = false
+  } else {
+    // Locked theme: preview only, show upgrade nudge
+    upgradeNudgeTheme.value = theme.name
+    showUpgradeNudge.value = true
+  }
+
+  // Future: when isPaid && endpoint exists, persist server-side
+  // if (isPaid.value) {
+  //   fetch('/api/user/preferences', { method: 'PATCH', ... })
+  // }
+}
 
 // ---------------------------------------------------------------------------
 // LLM configuration
@@ -194,6 +230,59 @@ async function linkTelegram() {
           <div>
             <div class="text-xs text-gray-400 mb-1">Username</div>
             <div class="text-white font-medium">{{ auth.user?.username ?? '—' }}</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Appearance -->
+      <section class="mb-8">
+        <h2 class="text-sm font-semibold text-white/50 uppercase tracking-wider mb-3">Appearance</h2>
+        <div class="bg-gray-800 rounded-xl p-4 space-y-4">
+          <p class="text-xs text-white/40">Select a theme. Free previews are available for all themes — upgrade to keep a paid theme across sessions.</p>
+          <div class="grid grid-cols-2 gap-2 sm:grid-cols-3">
+            <button
+              v-for="theme in THEMES"
+              :key="theme.id"
+              @click="onSelectTheme(theme.id)"
+              @mouseenter="onPreviewTheme(theme.id)"
+              @mouseleave="onPreviewTheme(activeTheme)"
+              :title="theme.name"
+              :aria-pressed="activeTheme === theme.id"
+              class="relative flex flex-col items-start gap-1.5 rounded-lg p-2.5 border transition-all text-left"
+              :class="[
+                activeTheme === theme.id
+                  ? 'border-indigo-500 ring-1 ring-indigo-500'
+                  : 'border-gray-700 hover:border-gray-500',
+              ]"
+            >
+              <!-- Canvas/accent swatch -->
+              <span
+                class="w-full h-6 rounded"
+                :style="{ background: `linear-gradient(135deg, ${theme.canvas} 60%, ${theme.accent} 100%)` }"
+              />
+              <span class="text-xs text-white/80 font-medium leading-tight">{{ theme.name }}</span>
+              <!-- Tier badge -->
+              <span
+                v-if="theme.tier !== 'free'"
+                class="absolute top-1.5 right-1.5 text-[9px] font-bold uppercase tracking-wide px-1 py-0.5 rounded"
+                :class="isThemeUnlocked(theme) ? 'bg-emerald-700/70 text-emerald-200' : 'bg-gray-700/80 text-white/40'"
+              >{{ isThemeUnlocked(theme) ? 'oss' : 'paid' }}</span>
+            </button>
+          </div>
+
+          <!-- Upgrade nudge -->
+          <div
+            v-if="showUpgradeNudge"
+            class="flex items-center justify-between gap-3 rounded-lg bg-indigo-900/40 border border-indigo-700/50 px-3 py-2.5 text-sm"
+          >
+            <span class="text-white/70">
+              <strong class="text-white">{{ upgradeNudgeTheme }}</strong> is a paid theme — upgrade to keep it.
+            </span>
+            <button
+              @click="showUpgradeNudge = false"
+              class="text-white/30 hover:text-white/70 text-xs shrink-0"
+              aria-label="Dismiss"
+            >✕</button>
           </div>
         </div>
       </section>

--- a/frontend/src/views/__tests__/SettingsView.test.ts
+++ b/frontend/src/views/__tests__/SettingsView.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ path: '/settings' }),
+  RouterLink: { template: '<a><slot /></a>' },
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn((url: string) => {
+    if (url === '/api/llm-config') {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          models: {},
+          llm: {
+            preferred_backend: 'anthropic',
+            thinking_enabled: false,
+            thinking_budget: 8000,
+            beacon_score_threshold: 10,
+            beacon_cooldown_minutes: 30,
+          },
+          model_roles: [],
+          defaults: { models: {}, llm: {} },
+        }),
+      })
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) })
+  }),
+}))
+
+vi.mock('../../components/GoogleCalendarSection.vue', () => ({
+  default: { template: '<div />' },
+}))
+vi.mock('../../components/AnthropicAccountSection.vue', () => ({
+  default: { template: '<div />' },
+}))
+vi.mock('../../components/ConnectionsSection.vue', () => ({
+  default: { template: '<div />' },
+}))
+
+describe('SettingsView - Appearance theme picker', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    delete document.documentElement.dataset.theme
+    delete document.documentElement.dataset.typeVoice
+    delete document.documentElement.dataset.themeSwap
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('renders a button for every THEMES entry with name and swatch', async () => {
+    const { THEMES } = await import('../../composables/useTheme')
+    const { default: SettingsView } = await import('../SettingsView.vue')
+    const wrapper = mount(SettingsView, {
+      global: { stubs: { 'router-link': { template: '<a><slot /></a>' } } },
+    })
+    await flushPromises()
+
+    for (const theme of THEMES) {
+      const btn = wrapper.find(`button[title="${theme.name}"]`)
+      expect(btn.exists()).toBe(true)
+      expect(btn.text()).toContain(theme.name)
+      const swatch = btn.find('span[style*="linear-gradient"]')
+      expect(swatch.exists()).toBe(true)
+    }
+  })
+
+  it('shows a tier badge on non-free themes', async () => {
+    const { default: SettingsView } = await import('../SettingsView.vue')
+    const wrapper = mount(SettingsView, {
+      global: { stubs: { 'router-link': { template: '<a><slot /></a>' } } },
+    })
+    await flushPromises()
+
+    // Free themes have no badge
+    const tetherBtn = wrapper.find('button[title="The Tether"]')
+    expect(tetherBtn.text()).not.toContain('paid')
+    expect(tetherBtn.text()).not.toContain('oss')
+
+    // Paid theme shows a badge
+    const terminalBtn = wrapper.find('button[title="Terminal"]')
+    expect(terminalBtn.text().toLowerCase()).toMatch(/paid|oss/)
+  })
+
+  it('clicking a free theme applies it and persists to localStorage', async () => {
+    const { default: SettingsView } = await import('../SettingsView.vue')
+    const wrapper = mount(SettingsView, {
+      global: { stubs: { 'router-link': { template: '<a><slot /></a>' } } },
+    })
+    await flushPromises()
+
+    await wrapper.find('button[title="Horizon"]').trigger('click')
+
+    expect(document.documentElement.dataset.theme).toBe('horizon')
+    expect(localStorage.getItem('tether-theme')).toBe('horizon')
+  })
+
+  it('clicking a paid theme previews on DOM but does NOT persist, and shows upgrade nudge', async () => {
+    const { default: SettingsView } = await import('../SettingsView.vue')
+    const wrapper = mount(SettingsView, {
+      global: { stubs: { 'router-link': { template: '<a><slot /></a>' } } },
+    })
+    await flushPromises()
+
+    await wrapper.find('button[title="Terminal"]').trigger('click')
+
+    // DOM was previewed
+    expect(document.documentElement.dataset.theme).toBe('terminal')
+    // But not persisted (user is not paid)
+    expect(localStorage.getItem('tether-theme')).toBeNull()
+    // Upgrade nudge shown
+    expect(wrapper.text()).toContain('Terminal')
+    expect(wrapper.text().toLowerCase()).toContain('upgrade')
+  })
+
+  it('hovering a theme button previews it via document.documentElement.dataset.theme', async () => {
+    const { default: SettingsView } = await import('../SettingsView.vue')
+    const wrapper = mount(SettingsView, {
+      global: { stubs: { 'router-link': { template: '<a><slot /></a>' } } },
+    })
+    await flushPromises()
+
+    await wrapper.find('button[title="Solstice"]').trigger('mouseenter')
+    expect(document.documentElement.dataset.theme).toBe('solstice')
+  })
+})

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __TETHER_EDITION__: string | undefined

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,4 +4,8 @@ import vue from '@vitejs/plugin-vue'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [vue()],
+  define: {
+    // Set TETHER_EDITION to 'cloud' by default; override with VITE_TETHER_EDITION env var
+    __TETHER_EDITION__: JSON.stringify(process.env.VITE_TETHER_EDITION ?? 'cloud'),
+  },
 })


### PR DESCRIPTION
## Summary
- Add design system CSS token files (canvas, motif, type, surfaces, etc.) imported from `main.ts`
- Add `useTheme` composable: `THEMES` registry, `applyTheme`, `previewTheme`, tier-locking via community-edition flag
- Add `usePremiumThemes` composable: lazy-loads premium theme CSS into a `<style id="premium-themes">` tag once `user.is_paid` flips
- Add Appearance section to `SettingsView` with swatch grid, tier badges, hover-to-preview, click-to-persist (free) or click-to-preview-with-upgrade-nudge (paid)
- Add `.crt` class + `position: relative` to `App.vue` root so the Terminal theme scanline overlay renders correctly
- Wire `__TETHER_EDITION__` define in `vite.config.ts` (declared in `vite-env.d.ts`)

## Test plan
- [x] `npx vue-tsc -b` passes with no errors
- [x] `npx vitest run` — 324/324 tests passing across 32 files
- [x] New tests cover useTheme apply/preview/persist, usePremiumThemes injection, and SettingsView picker behavior (free vs paid click paths, hover preview, tier badge rendering)
- [ ] Manual: open Settings → Appearance, hover swatches to preview, click free theme persists, click paid shows upgrade nudge without persisting
- [ ] Manual: select Terminal theme and verify scanline overlay appears (driven by `.crt::after` on App.vue root)