### PR TITLE
feat(frontend): motif dot picker on detail panels

### DIFF
--- a/frontend/src/components/AnchorBlock.vue
+++ b/frontend/src/components/AnchorBlock.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from 'vue'
 import TaskCard from './TaskCard.vue'
 import GroupContainer from './GroupContainer.vue'
+import MotifPicker, { type MotifSlot } from './MotifPicker.vue'
 import { usePlanStore } from '../stores/plan'
 import type { Task } from '../stores/plan'
 import { useMilestoneStore } from '../stores/milestones'
@@ -70,6 +71,22 @@ const groupedByContext = computed(() => {
 
 function contextTaskCount(ctx: { milestoneGroups: { tasks: TaskWithIndex[] }[]; ungrouped: TaskWithIndex[] }): number {
   return ctx.milestoneGroups.reduce((sum, g) => sum + g.tasks.length, 0) + ctx.ungrouped.length
+}
+
+// Local cache of motif selections per context subject. Backend support lands in a parallel stream;
+// PATCH attempts here are best-effort no-ops until then.
+const contextMotifs = ref<Record<string, MotifSlot>>({})
+
+async function setContextMotif(subject: string | null, slot: MotifSlot) {
+  if (!subject) return
+  contextMotifs.value = { ...contextMotifs.value, [subject]: slot }
+  try {
+    await api(`/api/context/${encodeURIComponent(subject)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ motif: slot }),
+    })
+  } catch { /* backend motif support pending — see feature/motif-db-api */ }
 }
 
 function onUpdate(task: Task, index: number) {
@@ -169,8 +186,26 @@ function onDrop(evt: DragEvent, toIndex: number) {
           </div>
         </template>
 
-        <!-- Context has >1 task — wrap in context GroupContainer -->
-        <GroupContainer v-else :label="ctx.label" :collapsible="true" :level="1" class="mb-2">
+        <!-- Context has >1 task — wrap in context GroupContainer with motif sidebar -->
+        <div v-else class="relative">
+          <div
+            v-if="ctx.contextSubject && contextMotifs[ctx.contextSubject]"
+            class="absolute left-0 top-0 bottom-0 w-0.5 pointer-events-none"
+            :style="{ background: `var(--motif-${contextMotifs[ctx.contextSubject]})` }"
+          />
+        <GroupContainer :label="ctx.label" :collapsible="true" :level="1" class="mb-2 group/ctx">
+          <template #header-right>
+            <div
+              v-if="ctx.contextSubject"
+              data-testid="context-motif-picker"
+              class="opacity-0 group-hover/ctx:opacity-100 transition-opacity ml-1"
+              @click.stop>
+              <MotifPicker
+                :model-value="contextMotifs[ctx.contextSubject] ?? null"
+                @update:model-value="(slot) => setContextMotif(ctx.contextSubject, slot)"
+              />
+            </div>
+          </template>
           <!-- Milestone sub-groups -->
           <template v-for="mg in ctx.milestoneGroups" :key="mg.milestone.id">
             <!-- Milestone group has 1 task — show standalone with tags visible -->
@@ -223,6 +258,7 @@ function onDrop(evt: DragEvent, toIndex: number) {
             + Add task
           </button>
         </GroupContainer>
+        </div>
       </template>
     </div>
 

--- a/frontend/src/components/AnchorBlock.vue
+++ b/frontend/src/components/AnchorBlock.vue
@@ -73,8 +73,11 @@ function contextTaskCount(ctx: { milestoneGroups: { tasks: TaskWithIndex[] }[]; 
   return ctx.milestoneGroups.reduce((sum, g) => sum + g.tasks.length, 0) + ctx.ungrouped.length
 }
 
-// Local cache of motif selections per context subject. Backend support lands in a parallel stream;
-// PATCH attempts here are best-effort no-ops until then.
+// Local cache of motif selections per context subject.
+// TODO(motif-db-api): backend read path not yet wired. When the parallel
+// `feature/motif-db-api` stream ships a `motif` field on context-entry responses,
+// seed this map from there (e.g. via a context store) so picks survive remount.
+// Until then, selections are lost on reload — acceptable per spec.
 const contextMotifs = ref<Record<string, MotifSlot>>({})
 
 async function setContextMotif(subject: string | null, slot: MotifSlot) {
@@ -86,7 +89,11 @@ async function setContextMotif(subject: string | null, slot: MotifSlot) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ motif: slot }),
     })
-  } catch { /* backend motif support pending — see feature/motif-db-api */ }
+  } catch (e) {
+    // Backend motif support pending (feature/motif-db-api). Log so non-network
+    // failures (bad JSON, undefined subject, etc.) remain visible during dev.
+    console.warn('setContextMotif failed:', e)
+  }
 }
 
 function onUpdate(task: Task, index: number) {

--- a/frontend/src/components/AnchorEditor.vue
+++ b/frontend/src/components/AnchorEditor.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import type { Anchor } from '../stores/anchors'
+import MotifPicker, { type MotifSlot } from './MotifPicker.vue'
 
 const props = withDefaults(defineProps<{
   anchor: Anchor
@@ -51,11 +52,15 @@ async function save() {
   <div class="bg-white/5 border rounded-xl p-4 flex flex-col gap-3"
        :class="isPending ? 'border-blue-400/40' : 'border-white/10'">
     <div class="flex items-center gap-3">
-      <input v-model="draft.color" type="color"
-             class="w-5 h-5 rounded-full cursor-pointer bg-transparent border-0 p-0" />
       <input v-model="draft.name" placeholder="Anchor name"
              class="bg-transparent font-semibold text-white flex-1 outline-none border-b border-white/20 pb-0.5"
              :class="isPending ? 'border-blue-400/40' : ''" />
+    </div>
+    <div data-testid="anchor-motif-picker">
+      <MotifPicker
+        :model-value="(draft.motif as MotifSlot | null | undefined) ?? null"
+        @update:model-value="(slot) => draft.motif = slot"
+      />
     </div>
 
     <div class="grid grid-cols-4 gap-3 text-sm">

--- a/frontend/src/components/MilestoneDetailPanel.vue
+++ b/frontend/src/components/MilestoneDetailPanel.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted } from 'vue'
 import { api } from '../lib/api'
 import SearchAutocomplete from './SearchAutocomplete.vue'
 import type { SearchResult } from './SearchAutocomplete.vue'
+import MotifPicker, { type MotifSlot } from './MotifPicker.vue'
 import { useMilestoneStore } from '../stores/milestones'
 import { usePlanStore } from '../stores/plan'
 import { useLinks } from '../composables/useLinks'
@@ -171,20 +172,13 @@ onMounted(async () => {
             class="bg-gray-800 text-white text-sm rounded px-2 py-1 border border-white/20 outline-none" />
         </div>
 
-        <!-- Color -->
-        <label class="flex flex-col gap-1 text-white/50 text-xs">
-          Color
-          <div class="flex items-center gap-2">
-            <input
-              :value="milestone.color ?? ''"
-              type="color"
-              @change="patchMilestone({ color: ($event.target as HTMLInputElement).value })"
-              class="bg-white/10 rounded h-8 w-12 cursor-pointer" />
-            <button v-if="milestone.color"
-                    @click="patchMilestone({ color: null })"
-                    class="text-xs text-white/30 hover:text-white/60">Clear</button>
-          </div>
-        </label>
+        <!-- Motif -->
+        <div data-testid="milestone-motif-picker" class="flex items-center gap-3">
+          <MotifPicker
+            :model-value="(milestone.motif as MotifSlot | null | undefined) ?? null"
+            @update:model-value="(slot) => patchMilestone({ motif: slot })"
+          />
+        </div>
 
         <!-- Description -->
         <div class="flex flex-col gap-1">

--- a/frontend/src/components/MotifPicker.vue
+++ b/frontend/src/components/MotifPicker.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="flex gap-2 items-center">
+    <span class="text-xs" style="color: var(--fg-4)">Color</span>
+    <button
+      v-for="slot in MOTIF_SLOTS"
+      :key="slot"
+      type="button"
+      data-testid="motif-dot"
+      :data-slot="slot"
+      class="w-5 h-5 rounded-full border-2 transition-all"
+      :style="{
+        background: `var(--motif-${slot})`,
+        borderColor: modelValue === slot ? `var(--motif-${slot})` : 'transparent',
+        outline: modelValue === slot ? `2px solid var(--motif-${slot})` : 'none',
+        outlineOffset: '2px'
+      }"
+      :title="slot"
+      @click.stop="$emit('update:modelValue', slot)"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+const MOTIF_SLOTS = ['anchor','focus','calm','energy','care','flow','dusk','quiet'] as const
+export type MotifSlot = typeof MOTIF_SLOTS[number]
+
+defineProps<{ modelValue: MotifSlot | null | undefined }>()
+defineEmits<{ 'update:modelValue': [slot: MotifSlot] }>()
+</script>

--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -121,9 +121,9 @@ function toggleFollowup(enabled: boolean) {
       :draggable="!editable && !!task.id"
       @dragstart="onDragStart"
       @click="navigable && task.id && pushPanel({ kind: 'task', entityId: task.id })">
-    <div v-if="task.color"
+    <div v-if="task.motif || task.color"
          class="absolute left-0 top-1 bottom-1 w-1 rounded-full pointer-events-none"
-         :style="{ background: task.color }" />
+         :style="{ background: task.motif ? `var(--motif-${task.motif})` : task.color! }" />
     <div class="flex flex-col gap-1 p-2 pl-3">
     <!-- Status pill (top-right) — dropdown only in editable mode (plan view) -->
     <div class="absolute top-1.5 right-1.5">

--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -4,6 +4,7 @@ import { api } from '../lib/api'
 import SearchAutocomplete from './SearchAutocomplete.vue'
 import RecurrencePicker from './RecurrencePicker.vue'
 import RecurrenceEditDialog from './RecurrenceEditDialog.vue'
+import MotifPicker, { type MotifSlot } from './MotifPicker.vue'
 import type { SearchResult } from './SearchAutocomplete.vue'
 import { usePlanStore } from '../stores/plan'
 import { useMilestoneStore } from '../stores/milestones'
@@ -133,6 +134,11 @@ function onTextChange(e: Event) {
 function onStatusChange(e: Event) {
   const status = (e.target as HTMLSelectElement).value as TaskStatus
   patchTask({ status })
+}
+
+// Motif
+function onMotifChange(slot: MotifSlot) {
+  patchTask({ motif: slot })
 }
 
 // Description
@@ -594,6 +600,14 @@ onMounted(async () => {
             <option value="skipped">Skipped</option>
             <option value="blocked">Blocked</option>
           </select>
+        </div>
+
+        <!-- Motif -->
+        <div data-testid="task-motif-picker" class="flex items-center gap-3">
+          <MotifPicker
+            :model-value="(task.motif as MotifSlot | null | undefined) ?? null"
+            @update:model-value="onMotifChange"
+          />
         </div>
 
         <!-- Calendar -->

--- a/frontend/src/components/__tests__/MotifPicker.test.ts
+++ b/frontend/src/components/__tests__/MotifPicker.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import MotifPicker from '../MotifPicker.vue'
+
+const SLOTS = ['anchor','focus','calm','energy','care','flow','dusk','quiet']
+
+describe('MotifPicker', () => {
+  it('renders 8 motif dots', () => {
+    const wrapper = mount(MotifPicker, { props: { modelValue: null } })
+    const dots = wrapper.findAll('[data-testid="motif-dot"]')
+    expect(dots).toHaveLength(8)
+    expect(dots.map(d => d.attributes('data-slot'))).toEqual(SLOTS)
+  })
+
+  it('emits update:modelValue with the clicked slot', async () => {
+    const wrapper = mount(MotifPicker, { props: { modelValue: null } })
+    await wrapper.find('[data-slot="focus"]').trigger('click')
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+    expect(wrapper.emitted('update:modelValue')![0]).toEqual(['focus'])
+  })
+
+  it('shows a ring/outline on the selected dot', () => {
+    const wrapper = mount(MotifPicker, { props: { modelValue: 'calm' } })
+    const selected = wrapper.find('[data-slot="calm"]')
+    const style = selected.attributes('style') || ''
+    expect(style).toContain('outline-color: var(--motif-calm)')
+    expect(style).toContain('border-color: var(--motif-calm)')
+
+    const unselected = wrapper.find('[data-slot="focus"]')
+    const unstyle = unselected.attributes('style') || ''
+    expect(unstyle).toContain('outline-style: none')
+    expect(unstyle).toContain('border-color: transparent')
+  })
+})

--- a/frontend/src/stores/milestones.ts
+++ b/frontend/src/stores/milestones.ts
@@ -23,6 +23,7 @@ export interface Milestone {
   status: MilestoneStatus
   status_override: boolean
   color: string | null
+  motif?: string | null
   created_at: string
   updated_at: string
   task_count: number
@@ -80,7 +81,7 @@ export const useMilestoneStore = defineStore('milestones', () => {
     return m
   }
 
-  async function patchMilestone(id: string, fields: Partial<Pick<Milestone, 'name' | 'description' | 'target_date' | 'status' | 'color'>>) {
+  async function patchMilestone(id: string, fields: Partial<Pick<Milestone, 'name' | 'description' | 'target_date' | 'status' | 'color' | 'motif'>>) {
     const resp = await api(`/api/milestones/${id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/stores/plan.ts
+++ b/frontend/src/stores/plan.ts
@@ -28,6 +28,7 @@ export interface Task {
   is_recurring_master?: boolean
   original_date?: string
   color?: string | null
+  motif?: string | null
 }
 
 export interface AnchorPlan { tasks: Task[]; notes: string }


### PR DESCRIPTION
## Summary
- Adds `MotifPicker.vue` — 8 motif-slot dots (`anchor`/`focus`/`calm`/`energy`/`care`/`flow`/`dusk`/`quiet`) using `--motif-{slot}` CSS vars from the design system
- Wires it into `TaskDetailPanel`, `MilestoneDetailPanel`, `AnchorEditor`, and an inline hover-revealed picker on context groups in `AnchorBlock`
- `TaskCard` sidebar now prefers `task.motif → var(--motif-…)` and falls back to `task.color`
- `Task` and `Milestone` types gain `motif?: string | null`; `patchMilestone` accepts motif

## Backend coupling
- `anchors.motif` already exists (PR #238).
- `tasks.motif`, `milestones.motif`, and context-entry motif are landing in parallel via `feature/motif-db-api` — the PATCH bodies here are no-ops until that ships.

## Tests
- New `MotifPicker.test.ts` (renders 8 dots, emits slot on click, ring on selected)
- Full `vitest run`: 332/332 passing
- No new typecheck errors (4 pre-existing `require`-typing errors in `TaskDetailPanelAnchor/Calendar.test.ts` are untouched)

## Test plan
- [ ] Open a task in the detail panel — pick a slot, confirm the dot rings + a PATCH fires
- [ ] Open a milestone — slot persists across panel re-open (round-trips through patchMilestone)
- [ ] Edit an anchor — slot saves with the anchor (uses `anchors.motif`)
- [ ] On an anchor day plan, hover a context group with >1 task — picker appears in the header; clicking a slot draws the per-context sidebar bar in that motif color
- [ ] Tasks with `task.motif` set show the motif-colored sidebar; tasks with only `task.color` still render the hex color