### PR TITLE
feat: user preferences API + anchor motif field

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -52,5 +52,5 @@ VAULT_KEY_B64: str = config.get("vault.key", default="")
 # Encode to bytes for Fernet (it expects the base64 string as bytes, not raw bytes)
 VAULT_KEY: bytes | None = VAULT_KEY_B64.encode() if VAULT_KEY_B64 else None
 
-import os as _os
-IS_COMMUNITY_EDITION: bool = _os.environ.get("TETHER_COMMUNITY_EDITION", "").lower() == "true"
+# Community Edition flag — self-hosters set TETHER_COMMUNITY_EDITION=true to unlock all paid features
+IS_COMMUNITY_EDITION: bool = os.environ.get("TETHER_COMMUNITY_EDITION", "").lower() == "true"

--- a/api/config.py
+++ b/api/config.py
@@ -51,3 +51,6 @@ GOOGLE_INTEGRATION_CALLBACK_URL: str = config.get(
 VAULT_KEY_B64: str = config.get("vault.key", default="")
 # Encode to bytes for Fernet (it expects the base64 string as bytes, not raw bytes)
 VAULT_KEY: bytes | None = VAULT_KEY_B64.encode() if VAULT_KEY_B64 else None
+
+import os as _os
+IS_COMMUNITY_EDITION: bool = _os.environ.get("TETHER_COMMUNITY_EDITION", "").lower() == "true"

--- a/api/main.py
+++ b/api/main.py
@@ -31,6 +31,7 @@ from api.routes import meetings as meetings_routes
 from api.routes import integrations as integrations_routes
 from api.routes import api_keys as api_keys_routes
 from api.routes import events as events_routes
+from api.routes import preferences as preferences_routes
 from api.ws import manager
 from api.auth import auth_dependency, decode_jwt
 from api.limiter import limiter
@@ -158,6 +159,7 @@ def create_app(lifespan_override=None) -> FastAPI:
     app.include_router(integrations_routes.router, prefix="/api")
     app.include_router(api_keys_routes.router, prefix="/api")
     app.include_router(events_routes.router, prefix="/api")
+    app.include_router(preferences_routes.router, prefix="/api")
 
     # --- Premium plugin hook ---
     try:

--- a/api/routes/anchors.py
+++ b/api/routes/anchors.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
+from typing import Literal
 import asyncpg
 from db.pg_queries import get_anchors, upsert_anchor, delete_anchor
 from db.pool_middleware import get_db_conn
@@ -19,6 +20,7 @@ class AnchorUpdate(BaseModel):
     color: str
     position: int
     followup_config: dict | None = None
+    motif: Literal["anchor", "focus", "calm", "energy", "care", "flow", "dusk", "quiet"] = "anchor"
 
 
 @router.get("/anchors")

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -51,6 +51,7 @@ def _safe_user(user: dict) -> dict:
         "username": user["username"],
         "email": user["email"],
         "is_admin": bool(user["is_admin"]),
+        "is_paid": cfg.IS_COMMUNITY_EDITION,
     }
 
 
@@ -161,6 +162,7 @@ async def me(request: Request, _auth=Depends(auth_dependency)):
         "user_id": request.state.user_id,
         "username": request.state.username,
         "is_admin": request.state.is_admin,
+        "is_paid": cfg.IS_COMMUNITY_EDITION,
     }
 
 

--- a/api/routes/preferences.py
+++ b/api/routes/preferences.py
@@ -1,0 +1,30 @@
+from pydantic import BaseModel
+from fastapi import APIRouter, Depends, Request
+from db.pool_middleware import get_db_conn
+from db.pg_queries.preferences import upsert_user_preference, get_user_preferences
+from api.auth import auth_dependency
+
+router = APIRouter(prefix="/user/preferences", tags=["preferences"])
+# NOTE: This router is included with prefix="/api" in main.py → final paths are /api/user/preferences
+
+
+class PreferencesBody(BaseModel):
+    theme: str | None = None
+    mode: str | None = None
+
+
+@router.get("")
+async def get_preferences(request: Request, _auth=Depends(auth_dependency), conn=Depends(get_db_conn)):
+    user_id = request.state.user_id
+    prefs = await get_user_preferences(conn, user_id)
+    return {"theme": prefs.get("theme"), "mode": prefs.get("mode")}
+
+
+@router.patch("")
+async def patch_preferences(body: PreferencesBody, request: Request, _auth=Depends(auth_dependency), conn=Depends(get_db_conn)):
+    user_id = request.state.user_id
+    if body.theme is not None:
+        await upsert_user_preference(conn, user_id, "theme", body.theme)
+    if body.mode is not None:
+        await upsert_user_preference(conn, user_id, "mode", body.mode)
+    return {"ok": True}

