### PR TITLE
fix(frontend): theme drawer + nav day-mode usability

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -105,7 +105,7 @@ async function logout() {
         <button
           @click="themeDrawerOpen = true"
           data-testid="theme-drawer-trigger"
-          class="text-[--fg-4] hover:text-[--fg-2] transition-colors p-1.5 rounded-lg hover:bg-[--bg-elev-3]"
+          class="text-[--fg-3] hover:text-[--fg-1] transition-colors p-1.5 rounded-lg hover:bg-[--bg-elev-3]"
           title="Theme"
           aria-label="Open theme picker"
         >
@@ -115,11 +115,11 @@ async function logout() {
         </button>
 
         <router-link v-if="authStore.user?.is_admin" to="/admin"
-                     class="text-xs text-[--fg-4] hover:text-[--fg-2] border border-[--border-1] rounded px-2 py-1 transition-colors">
+                     class="text-xs text-[--fg-3] hover:text-[--fg-1] border border-[--border-1] rounded px-2 py-1 transition-colors">
           Admin
         </router-link>
         <router-link to="/settings"
-                     class="text-[--fg-4] hover:text-[--fg-2] transition-colors p-1.5 rounded-lg hover:bg-[--bg-elev-3]"
+                     class="text-[--fg-3] hover:text-[--fg-1] transition-colors p-1.5 rounded-lg hover:bg-[--bg-elev-3]"
                      title="Settings">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
@@ -127,7 +127,7 @@ async function logout() {
           </svg>
         </router-link>
         <button @click="logout"
-                class="text-xs text-[--fg-4] hover:text-[--fg-2] border border-[--border-1] rounded px-2 py-1 transition-colors ml-1">
+                class="text-xs text-[--fg-3] hover:text-[--fg-1] border border-[--border-1] rounded px-2 py-1 transition-colors ml-1">
           Logout
         </button>
       </div>

--- a/frontend/src/components/ThemeDrawer.vue
+++ b/frontend/src/components/ThemeDrawer.vue
@@ -51,14 +51,14 @@ watch(() => props.modelValue, async (open) => {
 
 <template>
   <Teleport to="body">
-    <Transition name="fade">
-      <div
-        v-if="modelValue"
-        data-testid="theme-drawer-backdrop"
-        class="fixed inset-0 z-40 bg-black/40"
-        @click="close"
-      />
-    </Transition>
+    <!-- Invisible click-catcher: lets the user see the live-previewed UI behind the drawer
+         while still closing on outside-click. No visual scrim. -->
+    <div
+      v-if="modelValue"
+      data-testid="theme-drawer-backdrop"
+      class="fixed inset-0 z-40"
+      @click="close"
+    />
 
     <Transition name="slide-over">
       <aside
@@ -67,15 +67,15 @@ watch(() => props.modelValue, async (open) => {
         role="dialog"
         aria-modal="true"
         aria-label="Theme picker"
-        class="fixed top-0 right-0 z-50 h-full w-full sm:w-[420px] bg-gray-900 border-l border-white/10 shadow-2xl overflow-y-auto"
+        class="fixed top-0 right-0 z-50 h-full w-full sm:w-[340px] bg-[--bg-canvas] border-l border-[--border-1] shadow-2xl overflow-y-auto"
       >
-        <div class="flex items-center gap-2 px-4 py-3 border-b border-white/10">
-          <span class="text-sm font-semibold text-white/80">Theme</span>
+        <div class="flex items-center gap-2 px-4 py-3 border-b border-[--border-1]">
+          <span class="text-sm font-semibold text-[--fg-2]">Theme</span>
           <div class="flex-1" />
           <button
             ref="closeBtn"
             data-testid="theme-drawer-close"
-            class="text-white/30 hover:text-white transition-colors p-1 rounded hover:bg-white/10"
+            class="text-[--fg-4] hover:text-[--fg-1] transition-colors p-1 rounded hover:bg-[--bg-elev-3]"
             title="Close (Esc)"
             aria-label="Close"
             @click="close"
@@ -88,20 +88,20 @@ watch(() => props.modelValue, async (open) => {
 
         <div class="p-4 space-y-4">
           <!-- Day/night mode toggle -->
-          <div class="flex items-center justify-between rounded-lg bg-gray-800 px-3 py-2.5">
-            <span class="text-xs uppercase tracking-wider text-white/50">Mode</span>
+          <div class="flex items-center justify-between rounded-lg bg-[--bg-elev-2] px-3 py-2.5">
+            <span class="text-xs uppercase tracking-wider text-[--fg-4]">Mode</span>
             <div class="flex items-center gap-1" role="group" aria-label="Mode">
               <button
                 data-testid="mode-light"
                 class="px-2.5 py-1 rounded text-xs transition-colors"
-                :class="activeMode === 'light' ? 'bg-white/20 text-white' : 'text-white/50 hover:bg-white/10'"
+                :class="activeMode === 'light' ? 'bg-[--bg-elev-4] text-[--fg-1]' : 'text-[--fg-4] hover:bg-[--bg-elev-3]'"
                 :aria-pressed="activeMode === 'light'"
                 @click="setMode('light')"
               >Day</button>
               <button
                 data-testid="mode-dark"
                 class="px-2.5 py-1 rounded text-xs transition-colors"
-                :class="activeMode === 'dark' ? 'bg-white/20 text-white' : 'text-white/50 hover:bg-white/10'"
+                :class="activeMode === 'dark' ? 'bg-[--bg-elev-4] text-[--fg-1]' : 'text-[--fg-4] hover:bg-[--bg-elev-3]'"
                 :aria-pressed="activeMode === 'dark'"
                 @click="setMode('dark')"
               >Night</button>
@@ -109,7 +109,7 @@ watch(() => props.modelValue, async (open) => {
           </div>
 
           <!-- Theme swatch grid -->
-          <p class="text-xs text-white/40">Hover to preview, click to apply. Paid themes preview only until unlocked.</p>
+          <p class="text-xs text-[--fg-4]">Hover to preview, click to apply. Paid themes preview only until unlocked.</p>
           <div class="grid grid-cols-2 gap-2">
             <button
               v-for="theme in THEMES"
@@ -125,18 +125,18 @@ watch(() => props.modelValue, async (open) => {
               :class="[
                 activeTheme === theme.id
                   ? 'border-indigo-500 ring-1 ring-indigo-500'
-                  : 'border-gray-700 hover:border-gray-500',
+                  : 'border-[--border-1] hover:border-[--border-2]',
               ]"
             >
               <span
                 class="w-full h-6 rounded"
                 :style="{ background: `linear-gradient(135deg, ${theme.canvas} 60%, ${theme.accent} 100%)` }"
               />
-              <span class="text-xs text-white/80 font-medium leading-tight">{{ theme.name }}</span>
+              <span class="text-xs text-[--fg-2] font-medium leading-tight">{{ theme.name }}</span>
               <span
                 v-if="theme.tier !== 'free'"
                 class="absolute top-1.5 right-1.5 text-[9px] font-bold uppercase tracking-wide px-1 py-0.5 rounded"
-                :class="isThemeUnlocked(theme) ? 'bg-emerald-700/70 text-emerald-200' : 'bg-gray-700/80 text-white/40'"
+                :class="isThemeUnlocked(theme) ? 'bg-[--status-done-bg] text-[--status-done-fg]' : 'bg-[--bg-elev-3] text-[--fg-4]'"
               >{{ isThemeUnlocked(theme) ? 'oss' : 'paid' }}</span>
             </button>
           </div>
@@ -147,9 +147,6 @@ watch(() => props.modelValue, async (open) => {
 </template>
 
 <style scoped>
-.fade-enter-active, .fade-leave-active { transition: opacity 0.15s ease; }
-.fade-enter-from, .fade-leave-to { opacity: 0; }
-
 .slide-over-enter-active, .slide-over-leave-active {
   transition: transform 0.15s ease, opacity 0.15s ease;
 }

--- a/frontend/src/components/ThemeDrawer.vue
+++ b/frontend/src/components/ThemeDrawer.vue
@@ -75,7 +75,7 @@ watch(() => props.modelValue, async (open) => {
           <button
             ref="closeBtn"
             data-testid="theme-drawer-close"
-            class="text-[--fg-4] hover:text-[--fg-1] transition-colors p-1 rounded hover:bg-[--bg-elev-3]"
+            class="text-[--fg-3] hover:text-[--fg-1] transition-colors p-1 rounded hover:bg-[--bg-elev-3]"
             title="Close (Esc)"
             aria-label="Close"
             @click="close"

--- a/frontend/src/components/ThemeDrawer.vue
+++ b/frontend/src/components/ThemeDrawer.vue
@@ -67,7 +67,7 @@ watch(() => props.modelValue, async (open) => {
         role="dialog"
         aria-modal="true"
         aria-label="Theme picker"
-        class="fixed top-0 right-0 z-50 h-full w-full sm:w-[340px] bg-[--bg-canvas] border-l border-[--border-1] shadow-2xl overflow-y-auto"
+        class="fixed top-0 right-0 z-50 h-full w-full sm:w-[320px] bg-[--bg-canvas] border-l border-[--border-1] shadow-2xl overflow-y-auto"
       >
         <div class="flex items-center gap-2 px-4 py-3 border-b border-[--border-1]">
           <span class="text-sm font-semibold text-[--fg-2]">Theme</span>


### PR DESCRIPTION
## Summary
Two user-reported usability fixes on top of the just-merged theme system (PR #244 + #245):

- **Nav icon buttons invisible in light mode**: theme drawer trigger, admin, settings, logout used `text-[--fg-4]` (52% darkness on `--bg-canvas-veil`) → bumped to `text-[--fg-3]` / `hover:text-[--fg-1]` for legible contrast in both modes.
- **Drawer occluded the UI it was meant to preview**: removed the visible `bg-black/40` scrim (kept invisible click-catcher), narrowed drawer 420 → 340px, migrated drawer chrome to semantic tokens (`--bg-canvas`, `--border-1`, `--fg-*`, `--bg-elev-*`, `--status-done-{bg,fg}`) so the drawer itself reflects whichever theme you're hover-previewing.

A11y trade-off documented in the status file: removing the scrim means Tab can leak to background nav. `aria-modal="true"` is preserved for AT, but no focus trap — the drawer's purpose is interactive live preview.

## Test plan
- [x] `pnpm test` — 340 passing
- [x] `vue-tsc --noEmit` clean
- [x] `pr-review-toolkit:code-reviewer` pass — close-button finding addressed in `2c3ae4a`
- [ ] Manually verify the 🎨 button is visible in Paper/Horizon-light, drawer chrome reflects hovered theme, click-outside-the-drawer still closes