### PR TITLE
fix(frontend): address code review findings — isPaid wiring + premium…

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,7 +2,7 @@
 import { ref, watch } from 'vue'
 import { useAuthStore } from './stores/auth'
 import { useRouter } from 'vue-router'
-import { loadPremiumThemes } from './composables/usePremiumThemes'
+import { loadPremiumThemes, unloadPremiumThemes } from './composables/usePremiumThemes'
 import BotChat from './components/BotChat.vue'
 import SlideOverStack from './components/SlideOverStack.vue'
 
@@ -15,9 +15,11 @@ watch(
   () => authStore.user,
   (user) => {
     if (user?.is_paid) {
-      // token not available client-side via cookie auth — pass empty string;
-      // the endpoint will use session cookie instead when implemented
-      loadPremiumThemes('')
+      // Cookie auth handles identity; token param reserved for future API-key support
+      loadPremiumThemes()
+    } else {
+      // Remove premium CSS when user logs out or loses entitlement
+      unloadPremiumThemes()
     }
   },
   { immediate: true },

--- a/frontend/src/composables/__tests__/usePremiumThemes.test.ts
+++ b/frontend/src/composables/__tests__/usePremiumThemes.test.ts
@@ -111,4 +111,46 @@ describe('loadPremiumThemes', () => {
       }),
     )
   })
+
+  it('token parameter is optional — works with no arguments', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ themes: [] }),
+    } as Response))
+
+    const { loadPremiumThemes } = await import('../usePremiumThemes')
+    // Should not throw
+    await expect(loadPremiumThemes()).resolves.toBeUndefined()
+  })
+})
+
+describe('unloadPremiumThemes', () => {
+  beforeEach(() => {
+    document.getElementById('premium-themes')?.remove()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('removes the premium-themes style element if present', async () => {
+    const el = document.createElement('style')
+    el.id = 'premium-themes'
+    el.textContent = '.test {}'
+    document.head.appendChild(el)
+
+    expect(document.getElementById('premium-themes')).not.toBeNull()
+
+    const { unloadPremiumThemes } = await import('../usePremiumThemes')
+    unloadPremiumThemes()
+
+    expect(document.getElementById('premium-themes')).toBeNull()
+  })
+
+  it('is a no-op when element does not exist', async () => {
+    const { unloadPremiumThemes } = await import('../usePremiumThemes')
+    // Should not throw
+    expect(() => unloadPremiumThemes()).not.toThrow()
+  })
 })

--- a/frontend/src/composables/__tests__/useTheme.test.ts
+++ b/frontend/src/composables/__tests__/useTheme.test.ts
@@ -65,6 +65,16 @@ describe('useTheme', () => {
     expect(isThemeUnlocked(paidOssTheme)).toBe(false)
   })
 
+  it('isThemeUnlocked returns true for paid-oss themes when user is_paid', async () => {
+    vi.doMock('../../stores/auth', () => ({
+      useAuthStore: () => ({ user: { user_id: '1', username: 'alice', is_admin: false, is_paid: true } }),
+    }))
+    const { useTheme, THEMES } = await import('../useTheme')
+    const { isThemeUnlocked } = useTheme()
+    const paidOssTheme = THEMES.find(t => t.id === 'terminal')!
+    expect(isThemeUnlocked(paidOssTheme)).toBe(true)
+  })
+
   it('setMode updates data-mode and localStorage', async () => {
     const { useTheme } = await import('../useTheme')
     const { setMode } = useTheme()

--- a/frontend/src/composables/usePremiumThemes.ts
+++ b/frontend/src/composables/usePremiumThemes.ts
@@ -1,7 +1,8 @@
 /** Fetches server-side premium theme CSS and injects it into the document.
  *  Called on boot when the user is known to be premium. The endpoint does not
- *  exist yet — the call is a no-op until the backend ships it. */
-export async function loadPremiumThemes(token: string): Promise<void> {
+ *  exist yet — the call is a no-op until the backend ships it.
+ *  Uses cookie-based auth; the optional token param is reserved for future API-key auth. */
+export async function loadPremiumThemes(token = ''): Promise<void> {
   const res = await fetch('/api/premium/themes', {
     credentials: 'include',
     headers: token ? { Authorization: `Bearer ${token}` } : {},
@@ -15,4 +16,9 @@ export async function loadPremiumThemes(token: string): Promise<void> {
     document.head.appendChild(el)
   }
   el.textContent = themes.map(t => t.css).join('\n')
+}
+
+/** Removes the injected premium theme CSS element. Call on logout. */
+export function unloadPremiumThemes(): void {
+  document.getElementById('premium-themes')?.remove()
 }

--- a/frontend/src/composables/useTheme.ts
+++ b/frontend/src/composables/useTheme.ts
@@ -38,9 +38,9 @@ const isCommunityEdition = (() => {
 })()
 
 export function useTheme() {
-  useAuthStore() // reserved for future isPaid check — do not remove
-  // TODO: add is_paid to user type in stores/auth.ts when backend adds the field
-  const isPaid = computed(() => false)
+  const auth = useAuthStore()
+  // is_paid is optional on User — defaults to false until backend ships the field
+  const isPaid = computed(() => !!auth.user?.is_paid)
 
   const activeTheme = ref(localStorage.getItem('tether-theme') ?? 'tether')
   const activeMode = ref<'light' | 'dark'>(


### PR DESCRIPTION
… CSS cleanup

- Wire isPaid from auth.user.is_paid in useTheme (was hardcoded false)
- Add test: isThemeUnlocked returns true for paid-oss when user.is_paid is set
- Make loadPremiumThemes token param optional (default '')
- Add unloadPremiumThemes() to remove <style id="premium-themes"> on logout
- Wire unloadPremiumThemes in App.vue watch when user becomes null/unpaid
- Add tests for unloadPremiumThemes and optional token param