--- a/db/migrations/versions/b1c2d3e4f5a6_user_preferences.py
+++ b/db/migrations/versions/b1c2d3e4f5a6_user_preferences.py
@@ -1,0 +1,42 @@
+"""user_preferences table
+
+Stores per-user key/value preferences with RLS isolation.
+
+Revision ID: b1c2d3e4f5a6
+Revises: 2a3b4c5d6e7f
+Create Date: 2026-04-29
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "b1c2d3e4f5a6"
+down_revision: Union[str, Sequence[str], None] = "2a3b4c5d6e7f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE user_preferences (
+            user_id    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            key        VARCHAR(64) NOT NULL,
+            value      TEXT NOT NULL,
+            updated_at TIMESTAMPTZ DEFAULT now(),
+            PRIMARY KEY (user_id, key)
+        )
+        """
+    )
+    op.execute("ALTER TABLE user_preferences ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE user_preferences FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY user_preferences_user_isolation ON user_preferences
+            USING (user_id = current_setting('app.current_user_id', true)::uuid)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS user_preferences")

--- a/db/migrations/versions/c2d3e4f5a6b7_anchor_motif.py
+++ b/db/migrations/versions/c2d3e4f5a6b7_anchor_motif.py
@@ -1,0 +1,24 @@
+"""anchor motif column
+
+Adds a motif field to anchors for visual/thematic categorization.
+
+Revision ID: c2d3e4f5a6b7
+Revises: b1c2d3e4f5a6
+Create Date: 2026-04-29
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "c2d3e4f5a6b7"
+down_revision: Union[str, Sequence[str], None] = "b1c2d3e4f5a6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE anchors ADD COLUMN motif VARCHAR(16) NOT NULL DEFAULT 'anchor'")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE anchors DROP COLUMN IF EXISTS motif")

--- a/db/pg_queries/anchors.py
+++ b/db/pg_queries/anchors.py
@@ -10,9 +10,9 @@ async def upsert_anchor(conn: asyncpg.Connection, anchor: dict) -> None:
         """
         INSERT INTO anchors
             (id, user_id, name, time, duration_minutes, flexibility,
-             strictness, color, position, followup_config)
+             strictness, color, position, followup_config, motif)
         VALUES ($1, current_setting('app.current_user_id', true)::uuid,
-                $2, $3, $4, $5, $6, $7, $8, $9)
+                $2, $3, $4, $5, $6, $7, $8, $9, $10)
         ON CONFLICT (id) DO UPDATE SET
             name             = EXCLUDED.name,
             time             = EXCLUDED.time,
@@ -21,7 +21,8 @@ async def upsert_anchor(conn: asyncpg.Connection, anchor: dict) -> None:
             strictness       = EXCLUDED.strictness,
             color            = EXCLUDED.color,
             position         = EXCLUDED.position,
