### PR TITLE
fix: reject empty PATCH /api/user/preferences body; add overwrite test

### DIFF
--- a/api/routes/preferences.py
+++ b/api/routes/preferences.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from db.pool_middleware import get_db_conn
 from db.pg_queries.preferences import upsert_user_preference, get_user_preferences
 from api.auth import auth_dependency
@@ -22,6 +22,8 @@ async def get_preferences(request: Request, _auth=Depends(auth_dependency), conn
 
 @router.patch("")
 async def patch_preferences(body: PreferencesBody, request: Request, _auth=Depends(auth_dependency), conn=Depends(get_db_conn)):
+    if body.theme is None and body.mode is None:
+        raise HTTPException(status_code=400, detail="At least one field (theme, mode) must be provided")
     user_id = request.state.user_id
     if body.theme is not None:
         await upsert_user_preference(conn, user_id, "theme", body.theme)

--- a/tests/api/test_user_preferences.py
+++ b/tests/api/test_user_preferences.py
@@ -44,6 +44,23 @@ async def test_patch_preferences_mode(api_client, conn):
 
 
 @pytest.mark.asyncio
+async def test_patch_empty_body_rejected(api_client, conn):
+    """PATCH with no fields provided returns 400 (not a silent no-op success)."""
+    resp = await api_client.patch("/api/user/preferences", json={})
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_patch_overwrites_existing(api_client, conn):
+    """PATCH overwrites an existing preference value (exercises ON CONFLICT DO UPDATE)."""
+    await api_client.patch("/api/user/preferences", json={"theme": "dark"})
+    await api_client.patch("/api/user/preferences", json={"theme": "light"})
+    resp = await api_client.get("/api/user/preferences")
+    assert resp.status_code == 200
+    assert resp.json()["theme"] == "light"
+
+
+@pytest.mark.asyncio
 async def test_auth_me_includes_is_paid(api_client, conn):
     """GET /auth/me response includes is_paid as a bool (False when TETHER_COMMUNITY_EDITION not set)."""
     resp = await api_client.get("/auth/me")


### PR DESCRIPTION
Silent-failure-hunter caught: empty body silently returned {"ok": true} without writing anything to the DB. Now returns 400 with explicit message. Also adds test for ON CONFLICT DO UPDATE overwrite path.