### PR TITLE
feat(api): motif field on tasks, context_entries, milestones

### DIFF
--- a/api/routes/context.py
+++ b/api/routes/context.py
@@ -6,13 +6,11 @@ from db.pg_queries import (
     rename_context_subject,
 )
 from db.pool_middleware import get_db_conn
+from db.pg_queries._motif import VALID_MOTIFS
 from api.ws import manager
 from api.auth import auth_dependency
 
 router = APIRouter()
-
-
-VALID_MOTIFS = {"anchor", "focus", "calm", "energy", "care", "flow", "dusk", "quiet"}
 
 
 @router.get("/context")
@@ -39,7 +37,10 @@ async def put_context(subject: str, body: dict, request: Request,
                       conn: asyncpg.Connection = Depends(get_db_conn)):
     motif = body.get("motif")
     if motif is not None and motif not in VALID_MOTIFS:
-        raise HTTPException(status_code=422, detail=f"Invalid motif: {motif!r}")
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid motif: {motif!r}. Must be one of {sorted(VALID_MOTIFS)}",
+        )
     await upsert_context_entry(conn, subject, body.get("body", ""), motif=motif)
     await manager.broadcast({"type": "context_updated"}, request.state.user_id)
     return {"ok": True}

--- a/api/routes/context.py
+++ b/api/routes/context.py
@@ -12,6 +12,9 @@ from api.auth import auth_dependency
 router = APIRouter()
 
 
