### PR TITLE
feat(frontend): global theme picker drawer

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,6 +5,7 @@ import { useRouter } from 'vue-router'
 import { loadPremiumThemes, unloadPremiumThemes } from './composables/usePremiumThemes'
 import BotChat from './components/BotChat.vue'
 import SlideOverStack from './components/SlideOverStack.vue'
+import ThemeDrawer from './components/ThemeDrawer.vue'
 
 const authStore = useAuthStore()
 const router = useRouter()
@@ -25,6 +26,7 @@ watch(
   { immediate: true },
 )
 const chatOpen = ref(false)
+const themeDrawerOpen = ref(false)
 
 async function logout() {
   await authStore.logout()
@@ -86,6 +88,18 @@ async function logout() {
           Chat
         </button>
 
+        <button
+          @click="themeDrawerOpen = true"
+          data-testid="theme-drawer-trigger"
+          class="text-white/40 hover:text-white/80 transition-colors p-1.5 rounded-lg hover:bg-white/10"
+          title="Theme"
+          aria-label="Open theme picker"
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01" />
+          </svg>
+        </button>
+
         <router-link v-if="authStore.user?.is_admin" to="/admin"
                      class="text-xs text-white/40 hover:text-white/80 border border-white/10 rounded px-2 py-1 transition-colors">
           Admin
@@ -127,6 +141,9 @@ async function logout() {
 
     <!-- Global slide-over panel stack (outside router-view so it persists across routes) -->
     <SlideOverStack v-if="authStore.isAuthenticated" />
+
+    <!-- Global theme picker drawer -->
+    <ThemeDrawer v-if="authStore.isAuthenticated" v-model="themeDrawerOpen" />
   </div>
 </template>
 

--- a/frontend/src/components/ThemeDrawer.vue
+++ b/frontend/src/components/ThemeDrawer.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, watch } from 'vue'
+import { onMounted, onUnmounted, ref, watch, nextTick } from 'vue'
 import { useTheme } from '../composables/useTheme'
 
 const props = defineProps<{ modelValue: boolean }>()
 const emit = defineEmits<{ 'update:modelValue': [open: boolean] }>()
 
 const { THEMES, activeTheme, activeMode, isThemeUnlocked, applyTheme, previewTheme, setMode } = useTheme()
+
+const closeBtn = ref<HTMLButtonElement | null>(null)
+let lastFocused: HTMLElement | null = null
 
 function close() {
   emit('update:modelValue', false)
@@ -33,8 +36,16 @@ function onKeydown(e: KeyboardEvent) {
 onMounted(() => document.addEventListener('keydown', onKeydown))
 onUnmounted(() => document.removeEventListener('keydown', onKeydown))
 
-watch(() => props.modelValue, (open) => {
-  if (!open) onRestore()
+watch(() => props.modelValue, async (open) => {
+  if (open) {
+    lastFocused = (document.activeElement as HTMLElement) ?? null
+    await nextTick()
+    closeBtn.value?.focus()
+  } else {
+    onRestore()
+    lastFocused?.focus?.()
+    lastFocused = null
+  }
 })
 </script>
 
@@ -54,6 +65,7 @@ watch(() => props.modelValue, (open) => {
         v-if="modelValue"
         data-testid="theme-drawer"
         role="dialog"
+        aria-modal="true"
         aria-label="Theme picker"
         class="fixed top-0 right-0 z-50 h-full w-full sm:w-[420px] bg-gray-900 border-l border-white/10 shadow-2xl overflow-y-auto"
       >
@@ -61,6 +73,7 @@ watch(() => props.modelValue, (open) => {
           <span class="text-sm font-semibold text-white/80">Theme</span>
           <div class="flex-1" />
           <button
+            ref="closeBtn"
             data-testid="theme-drawer-close"
             class="text-white/30 hover:text-white transition-colors p-1 rounded hover:bg-white/10"
             title="Close (Esc)"

--- a/frontend/src/components/ThemeDrawer.vue
+++ b/frontend/src/components/ThemeDrawer.vue
@@ -1,0 +1,147 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, watch } from 'vue'
+import { useTheme } from '../composables/useTheme'
+
+const props = defineProps<{ modelValue: boolean }>()
+const emit = defineEmits<{ 'update:modelValue': [open: boolean] }>()
+
+const { THEMES, activeTheme, activeMode, isThemeUnlocked, applyTheme, previewTheme, setMode } = useTheme()
+
+function close() {
+  emit('update:modelValue', false)
+}
+
+function onPreview(themeId: string) {
+  previewTheme(themeId)
+}
+
+function onRestore() {
+  previewTheme(activeTheme.value)
+}
+
+function onSelect(themeId: string) {
+  const theme = THEMES.find(t => t.id === themeId)
+  if (!theme) return
+  previewTheme(themeId)
+  if (isThemeUnlocked(theme)) applyTheme(themeId)
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape' && props.modelValue) close()
+}
+
+onMounted(() => document.addEventListener('keydown', onKeydown))
+onUnmounted(() => document.removeEventListener('keydown', onKeydown))
+
+watch(() => props.modelValue, (open) => {
+  if (!open) onRestore()
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="fade">
+      <div
+        v-if="modelValue"
+        data-testid="theme-drawer-backdrop"
+        class="fixed inset-0 z-40 bg-black/40"
+        @click="close"
+      />
+    </Transition>
+
+    <Transition name="slide-over">
+      <aside
+        v-if="modelValue"
+        data-testid="theme-drawer"
+        role="dialog"
+        aria-label="Theme picker"
+        class="fixed top-0 right-0 z-50 h-full w-full sm:w-[420px] bg-gray-900 border-l border-white/10 shadow-2xl overflow-y-auto"
+      >
+        <div class="flex items-center gap-2 px-4 py-3 border-b border-white/10">
+          <span class="text-sm font-semibold text-white/80">Theme</span>
+          <div class="flex-1" />
+          <button
+            data-testid="theme-drawer-close"
+            class="text-white/30 hover:text-white transition-colors p-1 rounded hover:bg-white/10"
+            title="Close (Esc)"
+            aria-label="Close"
+            @click="close"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div class="p-4 space-y-4">
+          <!-- Day/night mode toggle -->
+          <div class="flex items-center justify-between rounded-lg bg-gray-800 px-3 py-2.5">
+            <span class="text-xs uppercase tracking-wider text-white/50">Mode</span>
+            <div class="flex items-center gap-1" role="group" aria-label="Mode">
+              <button
+                data-testid="mode-light"
+                class="px-2.5 py-1 rounded text-xs transition-colors"
+                :class="activeMode === 'light' ? 'bg-white/20 text-white' : 'text-white/50 hover:bg-white/10'"
+                :aria-pressed="activeMode === 'light'"
+                @click="setMode('light')"
+              >Day</button>
+              <button
+                data-testid="mode-dark"
+                class="px-2.5 py-1 rounded text-xs transition-colors"
+                :class="activeMode === 'dark' ? 'bg-white/20 text-white' : 'text-white/50 hover:bg-white/10'"
+                :aria-pressed="activeMode === 'dark'"
+                @click="setMode('dark')"
+              >Night</button>
+            </div>
+          </div>
+
+          <!-- Theme swatch grid -->
+          <p class="text-xs text-white/40">Hover to preview, click to apply. Paid themes preview only until unlocked.</p>
+          <div class="grid grid-cols-2 gap-2">
+            <button
+              v-for="theme in THEMES"
+              :key="theme.id"
+              data-testid="theme-swatch"
+              :data-theme-id="theme.id"
+              @click="onSelect(theme.id)"
+              @mouseenter="onPreview(theme.id)"
+              @mouseleave="onRestore"
+              :title="theme.name"
+              :aria-pressed="activeTheme === theme.id"
+              class="relative flex flex-col items-start gap-1.5 rounded-lg p-2.5 border transition-all text-left"
+              :class="[
+                activeTheme === theme.id
+                  ? 'border-indigo-500 ring-1 ring-indigo-500'
+                  : 'border-gray-700 hover:border-gray-500',
+              ]"
+            >
+              <span
+                class="w-full h-6 rounded"
+                :style="{ background: `linear-gradient(135deg, ${theme.canvas} 60%, ${theme.accent} 100%)` }"
+              />
+              <span class="text-xs text-white/80 font-medium leading-tight">{{ theme.name }}</span>
+              <span
+                v-if="theme.tier !== 'free'"
+                class="absolute top-1.5 right-1.5 text-[9px] font-bold uppercase tracking-wide px-1 py-0.5 rounded"
+                :class="isThemeUnlocked(theme) ? 'bg-emerald-700/70 text-emerald-200' : 'bg-gray-700/80 text-white/40'"
+              >{{ isThemeUnlocked(theme) ? 'oss' : 'paid' }}</span>
+            </button>
+          </div>
+        </div>
+      </aside>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.fade-enter-active, .fade-leave-active { transition: opacity 0.15s ease; }
+.fade-enter-from, .fade-leave-to { opacity: 0; }
+
+.slide-over-enter-active, .slide-over-leave-active {
+  transition: transform 0.15s ease, opacity 0.15s ease;
+}
+.slide-over-enter-from, .slide-over-leave-to {
+  transform: translateX(100%);
+  opacity: 0;
+}
+</style>

--- a/frontend/src/components/__tests__/ThemeDrawer.test.ts
+++ b/frontend/src/components/__tests__/ThemeDrawer.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('../../stores/auth', () => ({
+  useAuthStore: () => ({ user: null }),
+}))
+
+import ThemeDrawer from '../ThemeDrawer.vue'
+
+describe('ThemeDrawer', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    delete document.documentElement.dataset.theme
+    delete document.documentElement.dataset.mode
+    delete document.documentElement.dataset.typeVoice
+    localStorage.clear()
+    // Remove any teleported nodes from a prior test
+    while (document.body.firstChild) document.body.removeChild(document.body.firstChild)
+  })
+
+  it('does not render content when modelValue is false', () => {
+    mount(ThemeDrawer, { props: { modelValue: false }, attachTo: document.body })
+    expect(document.body.querySelector('[data-testid="theme-drawer"]')).toBeNull()
+  })
+
+  it('renders all 7 themes when open', () => {
+    mount(ThemeDrawer, { props: { modelValue: true }, attachTo: document.body })
+    const swatches = document.body.querySelectorAll('[data-testid="theme-swatch"]')
+    expect(swatches).toHaveLength(7)
+    const ids = Array.from(swatches).map(s => s.getAttribute('data-theme-id'))
+    expect(ids).toEqual(['tether','horizon','contrast','terminal','solstice','dracula','paper'])
+  })
+
+  it('hover on a swatch previews the theme on documentElement', () => {
+    mount(ThemeDrawer, { props: { modelValue: true }, attachTo: document.body })
+    const horizon = document.body.querySelector('[data-theme-id="horizon"]') as HTMLElement
+    expect(horizon).toBeTruthy()
+    horizon.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }))
+    expect(document.documentElement.dataset.theme).toBe('horizon')
+  })
+
+  it('clicking an unlocked theme applies it (persists + sets data-theme)', () => {
+    mount(ThemeDrawer, { props: { modelValue: true }, attachTo: document.body })
+    const horizon = document.body.querySelector('[data-theme-id="horizon"]') as HTMLElement
+    horizon.click()
+    expect(document.documentElement.dataset.theme).toBe('horizon')
+    expect(localStorage.getItem('tether-theme')).toBe('horizon')
+  })
+
+  it('clicking a paid (locked) theme previews but does not persist', () => {
+    mount(ThemeDrawer, { props: { modelValue: true }, attachTo: document.body })
+    const dracula = document.body.querySelector('[data-theme-id="dracula"]') as HTMLElement
+    dracula.click()
+    expect(document.documentElement.dataset.theme).toBe('dracula')
+    expect(localStorage.getItem('tether-theme')).toBeNull()
+  })
+
+  it('clicking close emits update:modelValue=false', () => {
+    const wrapper = mount(ThemeDrawer, { props: { modelValue: true }, attachTo: document.body })
+    const closeBtn = document.body.querySelector('[data-testid="theme-drawer-close"]') as HTMLElement
+    closeBtn.click()
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+    expect(wrapper.emitted('update:modelValue')![0]).toEqual([false])
+  })
+
+  it('clicking the backdrop emits update:modelValue=false', () => {
+    const wrapper = mount(ThemeDrawer, { props: { modelValue: true }, attachTo: document.body })
+    const backdrop = document.body.querySelector('[data-testid="theme-drawer-backdrop"]') as HTMLElement
+    backdrop.click()
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+    expect(wrapper.emitted('update:modelValue')![0]).toEqual([false])
+  })
+
+  it('day/night toggle calls setMode and reflects active mode', () => {
+    mount(ThemeDrawer, { props: { modelValue: true }, attachTo: document.body })
+    const light = document.body.querySelector('[data-testid="mode-light"]') as HTMLElement
+    light.click()
+    expect(document.documentElement.dataset.mode).toBe('light')
+    expect(localStorage.getItem('tether-mode')).toBe('light')
+    const dark = document.body.querySelector('[data-testid="mode-dark"]') as HTMLElement
+    dark.click()
+    expect(document.documentElement.dataset.mode).toBe('dark')
+    expect(localStorage.getItem('tether-mode')).toBe('dark')
+  })
+})


### PR DESCRIPTION
## Summary
- New `ThemeDrawer.vue` slide-over panel — 7-theme swatch grid + day/night mode toggle, hover-preview / click-apply, locked themes preview-only.
- Wired into `App.vue` nav with a 🎨 trigger button (authenticated only); panel mounted next to `SlideOverStack`.
- Closes via close button, Escape key, or backdrop click. A11y: `role=dialog` + `aria-modal=true` + focus management.

## Test plan
- [x] `pnpm test` — 340 passing (8 new in `ThemeDrawer.test.ts`)
- [x] `vue-tsc --noEmit` clean
- [x] `pr-review-toolkit:code-reviewer` pass; a11y finding addressed in `3fb6f96`
- [ ] Manually verify the drawer opens from any route, hover previews, click persists for free themes, locked themes preview-only