### PR TITLE
feat(auth): per-user is_paid from subscriptions table

### DIFF
--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -21,7 +21,8 @@ from api.oauth_state import make_signed_state, verify_signed_state
 import api.config as cfg
 import db.postgres as pg
 import db.pg_auth_queries as auth_queries
-from db.pg_queries import seed_default_anchors, seed_kanban_columns
+from db.pg_queries import seed_default_anchors, seed_kanban_columns, get_user_is_paid
+from db.pool_middleware import get_db_conn
 
 
 router = APIRouter()
@@ -45,13 +46,13 @@ def _set_auth_cookie(response: Response, token: str) -> None:
     )
 
 
-def _safe_user(user: dict) -> dict:
+def _safe_user(user: dict, is_paid: bool) -> dict:
     return {
         "user_id": user["id"],
         "username": user["username"],
         "email": user["email"],
         "is_admin": bool(user["is_admin"]),
-        "is_paid": cfg.IS_COMMUNITY_EDITION,
+        "is_paid": is_paid,
     }
 
 
@@ -100,6 +101,7 @@ async def register(body: RegisterBody, response: Response, request: Request):
         async with pg.get_conn(pool, user_id=user["id"]) as user_conn:
             await seed_default_anchors(user_conn)
             await seed_kanban_columns(user_conn)