+VALID_MOTIFS = {"anchor", "focus", "calm", "energy", "care", "flow", "dusk", "quiet"}
+
+
 @router.get("/context")
 async def list_context(_auth=Depends(auth_dependency),
                        conn: asyncpg.Connection = Depends(get_db_conn),
@@ -34,7 +37,10 @@ async def get_context(subject: str, _auth=Depends(auth_dependency),
 async def put_context(subject: str, body: dict, request: Request,
                       _auth=Depends(auth_dependency),
                       conn: asyncpg.Connection = Depends(get_db_conn)):
-    await upsert_context_entry(conn, subject, body.get("body", ""))
+    motif = body.get("motif")
+    if motif is not None and motif not in VALID_MOTIFS:
+        raise HTTPException(status_code=422, detail=f"Invalid motif: {motif!r}")
+    await upsert_context_entry(conn, subject, body.get("body", ""), motif=motif)
     await manager.broadcast({"type": "context_updated"}, request.state.user_id)
     return {"ok": True}
 

--- a/api/routes/milestones.py
+++ b/api/routes/milestones.py
@@ -5,17 +5,18 @@ from db.pg_queries import (
     link_milestone_task, unlink_milestone_task,
 )
 from db.pool_middleware import get_db_conn
+from db.pg_queries._motif import VALID_MOTIFS
 from api.auth import auth_dependency
 
 router = APIRouter()
 
 
-VALID_MOTIFS = {"anchor", "focus", "calm", "energy", "care", "flow", "dusk", "quiet"}
-
-
 def _validate_motif(body: dict) -> None:
     if "motif" in body and body["motif"] not in VALID_MOTIFS:
-        raise HTTPException(status_code=422, detail=f"Invalid motif: {body['motif']!r}")
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid motif: {body['motif']!r}. Must be one of {sorted(VALID_MOTIFS)}",
+        )
 
 
 @router.get("/milestones")

--- a/api/routes/milestones.py
+++ b/api/routes/milestones.py
@@ -10,6 +10,14 @@ from api.auth import auth_dependency
 router = APIRouter()
 
 
+VALID_MOTIFS = {"anchor", "focus", "calm", "energy", "care", "flow", "dusk", "quiet"}
+
+
+def _validate_motif(body: dict) -> None:
+    if "motif" in body and body["motif"] not in VALID_MOTIFS:
+        raise HTTPException(status_code=422, detail=f"Invalid motif: {body['motif']!r}")
+
+
 @router.get("/milestones")
 async def list_all_milestones(_auth=Depends(auth_dependency),
                               conn: asyncpg.Connection = Depends(get_db_conn)):
@@ -28,11 +36,13 @@ async def create_milestone_route(subject: str, body: dict,
                                  conn: asyncpg.Connection = Depends(get_db_conn)):
     if "name" not in body:
         raise HTTPException(status_code=422, detail="'name' is required")
+    _validate_motif(body)
     return await create_milestone(
         conn, subject, body["name"],
         description=body.get("description"),
         target_date=body.get("target_date"),
         color=body.get("color"),
+        motif=body.get("motif", "anchor"),
     )
 
 
@@ -40,6 +50,7 @@ async def create_milestone_route(subject: str, body: dict,
 async def patch_milestone_route(milestone_id: str, body: dict,
                                 _auth=Depends(auth_dependency),
                                 conn: asyncpg.Connection = Depends(get_db_conn)):
+    _validate_motif(body)
     result = await patch_milestone(conn, milestone_id, body)
     if result is None:
         raise HTTPException(status_code=404, detail="Milestone not found")

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -12,17 +12,18 @@ from db.pg_queries import (
 )
 from db.pg_queries.tasks import set_task_rrule, delete_anchor_occurrence, truncate_anchor_series
 from db.pool_middleware import get_db_conn
+from db.pg_queries._motif import VALID_MOTIFS
 from api.auth import auth_dependency
 
 router = APIRouter()
 
 
-VALID_MOTIFS = {"anchor", "focus", "calm", "energy", "care", "flow", "dusk", "quiet"}
-
-
 def _validate_motif(body: dict) -> None:
     if "motif" in body and body["motif"] not in VALID_MOTIFS:
-        raise HTTPException(status_code=422, detail=f"Invalid motif: {body['motif']!r}")
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid motif: {body['motif']!r}. Must be one of {sorted(VALID_MOTIFS)}",
+        )
 
 
 class TaskRruleBody(BaseModel):

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -17,6 +17,14 @@ from api.auth import auth_dependency
 router = APIRouter()
 
 
+VALID_MOTIFS = {"anchor", "focus", "calm", "energy", "care", "flow", "dusk", "quiet"}
+
+
+def _validate_motif(body: dict) -> None:
+    if "motif" in body and body["motif"] not in VALID_MOTIFS:
+        raise HTTPException(status_code=422, detail=f"Invalid motif: {body['motif']!r}")
+
+
 class TaskRruleBody(BaseModel):
     rrule: str | None
 
@@ -50,6 +58,7 @@ async def create_unscheduled(body: dict, request: Request,
                              conn: asyncpg.Connection = Depends(get_db_conn)):
     if "text" not in body:
         raise HTTPException(status_code=422, detail="'text' is required")
+    _validate_motif(body)
     milestone_id = body.get("milestone_id")
     date = body.get("date")
     anchor_id = body.get("anchor_id")
@@ -59,6 +68,7 @@ async def create_unscheduled(body: dict, request: Request,
             description=body.get("description"),
             status=body.get("status", "pending"),
             context_subject=body.get("context_subject"),
+            motif=body.get("motif", "anchor"),
         )
         if milestone_id:
             await link_milestone_task(conn, milestone_id, task["id"])
@@ -83,6 +93,7 @@ async def get_task(task_uuid: str, _auth=Depends(auth_dependency),
 async def patch_task(task_uuid: str, body: dict,
                      _auth=Depends(auth_dependency),
                      conn: asyncpg.Connection = Depends(get_db_conn)):
+    _validate_motif(body)
     async with conn.transaction():
         result = await patch_task_fields(conn, task_uuid, body)
     if result is None:

--- a/db/migrations/versions/d3e4f5a6b7c8_tasks_motif.py
+++ b/db/migrations/versions/d3e4f5a6b7c8_tasks_motif.py
@@ -1,0 +1,24 @@
+"""tasks motif column
+
+Adds a motif field to tasks for visual/thematic categorization.
+
+Revision ID: d3e4f5a6b7c8
+Revises: c2d3e4f5a6b7
+Create Date: 2026-04-29
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "d3e4f5a6b7c8"
+down_revision: Union[str, Sequence[str], None] = "c2d3e4f5a6b7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE tasks ADD COLUMN motif VARCHAR(16) NOT NULL DEFAULT 'anchor'")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE tasks DROP COLUMN IF EXISTS motif")

--- a/db/migrations/versions/e4f5a6b7c8d9_context_entries_motif.py
+++ b/db/migrations/versions/e4f5a6b7c8d9_context_entries_motif.py
@@ -1,0 +1,24 @@
+"""context_entries motif column
+
+Adds a motif field to context_entries for visual/thematic categorization.
+
+Revision ID: e4f5a6b7c8d9
+Revises: d3e4f5a6b7c8
+Create Date: 2026-04-29
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "e4f5a6b7c8d9"
+down_revision: Union[str, Sequence[str], None] = "d3e4f5a6b7c8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE context_entries ADD COLUMN motif VARCHAR(16) NOT NULL DEFAULT 'anchor'")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE context_entries DROP COLUMN IF EXISTS motif")

--- a/db/migrations/versions/f5a6b7c8d9e0_milestones_motif.py
+++ b/db/migrations/versions/f5a6b7c8d9e0_milestones_motif.py
@@ -1,0 +1,24 @@
+"""milestones motif column
+
+Adds a motif field to milestones for visual/thematic categorization.
+
+Revision ID: f5a6b7c8d9e0
+Revises: e4f5a6b7c8d9
+Create Date: 2026-04-29
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "f5a6b7c8d9e0"
+down_revision: Union[str, Sequence[str], None] = "e4f5a6b7c8d9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE milestones ADD COLUMN motif VARCHAR(16) NOT NULL DEFAULT 'anchor'")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE milestones DROP COLUMN IF EXISTS motif")

--- a/db/pg_queries/_motif.py
+++ b/db/pg_queries/_motif.py
@@ -1,0 +1,14 @@
+"""Shared motif vocabulary — single source of truth for valid motif values."""
+from __future__ import annotations
+
+VALID_MOTIFS: frozenset[str] = frozenset(
+    {"anchor", "focus", "calm", "energy", "care", "flow", "dusk", "quiet"}
+)
+
+
+def validate_motif(motif: str) -> None:
+    """Raise ValueError if motif is not one of the allowed values."""
+    if motif not in VALID_MOTIFS:
+        raise ValueError(
+            f"Invalid motif: {motif!r}. Must be one of {sorted(VALID_MOTIFS)}"
+        )

--- a/db/pg_queries/context.py
+++ b/db/pg_queries/context.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import asyncpg
 
+from db.pg_queries._motif import validate_motif
+
 
 async def upsert_context_entry(
     conn: asyncpg.Connection,
@@ -12,9 +14,13 @@ async def upsert_context_entry(
 ) -> int:
     """Upsert a context entry. Returns the surrogate id.
 
-    If motif is None, the existing motif is preserved on update and 'anchor'
-    is used on insert (the column default).
+    Pass motif=None to preserve the existing motif on update (or fall back to
+    the column default 'anchor' on insert). Pass an explicit motif string to
+    set/overwrite. Empty string and other invalid values raise ValueError —
+    there is no way to clear motif to NULL because the column is NOT NULL.
     """
+    if motif is not None:
+        validate_motif(motif)
     if motif is None:
         row = await conn.fetchrow(
             """

--- a/db/pg_queries/context.py
+++ b/db/pg_queries/context.py
@@ -4,20 +4,45 @@ from __future__ import annotations
 import asyncpg
 
 
-async def upsert_context_entry(conn: asyncpg.Connection, subject: str, body: str) -> int:
-    """Upsert a context entry. Returns the surrogate id."""
-    row = await conn.fetchrow(
-        """
-        INSERT INTO context_entries (user_id, subject, body, updated_at)
-        VALUES (current_setting('app.current_user_id', true)::uuid, $1, $2, now())
-        ON CONFLICT (user_id, subject) DO UPDATE SET
-            body       = EXCLUDED.body,
-            updated_at = EXCLUDED.updated_at
-        RETURNING id
-        """,
-        subject,
-        body,
-    )
+async def upsert_context_entry(
+    conn: asyncpg.Connection,
+    subject: str,
+    body: str,
+    motif: str | None = None,
+) -> int:
+    """Upsert a context entry. Returns the surrogate id.
+
+    If motif is None, the existing motif is preserved on update and 'anchor'
+    is used on insert (the column default).
+    """
+    if motif is None:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO context_entries (user_id, subject, body, updated_at)
+            VALUES (current_setting('app.current_user_id', true)::uuid, $1, $2, now())
+            ON CONFLICT (user_id, subject) DO UPDATE SET
+                body       = EXCLUDED.body,
+                updated_at = EXCLUDED.updated_at
+            RETURNING id
+            """,
+            subject,
+            body,
+        )
+    else:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO context_entries (user_id, subject, body, motif, updated_at)
+            VALUES (current_setting('app.current_user_id', true)::uuid, $1, $2, $3, now())
+            ON CONFLICT (user_id, subject) DO UPDATE SET
+                body       = EXCLUDED.body,
+                motif      = EXCLUDED.motif,
+                updated_at = EXCLUDED.updated_at
+            RETURNING id
+            """,
+            subject,
+            body,
+            motif,
+        )
     return row["id"]
 
 