-            followup_config  = EXCLUDED.followup_config
+            followup_config  = EXCLUDED.followup_config,
+            motif            = EXCLUDED.motif
         """,
         _uuid.UUID(anchor["id"]),
         anchor["name"],
@@ -32,6 +33,7 @@ async def upsert_anchor(conn: asyncpg.Connection, anchor: dict) -> None:
         anchor.get("color", "#888888"),
         anchor.get("position", 0),
         anchor.get("followup_config"),
+        anchor.get("motif", "anchor"),
     )
 
 
@@ -63,7 +65,7 @@ async def get_anchors(conn: asyncpg.Connection) -> list[dict]:
 
 async def patch_anchor(conn: asyncpg.Connection, anchor_id: str, fields: dict) -> None:
     allowed = {"name", "time", "duration_minutes", "flexibility", "strictness",
-               "color", "position", "followup_config"}
+               "color", "position", "followup_config", "motif"}
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:
         return

--- a/db/pg_queries/preferences.py
+++ b/db/pg_queries/preferences.py
@@ -1,0 +1,19 @@
+"""Async Postgres queries — user_preferences table."""
+from __future__ import annotations
+import asyncpg
+
+
+async def upsert_user_preference(conn: asyncpg.Connection, user_id: str, key: str, value: str) -> None:
+    await conn.execute(
+        """INSERT INTO user_preferences (user_id, key, value)
+           VALUES ($1::uuid, $2, $3)
+           ON CONFLICT (user_id, key) DO UPDATE SET value = $3, updated_at = now()""",
+        user_id, key, value,
+    )
+
+
+async def get_user_preferences(conn: asyncpg.Connection, user_id: str) -> dict[str, str]:
+    rows = await conn.fetch(
+        "SELECT key, value FROM user_preferences WHERE user_id = $1::uuid", user_id
+    )
+    return {r["key"]: r["value"] for r in rows}

--- a/tests/api/test_anchor_motif.py
+++ b/tests/api/test_anchor_motif.py
@@ -1,0 +1,75 @@
+"""Tests for motif field in anchor create/update responses."""
+import pytest
+from unittest.mock import patch
+
+ANCHOR_BASE = {
+    "name": "Focus Block",
+    "time": "09:00",
+    "duration_minutes": 90,
+    "flexibility": "flexible",
+    "strictness": 3,
+    "color": "#7c6af7",
+    "position": 0,
+}
+
+
+@pytest.mark.asyncio
+async def test_post_anchor_with_motif(api_client, conn):
+    """POST anchor with motif 'focus' → GET returns that anchor with motif == 'focus'."""
+    payload = {**ANCHOR_BASE, "motif": "focus"}
+    with patch("api.routes.anchors.sync_crontab"):
+        resp = await api_client.post("/api/anchors", json=payload)
+    assert resp.status_code == 200
+    anchor_id = resp.json()["id"]
+
+    resp = await api_client.get("/api/anchors")
+    assert resp.status_code == 200
+    anchors = resp.json()
+    created = next((a for a in anchors if a["id"] == anchor_id), None)
+    assert created is not None
+    assert created["motif"] == "focus"
+
+
+@pytest.mark.asyncio
+async def test_post_anchor_default_motif(api_client, conn):
+    """POST anchor without motif → GET returns anchor with motif == 'anchor' (default)."""
+    with patch("api.routes.anchors.sync_crontab"):
+        resp = await api_client.post("/api/anchors", json=ANCHOR_BASE)
+    assert resp.status_code == 200
+    anchor_id = resp.json()["id"]
+
+    resp = await api_client.get("/api/anchors")
+    assert resp.status_code == 200
+    anchors = resp.json()
+    created = next((a for a in anchors if a["id"] == anchor_id), None)
+    assert created is not None
+    assert created["motif"] == "anchor"
+
+
+@pytest.mark.asyncio
+async def test_put_anchor_updates_motif(api_client, conn):
+    """PUT anchor updating motif to 'calm' → GET returns updated motif."""
+    with patch("api.routes.anchors.sync_crontab"):
+        post_resp = await api_client.post("/api/anchors", json=ANCHOR_BASE)
+    assert post_resp.status_code == 200
+    anchor_id = post_resp.json()["id"]
+
+    payload = {**ANCHOR_BASE, "motif": "calm"}
+    with patch("api.routes.anchors.sync_crontab"):
+        put_resp = await api_client.put(f"/api/anchors/{anchor_id}", json=payload)
+    assert put_resp.status_code == 200
+
+    resp = await api_client.get("/api/anchors")
+    anchors = resp.json()
+    updated = next((a for a in anchors if a["id"] == anchor_id), None)
+    assert updated is not None
+    assert updated["motif"] == "calm"
+
+
+@pytest.mark.asyncio
+async def test_post_anchor_invalid_motif(api_client, conn):
+    """POST anchor with invalid motif value → 422 response."""
+    payload = {**ANCHOR_BASE, "motif": "unknown"}
+    with patch("api.routes.anchors.sync_crontab"):
+        resp = await api_client.post("/api/anchors", json=payload)
+    assert resp.status_code == 422

--- a/tests/api/test_user_preferences.py
+++ b/tests/api/test_user_preferences.py
@@ -1,0 +1,52 @@
+"""Tests for GET/PATCH /api/user/preferences and is_paid in /auth/me."""
+import pytest
+from tests.api.conftest import TEST_USER_ID
+
+
+@pytest.mark.asyncio
+async def test_get_preferences_empty(api_client, conn):
+    """GET /api/user/preferences returns None for both fields when no prefs set."""
+    resp = await api_client.get("/api/user/preferences")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["theme"] is None
+    assert data["mode"] is None
+
+
+@pytest.mark.asyncio
+async def test_patch_preferences_theme(api_client, conn):
+    """PATCH /api/user/preferences with theme returns ok."""
+    resp = await api_client.patch("/api/user/preferences", json={"theme": "dark"})
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_get_preferences_after_patch_theme(api_client, conn):
+    """After patching theme, GET returns updated theme and mode still None."""
+    await api_client.patch("/api/user/preferences", json={"theme": "dark"})
+    resp = await api_client.get("/api/user/preferences")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["theme"] == "dark"
+    assert data["mode"] is None
+
+
+@pytest.mark.asyncio
+async def test_patch_preferences_mode(api_client, conn):
+    """Patching mode separately also works and is reflected in GET."""
+    await api_client.patch("/api/user/preferences", json={"mode": "compact"})
+    resp = await api_client.get("/api/user/preferences")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["mode"] == "compact"
+    assert data["theme"] is None
+
+
+@pytest.mark.asyncio
+async def test_auth_me_includes_is_paid(api_client, conn):
+    """GET /auth/me response includes is_paid field."""
+    resp = await api_client.get("/auth/me")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "is_paid" in data

--- a/tests/api/test_user_preferences.py
+++ b/tests/api/test_user_preferences.py
@@ -45,8 +45,11 @@ async def test_patch_preferences_mode(api_client, conn):
 
 @pytest.mark.asyncio
 async def test_auth_me_includes_is_paid(api_client, conn):
-    """GET /auth/me response includes is_paid field."""
+    """GET /auth/me response includes is_paid as a bool (False when TETHER_COMMUNITY_EDITION not set)."""
     resp = await api_client.get("/auth/me")
     assert resp.status_code == 200
     data = resp.json()
     assert "is_paid" in data
+    assert isinstance(data["is_paid"], bool)
+    # In test env TETHER_COMMUNITY_EDITION is not set → False
+    assert data["is_paid"] is False


### PR DESCRIPTION
## Summary

- **IS_COMMUNITY_EDITION flag**: `TETHER_COMMUNITY_EDITION=true` env var grants `is_paid: true` to all users on self-hosted deployments — self-hosters get all paid features without per-user subscription tracking
- **User preferences API**: New `GET/PATCH /api/user/preferences` endpoints backed by a `user_preferences` key/value table with full RLS isolation; supports `theme` and `mode` fields
- **Anchor motif field**: `motif` column added to `anchors` table with `Literal` validation (8 valid values: `anchor | focus | calm | energy | care | flow | dusk | quiet`); included in GET/POST/PUT anchor responses

## Changes

- `api/config.py` — `IS_COMMUNITY_EDITION` flag
- `api/routes/auth.py` — `is_paid` in `_safe_user` and `/auth/me`
- `db/migrations/versions/b1c2d3e4f5a6_user_preferences.py` — new table with RLS
- `db/pg_queries/preferences.py` — `upsert_user_preference`, `get_user_preferences`
- `api/routes/preferences.py` — `GET/PATCH /api/user/preferences`
- `api/main.py` — register preferences router
- `db/migrations/versions/c2d3e4f5a6b7_anchor_motif.py` — `ALTER TABLE anchors ADD COLUMN motif`
- `db/pg_queries/anchors.py` — motif in upsert + patch
- `api/routes/anchors.py` — `AnchorUpdate.motif` with `Literal` validation
- `tests/api/test_user_preferences.py` — preferences round-trip tests + `is_paid` assertion
- `tests/api/test_anchor_motif.py` — motif round-trip + invalid value → 422 tests

## Migration chain

`2a3b4c5d6e7f` → `b1c2d3e4f5a6` (user_preferences) → `c2d3e4f5a6b7` (anchor motif)

Linear head maintained.

## Test plan

- [ ] `pytest tests/api/test_user_preferences.py -v` — preferences CRUD + is_paid assertion
- [ ] `pytest tests/api/test_anchor_motif.py -v` — motif round-trip, default, invalid 422
- [ ] `alembic upgrade head` on staging to apply migrations