+            is_paid = await get_user_is_paid(user_conn)
     except Exception:
         logging.getLogger(__name__).error(
             "Failed to seed defaults for new user %s — account exists but may be missing defaults",
@@ -109,7 +111,7 @@ async def register(body: RegisterBody, response: Response, request: Request):
 
     token = create_jwt(user["id"], user["username"], bool(user["is_admin"]))
     _set_auth_cookie(response, token)
-    return _safe_user(user)
+    return _safe_user(user, is_paid)
 
 
 # ---------------------------------------------------------------------------
@@ -137,9 +139,12 @@ async def login(body: LoginBody, response: Response, request: Request):
     if not verify_password(body.password, user["password_hash"]):
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
+    async with pg.get_conn(pool, user_id=user["id"]) as user_conn:
+        is_paid = await get_user_is_paid(user_conn)
+
     token = create_jwt(user["id"], user["username"], bool(user["is_admin"]))
     _set_auth_cookie(response, token)
-    return _safe_user(user)
+    return _safe_user(user, is_paid)
 
 
 # ---------------------------------------------------------------------------
@@ -157,12 +162,13 @@ async def logout(response: Response):
 # ---------------------------------------------------------------------------
 
 @router.get("/auth/me")
-async def me(request: Request, _auth=Depends(auth_dependency)):
+async def me(request: Request, _auth=Depends(auth_dependency), conn=Depends(get_db_conn)):
+    is_paid = await get_user_is_paid(conn)
     return {
         "user_id": request.state.user_id,
         "username": request.state.username,
         "is_admin": request.state.is_admin,
-        "is_paid": cfg.IS_COMMUNITY_EDITION,
+        "is_paid": is_paid,
     }
 
 

--- a/db/pg_queries/__init__.py
+++ b/db/pg_queries/__init__.py
@@ -76,3 +76,6 @@ from db.pg_queries.journal import (
 from db.pg_queries.activity import (
     acquire_lease, release_lease, heartbeat_lease, get_active_writers,
 )
+from db.pg_queries.subscriptions import (
+    get_user_is_paid,
+)

--- a/db/pg_queries/subscriptions.py
+++ b/db/pg_queries/subscriptions.py
@@ -1,0 +1,15 @@
+"""Async Postgres queries — subscriptions table."""
+from __future__ import annotations
+
+import asyncpg
+
+
+async def get_user_is_paid(conn: asyncpg.Connection) -> bool:
+    """Return True iff the current user has a subscription with plan != 'free'.
+
+    Relies on RLS: the conn must be user-scoped via current_setting('app.current_user_id').
+    A missing subscription row is treated as 'free' (returns False), so newly
+    registered users start unpaid until a subscription row is created.
+    """
+    plan = await conn.fetchval("SELECT plan FROM subscriptions LIMIT 1")
+    return plan is not None and plan != "free"

--- a/db/pg_queries/subscriptions.py
+++ b/db/pg_queries/subscriptions.py
@@ -5,11 +5,27 @@ import asyncpg
 
 
 async def get_user_is_paid(conn: asyncpg.Connection) -> bool:
-    """Return True iff the current user has a subscription with plan != 'free'.
+    """Return True iff the current user has an active subscription with plan != 'free'.
 
     Relies on RLS: the conn must be user-scoped via current_setting('app.current_user_id').
-    A missing subscription row is treated as 'free' (returns False), so newly
-    registered users start unpaid until a subscription row is created.
+    Raises RuntimeError if the RLS context is not set, so a future caller that
+    forgets to pass a user-scoped conn fails loudly instead of silently marking
+    every user as unpaid.
+
+    A row with status != 'active' (e.g. 'cancelled', 'past_due') does not grant
+    paid access — billing state, not the plan column alone, drives is_paid.
+    A missing row is treated as free.
     """
-    plan = await conn.fetchval("SELECT plan FROM subscriptions LIMIT 1")
+    rls_user_id = await conn.fetchval(
+        "SELECT current_setting('app.current_user_id', true)"
+    )
+    if not rls_user_id:
+        raise RuntimeError(
+            "get_user_is_paid called without a user-scoped connection "
+            "(app.current_user_id not set)"
+        )
+    plan = await conn.fetchval(
+        "SELECT plan FROM subscriptions WHERE status = 'active' LIMIT 1"
+    )
+    # plan is None when no active row exists (legitimate free state).
     return plan is not None and plan != "free"

--- a/tests/api/test_user_preferences.py
+++ b/tests/api/test_user_preferences.py
@@ -93,3 +93,27 @@ async def test_auth_me_is_paid_true_for_premium_plan(api_client, conn):
     resp = await api_client.get("/auth/me")
     assert resp.status_code == 200
     assert resp.json()["is_paid"] is True
+
+
+@pytest.mark.asyncio
+async def test_auth_me_is_paid_false_for_cancelled_premium(api_client, conn):
+    """A premium subscription with status!='active' does not grant paid access."""
+    await conn.execute(
+        "INSERT INTO subscriptions (user_id, plan, status) VALUES ($1::uuid, 'premium', 'cancelled')",
+        TEST_USER_ID,
+    )
+    resp = await api_client.get("/auth/me")
+    assert resp.status_code == 200
+    assert resp.json()["is_paid"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_user_is_paid_raises_without_rls_context(conn):
+    """get_user_is_paid raises RuntimeError when called on an unscoped connection,
+    so a future caller that forgets to pass a user-scoped conn fails loudly."""
+    from db.pg_queries import get_user_is_paid
+
+    # Reset the RLS context that the conn fixture set, simulating an unscoped conn.
+    await conn.execute("SELECT set_config('app.current_user_id', '', true)")
+    with pytest.raises(RuntimeError, match="user-scoped connection"):
+        await get_user_is_paid(conn)

--- a/tests/api/test_user_preferences.py
+++ b/tests/api/test_user_preferences.py
@@ -61,12 +61,35 @@ async def test_patch_overwrites_existing(api_client, conn):
 
 
 @pytest.mark.asyncio
-async def test_auth_me_includes_is_paid(api_client, conn):
-    """GET /auth/me response includes is_paid as a bool (False when TETHER_COMMUNITY_EDITION not set)."""
+async def test_auth_me_includes_is_paid_no_subscription(api_client, conn):
+    """GET /auth/me returns is_paid=False when the user has no subscription row."""
     resp = await api_client.get("/auth/me")
     assert resp.status_code == 200
     data = resp.json()
     assert "is_paid" in data
     assert isinstance(data["is_paid"], bool)
-    # In test env TETHER_COMMUNITY_EDITION is not set → False
     assert data["is_paid"] is False
+
+
+@pytest.mark.asyncio
+async def test_auth_me_is_paid_false_for_free_plan(api_client, conn):
+    """A subscription row with plan='free' yields is_paid=False."""
+    await conn.execute(
+        "INSERT INTO subscriptions (user_id, plan) VALUES ($1::uuid, 'free')",
+        TEST_USER_ID,
+    )
+    resp = await api_client.get("/auth/me")
+    assert resp.status_code == 200
+    assert resp.json()["is_paid"] is False
+
+
+@pytest.mark.asyncio
+async def test_auth_me_is_paid_true_for_premium_plan(api_client, conn):
+    """A subscription row with plan!='free' (e.g. 'premium') yields is_paid=True."""
+    await conn.execute(
+        "INSERT INTO subscriptions (user_id, plan) VALUES ($1::uuid, 'premium')",
+        TEST_USER_ID,
+    )
+    resp = await api_client.get("/auth/me")
+    assert resp.status_code == 200
+    assert resp.json()["is_paid"] is True


### PR DESCRIPTION
## Summary
- `_safe_user(user, is_paid)` is now a pure function. `is_paid` is derived per-user from the `subscriptions` table instead of the unrelated `cfg.IS_COMMUNITY_EDITION` flag.
- New `db/pg_queries/subscriptions.py::get_user_is_paid(conn)` — returns True iff an active subscription with `plan != 'free'` exists for the RLS-scoped user. Missing row → False (free).
- `WHERE status = 'active'` filter ensures cancelled / past_due rows do not grant paid access — billing state, not the plan column alone, drives `is_paid`.
- Defense-in-depth: `get_user_is_paid` raises `RuntimeError` if called on a conn without `app.current_user_id` set, so a future caller forgetting to use a user-scoped conn fails loudly instead of silently marking every user as unpaid.
- `/auth/me` now uses `Depends(get_db_conn)` (JWT → user-scoped pool conn).
- register/login open user-scoped conns via `pg.get_conn(pool, user_id=...)` to call `get_user_is_paid`.
- `IS_COMMUNITY_EDITION` flag left untouched (different purpose).

## Test plan
- [x] `tests/api/test_user_preferences.py`:
  - no subscription row → `is_paid: False`
  - `plan='free'` → False
  - `plan='premium'` → True
  - `plan='premium', status='cancelled'` → False
  - unscoped conn → `RuntimeError` from `get_user_is_paid`
- [ ] CI green