@@ -29,7 +54,7 @@ async def get_context_entries(
     if prefix:
         rows = await conn.fetch(
             """
-            SELECT subject, body, updated_at
+            SELECT subject, body, motif, updated_at
             FROM context_entries
             WHERE (subject = $1 OR subject LIKE $2)
               AND user_id = current_setting('app.current_user_id', true)::uuid
@@ -41,7 +66,7 @@ async def get_context_entries(
     elif top_level_only:
         rows = await conn.fetch(
             """
-            SELECT subject, body, updated_at
+            SELECT subject, body, motif, updated_at
             FROM context_entries
             WHERE subject NOT LIKE '%/%'
               AND user_id = current_setting('app.current_user_id', true)::uuid
@@ -51,7 +76,7 @@ async def get_context_entries(
     else:
         rows = await conn.fetch(
             """
-            SELECT subject, body, updated_at
+            SELECT subject, body, motif, updated_at
             FROM context_entries
             WHERE user_id = current_setting('app.current_user_id', true)::uuid
             ORDER BY subject

--- a/db/pg_queries/milestones.py
+++ b/db/pg_queries/milestones.py
@@ -6,6 +6,7 @@ import uuid as _uuid
 import asyncpg
 
 from db.pg_queries.errors import StaleReadError
+from db.pg_queries._motif import validate_motif
 
 
 def _derive_milestone_status(statuses: list[str]) -> str:
@@ -29,6 +30,7 @@ async def create_milestone(
     color: str | None = None,
     motif: str = "anchor",
 ) -> dict:
+    validate_motif(motif)
     user_uuid = await conn.fetchval(
         "SELECT current_setting('app.current_user_id', true)::uuid"
     )
@@ -168,6 +170,7 @@ async def patch_milestone(
         params.append(fields["color"])
         set_parts.append(f"color = ${len(params)}")
     if "motif" in fields:
+        validate_motif(fields["motif"])
         params.append(fields["motif"])
         set_parts.append(f"motif = ${len(params)}")
     if "status" in fields:

--- a/db/pg_queries/milestones.py
+++ b/db/pg_queries/milestones.py
@@ -27,6 +27,7 @@ async def create_milestone(
     description: str | None = None,
     target_date: str | None = None,
     color: str | None = None,
+    motif: str = "anchor",
 ) -> dict:
     user_uuid = await conn.fetchval(
         "SELECT current_setting('app.current_user_id', true)::uuid"
@@ -38,12 +39,12 @@ async def create_milestone(
     row = await conn.fetchrow(
         """
         INSERT INTO milestones
-            (id, user_id, context_entry_id, name, description, target_date, color)
-        VALUES ($1, $2, $3, $4, $5, $6, $7)
-        RETURNING id, name, description, target_date, color, status, status_override,
+            (id, user_id, context_entry_id, name, description, target_date, color, motif)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        RETURNING id, name, description, target_date, color, motif, status, status_override,
                   created_at, updated_at, version
         """,
-        _uuid.uuid4(), user_uuid, entry_id, name, description, target_date, color,
+        _uuid.uuid4(), user_uuid, entry_id, name, description, target_date, color, motif,
     )
     return {
         "id": str(row["id"]),
@@ -52,6 +53,7 @@ async def create_milestone(
         "description": row["description"],
         "target_date": row["target_date"],
         "color": row["color"],
+        "motif": row["motif"],
         "status": "pending",
         "status_override": False,
         "created_at": row["created_at"],
@@ -129,6 +131,7 @@ async def get_milestones(
             "description": m["description"],
             "target_date": m["target_date"],
             "color": m["color"],
+            "motif": m["motif"],
             "status": m["status"] if m["status_override"] else _derive_milestone_status(statuses),
             "status_override": bool(m["status_override"]),
             "created_at": m["created_at"],
@@ -164,6 +167,9 @@ async def patch_milestone(
     if "color" in fields:
         params.append(fields["color"])
         set_parts.append(f"color = ${len(params)}")
+    if "motif" in fields:
+        params.append(fields["motif"])
+        set_parts.append(f"motif = ${len(params)}")
     if "status" in fields:
         params.append(fields["status"])
         set_parts.append(f"status = ${len(params)}")

--- a/db/pg_queries/plans.py
+++ b/db/pg_queries/plans.py
@@ -42,7 +42,7 @@ async def get_plan(conn: asyncpg.Connection, date: str) -> dict:
     task_rows = await conn.fetch(
         """
         SELECT uuid, anchor_id, text, status, notes, position,
-               followup_config, description, context_subject, context_node_id, version
+               followup_config, description, context_subject, context_node_id, motif, version
         FROM tasks
         WHERE plan_date = $1
         ORDER BY anchor_id, position
@@ -62,7 +62,7 @@ async def get_plan(conn: asyncpg.Connection, date: str) -> dict:
         """
         SELECT uuid, anchor_id, text, status, notes, position,
                rrule, color, context_subject, context_node_id,
-               followup_config, description, version, exdates
+               followup_config, description, motif, version, exdates
         FROM tasks
         WHERE anchor_id IS NOT NULL
           AND rrule IS NOT NULL
@@ -100,6 +100,7 @@ async def get_plan(conn: asyncpg.Connection, date: str) -> dict:
             "context_subject": master["context_subject"],
             "context_node_id": str(master["context_node_id"]) if master["context_node_id"] else None,
             "followup_config": master["followup_config"],
+            "motif": master["motif"] or "anchor",
             "version": master["version"] or 0,
             "anchor_id": aid,
             "plan_date": date,
@@ -165,6 +166,7 @@ def _row_to_task(row, *, include_schedule: bool = False) -> dict:
         "context_subject": r.get("context_subject"),
         "context_node_id": str(r["context_node_id"]) if r.get("context_node_id") else None,
         "followup_config": r.get("followup_config"),  # asyncpg already deserialises JSONB
+        "motif": r.get("motif", "anchor"),
         "version": r.get("version", 0),
         "blocks": [],
         "blocked_by": [],

--- a/db/pg_queries/plans.py
+++ b/db/pg_queries/plans.py
@@ -100,7 +100,7 @@ async def get_plan(conn: asyncpg.Connection, date: str) -> dict:
             "context_subject": master["context_subject"],
             "context_node_id": str(master["context_node_id"]) if master["context_node_id"] else None,
             "followup_config": master["followup_config"],
-            "motif": master["motif"] or "anchor",
+            "motif": master["motif"],
             "version": master["version"] or 0,
             "anchor_id": aid,
             "plan_date": date,
@@ -166,7 +166,7 @@ def _row_to_task(row, *, include_schedule: bool = False) -> dict:
         "context_subject": r.get("context_subject"),
         "context_node_id": str(r["context_node_id"]) if r.get("context_node_id") else None,
         "followup_config": r.get("followup_config"),  # asyncpg already deserialises JSONB
-        "motif": r.get("motif", "anchor"),
+        "motif": r["motif"],
         "version": r.get("version", 0),
         "blocks": [],
         "blocked_by": [],

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import asyncpg
 
 from db.pg_queries.errors import StaleReadError
+from db.pg_queries._motif import validate_motif
 from db.pg_queries.plans import _row_to_task
 
 if TYPE_CHECKING:
@@ -164,6 +165,7 @@ async def patch_task_fields(
         params.append(_parse_ts(val) if val is not None else None)
         set_parts.append(f"end_time = ${len(params)}")
     if "motif" in fields:
+        validate_motif(fields["motif"])
         params.append(fields["motif"])
         set_parts.append(f"motif = ${len(params)}")
 
@@ -264,6 +266,7 @@ async def create_unscheduled_task(
     motif: str = "anchor",
 ) -> dict:
     """Create a task with no plan_date or anchor_id (backlog task)."""
+    validate_motif(motif)
     user_uuid = await conn.fetchval(
         "SELECT current_setting('app.current_user_id', true)::uuid"
     )
@@ -360,7 +363,7 @@ async def move_task_atomic(
 async def search_tasks(conn: asyncpg.Connection, q: str) -> list[dict]:
     rows = await conn.fetch(
         """
-        SELECT uuid, text, status, plan_date, anchor_id, context_subject, version
+        SELECT uuid, text, status, plan_date, anchor_id, context_subject, motif, version
         FROM tasks
         WHERE text ILIKE '%' || $1 || '%'
         ORDER BY plan_date DESC NULLS LAST, text
@@ -668,7 +671,7 @@ async def upsert_task_from_draft(
             version            = tasks.version + 1
         RETURNING
             uuid, text, status, position, followup_config,
-            description, context_subject, context_node_id, version
+            description, context_subject, context_node_id, motif, version
         """,
         new_uuid,
         user_id,

--- a/db/pg_queries/tasks.py
+++ b/db/pg_queries/tasks.py
@@ -108,7 +108,7 @@ async def upsert_tasks(
     all_rows = await conn.fetch(
         """
         SELECT uuid, text, status, position, followup_config,
-               description, context_subject, context_node_id, version
+               description, context_subject, context_node_id, motif, version
         FROM tasks
         WHERE plan_date = $1 AND anchor_id = $2
         ORDER BY position
@@ -163,6 +163,9 @@ async def patch_task_fields(
         val = fields["end_time"]
         params.append(_parse_ts(val) if val is not None else None)
         set_parts.append(f"end_time = ${len(params)}")
+    if "motif" in fields:
+        params.append(fields["motif"])
+        set_parts.append(f"motif = ${len(params)}")
 
     if not set_parts:
         return None
@@ -193,7 +196,7 @@ async def patch_task_fields(
     row = await conn.fetchrow(
         """
         SELECT uuid, text, status, position, followup_config,
-               description, context_subject, context_node_id, version
+               description, context_subject, context_node_id, motif, version
         FROM tasks WHERE uuid = $1
         """,
         _uuid.UUID(task_uuid),
@@ -212,7 +215,7 @@ async def patch_task_fields(
         row = await conn.fetchrow(
             """
             SELECT uuid, text, status, position, followup_config,
-                   description, context_subject, context_node_id, version
+                   description, context_subject, context_node_id, motif, version
             FROM tasks WHERE uuid = $1
             """,
             _uuid.UUID(task_uuid),
@@ -226,7 +229,7 @@ async def get_task_by_uuid(conn: asyncpg.Connection, task_uuid: str) -> dict | N
     row = await conn.fetchrow(
         """
         SELECT uuid, plan_date, anchor_id, text, status, position,
-               followup_config, description, context_subject, context_node_id, version,
+               followup_config, description, context_subject, context_node_id, motif, version,
                rrule, exdates
         FROM tasks WHERE uuid = $1
         """,
@@ -244,7 +247,7 @@ async def get_all_tasks(conn: asyncpg.Connection) -> list[dict]:
     rows = await conn.fetch(
         """
         SELECT uuid, plan_date, anchor_id, text, status, position,
-               followup_config, description, context_subject, context_node_id, version
+               followup_config, description, context_subject, context_node_id, motif, version
         FROM tasks
         ORDER BY plan_date DESC NULLS LAST, anchor_id, position
         """
@@ -258,6 +261,7 @@ async def create_unscheduled_task(
     description: str | None = None,
     status: str = "pending",
     context_subject: str | None = None,
+    motif: str = "anchor",
 ) -> dict:
     """Create a task with no plan_date or anchor_id (backlog task)."""
     user_uuid = await conn.fetchval(
@@ -266,11 +270,11 @@ async def create_unscheduled_task(
     new_uuid = _uuid.uuid4()
     row = await conn.fetchrow(
         """
-        INSERT INTO tasks (uuid, user_id, text, status, description, context_subject)
-        VALUES ($1, $2, $3, $4, $5, $6)
-        RETURNING uuid, text, status, position, followup_config, description, context_subject, context_node_id, version
+        INSERT INTO tasks (uuid, user_id, text, status, description, context_subject, motif)
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        RETURNING uuid, text, status, position, followup_config, description, context_subject, context_node_id, motif, version
         """,
-        new_uuid, user_uuid, text, status, description, context_subject,
+        new_uuid, user_uuid, text, status, description, context_subject, motif,
     )
     new_task = _row_to_task(row)
     await resolve_blocked_status(conn, new_task["id"])
@@ -281,7 +285,7 @@ async def get_unscheduled_tasks(conn: asyncpg.Connection) -> list[dict]:
     rows = await conn.fetch(
         """
         SELECT uuid, text, status, position, followup_config,
-               description, context_subject, context_node_id, version
+               description, context_subject, context_node_id, motif, version
         FROM tasks WHERE plan_date IS NULL
         ORDER BY position
         """

--- a/tests/api/test_motif_fields.py
+++ b/tests/api/test_motif_fields.py
@@ -1,0 +1,149 @@
+"""Motif field round-trip tests for tasks, context_entries, and milestones."""
+import pytest
+from db.pg_queries import upsert_context_entry
+
+
+@pytest.mark.asyncio
+async def test_post_task_with_motif(api_client, conn):
+    resp = await api_client.post(
+        "/api/tasks/unscheduled", json={"text": "Task A", "motif": "focus"}
+    )
+    assert resp.status_code == 200
+    task_id = resp.json()["id"]
+
+    resp = await api_client.get(f"/api/tasks/{task_id}")
+    assert resp.status_code == 200
+    assert resp.json()["motif"] == "focus"
+
+
+@pytest.mark.asyncio
+async def test_post_task_default_motif(api_client, conn):
+    resp = await api_client.post("/api/tasks/unscheduled", json={"text": "Task B"})
+    assert resp.status_code == 200
+    task_id = resp.json()["id"]
+    assert resp.json()["motif"] == "anchor"
+
+    resp = await api_client.get(f"/api/tasks/{task_id}")
+    assert resp.json()["motif"] == "anchor"
+
+
+@pytest.mark.asyncio
+async def test_post_task_invalid_motif(api_client, conn):
+    resp = await api_client.post(
+        "/api/tasks/unscheduled", json={"text": "Task C", "motif": "invalid"}
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_task_motif(api_client, conn):
+    resp = await api_client.post("/api/tasks/unscheduled", json={"text": "Task D"})
+    task_id = resp.json()["id"]
+
+    resp = await api_client.patch(f"/api/tasks/{task_id}", json={"motif": "calm"})
+    assert resp.status_code == 200
+    assert resp.json()["motif"] == "calm"
+
+    resp = await api_client.get(f"/api/tasks/{task_id}")
+    assert resp.json()["motif"] == "calm"
+
+
+@pytest.mark.asyncio
+async def test_patch_task_invalid_motif(api_client, conn):
+    resp = await api_client.post("/api/tasks/unscheduled", json={"text": "Task E"})
+    task_id = resp.json()["id"]
+    resp = await api_client.patch(f"/api/tasks/{task_id}", json={"motif": "bogus"})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_put_context_with_motif(api_client, conn):
+    resp = await api_client.put(
+        "/api/context/MotifProj", json={"body": "hello", "motif": "energy"}
+    )
+    assert resp.status_code == 200
+
+    resp = await api_client.get("/api/context/MotifProj")
+    assert resp.status_code == 200
+    assert resp.json()["motif"] == "energy"
+
+
+@pytest.mark.asyncio
+async def test_put_context_default_motif(api_client, conn):
+    resp = await api_client.put("/api/context/MotifProj2", json={"body": "hi"})
+    assert resp.status_code == 200
+
+    resp = await api_client.get("/api/context/MotifProj2")
+    assert resp.json()["motif"] == "anchor"
+
+
+@pytest.mark.asyncio
+async def test_put_context_invalid_motif(api_client, conn):
+    resp = await api_client.put(
+        "/api/context/MotifProj3", json={"body": "x", "motif": "nope"}
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_post_milestone_with_motif(api_client, conn):
+    await upsert_context_entry(conn, "MProj", "body")
+    resp = await api_client.post(
+        "/api/context/MProj/milestones",
+        json={"name": "M1", "motif": "flow"},
+    )
+    assert resp.status_code == 200
+    milestone_id = resp.json()["id"]
+    assert resp.json()["motif"] == "flow"
+
+    resp = await api_client.get("/api/context/MProj/milestones")
+    matched = next(m for m in resp.json() if m["id"] == milestone_id)
+    assert matched["motif"] == "flow"
+
+
+@pytest.mark.asyncio
+async def test_post_milestone_default_motif(api_client, conn):
+    await upsert_context_entry(conn, "MProj2", "body")
+    resp = await api_client.post(
+        "/api/context/MProj2/milestones", json={"name": "M2"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["motif"] == "anchor"
+
+
+@pytest.mark.asyncio
+async def test_post_milestone_invalid_motif(api_client, conn):
+    await upsert_context_entry(conn, "MProj3", "body")
+    resp = await api_client.post(
+        "/api/context/MProj3/milestones",
+        json={"name": "M3", "motif": "weird"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_milestone_motif(api_client, conn):
+    await upsert_context_entry(conn, "MProj4", "body")
+    resp = await api_client.post(
+        "/api/context/MProj4/milestones", json={"name": "M4"}
+    )
+    milestone_id = resp.json()["id"]
+
+    resp = await api_client.patch(
+        f"/api/milestones/{milestone_id}", json={"motif": "dusk"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["motif"] == "dusk"
+
+
+@pytest.mark.asyncio
+async def test_patch_milestone_invalid_motif(api_client, conn):
+    await upsert_context_entry(conn, "MProj5", "body")
+    resp = await api_client.post(
+        "/api/context/MProj5/milestones", json={"name": "M5"}
+    )
+    milestone_id = resp.json()["id"]
+    resp = await api_client.patch(
+        f"/api/milestones/{milestone_id}", json={"motif": "huh"}
+    )
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary

- Three sequential Alembic migrations chain off `c2d3e4f5a6b7` (anchor motif from PR #238): adds `motif VARCHAR(16) NOT NULL DEFAULT 'anchor'` to `tasks`, `context_entries`, `milestones`.
- Routes accept and return motif on POST/PATCH/PUT for tasks, milestones, and context. Invalid values return 422 with the allowed list in the detail. `PUT /api/context/{subject}` preserves the existing motif when not provided so partial updates of body don't silently reset it.
- `db/pg_queries/_motif.py` is the single source of truth for `VALID_MOTIFS`. Validation also runs at the query layer (create_unscheduled_task, patch_task_fields, create_milestone, patch_milestone, upsert_context_entry) so MCP and bot callers can't bypass route validation.
- `plans._row_to_task` switched from a silent `.get("motif", "anchor")` fallback to strict `r["motif"]`. `search_tasks` SELECT and event-upsert RETURNING were extended to include motif.

## Migration chain

`... → c2d3e4f5a6b7 (anchors.motif) → d3e4f5a6b7c8 (tasks.motif) → e4f5a6b7c8d9 (context_entries.motif) → f5a6b7c8d9e0 (milestones.motif)` — single linear head.

## Reviewer pass

- `pr-review-toolkit:code-reviewer` — no high-confidence issues.
- `pr-review-toolkit:silent-failure-hunter` — addressed: VALID_MOTIFS centralization, query-layer validation, empty-string slip in `upsert_context_entry`, removed cargo-cult fallbacks in `_row_to_task`.

## Known follow-ups (out of scope)

- No DB-level `CHECK` constraint on motif. Matches the existing anchor motif migration pattern; adding it would require backfilling/altering the anchor table too.
- Typo'd sibling keys in dict-body routes silently default to `'anchor'` (e.g., `{"Motif": "focus"}`). Endemic across the codebase, not motif-specific.

## Test plan

- [ ] CI green on `tests/api/test_motif_fields.py` (13 round-trip tests: POST/PATCH/PUT × valid/default/invalid for tasks, milestones, context)
- [ ] CI green on broader test suite (no regressions in plans/tasks/milestones reads)
- [ ] Migrations apply cleanly on Pi staging