### PR TITLE
fix(frontend): migrate unstyled pages to CSS tokens, fix bot/kanban/calendar

### DIFF
--- a/frontend/src/components/BotChat.vue
+++ b/frontend/src/components/BotChat.vue
@@ -40,15 +40,15 @@ function onKeydown(e: KeyboardEvent) {
 <template>
   <div class="flex flex-col h-full" @keydown="onKeydown">
     <!-- Header -->
-    <div class="flex items-center gap-2 px-4 py-3 border-b border-white/10 flex-shrink-0">
+    <div class="flex items-center gap-2 px-4 py-3 border-b border-[--border-1] flex-shrink-0">
       <span
         class="w-2 h-2 rounded-full"
-        :class="chatStore.heartbeat ? 'bg-green-400' : 'bg-red-400'"
+        :class="chatStore.heartbeat ? 'bg-[--status-done-fg]' : 'bg-[--status-block-fg]'"
         title="Bot status"
       />
-      <span class="font-semibold text-sm">Tether</span>
+      <span class="font-semibold text-sm text-[--fg-1]">Tether</span>
       <button
-        class="ml-auto text-white/40 hover:text-white/80 transition-colors p-1"
+        class="ml-auto text-[--fg-4] hover:text-[--fg-1] transition-colors p-1"
         aria-label="Close chat"
         type="button"
         @click="emit('close')"
@@ -66,27 +66,27 @@ function onKeydown(e: KeyboardEvent) {
       @scroll="onScroll"
     >
       <MessageBubble v-for="m in chatStore.messages" :key="m.id" :msg="m" />
-      <p v-if="chatStore.messages.length === 0" class="text-xs text-white/30 text-center pt-8">
+      <p v-if="chatStore.messages.length === 0" class="text-xs text-[--fg-5] text-center pt-8">
         Send a message to start chatting.
       </p>
     </div>
 
     <!-- Composer -->
     <form
-      class="border-t border-white/10 p-3 flex gap-2 flex-shrink-0"
+      class="border-t border-[--border-1] p-3 flex gap-2 flex-shrink-0"
       @submit.prevent="onSubmit"
     >
       <textarea
         v-model="draft"
         rows="1"
         placeholder="Message Tether…"
-        class="flex-1 bg-white/5 rounded-lg px-3 py-2 text-sm outline-none resize-none focus:ring-1 focus:ring-indigo-500"
+        class="flex-1 bg-[--bg-input] text-[--fg-1] border border-[--border-input] rounded-lg px-3 py-2 text-sm outline-none resize-none focus:ring-1 focus:ring-[--accent]"
         @keydown.enter.exact.prevent="onSubmit"
       />
       <button
         type="submit"
         :disabled="chatStore.isStreaming || !draft.trim()"
-        class="text-xs px-3 rounded-lg bg-white/10 hover:bg-white/20 disabled:opacity-30 transition-colors self-end py-2"
+        class="text-xs px-3 rounded-lg bg-[--bg-elev-2] text-[--fg-2] hover:bg-[--bg-elev-3] disabled:opacity-30 transition-colors self-end py-2"
       >
         Send
       </button>

--- a/frontend/src/components/ContextEditor.vue
+++ b/frontend/src/components/ContextEditor.vue
@@ -81,18 +81,18 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="min-h-screen bg-gray-900 text-white p-6"
+  <div class="min-h-screen bg-[--bg-canvas] text-[--fg-1] p-6"
        @dragover="autoScrollDragOver"
        @drop="autoScrollCleanup">
     <div class="flex items-center justify-between mb-4">
       <h2 class="text-lg font-semibold">Context</h2>
-      <label class="flex items-center gap-1.5 text-xs text-white/40 hover:text-white/60 cursor-pointer select-none">
+      <label class="flex items-center gap-1.5 text-xs text-[--fg-4] hover:text-[--fg-2] cursor-pointer select-none">
         <input type="checkbox" v-model="contextStore.showArchived"
                class="accent-blue-500 w-3.5 h-3.5" />
         Show archived
       </label>
     </div>
-    <p v-if="error" class="text-red-400 text-sm mb-2">{{ error }}</p>
+    <p v-if="error" class="text-[--status-block-fg] text-sm mb-2">{{ error }}</p>
 
     <div class="flex flex-col gap-3">
       <ContextTreeNode
@@ -104,7 +104,7 @@ onMounted(async () => {
 
     <!-- Root-level drop zone for reparenting nodes to root -->
     <div class="mt-3 border-2 border-dashed rounded-lg px-4 py-2 text-center text-xs transition-colors"
-         :class="rootDropOver ? 'border-blue-400/60 bg-blue-400/10 text-blue-300' : 'border-white/10 text-white/30'"
+         :class="rootDropOver ? 'border-[--accent] bg-[--accent-veil] text-[--accent]' : 'border-[--border-1] text-[--fg-5]'"
          @dragover="onRootDragOver"
          @dragleave="onRootDragLeave"
          @drop="onRootDrop">
@@ -114,9 +114,9 @@ onMounted(async () => {
     <!-- Add root entry form -->
     <div class="mt-4 flex gap-2">
       <input v-model="newName" placeholder="New context entry name..."
-             class="flex-1 bg-white/10 text-white rounded-lg px-3 py-2 outline-none"
+             class="flex-1 bg-[--bg-input] text-[--fg-1] border border-[--border-input] rounded-lg px-3 py-2 outline-none focus:border-[--accent]"
              @keyup.enter="addRootNode" />
-      <button @click="addRootNode" class="px-4 py-2 bg-blue-500/20 text-blue-300 rounded-lg text-sm">
+      <button @click="addRootNode" class="px-4 py-2 bg-[--accent-veil] text-[--accent] rounded-lg text-sm hover:bg-[--accent-soft]">
         + Add
       </button>
     </div>

--- a/frontend/src/components/KanbanColumn.vue
+++ b/frontend/src/components/KanbanColumn.vue
@@ -131,9 +131,9 @@ function onColumnDrop(evt: DragEvent) {
 <template>
   <div class="flex flex-col min-w-[320px] max-w-[380px] bg-[--bg-elev-1] border border-[--border-1] rounded-xl flex-shrink-0 min-h-0">
     <!-- Column header (fixed, does not scroll) -->
-    <div class="flex items-center gap-2 px-3 py-2.5 border-b border-[--border-1] flex-shrink-0">
+    <div class="flex items-center gap-2 px-3 py-2.5 border-b border-[--border-1] bg-[--bg-elev-2] flex-shrink-0">
       <span v-if="column.color" class="w-2.5 h-2.5 rounded-full flex-shrink-0" :style="{ background: column.color }" />
-      <span class="text-sm font-semibold uppercase tracking-wide"
+      <span class="text-sm font-semibold uppercase tracking-wide text-[--fg-1]"
             :style="column.color ? { color: column.color } : {}">
         {{ column.name }}
       </span>
@@ -142,7 +142,7 @@ function onColumnDrop(evt: DragEvent) {
 
     <!-- Scrollable body (fills remaining column height) -->
     <div class="flex-1 overflow-y-auto p-2 space-y-2 min-h-0 transition-all"
-         :class="dragEnterCount > 0 ? 'ring-2 ring-blue-400/50 bg-blue-400/5' : ''"
+         :class="dragEnterCount > 0 ? 'ring-2 ring-[--accent] bg-[--accent-veil]' : ''"
          @dragenter="onColumnDragEnter"
          @dragover="onColumnDragOver"
          @dragleave="onColumnDragLeave"

--- a/frontend/src/components/MessageBubble.vue
+++ b/frontend/src/components/MessageBubble.vue
@@ -16,21 +16,47 @@ const renderedHtml = computed(() => {
 <template>
   <!-- System message: centered, no bubble -->
   <div v-if="msg.role === 'system'" class="flex justify-center text-center py-1">
-    <span class="text-xs italic text-white/40">{{ msg.content }}</span>
+    <span class="text-xs italic text-[--fg-4]">{{ msg.content }}</span>
   </div>
 
   <!-- User message: right-aligned bubble, plain text -->
   <div v-else-if="msg.role === 'user'" class="flex justify-end">
-    <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2 bg-indigo-600 text-white text-sm whitespace-pre-wrap break-words">
+    <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2 bg-[--accent] text-[--accent-fg] text-sm whitespace-pre-wrap break-words">
       {{ msg.content }}
     </div>
   </div>
 
-  <!-- Bot message: left-aligned bubble, markdown rendered -->
+  <!-- Bot message: left-aligned bubble, markdown rendered.
+       prose-invert is intentionally omitted — token-based fg colors handle
+       light/dark mode, whereas prose-invert hard-codes white text and made
+       bot replies unreadable in Paper / Tether-light. -->
   <div v-else class="flex justify-start">
     <div
-      class="max-w-[75%] rounded-2xl rounded-bl-sm px-4 py-2 bg-white/10 text-white/90 text-sm prose prose-invert prose-sm break-words"
+      class="max-w-[75%] rounded-2xl rounded-bl-sm px-4 py-2 bg-[--bg-elev-2] text-[--fg-1] text-sm prose prose-sm break-words bot-bubble"
       v-html="renderedHtml"
     />
   </div>
 </template>
+
+<style scoped>
+/* Tailwind's `prose` hard-codes color via --tw-prose-* variables. Re-point
+   them at theme tokens so bot replies stay readable in every theme/mode. */
+.bot-bubble :deep() {
+  --tw-prose-body: var(--fg-1);
+  --tw-prose-headings: var(--fg-1);
+  --tw-prose-lead: var(--fg-2);
+  --tw-prose-links: var(--accent);
+  --tw-prose-bold: var(--fg-1);
+  --tw-prose-counters: var(--fg-3);
+  --tw-prose-bullets: var(--fg-4);
+  --tw-prose-hr: var(--border-1);
+  --tw-prose-quotes: var(--fg-2);
+  --tw-prose-quote-borders: var(--border-2);
+  --tw-prose-captions: var(--fg-3);
+  --tw-prose-code: var(--fg-1);
+  --tw-prose-pre-code: var(--fg-1);
+  --tw-prose-pre-bg: var(--bg-elev-1);
+  --tw-prose-th-borders: var(--border-2);
+  --tw-prose-td-borders: var(--border-1);
+}
+</style>

--- a/frontend/src/components/MessageBubble.vue
+++ b/frontend/src/components/MessageBubble.vue
@@ -41,7 +41,7 @@ const renderedHtml = computed(() => {
 <style scoped>
 /* Tailwind's `prose` hard-codes color via --tw-prose-* variables. Re-point
    them at theme tokens so bot replies stay readable in every theme/mode. */
-.bot-bubble :deep() {
+.bot-bubble {
   --tw-prose-body: var(--fg-1);
   --tw-prose-headings: var(--fg-1);
   --tw-prose-lead: var(--fg-2);

--- a/frontend/src/components/MonthView.vue
+++ b/frontend/src/components/MonthView.vue
@@ -90,15 +90,15 @@ watch(viewDate, loadMonth)
 <template>
   <div>
     <div class="flex items-center gap-2 mb-4">
-      <button @click="prevMonth" class="text-white/40 hover:text-white text-lg px-1">‹</button>
-      <span class="text-sm font-medium min-w-[140px] text-center">{{ monthLabel }}</span>
-      <button @click="nextMonth" class="text-white/40 hover:text-white text-lg px-1">›</button>
+      <button @click="prevMonth" class="text-[--fg-4] hover:text-[--fg-1] text-lg px-1">‹</button>
+      <span class="text-sm font-medium min-w-[140px] text-center text-[--fg-1]">{{ monthLabel }}</span>
+      <button @click="nextMonth" class="text-[--fg-4] hover:text-[--fg-1] text-lg px-1">›</button>
     </div>
 
     <!-- Day-of-week headers -->
     <div class="grid grid-cols-7 gap-1 mb-1">
       <div v-for="d in ['Mon','Tue','Wed','Thu','Fri','Sat','Sun']" :key="d"
-           class="text-center text-xs text-white/30 py-1">{{ d }}</div>
+           class="text-center text-xs text-[--fg-5] py-1">{{ d }}</div>
     </div>
 
     <!-- Calendar grid -->
@@ -107,21 +107,21 @@ watch(viewDate, loadMonth)
         v-for="date in calendarDates" :key="date"
         class="relative min-h-[64px] rounded-lg p-1.5 cursor-pointer transition-colors"
         :class="[
-          isCurrentMonth(date) ? 'bg-white/5 hover:bg-white/10' : 'bg-white/2 opacity-40',
-          date === planStore.today ? 'ring-1 ring-white/30' : '',
+          isCurrentMonth(date) ? 'bg-[--bg-elev-2] hover:bg-[--bg-elev-3]' : 'bg-[--bg-elev-1] opacity-40',
+          date === planStore.today ? 'ring-1 ring-[--accent]' : '',
         ]"
         @click="planStore.fetchPlan(date)"
         @dragover.prevent="onDragOverCell(date)"
         @drop.prevent>
-        <div class="text-xs text-white/50 mb-1">
+        <div class="text-xs text-[--fg-3] mb-1">
           {{ new Date(date + 'T12:00:00').getDate() }}
         </div>
         <template v-if="taskCounts(date).total > 0">
-          <div class="text-xs text-white/60">
+          <div class="text-xs text-[--fg-2]">
             {{ taskCounts(date).done }}/{{ taskCounts(date).total }}
           </div>
-          <div class="mt-1 h-1 bg-white/10 rounded-full overflow-hidden">
-            <div class="h-full bg-green-400 rounded-full"
+          <div class="mt-1 h-1 bg-[--bg-elev-3] rounded-full overflow-hidden">
+            <div class="h-full bg-[--status-done-fg] rounded-full"
                  :style="{ width: `${(taskCounts(date).done / taskCounts(date).total) * 100}%` }" />
           </div>
         </template>

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -774,7 +774,7 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
               v-for="task in tasks"
               :key="task.id"
               draggable="true"
-              class="text-xs px-1.5 py-1 rounded cursor-grab hover:bg-[--bg-elev-2] text-[--fg-2] hover:text-[--fg-2] transition-colors truncate"
+              class="text-xs px-1.5 py-1 rounded cursor-grab hover:bg-[--bg-elev-2] text-[--fg-3] hover:text-[--fg-1] transition-colors truncate"
               :class="task.status === 'done' ? 'line-through opacity-40' : ''"
               @click.stop="pushPanel({ kind: 'task', entityId: task.id })"
               @dragstart="(e: DragEvent) => {
@@ -1016,7 +1016,7 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
               <!-- Focused day highlight (stronger than today) -->
               <div
                 v-if="focusedDay === dayKeys[i]"
-                class="absolute inset-0 bg-[--accent-soft] pointer-events-none"
+                class="absolute inset-0 bg-[--accent-veil] pointer-events-none"
               />
 
               <!-- Overlap background bands — light tint over time windows with simultaneous events -->

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -726,18 +726,18 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 </script>
 
 <template>
-  <div class="flex h-full bg-gray-900 text-white overflow-hidden">
+  <div class="flex h-full bg-[--bg-canvas] text-[--fg-1] overflow-hidden">
 
     <!-- ── Anchor / Side Panel ── -->
     <aside
       data-testid="anchor-panel"
-      class="flex-shrink-0 border-r border-white/10 flex flex-col transition-all duration-200 relative"
+      class="flex-shrink-0 border-r border-[--border-1] flex flex-col transition-all duration-200 relative"
       :style="anchorPanelOpen ? { width: sidebarWidth + 'px' } : { width: '40px' }"
     >
       <!-- Toggle button -->
       <button
         data-testid="anchor-panel-toggle"
-        class="flex items-center justify-center h-10 w-full border-b border-white/10 hover:bg-white/10 transition-colors text-white/50 hover:text-white flex-shrink-0"
+        class="flex items-center justify-center h-10 w-full border-b border-[--border-1] hover:bg-[--bg-elev-3] transition-colors text-[--fg-3] hover:text-[--fg-1] flex-shrink-0"
         :title="anchorPanelOpen ? 'Collapse panel' : 'Expand panel'"
         @click="anchorPanelOpen = !anchorPanelOpen"
       >
@@ -753,7 +753,7 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
         class="flex-1 overflow-y-auto p-2 space-y-2"
       >
         <!-- Focused day label -->
-        <div class="text-xs text-white/40 uppercase tracking-wide px-1 pt-1 select-none">
+        <div class="text-xs text-[--fg-4] uppercase tracking-wide px-1 pt-1 select-none">
           {{ new Date(focusedDay + 'T12:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' }) }}
         </div>
 
@@ -761,12 +761,12 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
         <div
           v-for="{ anchor, tasks } in (activeFilterCount > 0 ? filteredAnchorsWithTasks : anchorsWithTasks)"
           :key="anchor.id"
-          class="rounded-lg border border-white/5 overflow-hidden"
+          class="rounded-lg border border-[--border-soft] overflow-hidden"
         >
           <!-- Anchor header -->
           <div class="flex items-center gap-1.5 px-2 py-1.5" :style="{ borderLeft: `3px solid ${anchor.color}` }">
-            <span class="text-xs font-medium text-white/80 truncate flex-1">{{ anchor.name }}</span>
-            <span class="text-[10px] text-white/30">{{ anchor.time }}</span>
+            <span class="text-xs font-medium text-[--fg-2] truncate flex-1">{{ anchor.name }}</span>
+            <span class="text-[10px] text-[--fg-5]">{{ anchor.time }}</span>
           </div>
           <!-- Task list — max height + scroll so one long anchor doesn't consume the panel -->
           <ul class="flex flex-col gap-0.5 px-1 pb-1 max-h-36 overflow-y-auto">
@@ -774,7 +774,7 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
               v-for="task in tasks"
               :key="task.id"
               draggable="true"
-              class="text-xs px-1.5 py-1 rounded cursor-grab hover:bg-white/5 text-white/60 hover:text-white/90 transition-colors truncate"
+              class="text-xs px-1.5 py-1 rounded cursor-grab hover:bg-[--bg-elev-2] text-[--fg-2] hover:text-[--fg-2] transition-colors truncate"
               :class="task.status === 'done' ? 'line-through opacity-40' : ''"
               @click.stop="pushPanel({ kind: 'task', entityId: task.id })"
               @dragstart="(e: DragEvent) => {
@@ -786,13 +786,13 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
             >
               {{ task.text }}
             </li>
-            <li v-if="!tasks.length" class="text-[11px] text-white/20 px-1.5 py-0.5">No tasks</li>
+            <li v-if="!tasks.length" class="text-[11px] text-[--fg-6] px-1.5 py-0.5">No tasks</li>
           </ul>
         </div>
 
-        <div v-if="!anchorsWithTasks.length" class="text-xs text-white/30 px-1">No anchors</div>
+        <div v-if="!anchorsWithTasks.length" class="text-xs text-[--fg-5] px-1">No anchors</div>
 
-        <div class="text-[10px] text-white/20 px-1 pt-2 select-none leading-tight">
+        <div class="text-[10px] text-[--fg-6] px-1 pt-2 select-none leading-tight">
           Drag tasks into the calendar to schedule them
         </div>
       </div>
@@ -800,7 +800,7 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
       <!-- Resize handle — only visible when panel is open -->
       <div
         v-if="anchorPanelOpen"
-        class="absolute top-0 right-0 w-1 h-full cursor-col-resize hover:bg-indigo-500/40 transition-colors z-10"
+        class="absolute top-0 right-0 w-1 h-full cursor-col-resize hover:bg-[--accent-soft] transition-colors z-10"
         @mousedown.prevent="onResizeHandleMousedown"
       />
     </aside>
@@ -809,20 +809,20 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
     <div class="flex-1 flex flex-col min-w-0 overflow-hidden">
 
       <!-- Toolbar -->
-      <header class="flex items-center gap-3 px-4 py-2 border-b border-white/10 flex-shrink-0">
+      <header class="flex items-center gap-3 px-4 py-2 border-b border-[--border-1] flex-shrink-0">
         <h1 class="text-lg font-bold">Calendar</h1>
         <div class="flex items-center gap-1 ml-2">
-          <button @click="navigatePrev" class="px-2 py-0.5 rounded hover:bg-white/10 text-white/60 hover:text-white text-sm transition-colors">‹</button>
-          <button @click="goToday" class="px-2 py-0.5 rounded hover:bg-white/10 text-white/60 hover:text-white text-xs transition-colors">Today</button>
-          <button @click="navigateNext" class="px-2 py-0.5 rounded hover:bg-white/10 text-white/60 hover:text-white text-sm transition-colors">›</button>
+          <button @click="navigatePrev" class="px-2 py-0.5 rounded hover:bg-[--bg-elev-3] text-[--fg-2] hover:text-[--fg-1] text-sm transition-colors">‹</button>
+          <button @click="goToday" class="px-2 py-0.5 rounded hover:bg-[--bg-elev-3] text-[--fg-2] hover:text-[--fg-1] text-xs transition-colors">Today</button>
+          <button @click="navigateNext" class="px-2 py-0.5 rounded hover:bg-[--bg-elev-3] text-[--fg-2] hover:text-[--fg-1] text-sm transition-colors">›</button>
         </div>
-        <span class="text-sm text-white/50">
+        <span class="text-sm text-[--fg-3]">
           {{ viewMode === 'month' ? monthLabel : weekLabel }}
         </span>
         <!-- View mode toggle -->
         <button
           data-testid="view-mode-toggle"
-          class="ml-auto flex items-center gap-1 px-2 py-0.5 rounded text-xs text-white/50 hover:text-white hover:bg-white/10 transition-colors border border-white/10"
+          class="ml-auto flex items-center gap-1 px-2 py-0.5 rounded text-xs text-[--fg-3] hover:text-[--fg-1] hover:bg-[--bg-elev-3] transition-colors border border-[--border-1]"
           @click="viewMode = viewMode === 'week' ? 'month' : 'week'"
         >
           {{ viewMode === 'week' ? 'Month' : 'Week' }}
@@ -834,12 +834,12 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
             data-testid="filter-button"
             class="flex items-center gap-1 px-2 py-0.5 rounded text-xs border transition-colors"
             :class="activeFilterCount > 0
-              ? 'text-indigo-300 border-indigo-500/40 bg-indigo-500/10 hover:bg-indigo-500/20'
-              : 'text-white/50 border-white/10 hover:text-white hover:bg-white/10'"
+              ? 'text-[--accent] border-[--accent-soft] bg-[--accent-veil] hover:bg-[--accent-soft]'
+              : 'text-[--fg-3] border-[--border-1] hover:text-[--fg-1] hover:bg-[--bg-elev-3]'"
             @click.stop="filterOpen = !filterOpen"
           >
             Filter
-            <span v-if="activeFilterCount > 0" class="bg-indigo-500 text-white rounded-full text-[10px] px-1 leading-none py-0.5 font-bold">
+            <span v-if="activeFilterCount > 0" class="bg-[--accent] text-[--accent-fg] rounded-full text-[10px] px-1 leading-none py-0.5 font-bold">
               {{ activeFilterCount }}
             </span>
           </button>
@@ -872,7 +872,7 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
           <div
             v-for="label in DAY_LABELS"
             :key="label"
-            class="text-center text-xs text-white/30 py-1"
+            class="text-center text-xs text-[--fg-5] py-1"
           >
             {{ label }}
           </div>
@@ -886,14 +886,14 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
             :data-day="date"
             class="min-h-[72px] rounded-lg p-1.5 cursor-pointer transition-colors"
             :class="[
-              isCurrentMonth(date) ? 'bg-white/5 hover:bg-white/10' : 'bg-white/[0.02] opacity-40',
-              date === today ? 'ring-1 ring-indigo-400/50' : '',
-              date === focusedDay ? 'ring-1 ring-indigo-400' : '',
+              isCurrentMonth(date) ? 'bg-[--bg-elev-2] hover:bg-[--bg-elev-3]' : 'bg-[--bg-elev-1] opacity-40',
+              date === today ? 'ring-1 ring-[--accent-soft]' : '',
+              date === focusedDay ? 'ring-1 ring-[--accent]' : '',
             ]"
             @click="clickMonthDay(date)"
           >
             <div class="text-xs font-medium mb-1"
-                 :class="date === today ? 'text-indigo-400' : 'text-white/50'">
+                 :class="date === today ? 'text-[--accent]' : 'text-[--fg-3]'">
               {{ new Date(date + 'T12:00:00').getDate() }}
             </div>
             <!-- Event pills -->
@@ -908,7 +908,7 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
               </div>
               <div
                 v-if="eventsForDay(date).length > 3"
-                class="text-[10px] text-white/40 px-1"
+                class="text-[10px] text-[--fg-4] px-1"
               >
                 +{{ eventsForDay(date).length - 3 }} more
               </div>
@@ -927,17 +927,17 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
           <div class="sticky top-0 z-10">
 
             <!-- Day-of-week header -->
-            <div class="flex border-b border-white/10 bg-gray-900 pl-12">
+            <div class="flex border-b border-[--border-1] bg-[--bg-canvas] pl-12">
               <div
                 v-for="(day, i) in days"
                 :key="dayKeys[i]"
                 :data-testid="`day-header-${i}`"
                 :data-day="dayKeys[i]"
                 :data-focused="focusedDay === dayKeys[i] ? 'true' : undefined"
-                class="flex-1 text-center py-1.5 text-xs cursor-pointer hover:bg-white/5 transition-colors select-none"
+                class="flex-1 text-center py-1.5 text-xs cursor-pointer hover:bg-[--bg-elev-2] transition-colors select-none"
                 :class="[
-                  dayKeys[i] === today ? 'text-indigo-400 font-semibold' : 'text-white/50',
-                  focusedDay === dayKeys[i] ? 'bg-indigo-500/10' : '',
+                  dayKeys[i] === today ? 'text-[--accent] font-semibold' : 'text-[--fg-3]',
+                  focusedDay === dayKeys[i] ? 'bg-[--accent-veil]' : '',
                 ]"
                 @click="focusDay(dayKeys[i])"
               >
@@ -946,11 +946,11 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
             </div>
 
             <!-- All-day band — one row above the timed grid, one chip per is_all_day event -->
-            <div data-testid="all-day-band" class="sticky flex border-b border-white/10 bg-gray-900/80 pl-12">
+            <div data-testid="all-day-band" class="sticky flex border-b border-[--border-1] bg-[--bg-canvas-veil] pl-12">
             <div
               v-for="(_, i) in days"
               :key="dayKeys[i]"
-              class="flex-1 min-h-[24px] flex flex-wrap gap-0.5 px-1 py-0.5 border-l border-white/5"
+              class="flex-1 min-h-[24px] flex flex-wrap gap-0.5 px-1 py-0.5 border-l border-[--border-soft]"
             >
               <div
                 v-for="ev in allDayEventsByDay[dayKeys[i]]"
@@ -974,7 +974,7 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
               <div
                 v-for="h in hours"
                 :key="h"
-                class="border-b border-white/5 text-right pr-1 text-[10px] text-white/30"
+                class="border-b border-[--border-soft] text-right pr-1 text-[10px] text-[--fg-5]"
                 :style="{ height: `${HOUR_HEIGHT}px`, lineHeight: `${HOUR_HEIGHT}px` }"
               >
                 {{ h === 0 ? '' : `${h % 12 || 12}${h < 12 ? 'am' : 'pm'}` }}
@@ -987,10 +987,10 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
               :key="dayKeys[i]"
               :data-testid="`day-col-${dayKeys[i]}`"
               :data-day-col="dayKeys[i]"
-              class="flex-1 relative border-l border-white/5 min-w-0"
+              class="flex-1 relative border-l border-[--border-soft] min-w-0"
               :class="[
-                dragOverDay === dayKeys[i] ? 'bg-indigo-500/10' : '',
-                focusedDay === dayKeys[i] ? 'ring-1 ring-inset ring-indigo-400/30' : '',
+                dragOverDay === dayKeys[i] ? 'bg-[--accent-veil]' : '',
+                focusedDay === dayKeys[i] ? 'ring-1 ring-inset ring-[--accent-soft]' : '',
               ]"
               :style="{ height: `${HOUR_HEIGHT * (END_HOUR - START_HOUR)}px` }"
               @click.self="focusDay(dayKeys[i])"
@@ -1003,20 +1003,20 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
               <div
                 v-for="h in hours"
                 :key="h"
-                class="absolute inset-x-0 border-b border-white/5"
+                class="absolute inset-x-0 border-b border-[--border-soft]"
                 :style="{ top: `${(h - START_HOUR) * HOUR_HEIGHT}px`, height: `${HOUR_HEIGHT}px` }"
               />
 
               <!-- Today highlight -->
               <div
                 v-if="dayKeys[i] === today"
-                class="absolute inset-0 bg-indigo-500/5 pointer-events-none"
+                class="absolute inset-0 bg-[--accent-veil] pointer-events-none"
               />
 
               <!-- Focused day highlight (stronger than today) -->
               <div
                 v-if="focusedDay === dayKeys[i]"
-                class="absolute inset-0 bg-indigo-400/8 pointer-events-none"
+                class="absolute inset-0 bg-[--accent-soft] pointer-events-none"
               />
 
               <!-- Overlap background bands — light tint over time windows with simultaneous events -->
@@ -1024,7 +1024,7 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
                 v-for="(band, bi) in overlapBandsByDay[dayKeys[i]]"
                 :key="'overlap-bg-' + bi"
                 data-testid="overlap-background"
-                class="absolute inset-x-0 bg-white/5 pointer-events-none rounded-sm"
+                class="absolute inset-x-0 bg-[--bg-elev-2] pointer-events-none rounded-sm"
                 :style="{ top: `${band.topPx}px`, height: `${band.heightPx}px` }"
               />
 
@@ -1054,7 +1054,7 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
               <!-- Drop indicator (sidebar DnD) -->
               <div
                 v-if="dragOverDay === dayKeys[i] && dragOverHour !== null"
-                class="absolute inset-x-1 h-0.5 bg-indigo-400 rounded pointer-events-none z-20"
+                class="absolute inset-x-1 h-0.5 bg-[--accent] rounded pointer-events-none z-20"
                 :style="{ top: `${(dragOverHour! - START_HOUR) * HOUR_HEIGHT}px` }"
               />
             </div>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -85,23 +85,23 @@ const dayStats = computed(() => {
 </script>
 
 <template>
-  <div class="min-h-screen bg-gray-900 text-white p-6">
+  <div class="min-h-screen bg-[--bg-canvas] text-[--fg-1] p-6">
     <div class="flex items-center gap-4 mb-6">
       <h1 class="text-2xl font-bold">Dashboard</h1>
       <div class="flex items-center gap-2 text-sm">
         <span class="w-2 h-2 rounded-full"
               :class="botStatus === 'ok' ? 'bg-green-400' : botStatus === 'stale' ? 'bg-yellow-400' : 'bg-red-400'" />
-        <span class="text-white/50">Bot {{ botStatus }}</span>
+        <span class="text-[--fg-3]">Bot {{ botStatus }}</span>
       </div>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
       <!-- Now Box -->
-      <div class="bg-white/5 border border-white/10 rounded-xl p-4">
+      <div class="bg-[--bg-elev-2] border border-[--border-1] rounded-xl p-4">
         <div class="flex items-center gap-2 mb-3">
           <div v-if="currentAnchor" class="w-3 h-3 rounded-full" :style="{ background: currentAnchor.color }" />
           <h2 class="font-semibold text-lg">{{ currentAnchor?.name ?? 'No active block' }}</h2>
-          <span class="text-white/40 text-sm ml-auto">{{ currentAnchor?.time }}</span>
+          <span class="text-[--fg-4] text-sm ml-auto">{{ currentAnchor?.time }}</span>
         </div>
         <div v-if="allDayEventsToday.length" class="flex flex-wrap gap-1 mb-2">
           <div v-for="ev in allDayEventsToday" :key="ev.id"
@@ -114,21 +114,21 @@ const dayStats = computed(() => {
         <ul class="flex flex-col gap-1.5">
           <TaskCard v-for="task in currentTasks" :key="task.id"
             :task="task" :editable="false" :show-remove="false" :show-detail-link="false" :compact="true" />
-          <li v-if="!currentTasks.length" class="text-white/30 text-sm">No tasks</li>
+          <li v-if="!currentTasks.length" class="text-[--fg-5] text-sm">No tasks</li>
         </ul>
         <button v-if="currentAnchor" type="button" @click="onAddTaskToNow"
-                class="mt-2 text-xs text-white/40 hover:text-white/70 w-full text-left">
+                class="mt-2 text-xs text-[--fg-4] hover:text-[--fg-2] w-full text-left">
           + Add task
         </button>
       </div>
 
       <!-- Today Box -->
-      <div class="bg-white/5 border border-white/10 rounded-xl p-4">
+      <div class="bg-[--bg-elev-2] border border-[--border-1] rounded-xl p-4">
         <h2 class="font-semibold text-lg mb-3">Today</h2>
         <ul class="flex flex-col gap-2">
           <li v-for="s in dayStats" :key="s.anchor.id"
               class="flex items-center gap-2 text-sm"
-              :class="currentAnchor?.id === s.anchor.id ? 'text-white' : 'text-white/40'">
+              :class="currentAnchor?.id === s.anchor.id ? 'text-[--fg-1]' : 'text-[--fg-4]'">
             <div class="w-2 h-2 rounded-full flex-shrink-0" :style="{ background: s.anchor.color }" />
             <span class="flex-1">{{ s.anchor.name }}</span>
             <span class="text-xs">{{ s.done }}/{{ s.total }}</span>
@@ -137,9 +137,9 @@ const dayStats = computed(() => {
       </div>
 
       <!-- This Week Box -->
-      <div class="bg-white/5 border border-white/10 rounded-xl p-4">
+      <div class="bg-[--bg-elev-2] border border-[--border-1] rounded-xl p-4">
         <h2 class="font-semibold text-lg mb-3">This Week</h2>
-        <p class="text-white/30 text-sm">Coming soon</p>
+        <p class="text-[--fg-5] text-sm">Coming soon</p>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

Wave 1 of the visual-bug sweep. Migrates a handful of views/components from hardcoded Tailwind colors to the `themes.css` token layer, plus three critical "broken in light mode" fixes uncovered along the way.

- **Bot text invisible in light themes** — `prose-invert` was hard-coding white through `--tw-prose-*` CSS vars. Dropped `prose-invert` on the bot bubble and re-pointed every `--tw-prose-*` at theme tokens (`--fg-1`, `--accent`, `--border-{1,2}`, `--bg-elev-1`, etc.) so bot replies stay readable across all 4 free themes × light/dark.
- **Kanban column shell invisible in light themes** — was `bg-white/[0.03]` (3% white tint over canvas). Now `bg-[--bg-elev-1] border-[--border-1]`; header on `--bg-elev-2`; drag-target ring on `--accent`/`--accent-veil`.
- **GroupContainer hardcoded gray-900 as canvas** — `mixWithDark(hex, alpha)` baked `rgb(17,24,39)` into the JS. Replaced with CSS `color-mix(in srgb, color X%, var(--bg-canvas))` so the opaque-mixing intent tracks the active theme. Placeholder pill bumped from `text-white/50` to `text-[--fg-3]` for legibility.
- **Token migrations** — CalendarView, DashboardView, ContextEditor, MonthView, KanbanColumn, GroupContainer all moved to `--bg-canvas`/`--bg-elev-{1..4}`/`--fg-{1..7}`/`--border-{1,2,soft,input}`/`--accent*`/`--status-*` semantic tokens.

### Files changed
- `views/CalendarView.vue` · `views/DashboardView.vue`
- `components/ContextEditor.vue` · `components/BotChat.vue` · `components/MessageBubble.vue`
- `components/MonthView.vue` · `components/KanbanColumn.vue` · `components/GroupContainer.vue`

### Code review
`pr-review-toolkit:code-reviewer` pass found 3 confidence-≥80 findings, all addressed in `d83e6bb`:
1. Empty `:deep()` parens in MessageBubble (Vue compiler drops the rule, prose-vars fix non-functional) → drop the wrapper; custom-prop inheritance handles cascade.
2. CalendarView sidebar task hover was a no-op (`text-[--fg-2]` both states) → `text-[--fg-3] hover:text-[--fg-1]`.
3. CalendarView focused-day overlay ~2.5x too strong (`--accent-soft` ~20%) → `--accent-veil` (~12%) to roughly match the original ~8% indigo-400/8.

`npm run build` clean, zero TS errors.

## Test plan

- [ ] Open `/dashboard`, `/calendar`, `/context`, `/kanban` in each free theme (tether, horizon, contrast, terminal) × light/dark mode — no hardcoded gray-900/white-on-white surfaces.
- [ ] Open the bot chat panel in Paper/Tether-light and confirm bot markdown replies render in `--fg-1` text on `--bg-elev-2` (was white-on-light = invisible).
- [ ] Verify Kanban columns have a visible card shell in light themes (was a 3% white tint on white canvas = invisible).
- [ ] Drag a task into a Kanban column — drag-target ring shows in `--accent`/`--accent-veil`.
- [ ] Hover a sidebar task in the calendar focused-day panel — text brightens from `--fg-3` to `--fg-1`.
- [ ] Click a calendar day to focus — focused tint visible but events still readable (was washing them out at `--accent-soft`).