### PR TITLE
feat(frontend): migrate visible surface to CSS token layer + transparent tasks

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -41,36 +41,36 @@ async function logout() {
         <span class="text-lg font-bold tracking-tight">Tether</span>
         <div class="flex items-center gap-1">
           <router-link to="/dashboard"
-                       class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-white/10"
-                       :class="$route.path.startsWith('/dashboard') ? 'bg-white/20 text-[--fg-1]' : 'text-[--fg-3]'">
+                       class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-[--bg-elev-3]"
+                       :class="$route.path.startsWith('/dashboard') ? 'bg-[--bg-elev-4] text-[--fg-1]' : 'text-[--fg-3]'">
             Dashboard
           </router-link>
           <router-link to="/calendar"
-                       class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-white/10"
-                       :class="$route.path.startsWith('/calendar') ? 'bg-white/20 text-[--fg-1]' : 'text-[--fg-3]'">
+                       class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-[--bg-elev-3]"
+                       :class="$route.path.startsWith('/calendar') ? 'bg-[--bg-elev-4] text-[--fg-1]' : 'text-[--fg-3]'">
             Calendar
           </router-link>
           <router-link to="/plan/day"
-                       class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-white/10"
-                       active-class="bg-white/20 text-[--fg-1]"
-                       :class="$route.path.startsWith('/plan') ? 'bg-white/20 text-[--fg-1]' : 'text-[--fg-3]'">
+                       class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-[--bg-elev-3]"
+                       active-class="bg-[--bg-elev-4] text-[--fg-1]"
+                       :class="$route.path.startsWith('/plan') ? 'bg-[--bg-elev-4] text-[--fg-1]' : 'text-[--fg-3]'">
             Plan
           </router-link>
           <router-link to="/context"
-                       class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-white/10"
-                       active-class="bg-white/20 text-[--fg-1]"
-                       :class="$route.path === '/context' ? 'bg-white/20 text-[--fg-1]' : 'text-[--fg-3]'">
+                       class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-[--bg-elev-3]"
+                       active-class="bg-[--bg-elev-4] text-[--fg-1]"
+                       :class="$route.path === '/context' ? 'bg-[--bg-elev-4] text-[--fg-1]' : 'text-[--fg-3]'">
             Context
           </router-link>
           <router-link to="/anchors"
-                       class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-white/10"
-                       active-class="bg-white/20 text-[--fg-1]"
-                       :class="$route.path === '/anchors' ? 'bg-white/20 text-[--fg-1]' : 'text-[--fg-3]'">
+                       class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-[--bg-elev-3]"
+                       active-class="bg-[--bg-elev-4] text-[--fg-1]"
+                       :class="$route.path === '/anchors' ? 'bg-[--bg-elev-4] text-[--fg-1]' : 'text-[--fg-3]'">
             Anchors
           </router-link>
           <router-link to="/kanban"
-                       class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-white/10"
-                       :class="$route.path.startsWith('/kanban') ? 'bg-white/20 text-[--fg-1]' : 'text-[--fg-3]'">
+                       class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-[--bg-elev-3]"
+                       :class="$route.path.startsWith('/kanban') ? 'bg-[--bg-elev-4] text-[--fg-1]' : 'text-[--fg-3]'">
             Kanban
           </router-link>
         </div>
@@ -79,7 +79,7 @@ async function logout() {
         <!-- Chat toggle pill -->
         <button
           @click="chatOpen = !chatOpen"
-          class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-white/10"
+          class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-[--bg-elev-3]"
           :class="chatOpen ? 'bg-indigo-600/40 text-[--fg-1]' : 'text-[--fg-3]'"
           title="Toggle chat (Ctrl+/)"
         >
@@ -87,11 +87,11 @@ async function logout() {
         </button>
 
         <router-link v-if="authStore.user?.is_admin" to="/admin"
-                     class="text-xs text-[--fg-4] hover:text-[--fg-2] border border-white/10 rounded px-2 py-1 transition-colors">
+                     class="text-xs text-[--fg-4] hover:text-[--fg-2] border border-[--border-1] rounded px-2 py-1 transition-colors">
           Admin
         </router-link>
         <router-link to="/settings"
-                     class="text-[--fg-4] hover:text-[--fg-2] transition-colors p-1.5 rounded-lg hover:bg-white/10"
+                     class="text-[--fg-4] hover:text-[--fg-2] transition-colors p-1.5 rounded-lg hover:bg-[--bg-elev-3]"
                      title="Settings">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
@@ -99,7 +99,7 @@ async function logout() {
           </svg>
         </router-link>
         <button @click="logout"
-                class="text-xs text-[--fg-4] hover:text-[--fg-2] border border-white/10 rounded px-2 py-1 transition-colors ml-1">
+                class="text-xs text-[--fg-4] hover:text-[--fg-2] border border-[--border-1] rounded px-2 py-1 transition-colors ml-1">
           Logout
         </button>
       </div>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -33,44 +33,44 @@ async function logout() {
 </script>
 
 <template>
-  <div class="crt relative min-h-screen bg-gray-900 text-white">
+  <div class="crt relative min-h-screen bg-[--bg-canvas] text-[--fg-1]">
     <!-- Navigation bar (shown when authenticated) -->
     <nav v-if="authStore.isAuthenticated"
-         class="flex items-center justify-between px-6 py-3 border-b border-white/10 bg-gray-900/80 backdrop-blur-sm sticky top-0 z-10">
+         class="flex items-center justify-between px-6 py-3 border-b border-[--border-1] bg-[--bg-canvas-veil] backdrop-blur-sm sticky top-0 z-10">
       <div class="flex items-center gap-6">
         <span class="text-lg font-bold tracking-tight">Tether</span>
         <div class="flex items-center gap-1">
           <router-link to="/dashboard"
                        class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-white/10"
-                       :class="$route.path.startsWith('/dashboard') ? 'bg-white/20 text-white' : 'text-white/60'">
+                       :class="$route.path.startsWith('/dashboard') ? 'bg-white/20 text-[--fg-1]' : 'text-[--fg-3]'">
             Dashboard
           </router-link>
           <router-link to="/calendar"
                        class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-white/10"
-                       :class="$route.path.startsWith('/calendar') ? 'bg-white/20 text-white' : 'text-white/60'">
+                       :class="$route.path.startsWith('/calendar') ? 'bg-white/20 text-[--fg-1]' : 'text-[--fg-3]'">
             Calendar
           </router-link>
           <router-link to="/plan/day"
                        class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-white/10"
-                       active-class="bg-white/20 text-white"
-                       :class="$route.path.startsWith('/plan') ? 'bg-white/20 text-white' : 'text-white/60'">
+                       active-class="bg-white/20 text-[--fg-1]"
+                       :class="$route.path.startsWith('/plan') ? 'bg-white/20 text-[--fg-1]' : 'text-[--fg-3]'">
             Plan
           </router-link>
           <router-link to="/context"
                        class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-white/10"
-                       active-class="bg-white/20 text-white"
-                       :class="$route.path === '/context' ? 'bg-white/20 text-white' : 'text-white/60'">
+                       active-class="bg-white/20 text-[--fg-1]"
+                       :class="$route.path === '/context' ? 'bg-white/20 text-[--fg-1]' : 'text-[--fg-3]'">
             Context
           </router-link>
           <router-link to="/anchors"
                        class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-white/10"
-                       active-class="bg-white/20 text-white"
-                       :class="$route.path === '/anchors' ? 'bg-white/20 text-white' : 'text-white/60'">
+                       active-class="bg-white/20 text-[--fg-1]"
+                       :class="$route.path === '/anchors' ? 'bg-white/20 text-[--fg-1]' : 'text-[--fg-3]'">
             Anchors
           </router-link>
           <router-link to="/kanban"
                        class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-white/10"
-                       :class="$route.path.startsWith('/kanban') ? 'bg-white/20 text-white' : 'text-white/60'">
+                       :class="$route.path.startsWith('/kanban') ? 'bg-white/20 text-[--fg-1]' : 'text-[--fg-3]'">
             Kanban
           </router-link>
         </div>
@@ -80,18 +80,18 @@ async function logout() {
         <button
           @click="chatOpen = !chatOpen"
           class="px-3 py-1.5 rounded-lg text-sm transition-colors hover:bg-white/10"
-          :class="chatOpen ? 'bg-indigo-600/40 text-white' : 'text-white/60'"
+          :class="chatOpen ? 'bg-indigo-600/40 text-[--fg-1]' : 'text-[--fg-3]'"
           title="Toggle chat (Ctrl+/)"
         >
           Chat
         </button>
 
         <router-link v-if="authStore.user?.is_admin" to="/admin"
-                     class="text-xs text-white/40 hover:text-white/80 border border-white/10 rounded px-2 py-1 transition-colors">
+                     class="text-xs text-[--fg-4] hover:text-[--fg-2] border border-white/10 rounded px-2 py-1 transition-colors">
           Admin
         </router-link>
         <router-link to="/settings"
-                     class="text-white/40 hover:text-white/80 transition-colors p-1.5 rounded-lg hover:bg-white/10"
+                     class="text-[--fg-4] hover:text-[--fg-2] transition-colors p-1.5 rounded-lg hover:bg-white/10"
                      title="Settings">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
@@ -99,7 +99,7 @@ async function logout() {
           </svg>
         </router-link>
         <button @click="logout"
-                class="text-xs text-white/40 hover:text-white/80 border border-white/10 rounded px-2 py-1 transition-colors ml-1">
+                class="text-xs text-[--fg-4] hover:text-[--fg-2] border border-white/10 rounded px-2 py-1 transition-colors ml-1">
           Logout
         </button>
       </div>
@@ -115,7 +115,7 @@ async function logout() {
       <Transition name="chat-slide">
         <aside
           v-if="chatOpen"
-          class="w-[420px] flex-shrink-0 border-l border-white/10 bg-gray-900 flex flex-col"
+          class="w-[420px] flex-shrink-0 border-l border-[--border-1] bg-[--bg-canvas] flex flex-col"
         >
           <BotChat @close="chatOpen = false" />
         </aside>

--- a/frontend/src/components/AnchorBlock.vue
+++ b/frontend/src/components/AnchorBlock.vue
@@ -142,7 +142,7 @@ function onDrop(evt: DragEvent, toIndex: number) {
     <div class="pl-3">
   <GroupContainer :label="`${anchorName} · ${time}`" :color="color" :collapsible="true" :level="0">
     <template #header-right>
-      <span class="text-xs text-white/30">{{ anchorPlan.tasks.length }}</span>
+      <span class="text-xs text-[--fg-5]">{{ anchorPlan.tasks.length }}</span>
     </template>
 
     <div ref="tasksRef" class="space-y-px">
@@ -201,7 +201,7 @@ function onDrop(evt: DragEvent, toIndex: number) {
               </div>
               <button type="button"
                       @click.stop="onAddNewTask({ ...(ctx.contextSubject ? { context_subject: ctx.contextSubject } : {}), milestone_id: mg.milestone.id })"
-                      class="mt-1 text-xs text-white/40 hover:text-white/70 w-full text-left">
+                      class="mt-1 text-xs text-[--fg-4] hover:text-[--fg-2] w-full text-left">
                 + Add task
               </button>
             </GroupContainer>
@@ -219,7 +219,7 @@ function onDrop(evt: DragEvent, toIndex: number) {
 
           <button type="button"
                   @click.stop="onAddNewTask(ctx.contextSubject ? { context_subject: ctx.contextSubject } : {})"
-                  class="mt-1 text-xs text-white/40 hover:text-white/70 w-full text-left">
+                  class="mt-1 text-xs text-[--fg-4] hover:text-[--fg-2] w-full text-left">
             + Add task
           </button>
         </GroupContainer>
@@ -227,7 +227,7 @@ function onDrop(evt: DragEvent, toIndex: number) {
     </div>
 
     <button type="button" @click="onAddNewTask()"
-            class="mt-2 text-xs text-white/40 hover:text-white/70">+ Add task</button>
+            class="mt-2 text-xs text-[--fg-4] hover:text-[--fg-2]">+ Add task</button>
   </GroupContainer>
     </div>
   </div>

--- a/frontend/src/components/DayColumn.vue
+++ b/frontend/src/components/DayColumn.vue
@@ -31,9 +31,9 @@ const label = computed(() => {
     <button
       @click="expanded = !expanded"
       class="text-center py-2 px-1 rounded-t-lg text-xs font-medium"
-      :class="isToday ? 'bg-white/20 text-white' : 'bg-white/5 text-white/60 hover:bg-white/10'">
+      :class="isToday ? 'bg-white/20 text-[--fg-1]' : 'bg-[--bg-elev-1] text-[--fg-3] hover:bg-[--bg-elev-3]'">
       {{ label }}
-      <span class="block text-white/40 text-xs font-normal mt-0.5">
+      <span class="block text-[--fg-4] text-xs font-normal mt-0.5">
         {{ doneTasks }}/{{ totalTasks }} ✓
       </span>
     </button>
@@ -53,7 +53,7 @@ const label = computed(() => {
       <div
         v-for="anchor in anchorStore.anchors"
         :key="anchor.id"
-        class="rounded px-2 py-1 text-xs text-white/60 truncate"
+        class="rounded px-2 py-1 text-xs text-[--fg-3] truncate"
         :style="{ background: anchor.color + '33' }">
         {{ anchor.name }}
       </div>

--- a/frontend/src/components/DayColumn.vue
+++ b/frontend/src/components/DayColumn.vue
@@ -31,7 +31,7 @@ const label = computed(() => {
     <button
       @click="expanded = !expanded"
       class="text-center py-2 px-1 rounded-t-lg text-xs font-medium"
-      :class="isToday ? 'bg-white/20 text-[--fg-1]' : 'bg-[--bg-elev-1] text-[--fg-3] hover:bg-[--bg-elev-3]'">
+      :class="isToday ? 'bg-[--bg-elev-4] text-[--fg-1]' : 'bg-[--bg-elev-1] text-[--fg-3] hover:bg-[--bg-elev-3]'">
       {{ label }}
       <span class="block text-[--fg-4] text-xs font-normal mt-0.5">
         {{ doneTasks }}/{{ totalTasks }} ✓

--- a/frontend/src/components/DayTimeline.vue
+++ b/frontend/src/components/DayTimeline.vue
@@ -375,7 +375,7 @@ function timedEventStyle(event: CalendarEvent) {
           v-for="(band, bi) in overlapBands"
           :key="'overlap-' + bi"
           data-testid="overlap-background"
-          class="absolute inset-x-0 bg-white/5 pointer-events-none rounded-sm"
+          class="absolute inset-x-0 bg-[--bg-elev-1] pointer-events-none rounded-sm"
           :style="{ top: `${band.topPx}px`, height: `${band.heightPx}px` }"
         />
 
@@ -409,7 +409,7 @@ function timedEventStyle(event: CalendarEvent) {
         >
           <!-- Drag grip (HTML5 demote drag) — narrow left strip -->
           <div
-            class="flex-shrink-0 w-2 cursor-grab z-20 rounded-l opacity-0 hover:opacity-100 bg-white/20 transition-opacity"
+            class="flex-shrink-0 w-2 cursor-grab z-20 rounded-l opacity-0 hover:opacity-100 bg-[--bg-elev-4] transition-opacity"
             :title="'Drag to anchor column to un-schedule'"
             draggable="true"
             @dragstart.stop="(de) => onEventDragstart(ev, de)"

--- a/frontend/src/components/DayTimeline.vue
+++ b/frontend/src/components/DayTimeline.vue
@@ -318,16 +318,16 @@ function timedEventStyle(event: CalendarEvent) {
 </script>
 
 <template>
-  <div data-testid="day-timeline" class="flex flex-col bg-gray-900 border border-white/10 rounded-lg overflow-hidden select-none">
+  <div data-testid="day-timeline" class="flex flex-col bg-[--bg-elev-1] border border-[--border-1] rounded-lg overflow-hidden select-none">
     <!-- All-day events strip -->
     <div
       data-testid="allday-strip"
-      class="flex flex-col gap-0.5 px-2 py-1 border-b border-white/10 min-h-[28px]"
+      class="flex flex-col gap-0.5 px-2 py-1 border-b border-[--border-1] min-h-[28px]"
     >
       <div
         v-for="ev in allDayEvents"
         :key="ev.id"
-        class="text-xs px-1.5 py-0.5 rounded text-white truncate cursor-pointer"
+        class="text-xs px-1.5 py-0.5 rounded text-[--fg-1] truncate cursor-pointer"
         :style="{ backgroundColor: ev.color ?? '#6366f1' }"
         @click="emit('open-event', ev)"
       >
@@ -351,7 +351,7 @@ function timedEventStyle(event: CalendarEvent) {
           v-for="{ hour, label } in hourLabels"
           :key="hour"
           :data-testid="`time-label-${hour}`"
-          class="absolute right-1 text-[10px] text-white/30 leading-none"
+          class="absolute right-1 text-[10px] text-[--fg-5] leading-none"
           :style="{ top: `${(hour - AXIS_START_HOUR) * 60 * PX_PER_MINUTE}px` }"
         >
           {{ label }}
@@ -383,7 +383,7 @@ function timedEventStyle(event: CalendarEvent) {
         <div
           v-for="{ hour } in hourLabels"
           :key="'line-' + hour"
-          class="absolute inset-x-0 border-t border-white/5 pointer-events-none"
+          class="absolute inset-x-0 border-t border-[--border-soft] pointer-events-none"
           :style="{ top: `${(hour - AXIS_START_HOUR) * 60 * PX_PER_MINUTE}px` }"
         />
 

--- a/frontend/src/components/DetailPanel.vue
+++ b/frontend/src/components/DetailPanel.vue
@@ -22,7 +22,7 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown))
     <div class="fixed inset-0 z-40 bg-black/40" @click="close" />
 
     <!-- Panel -->
-    <div class="fixed top-0 right-0 z-50 h-full w-full sm:w-[480px] lg:w-[520px] bg-gray-900 border-l border-white/10 shadow-2xl overflow-y-auto animate-slide-in">
+    <div class="fixed top-0 right-0 z-50 h-full w-full sm:w-[480px] lg:w-[520px] bg-[--bg-canvas] border-l border-[--border-1] shadow-2xl overflow-y-auto animate-slide-in">
       <slot />
     </div>
   </Teleport>

--- a/frontend/src/components/GroupContainer.vue
+++ b/frontend/src/components/GroupContainer.vue
@@ -17,28 +17,9 @@ const emit = defineEmits<{ (e: 'header-click'): void }>()
 
 const collapsed = ref(false)
 
-// Opaque background colors — mix color with base dark bg to prevent bleed-through
-// Base dark bg is approximately rgb(17, 24, 39) — gray-900
-function mixWithDark(hex: string, alpha: number): string {
-  const r = parseInt(hex.slice(1, 3), 16)
-  const g = parseInt(hex.slice(3, 5), 16)
-  const b = parseInt(hex.slice(5, 7), 16)
-  const base = { r: 17, g: 24, b: 39 }
-  const mr = Math.round(base.r * (1 - alpha) + r * alpha)
-  const mg = Math.round(base.g * (1 - alpha) + g * alpha)
-  const mb = Math.round(base.b * (1 - alpha) + b * alpha)
-  return `rgb(${mr},${mg},${mb})`
-}
-
-const containerBg = computed(() => {
-  if (props.color) return mixWithDark(props.color, 0.08)
-  return props.level === 0 ? 'var(--bg-elev-2)' : 'var(--bg-elev-1)'
-})
-
-const headerBg = computed(() => {
-  if (props.color) return mixWithDark(props.color, 0.12)
-  return props.level === 0 ? 'var(--bg-elev-3)' : 'var(--bg-elev-1)'
-})
+// Sidebar line color: use the group's color if provided, else neutral fg-5 placeholder
+// (real motif field is coming via a separate backend stream).
+const railColor = computed(() => props.color || 'var(--fg-5)')
 
 const stickyTop = computed(() => {
   if (props.level === 0) return `${props.stickyOffset}px`
@@ -47,20 +28,20 @@ const stickyTop = computed(() => {
 </script>
 
 <template>
-  <div :class="[
-    'rounded-lg transition-all cursor-pointer',
-    level === 0 ? 'border border-[--border-1] p-3' : 'border border-[--border-soft] p-2 ml-1',
-  ]"
-  :style="{ backgroundColor: containerBg }"
-  @click="collapsible && (collapsed = !collapsed)">
+  <div class="relative cursor-pointer pl-3"
+       @click="collapsible && (collapsed = !collapsed)">
+    <!-- Sidebar rail -->
+    <div class="absolute left-0 top-1 bottom-0 w-px"
+         :style="{ background: railColor, opacity: 0.55 }" />
+
     <!-- Pill heading (sticky below nav bar) -->
     <div
-      class="flex items-center gap-2 select-none sticky z-10 rounded py-0.5"
-      :class="[collapsed ? '' : 'mb-2']"
-      :style="{ backgroundColor: headerBg, top: stickyTop }">
-      <span class="text-xs font-medium uppercase tracking-wide px-2 py-0.5 rounded-full"
-            :style="color ? { backgroundColor: color + '22', color } : {}"
-            :class="color ? '' : 'text-[--fg-3] bg-white/10'"
+      class="flex items-center gap-2 select-none sticky z-10 py-0.5"
+      :class="[collapsed ? '' : 'mb-1']"
+      :style="{ top: stickyTop }">
+      <span class="text-xs font-medium uppercase tracking-wide"
+            :style="color ? { color } : {}"
+            :class="color ? '' : 'text-[--fg-3]'"
             @click.stop="emit('header-click')">
         {{ label }}
       </span>

--- a/frontend/src/components/GroupContainer.vue
+++ b/frontend/src/components/GroupContainer.vue
@@ -32,12 +32,12 @@ function mixWithDark(hex: string, alpha: number): string {
 
 const containerBg = computed(() => {
   if (props.color) return mixWithDark(props.color, 0.08)
-  return props.level === 0 ? 'rgb(20,27,42)' : 'rgb(17,24,39)'
+  return props.level === 0 ? 'var(--bg-elev-2)' : 'var(--bg-elev-1)'
 })
 
 const headerBg = computed(() => {
   if (props.color) return mixWithDark(props.color, 0.12)
-  return props.level === 0 ? 'rgb(22,29,44)' : 'rgb(17,24,39)'
+  return props.level === 0 ? 'var(--bg-elev-3)' : 'var(--bg-elev-1)'
 })
 
 const stickyTop = computed(() => {
@@ -49,7 +49,7 @@ const stickyTop = computed(() => {
 <template>
   <div :class="[
     'rounded-lg transition-all cursor-pointer',
-    level === 0 ? 'border border-white/10 p-3' : 'border border-white/[0.06] p-2 ml-1',
+    level === 0 ? 'border border-[--border-1] p-3' : 'border border-[--border-soft] p-2 ml-1',
   ]"
   :style="{ backgroundColor: containerBg }"
   @click="collapsible && (collapsed = !collapsed)">
@@ -60,11 +60,11 @@ const stickyTop = computed(() => {
       :style="{ backgroundColor: headerBg, top: stickyTop }">
       <span class="text-xs font-medium uppercase tracking-wide px-2 py-0.5 rounded-full"
             :style="color ? { backgroundColor: color + '22', color } : {}"
-            :class="color ? '' : 'text-white/50 bg-white/10'"
+            :class="color ? '' : 'text-[--fg-3] bg-white/10'"
             @click.stop="emit('header-click')">
         {{ label }}
       </span>
-      <span v-if="collapsible" class="text-white/30 text-xs transition-transform"
+      <span v-if="collapsible" class="text-[--fg-5] text-xs transition-transform"
             :class="collapsed ? '' : 'rotate-90'">▸</span>
       <slot name="header-right" />
     </div>

--- a/frontend/src/components/KanbanColumn.vue
+++ b/frontend/src/components/KanbanColumn.vue
@@ -129,15 +129,15 @@ function onColumnDrop(evt: DragEvent) {
 </script>
 
 <template>
-  <div class="flex flex-col min-w-[320px] max-w-[380px] bg-white/[0.03] border border-white/10 rounded-xl flex-shrink-0 min-h-0">
+  <div class="flex flex-col min-w-[320px] max-w-[380px] bg-[--bg-elev-1] border border-[--border-1] rounded-xl flex-shrink-0 min-h-0">
     <!-- Column header (fixed, does not scroll) -->
-    <div class="flex items-center gap-2 px-3 py-2.5 border-b border-white/10 flex-shrink-0">
+    <div class="flex items-center gap-2 px-3 py-2.5 border-b border-[--border-1] flex-shrink-0">
       <span v-if="column.color" class="w-2.5 h-2.5 rounded-full flex-shrink-0" :style="{ background: column.color }" />
       <span class="text-sm font-semibold uppercase tracking-wide"
             :style="column.color ? { color: column.color } : {}">
         {{ column.name }}
       </span>
-      <span class="text-xs text-white/30 ml-auto">{{ tasks.length }}</span>
+      <span class="text-xs text-[--fg-5] ml-auto">{{ tasks.length }}</span>
     </div>
 
     <!-- Scrollable body (fills remaining column height) -->
@@ -148,13 +148,13 @@ function onColumnDrop(evt: DragEvent) {
          @dragleave="onColumnDragLeave"
          @drop="onColumnDrop">
       <template v-if="!tasks.length">
-        <p class="text-white/20 text-xs text-center py-4">No tasks</p>
+        <p class="text-[--fg-6] text-xs text-center py-4">No tasks</p>
       </template>
 
       <template v-for="group in grouped" :key="group.label">
         <GroupContainer :label="group.label" :collapsible="true" :level="0" :stickyOffset="0">
           <template #header-right>
-            <span class="text-xs text-white/30">{{ group.tasks.length }}</span>
+            <span class="text-xs text-[--fg-5]">{{ group.tasks.length }}</span>
           </template>
 
           <!-- Milestone sub-groups -->
@@ -178,7 +178,7 @@ function onColumnDrop(evt: DragEvent) {
                 @update="onTaskUpdate" />
             </div>
             <button @click.stop="emit('add-task', addOpts(group.contextSubject, mg.id))"
-                    class="mt-1 text-xs text-white/40 hover:text-white/70 w-full text-left">
+                    class="mt-1 text-xs text-[--fg-4] hover:text-[--fg-2] w-full text-left">
               + Add task
             </button>
           </GroupContainer>
@@ -196,13 +196,13 @@ function onColumnDrop(evt: DragEvent) {
           </div>
 
           <button @click.stop="emit('add-task', addOpts(group.contextSubject))"
-                  class="mt-1 text-xs text-white/40 hover:text-white/70 w-full text-left">
+                  class="mt-1 text-xs text-[--fg-4] hover:text-[--fg-2] w-full text-left">
             + Add task
           </button>
         </GroupContainer>
       </template>
 
-      <button @click="emit('add-task', {})" class="mt-2 text-xs text-white/40 hover:text-white/70 w-full text-left">
+      <button @click="emit('add-task', {})" class="mt-2 text-xs text-[--fg-4] hover:text-[--fg-2] w-full text-left">
         + Add task
       </button>
     </div>

--- a/frontend/src/components/KanbanColumn.vue
+++ b/frontend/src/components/KanbanColumn.vue
@@ -167,7 +167,7 @@ function onColumnDrop(evt: DragEvent) {
             :stickyOffset="0"
             class="mb-1"
             @header-click="pushPanel({ kind: 'milestone', entityId: mg.id })">
-            <div class="space-y-1">
+            <div class="space-y-px">
               <TaskCard
                 v-for="task in mg.tasks"
                 :key="task.id"

--- a/frontend/src/components/SlideOverStack.vue
+++ b/frontend/src/components/SlideOverStack.vue
@@ -47,14 +47,14 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown))
       <div
         v-for="(panel, index) in stack"
         :key="panel.id"
-        class="fixed top-0 right-0 z-50 h-full w-full sm:w-[480px] lg:w-[520px] bg-gray-900 border-l border-white/10 shadow-2xl overflow-y-auto"
+        class="fixed top-0 right-0 z-50 h-full w-full sm:w-[480px] lg:w-[520px] bg-[--bg-canvas] border-l border-[--border-1] shadow-2xl overflow-y-auto"
         :style="panelStyle(index)"
       >
         <!-- Back button / close -->
-        <div class="flex items-center gap-2 px-4 py-3 border-b border-white/10 flex-shrink-0">
+        <div class="flex items-center gap-2 px-4 py-3 border-b border-[--border-1] flex-shrink-0">
           <button
             v-if="index > 0"
-            class="text-white/50 hover:text-white transition-colors text-sm mr-1"
+            class="text-[--fg-3] hover:text-[--fg-1] transition-colors text-sm mr-1"
             title="Back"
             @click="pop"
           >
@@ -62,7 +62,7 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown))
           </button>
           <div class="flex-1" />
           <button
-            class="text-white/30 hover:text-white transition-colors p-1 rounded hover:bg-white/10"
+            class="text-[--fg-5] hover:text-[--fg-1] transition-colors p-1 rounded hover:bg-white/10"
             title="Close all (Esc)"
             @click="close"
           >

--- a/frontend/src/components/SlideOverStack.vue
+++ b/frontend/src/components/SlideOverStack.vue
@@ -62,7 +62,7 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown))
           </button>
           <div class="flex-1" />
           <button
-            class="text-[--fg-5] hover:text-[--fg-1] transition-colors p-1 rounded hover:bg-white/10"
+            class="text-[--fg-5] hover:text-[--fg-1] transition-colors p-1 rounded hover:bg-[--bg-elev-3]"
             title="Close all (Esc)"
             @click="close"
           >

--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -31,10 +31,10 @@ const emit = defineEmits<{
 // Status pill colors (text + bg for the clickable pill)
 const STATUS_PILL: Record<TaskStatus, { bg: string; text: string; label: string }> = {
   pending:     { bg: 'bg-[--status-todo-bg]', text: 'text-[--status-todo-fg]', label: 'todo' },
-  in_progress: { bg: 'bg-blue-500/20', text: 'text-blue-300', label: 'doing' },
-  done:        { bg: 'bg-green-500/20', text: 'text-green-300', label: 'done' },
-  skipped:     { bg: 'bg-orange-500/20', text: 'text-orange-300', label: 'skip' },
-  blocked:     { bg: 'bg-red-500/20', text: 'text-red-300', label: 'blocked' },
+  in_progress: { bg: 'bg-[--status-doing-bg]', text: 'text-[--status-doing-fg]', label: 'doing' },
+  done:        { bg: 'bg-[--status-done-bg]', text: 'text-[--status-done-fg]', label: 'done' },
+  skipped:     { bg: 'bg-[--status-skip-bg]', text: 'text-[--status-skip-fg]', label: 'skip' },
+  blocked:     { bg: 'bg-[--status-block-bg]', text: 'text-[--status-block-fg]', label: 'blocked' },
 }
 
 // Tasks are transparent — the parent AnchorBlock's --m-band provides the surface.

--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -37,13 +37,14 @@ const STATUS_PILL: Record<TaskStatus, { bg: string; text: string; label: string 
   blocked:     { bg: 'bg-red-500/20', text: 'text-red-300', label: 'blocked' },
 }
 
-// Card background — opaque colors to prevent parent GroupContainer color bleed
-const STATUS_CARD_STYLE: Record<TaskStatus, Record<string, string>> = {
-  pending:     { backgroundColor: 'var(--bg-elev-1)' },
-  in_progress: { backgroundColor: 'var(--status-doing-card)' },
-  done:        { backgroundColor: 'var(--status-done-card)', opacity: '0.7' },
-  skipped:     { backgroundColor: 'var(--status-skip-card)', opacity: '0.5' },
-  blocked:     { backgroundColor: 'var(--status-block-card)' },
+// Tasks are transparent — the parent AnchorBlock's --m-band provides the surface.
+// Status is communicated by text dimming + pill + per-task sidebar line only.
+const STATUS_ROW_STYLE: Record<TaskStatus, Record<string, string>> = {
+  pending:     {},
+  in_progress: {},
+  done:        { opacity: '0.55' },
+  skipped:     { opacity: '0.45' },
+  blocked:     {},
 }
 
 const isOverdue = computed(() => {
@@ -116,13 +117,13 @@ function toggleFollowup(enabled: boolean) {
 </script>
 
 <template>
-  <div class="group rounded-md transition-colors cursor-pointer relative"
-      :style="STATUS_CARD_STYLE[task.status]"
+  <div class="group transition-colors cursor-pointer relative"
+      :style="STATUS_ROW_STYLE[task.status]"
       :draggable="!editable && !!task.id"
       @dragstart="onDragStart"
       @click="navigable && task.id && pushPanel({ kind: 'task', entityId: task.id })">
     <div v-if="task.color"
-         class="absolute left-0 top-1 bottom-1 w-1 rounded-full pointer-events-none"
+         class="absolute left-0 top-1 bottom-1 w-0.5 rounded-full pointer-events-none"
          :style="{ background: task.color }" />
     <div class="flex flex-col gap-1 p-2 pl-3">
     <!-- Status pill (top-right) — dropdown only in editable mode (plan view) -->

--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -30,7 +30,7 @@ const emit = defineEmits<{
 
 // Status pill colors (text + bg for the clickable pill)
 const STATUS_PILL: Record<TaskStatus, { bg: string; text: string; label: string }> = {
-  pending:     { bg: 'bg-white/10', text: 'text-white/50', label: 'todo' },
+  pending:     { bg: 'bg-[--status-todo-bg]', text: 'text-[--status-todo-fg]', label: 'todo' },
   in_progress: { bg: 'bg-blue-500/20', text: 'text-blue-300', label: 'doing' },
   done:        { bg: 'bg-green-500/20', text: 'text-green-300', label: 'done' },
   skipped:     { bg: 'bg-orange-500/20', text: 'text-orange-300', label: 'skip' },
@@ -39,11 +39,11 @@ const STATUS_PILL: Record<TaskStatus, { bg: string; text: string; label: string 
 
 // Card background — opaque colors to prevent parent GroupContainer color bleed
 const STATUS_CARD_STYLE: Record<TaskStatus, Record<string, string>> = {
-  pending:     { backgroundColor: 'rgb(22,29,44)' },           // slight lift from base
-  in_progress: { backgroundColor: 'rgb(20,30,55)' },           // blue tint
-  done:        { backgroundColor: 'rgb(19,30,38)', opacity: '0.7' },  // green tint, dimmed
-  skipped:     { backgroundColor: 'rgb(28,27,37)', opacity: '0.5' },  // orange tint, more dimmed
-  blocked:     { backgroundColor: 'rgb(30,22,37)' },           // red tint
+  pending:     { backgroundColor: 'var(--bg-elev-1)' },
+  in_progress: { backgroundColor: 'var(--status-doing-card)' },
+  done:        { backgroundColor: 'var(--status-done-card)', opacity: '0.7' },
+  skipped:     { backgroundColor: 'var(--status-skip-card)', opacity: '0.5' },
+  blocked:     { backgroundColor: 'var(--status-block-card)' },
 }
 
 const isOverdue = computed(() => {
@@ -136,12 +136,12 @@ function toggleFollowup(enabled: boolean) {
       </button>
       <Teleport to="body">
         <div v-if="showStatusDropdown"
-             class="fixed z-50 bg-gray-800 border border-white/20 rounded-lg shadow-xl py-1 min-w-[100px]"
+             class="fixed z-50 bg-[--bg-popover] border border-[--border-2] rounded-lg shadow-xl py-1 min-w-[100px]"
              :style="statusDropdownStyle">
           <button
             v-for="s in ALL_STATUSES" :key="s"
             @click.stop="setStatus(s)"
-            :class="[STATUS_PILL[s].bg, STATUS_PILL[s].text, s === task.status ? 'ring-1 ring-white/30' : '']"
+            :class="[STATUS_PILL[s].bg, STATUS_PILL[s].text, s === task.status ? 'ring-1 ring-[--fg-5]' : '']"
             class="block w-full text-left text-xs px-3 py-1.5 hover:bg-white/10 transition-colors">
             {{ STATUS_PILL[s].label }}
           </button>
@@ -157,7 +157,7 @@ function toggleFollowup(enabled: boolean) {
         :class="task.status === 'done' ? 'line-through opacity-40' : ''"
         @click.stop
         @change="updateText"
-        class="w-full bg-transparent border-b border-white/20 focus:border-white/60 outline-none text-sm py-0.5" />
+        class="w-full bg-transparent border-b border-[--border-1] focus:border-[--border-2] outline-none text-sm py-0.5" />
       <span
         v-else
         class="text-sm break-words"
@@ -180,7 +180,7 @@ function toggleFollowup(enabled: boolean) {
         <span
           v-if="task.context_subject"
           @click.stop
-          class="text-[10px] px-1.5 py-0.5 rounded bg-white/10 text-white/40">
+          class="text-[10px] px-1.5 py-0.5 rounded bg-white/10 text-[--fg-4]">
           {{ task.context_subject }}
         </span>
         <span
@@ -188,7 +188,7 @@ function toggleFollowup(enabled: boolean) {
           @click.stop="pushPanel({ kind: 'milestone', entityId: m.id })"
           :style="m.color ? { backgroundColor: m.color + '33', color: m.color, borderColor: m.color + '66' } : {}"
           class="text-[10px] px-1.5 py-0.5 rounded border cursor-pointer"
-          :class="m.color ? '' : 'bg-white/10 text-white/50 border-transparent hover:bg-white/20'">
+          :class="m.color ? '' : 'bg-white/10 text-[--fg-3] border-transparent hover:bg-white/20'">
           {{ m.name }}
         </span>
       </template>
@@ -199,19 +199,19 @@ function toggleFollowup(enabled: boolean) {
       <button
         v-if="showRemove"
         @click.stop="emit('remove')"
-        class="text-white/30 hover:text-white/70 text-xs opacity-0 group-hover:opacity-100 transition-opacity">✕</button>
+        class="text-[--fg-5] hover:text-[--fg-2] text-xs opacity-0 group-hover:opacity-100 transition-opacity">✕</button>
     </div>
     <div v-if="showDetailLink && !compact">
       <button
         @click="openFollowup"
-        class="text-white/20 hover:text-white/50 text-xs opacity-0 group-hover:opacity-100 transition-opacity ml-1">
+        class="text-[--fg-6] hover:text-[--fg-3] text-xs opacity-0 group-hover:opacity-100 transition-opacity ml-1">
         ⚙
       </button>
       <Teleport to="body">
       <div v-if="showFollowup"
-           class="fixed z-50 bg-gray-800 border border-white/20 rounded-xl p-3 min-w-[200px] shadow-xl"
+           class="fixed z-50 bg-[--bg-popover] border border-[--border-2] rounded-xl p-3 min-w-[200px] shadow-xl"
            :style="popoverStyle">
-        <label class="flex items-center gap-2 text-xs text-white/70 mb-2">
+        <label class="flex items-center gap-2 text-xs text-[--fg-2] mb-2">
           <input type="checkbox"
                  :checked="task.followup_config?.enabled ?? false"
                  @change="(e) => toggleFollowup((e.target as HTMLInputElement).checked)"
@@ -219,14 +219,14 @@ function toggleFollowup(enabled: boolean) {
           Override anchor follow-up
         </label>
         <template v-if="task.followup_config?.enabled">
-          <div class="grid grid-cols-2 gap-2 text-xs text-white/50">
+          <div class="grid grid-cols-2 gap-2 text-xs text-[--fg-3]">
             <label class="flex flex-col gap-0.5">
               Pre interval
               <input
                 :value="task.followup_config.pre_ack_interval_min"
                 type="number" min="1"
                 @change="emit('update', { ...task, followup_config: { ...task.followup_config!, pre_ack_interval_min: +($event.target as HTMLInputElement).value } })"
-                class="bg-white/10 text-white rounded px-1.5 py-0.5 outline-none w-16" />
+                class="bg-white/10 text-[--fg-1] rounded px-1.5 py-0.5 outline-none w-16" />
             </label>
             <label class="flex flex-col gap-0.5">
               Max pings
@@ -234,11 +234,11 @@ function toggleFollowup(enabled: boolean) {
                 :value="task.followup_config.pre_ack_max_pings"
                 type="number" min="1"
                 @change="emit('update', { ...task, followup_config: { ...task.followup_config!, pre_ack_max_pings: +($event.target as HTMLInputElement).value } })"
-                class="bg-white/10 text-white rounded px-1.5 py-0.5 outline-none w-16" />
+                class="bg-white/10 text-[--fg-1] rounded px-1.5 py-0.5 outline-none w-16" />
             </label>
           </div>
         </template>
-        <button @click="showFollowup = false" class="mt-2 text-xs text-white/40 hover:text-white/70 w-full text-right">
+        <button @click="showFollowup = false" class="mt-2 text-xs text-[--fg-4] hover:text-[--fg-2] w-full text-right">
           done
         </button>
       </div>

--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -143,7 +143,7 @@ function toggleFollowup(enabled: boolean) {
             v-for="s in ALL_STATUSES" :key="s"
             @click.stop="setStatus(s)"
             :class="[STATUS_PILL[s].bg, STATUS_PILL[s].text, s === task.status ? 'ring-1 ring-[--fg-5]' : '']"
-            class="block w-full text-left text-xs px-3 py-1.5 hover:bg-white/10 transition-colors">
+            class="block w-full text-left text-xs px-3 py-1.5 hover:bg-[--bg-elev-3] transition-colors">
             {{ STATUS_PILL[s].label }}
           </button>
         </div>
@@ -174,14 +174,14 @@ function toggleFollowup(enabled: boolean) {
         {{ (task as any).plan_date }}{{ (task as any).anchor_id ? ' · ' + (task as any).anchor_id : '' }}
       </span>
       <span v-if="isOverdue" @click.stop
-            class="text-[10px] px-1.5 py-0.5 rounded bg-red-500/20 text-red-300 font-medium">
+            class="text-[10px] px-1.5 py-0.5 rounded bg-[--status-block-bg] text-[--status-block-fg] font-medium">
         overdue
       </span>
       <template v-if="!hideTags">
         <span
           v-if="task.context_subject"
           @click.stop
-          class="text-[10px] px-1.5 py-0.5 rounded bg-white/10 text-[--fg-4]">
+          class="text-[10px] px-1.5 py-0.5 rounded bg-[--bg-elev-3] text-[--fg-4]">
           {{ task.context_subject }}
         </span>
         <span
@@ -189,7 +189,7 @@ function toggleFollowup(enabled: boolean) {
           @click.stop="pushPanel({ kind: 'milestone', entityId: m.id })"
           :style="m.color ? { backgroundColor: m.color + '33', color: m.color, borderColor: m.color + '66' } : {}"
           class="text-[10px] px-1.5 py-0.5 rounded border cursor-pointer"
-          :class="m.color ? '' : 'bg-white/10 text-[--fg-3] border-transparent hover:bg-white/20'">
+          :class="m.color ? '' : 'bg-[--bg-elev-3] text-[--fg-3] border-transparent hover:bg-[--bg-elev-4]'">
           {{ m.name }}
         </span>
       </template>
@@ -227,7 +227,7 @@ function toggleFollowup(enabled: boolean) {
                 :value="task.followup_config.pre_ack_interval_min"
                 type="number" min="1"
                 @change="emit('update', { ...task, followup_config: { ...task.followup_config!, pre_ack_interval_min: +($event.target as HTMLInputElement).value } })"
-                class="bg-white/10 text-[--fg-1] rounded px-1.5 py-0.5 outline-none w-16" />
+                class="bg-[--bg-elev-3] text-[--fg-1] rounded px-1.5 py-0.5 outline-none w-16" />
             </label>
             <label class="flex flex-col gap-0.5">
               Max pings
@@ -235,7 +235,7 @@ function toggleFollowup(enabled: boolean) {
                 :value="task.followup_config.pre_ack_max_pings"
                 type="number" min="1"
                 @change="emit('update', { ...task, followup_config: { ...task.followup_config!, pre_ack_max_pings: +($event.target as HTMLInputElement).value } })"
-                class="bg-white/10 text-[--fg-1] rounded px-1.5 py-0.5 outline-none w-16" />
+                class="bg-[--bg-elev-3] text-[--fg-1] rounded px-1.5 py-0.5 outline-none w-16" />
             </label>
           </div>
         </template>

--- a/frontend/src/components/TaskList.vue
+++ b/frontend/src/components/TaskList.vue
@@ -29,5 +29,5 @@ function remove(i: number) {
       @update="updateTask(i, $event)"
       @remove="remove(i)" />
   </ul>
-  <button @click="add" class="mt-2 text-xs text-white/40 hover:text-white/70">+ Add task</button>
+  <button @click="add" class="mt-2 text-xs text-[--fg-4] hover:text-[--fg-2]">+ Add task</button>
 </template>


### PR DESCRIPTION
## Summary

Migrates the user-visible frontend surface from hardcoded Tailwind color classes (`bg-gray-900`, `text-white/X`, `border-white/X`, `bg-blue-500/20`, etc.) to the semantic CSS token layer in `frontend/src/assets/themes.css`.

Also reworks `TaskCard` and `GroupContainer` to be **fully transparent** — no card background, no border. The parent `AnchorBlock`'s `var(--m-band)` now provides the single background source, so anchor contents read as one continuous motif-tinted surface (per `tether-design/preview/components-anchor-block.html`). Status is conveyed via text dimming + status pill + per-task sidebar tick only.

### Components migrated
- `App.vue` — root + nav
- `GroupContainer.vue` — fully transparent rework, sidebar rail uses `--fg-5` fallback
- `TaskCard.vue` — fully transparent rework, STATUS_PILL on `--status-{doing,done,skip,block}-{bg,fg}` tokens, status-row uses opacity instead of color cards
- `KanbanColumn.vue` + `DayColumn.vue` — `gap-px` row layout
- `DayTimeline.vue` — panel chrome on `--bg-elev-1` / `--border-1`
- `AnchorBlock.vue` + `TaskList.vue` — `text-[--fg-4]` ramps on hint text
- `SlideOverStack.vue` + `DetailPanel.vue` — slide-over chrome on `--bg-canvas` / `--border-1`

### Out of scope (follow-up PR)
24 files still on hardcoded classes — primarily slide-over content (TaskDetailPanel, MilestoneDetailPanel) and editors (AnchorEditor, RecurrencePicker) and settings. Splitting keeps this PR reviewable; main routes are fully tokenized after merge.

## Test plan
- [ ] `pnpm typecheck` (note: pre-existing `require()` errors in TaskDetailPanel*.test.ts unrelated to this PR)
- [ ] Verify AnchorBlock motif band visible across statuses, tasks render as continuous list
- [ ] Verify GroupContainer sticky heading legible during scroll
- [ ] Verify status pill colors render via tokens (not hardcoded blue/green/orange/red)
- [ ] Verify slide-over panels and DetailPanel chrome still legible