### PR TITLE
fix(frontend): Wave 1 — anchor sidebar dedupe, day/night nav toggle, SettingsView tokens

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -6,9 +6,15 @@ import { loadPremiumThemes, unloadPremiumThemes } from './composables/usePremium
 import BotChat from './components/BotChat.vue'
 import SlideOverStack from './components/SlideOverStack.vue'
 import ThemeDrawer from './components/ThemeDrawer.vue'
+import { useTheme } from './composables/useTheme'
 
 const authStore = useAuthStore()
 const router = useRouter()
+const { activeMode, setMode } = useTheme()
+
+function toggleMode() {
+  setMode(activeMode.value === 'dark' ? 'light' : 'dark')
+}
 
 // Load premium theme CSS once the user is known to be authenticated.
 // isPaid is always false today; this fires when backend adds the field.
@@ -88,10 +94,17 @@ async function logout() {
           Chat
         </button>
 
+        <button @click="toggleMode"
+                class="text-[--fg-3] hover:text-[--fg-1] transition-colors p-1.5 rounded-lg hover:bg-[--bg-elev-3] text-sm leading-none"
+                :title="activeMode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'">
+          <span v-if="activeMode === 'dark'">☀</span>
+          <span v-else>☾</span>
+        </button>
+
         <button
           @click="themeDrawerOpen = true"
           data-testid="theme-drawer-trigger"
-          class="text-white/40 hover:text-white/80 transition-colors p-1.5 rounded-lg hover:bg-white/10"
+          class="text-[--fg-4] hover:text-[--fg-2] transition-colors p-1.5 rounded-lg hover:bg-[--bg-elev-3]"
           title="Theme"
           aria-label="Open theme picker"
         >

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -96,7 +96,8 @@ async function logout() {
 
         <button @click="toggleMode"
                 class="text-[--fg-3] hover:text-[--fg-1] transition-colors p-1.5 rounded-lg hover:bg-[--bg-elev-3] text-sm leading-none"
-                :title="activeMode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'">
+                :title="activeMode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'"
+                :aria-label="activeMode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'">
           <span v-if="activeMode === 'dark'">☀</span>
           <span v-else>☾</span>
         </button>

--- a/frontend/src/components/AnchorBlock.vue
+++ b/frontend/src/components/AnchorBlock.vue
@@ -164,7 +164,7 @@ function onDrop(evt: DragEvent, toIndex: number) {
   <div :data-motif="motif ?? 'anchor'" class="relative">
     <div class="absolute left-0 top-0 bottom-0 w-1 rounded-full pointer-events-none" :style="{ background: 'var(--m)' }" />
     <div class="pl-3">
-  <GroupContainer :label="`${anchorName} · ${time}`" :color="color" :collapsible="true" :level="0">
+  <GroupContainer :label="`${anchorName} · ${time}`" :collapsible="true" :level="0">
     <template #header-right>
       <span class="text-xs text-[--fg-5]">{{ anchorPlan.tasks.length }}</span>
     </template>

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -338,7 +338,7 @@ async function linkTelegram() {
               <button
                 @click="linkTelegram"
                 :disabled="telegramStatus === 'loading' || !telegramCode.trim()"
-                class="bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-[--fg-1] text-sm font-medium rounded-lg px-4 py-2 transition-colors"
+                class="bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg px-4 py-2 transition-colors"
               >
                 {{ telegramStatus === 'loading' ? '…' : 'Link' }}
               </button>
@@ -424,7 +424,7 @@ async function linkTelegram() {
             <button
               @click="saveArchiveSettings"
               :disabled="archiveStatus === 'saving'"
-              class="flex-1 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-[--fg-1] text-sm font-medium rounded-lg px-4 py-2 transition-colors"
+              class="flex-1 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg px-4 py-2 transition-colors"
             >
               {{ archiveStatus === 'saving' ? 'Saving...' : 'Save' }}
             </button>
@@ -538,7 +538,7 @@ async function linkTelegram() {
             <button
               @click="saveLLMConfig"
               :disabled="llmStatus === 'saving'"
-              class="flex-1 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-[--fg-1] text-sm font-medium rounded-lg px-4 py-2 transition-colors"
+              class="flex-1 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg px-4 py-2 transition-colors"
             >
               {{ llmStatus === 'saving' ? 'Saving...' : 'Save' }}
             </button>

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -215,30 +215,30 @@ async function linkTelegram() {
 </script>
 
 <template>
-  <div class="min-h-screen bg-gray-900 text-white p-6">
+  <div class="min-h-screen bg-[--bg-canvas] text-[--fg-1] p-6">
     <div class="max-w-lg mx-auto">
       <!-- Header -->
       <div class="flex items-center gap-3 mb-8">
-        <router-link to="/" class="text-white/40 hover:text-white text-sm">← Back</router-link>
+        <router-link to="/" class="text-[--fg-4] hover:text-[--fg-1] text-sm">← Back</router-link>
         <h1 class="text-xl font-bold">Settings</h1>
       </div>
 
       <!-- Account -->
       <section class="mb-8">
-        <h2 class="text-sm font-semibold text-white/50 uppercase tracking-wider mb-3">Account</h2>
-        <div class="bg-gray-800 rounded-xl p-4 space-y-3">
+        <h2 class="text-sm font-semibold text-[--fg-3] uppercase tracking-wider mb-3">Account</h2>
+        <div class="bg-[--bg-elev-1] rounded-xl p-4 space-y-3">
           <div>
-            <div class="text-xs text-gray-400 mb-1">Username</div>
-            <div class="text-white font-medium">{{ auth.user?.username ?? '—' }}</div>
+            <div class="text-xs text-[--fg-4] mb-1">Username</div>
+            <div class="text-[--fg-1] font-medium">{{ auth.user?.username ?? '—' }}</div>
           </div>
         </div>
       </section>
 
       <!-- Appearance -->
       <section class="mb-8">
-        <h2 class="text-sm font-semibold text-white/50 uppercase tracking-wider mb-3">Appearance</h2>
-        <div class="bg-gray-800 rounded-xl p-4 space-y-4">
-          <p class="text-xs text-white/40">Select a theme. Free previews are available for all themes — upgrade to keep a paid theme across sessions.</p>
+        <h2 class="text-sm font-semibold text-[--fg-3] uppercase tracking-wider mb-3">Appearance</h2>
+        <div class="bg-[--bg-elev-1] rounded-xl p-4 space-y-4">
+          <p class="text-xs text-[--fg-4]">Select a theme. Free previews are available for all themes — upgrade to keep a paid theme across sessions.</p>
           <div class="grid grid-cols-2 gap-2 sm:grid-cols-3">
             <button
               v-for="theme in THEMES"
@@ -252,7 +252,7 @@ async function linkTelegram() {
               :class="[
                 activeTheme === theme.id
                   ? 'border-indigo-500 ring-1 ring-indigo-500'
-                  : 'border-gray-700 hover:border-gray-500',
+                  : 'border-[--border-1] hover:border-[--border-2]',
               ]"
             >
               <!-- Canvas/accent swatch -->
@@ -260,12 +260,12 @@ async function linkTelegram() {
                 class="w-full h-6 rounded"
                 :style="{ background: `linear-gradient(135deg, ${theme.canvas} 60%, ${theme.accent} 100%)` }"
               />
-              <span class="text-xs text-white/80 font-medium leading-tight">{{ theme.name }}</span>
+              <span class="text-xs text-[--fg-2] font-medium leading-tight">{{ theme.name }}</span>
               <!-- Tier badge -->
               <span
                 v-if="theme.tier !== 'free'"
                 class="absolute top-1.5 right-1.5 text-[9px] font-bold uppercase tracking-wide px-1 py-0.5 rounded"
-                :class="isThemeUnlocked(theme) ? 'bg-emerald-700/70 text-emerald-200' : 'bg-gray-700/80 text-white/40'"
+                :class="isThemeUnlocked(theme) ? 'bg-[--status-done-bg] text-[--status-done-fg]' : 'bg-[--bg-elev-3] text-[--fg-4]'"
               >{{ isThemeUnlocked(theme) ? 'oss' : 'paid' }}</span>
             </button>
           </div>
@@ -275,12 +275,12 @@ async function linkTelegram() {
             v-if="showUpgradeNudge"
             class="flex items-center justify-between gap-3 rounded-lg bg-indigo-900/40 border border-indigo-700/50 px-3 py-2.5 text-sm"
           >
-            <span class="text-white/70">
-              <strong class="text-white">{{ upgradeNudgeTheme }}</strong> is a paid theme — upgrade to keep it.
+            <span class="text-[--fg-2]">
+              <strong class="text-[--fg-1]">{{ upgradeNudgeTheme }}</strong> is a paid theme — upgrade to keep it.
             </span>
             <button
               @click="showUpgradeNudge = false"
-              class="text-white/30 hover:text-white/70 text-xs shrink-0"
+              class="text-[--fg-5] hover:text-[--fg-2] text-xs shrink-0"
               aria-label="Dismiss"
             >✕</button>
           </div>
@@ -289,41 +289,41 @@ async function linkTelegram() {
 
       <!-- Change Password -->
       <section class="mb-8">
-        <h2 class="text-sm font-semibold text-white/50 uppercase tracking-wider mb-3">Change Password</h2>
-        <div class="bg-gray-800 rounded-xl p-4 space-y-3">
+        <h2 class="text-sm font-semibold text-[--fg-3] uppercase tracking-wider mb-3">Change Password</h2>
+        <div class="bg-[--bg-elev-1] rounded-xl p-4 space-y-3">
           <input
             type="password"
             disabled
             placeholder="Current password"
-            class="w-full bg-gray-700/50 text-gray-500 rounded-lg px-3 py-2 text-sm border border-gray-700 cursor-not-allowed"
+            class="w-full bg-[--bg-elev-2] text-[--fg-5] rounded-lg px-3 py-2 text-sm border border-[--border-1] cursor-not-allowed"
           />
           <input
             type="password"
             disabled
             placeholder="New password"
-            class="w-full bg-gray-700/50 text-gray-500 rounded-lg px-3 py-2 text-sm border border-gray-700 cursor-not-allowed"
+            class="w-full bg-[--bg-elev-2] text-[--fg-5] rounded-lg px-3 py-2 text-sm border border-[--border-1] cursor-not-allowed"
           />
           <input
             type="password"
             disabled
             placeholder="Confirm new password"
-            class="w-full bg-gray-700/50 text-gray-500 rounded-lg px-3 py-2 text-sm border border-gray-700 cursor-not-allowed"
+            class="w-full bg-[--bg-elev-2] text-[--fg-5] rounded-lg px-3 py-2 text-sm border border-[--border-1] cursor-not-allowed"
           />
-          <p class="text-xs text-white/30">Password change coming soon.</p>
+          <p class="text-xs text-[--fg-5]">Password change coming soon.</p>
         </div>
       </section>
 
       <!-- Telegram Link -->
       <section class="mb-8">
-        <h2 class="text-sm font-semibold text-white/50 uppercase tracking-wider mb-3">Telegram</h2>
-        <div class="bg-gray-800 rounded-xl p-4">
-          <div v-if="telegramLinked" class="flex items-center gap-2 text-green-400 text-sm">
+        <h2 class="text-sm font-semibold text-[--fg-3] uppercase tracking-wider mb-3">Telegram</h2>
+        <div class="bg-[--bg-elev-1] rounded-xl p-4">
+          <div v-if="telegramLinked" class="flex items-center gap-2 text-[--status-done-fg] text-sm">
             <span>✓</span>
             <span>Telegram linked</span>
           </div>
           <template v-else>
-            <p class="text-sm text-white/60 mb-3">
-              Send <code class="bg-gray-700 px-1 rounded">/link</code> to your Tether bot to get a 6-digit code, then enter it below.
+            <p class="text-sm text-[--fg-3] mb-3">
+              Send <code class="bg-[--bg-elev-2] px-1 rounded">/link</code> to your Tether bot to get a 6-digit code, then enter it below.
             </p>
             <div class="flex gap-2">
               <input
@@ -332,18 +332,18 @@ async function linkTelegram() {
                 inputmode="numeric"
                 maxlength="6"
                 placeholder="123456"
-                class="flex-1 bg-gray-700 text-white rounded-lg px-3 py-2 text-sm border border-gray-600 focus:outline-none focus:border-indigo-500 placeholder-gray-500"
+                class="flex-1 bg-[--bg-elev-2] text-[--fg-1] rounded-lg px-3 py-2 text-sm border border-[--border-1] focus:outline-none focus:border-indigo-500 placeholder:text-[--fg-5]"
                 @keydown.enter="linkTelegram"
               />
               <button
                 @click="linkTelegram"
                 :disabled="telegramStatus === 'loading' || !telegramCode.trim()"
-                class="bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg px-4 py-2 transition-colors"
+                class="bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-[--fg-1] text-sm font-medium rounded-lg px-4 py-2 transition-colors"
               >
                 {{ telegramStatus === 'loading' ? '…' : 'Link' }}
               </button>
             </div>
-            <p v-if="telegramMessage" :class="telegramStatus === 'success' ? 'text-green-400' : 'text-red-400'" class="text-sm mt-2">
+            <p v-if="telegramMessage" :class="telegramStatus === 'success' ? 'text-[--status-done-fg]' : 'text-[--status-block-fg]'" class="text-sm mt-2">
               {{ telegramMessage }}
             </p>
           </template>
@@ -361,21 +361,21 @@ async function linkTelegram() {
 
       <!-- OAuth Connections -->
       <section class="mb-8">
-        <h2 class="text-sm font-semibold text-white/50 uppercase tracking-wider mb-3">OAuth Connections</h2>
-        <div class="bg-gray-800 rounded-xl p-4 space-y-2">
+        <h2 class="text-sm font-semibold text-[--fg-3] uppercase tracking-wider mb-3">OAuth Connections</h2>
+        <div class="bg-[--bg-elev-1] rounded-xl p-4 space-y-2">
           <button
             disabled
-            class="w-full bg-gray-700/50 text-white/40 text-sm font-medium rounded-lg px-4 py-2.5 border border-gray-600/50 flex items-center gap-2 cursor-not-allowed"
+            class="w-full bg-[--bg-elev-2] text-[--fg-4] text-sm font-medium rounded-lg px-4 py-2.5 border border-[--border-1] flex items-center gap-2 cursor-not-allowed"
           >
             <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd" />
             </svg>
             Connect GitHub
-            <span class="ml-auto text-[10px] bg-gray-600/60 text-white/40 rounded px-1.5 py-0.5 font-normal tracking-wide">coming soon</span>
+            <span class="ml-auto text-[10px] bg-[--bg-elev-3] text-[--fg-4] rounded px-1.5 py-0.5 font-normal tracking-wide">coming soon</span>
           </button>
           <button
             disabled
-            class="w-full bg-gray-700/50 text-white/40 text-sm font-medium rounded-lg px-4 py-2.5 border border-gray-600/50 flex items-center gap-2 cursor-not-allowed"
+            class="w-full bg-[--bg-elev-2] text-[--fg-4] text-sm font-medium rounded-lg px-4 py-2.5 border border-[--border-1] flex items-center gap-2 cursor-not-allowed"
           >
             <svg class="w-4 h-4 opacity-40" viewBox="0 0 24 24" aria-hidden="true">
               <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
@@ -384,52 +384,52 @@ async function linkTelegram() {
               <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
             </svg>
             Connect Google
-            <span class="ml-auto text-[10px] bg-gray-600/60 text-white/40 rounded px-1.5 py-0.5 font-normal tracking-wide">coming soon</span>
+            <span class="ml-auto text-[10px] bg-[--bg-elev-3] text-[--fg-4] rounded px-1.5 py-0.5 font-normal tracking-wide">coming soon</span>
           </button>
         </div>
       </section>
 
       <!-- Auto-Archive Rules -->
       <section class="mb-8">
-        <h2 class="text-sm font-semibold text-white/50 uppercase tracking-wider mb-3">Auto-Archive Rules</h2>
-        <div class="bg-gray-800 rounded-xl p-4 space-y-4">
-          <p class="text-sm text-white/60">
+        <h2 class="text-sm font-semibold text-[--fg-3] uppercase tracking-wider mb-3">Auto-Archive Rules</h2>
+        <div class="bg-[--bg-elev-1] rounded-xl p-4 space-y-4">
+          <p class="text-sm text-[--fg-3]">
             Automatically archive context nodes when they become stale. Leave blank to disable a rule.
           </p>
           <div class="grid grid-cols-2 gap-3">
             <div>
-              <label class="text-xs text-gray-400 mb-1 block">Archive after completion (days)</label>
+              <label class="text-xs text-[--fg-4] mb-1 block">Archive after completion (days)</label>
               <input
                 type="number"
                 v-model.number="archiveDaysCompleted"
                 min="1"
                 placeholder="e.g. 7"
-                class="w-full bg-gray-700 text-white rounded-lg px-3 py-2 text-sm border border-gray-600 focus:outline-none focus:border-indigo-500 placeholder-gray-500"
+                class="w-full bg-[--bg-elev-2] text-[--fg-1] rounded-lg px-3 py-2 text-sm border border-[--border-1] focus:outline-none focus:border-indigo-500 placeholder:text-[--fg-5]"
               />
-              <p class="text-xs text-gray-500 mt-1">Archive nodes whose tasks are all done for X days</p>
+              <p class="text-xs text-[--fg-5] mt-1">Archive nodes whose tasks are all done for X days</p>
             </div>
             <div>
-              <label class="text-xs text-gray-400 mb-1 block">Archive after inactivity (days)</label>
+              <label class="text-xs text-[--fg-4] mb-1 block">Archive after inactivity (days)</label>
               <input
                 type="number"
                 v-model.number="archiveDaysInactive"
                 min="1"
                 placeholder="e.g. 30"
-                class="w-full bg-gray-700 text-white rounded-lg px-3 py-2 text-sm border border-gray-600 focus:outline-none focus:border-indigo-500 placeholder-gray-500"
+                class="w-full bg-[--bg-elev-2] text-[--fg-1] rounded-lg px-3 py-2 text-sm border border-[--border-1] focus:outline-none focus:border-indigo-500 placeholder:text-[--fg-5]"
               />
-              <p class="text-xs text-gray-500 mt-1">Archive nodes with no updates for X days</p>
+              <p class="text-xs text-[--fg-5] mt-1">Archive nodes with no updates for X days</p>
             </div>
           </div>
           <div class="flex gap-2 pt-1">
             <button
               @click="saveArchiveSettings"
               :disabled="archiveStatus === 'saving'"
-              class="flex-1 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg px-4 py-2 transition-colors"
+              class="flex-1 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-[--fg-1] text-sm font-medium rounded-lg px-4 py-2 transition-colors"
             >
               {{ archiveStatus === 'saving' ? 'Saving...' : 'Save' }}
             </button>
           </div>
-          <p v-if="archiveMessage" :class="archiveStatus === 'saved' ? 'text-green-400' : 'text-red-400'" class="text-sm">
+          <p v-if="archiveMessage" :class="archiveStatus === 'saved' ? 'text-[--status-done-fg]' : 'text-[--status-block-fg]'" class="text-sm">
             {{ archiveMessage }}
           </p>
         </div>
@@ -437,15 +437,15 @@ async function linkTelegram() {
 
       <!-- LLM Configuration -->
       <section v-if="llmConfig" class="mb-8">
-        <h2 class="text-sm font-semibold text-white/50 uppercase tracking-wider mb-3">LLM Configuration</h2>
-        <div class="bg-gray-800 rounded-xl p-4 space-y-4">
+        <h2 class="text-sm font-semibold text-[--fg-3] uppercase tracking-wider mb-3">LLM Configuration</h2>
+        <div class="bg-[--bg-elev-1] rounded-xl p-4 space-y-4">
 
           <!-- Preferred Backend -->
           <div>
-            <label class="text-xs text-gray-400 mb-1 block">Preferred Backend</label>
+            <label class="text-xs text-[--fg-4] mb-1 block">Preferred Backend</label>
             <select
               v-model="llmConfig.llm.preferred_backend"
-              class="w-full bg-gray-700 text-white rounded-lg px-3 py-2 text-sm border border-gray-600 focus:outline-none focus:border-indigo-500"
+              class="w-full bg-[--bg-elev-2] text-[--fg-1] rounded-lg px-3 py-2 text-sm border border-[--border-1] focus:outline-none focus:border-indigo-500"
             >
               <option v-for="b in backendOptions" :key="b" :value="b">{{ b }}</option>
             </select>
@@ -454,12 +454,12 @@ async function linkTelegram() {
           <!-- Extended Thinking -->
           <div class="flex items-center justify-between">
             <div>
-              <div class="text-sm text-white">Extended Thinking</div>
-              <div class="text-xs text-gray-400">Allows deeper reasoning before responding</div>
+              <div class="text-sm text-[--fg-1]">Extended Thinking</div>
+              <div class="text-xs text-[--fg-4]">Allows deeper reasoning before responding</div>
             </div>
             <button
               @click="llmConfig.llm.thinking_enabled = !llmConfig.llm.thinking_enabled"
-              :class="llmConfig.llm.thinking_enabled ? 'bg-indigo-600' : 'bg-gray-600'"
+              :class="llmConfig.llm.thinking_enabled ? 'bg-indigo-600' : 'bg-[--bg-elev-3]'"
               class="relative w-11 h-6 rounded-full transition-colors"
             >
               <span
@@ -471,7 +471,7 @@ async function linkTelegram() {
 
           <!-- Thinking Budget -->
           <div v-if="llmConfig.llm.thinking_enabled">
-            <label class="text-xs text-gray-400 mb-1 block">
+            <label class="text-xs text-[--fg-4] mb-1 block">
               Thinking Budget: {{ llmConfig.llm.thinking_budget.toLocaleString() }} tokens
             </label>
             <input
@@ -482,38 +482,38 @@ async function linkTelegram() {
               step="1000"
               class="w-full accent-indigo-500"
             />
-            <div class="flex justify-between text-xs text-gray-500 mt-1">
+            <div class="flex justify-between text-xs text-[--fg-5] mt-1">
               <span>2K</span><span>16K</span><span>32K</span>
             </div>
           </div>
 
           <!-- Beacon Settings -->
-          <div class="border-t border-gray-700 pt-3 mt-3">
-            <div class="text-sm text-white mb-2">Beacon (Background Agent)</div>
+          <div class="border-t border-[--border-1] pt-3 mt-3">
+            <div class="text-sm text-[--fg-1] mb-2">Beacon (Background Agent)</div>
             <div class="grid grid-cols-2 gap-3">
               <div>
-                <label class="text-xs text-gray-400 mb-1 block">Score Threshold</label>
+                <label class="text-xs text-[--fg-4] mb-1 block">Score Threshold</label>
                 <input
                   type="number"
                   v-model.number="llmConfig.llm.beacon_score_threshold"
                   min="1" max="50"
-                  class="w-full bg-gray-700 text-white rounded-lg px-3 py-2 text-sm border border-gray-600 focus:outline-none focus:border-indigo-500"
+                  class="w-full bg-[--bg-elev-2] text-[--fg-1] rounded-lg px-3 py-2 text-sm border border-[--border-1] focus:outline-none focus:border-indigo-500"
                 />
               </div>
               <div>
-                <label class="text-xs text-gray-400 mb-1 block">Cooldown (min)</label>
+                <label class="text-xs text-[--fg-4] mb-1 block">Cooldown (min)</label>
                 <input
                   type="number"
                   v-model.number="llmConfig.llm.beacon_cooldown_minutes"
                   min="5" max="120"
-                  class="w-full bg-gray-700 text-white rounded-lg px-3 py-2 text-sm border border-gray-600 focus:outline-none focus:border-indigo-500"
+                  class="w-full bg-[--bg-elev-2] text-[--fg-1] rounded-lg px-3 py-2 text-sm border border-[--border-1] focus:outline-none focus:border-indigo-500"
                 />
               </div>
             </div>
           </div>
 
           <!-- Advanced: Model Roles -->
-          <div class="border-t border-gray-700 pt-3 mt-3">
+          <div class="border-t border-[--border-1] pt-3 mt-3">
             <button
               @click="showAdvanced = !showAdvanced"
               class="text-sm text-indigo-400 hover:text-indigo-300 flex items-center gap-1"
@@ -523,11 +523,11 @@ async function linkTelegram() {
             </button>
             <div v-if="showAdvanced" class="mt-3 space-y-2">
               <div v-for="role in llmConfig.model_roles" :key="role">
-                <label class="text-xs text-gray-400 mb-1 block">{{ role.replace(/_/g, ' ') }}</label>
+                <label class="text-xs text-[--fg-4] mb-1 block">{{ role.replace(/_/g, ' ') }}</label>
                 <input
                   type="text"
                   v-model="llmConfig.models[role]"
-                  class="w-full bg-gray-700 text-white rounded-lg px-3 py-2 text-sm border border-gray-600 focus:outline-none focus:border-indigo-500 font-mono text-xs"
+                  class="w-full bg-[--bg-elev-2] text-[--fg-1] rounded-lg px-3 py-2 text-sm border border-[--border-1] focus:outline-none focus:border-indigo-500 font-mono text-xs"
                 />
               </div>
             </div>
@@ -538,18 +538,18 @@ async function linkTelegram() {
             <button
               @click="saveLLMConfig"
               :disabled="llmStatus === 'saving'"
-              class="flex-1 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg px-4 py-2 transition-colors"
+              class="flex-1 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-[--fg-1] text-sm font-medium rounded-lg px-4 py-2 transition-colors"
             >
               {{ llmStatus === 'saving' ? 'Saving...' : 'Save' }}
             </button>
             <button
               @click="resetLLMDefaults"
-              class="bg-gray-700 hover:bg-gray-600 text-white text-sm font-medium rounded-lg px-4 py-2 border border-gray-600 transition-colors"
+              class="bg-[--bg-elev-2] hover:bg-[--bg-elev-3] text-[--fg-1] text-sm font-medium rounded-lg px-4 py-2 border border-[--border-1] transition-colors"
             >
               Reset Defaults
             </button>
           </div>
-          <p v-if="llmMessage" :class="llmStatus === 'saved' ? 'text-green-400' : 'text-red-400'" class="text-sm">
+          <p v-if="llmMessage" :class="llmStatus === 'saved' ? 'text-[--status-done-fg]' : 'text-[--status-block-fg]'" class="text-sm">
             {{ llmMessage }}
           </p>
         </div>


### PR DESCRIPTION
## Summary
Wave 1 follow-up to the merged theme-tailwind-migration PR #243, on the same branch rebased onto current main (which now has #243 + theme-drawer #244).

- **AnchorBlock dual-sidebar fix**: drop `:color` prop on outer GroupContainer so the only accent rail is the `var(--m)` motif line; the structural rail falls back to GroupContainer's neutral `--fg-5` hairline.
- **Day/night toggle in nav**: `☀/☾` button driven by `useTheme().setMode`, placed before the theme drawer trigger. Has `:title` + `:aria-label`. Rebase also migrated the theme-drawer button's leftover `text-white/X` and `bg-white/10` classes to elev tokens — in scope for this branch.
- **SettingsView CSS token migration**: ~70 hardcoded `bg-gray-*`/`text-white*`/`border-gray-*`/`placeholder-gray-*` classes plus semantic `green-400`/`red-400`/`emerald-700` swapped for the design token layer. Indigo accent classes preserved; `text-white` kept on indigo-fill buttons so light-mode contrast stays correct.

## Test plan
- [x] vue-tsc --noEmit clean
- [x] `pr-review-toolkit:code-reviewer` pass — no blockers; two minor notes (aria-label, white-on-indigo) addressed in `bf5e74d`
- [ ] Toggle day/night in nav, verify mode persists and SVG flips
- [ ] Inspect any anchor on Plan view — only the motif `var(--m)` rail visible (no double line)
- [ ] Settings page in both dark and light theme — no hardcoded grays/whites visible