### PR TITLE
feat(frontend): kanban column motif rail (status-driven defaults)

### DIFF
--- a/frontend/src/components/KanbanColumn.vue
+++ b/frontend/src/components/KanbanColumn.vue
@@ -20,6 +20,22 @@ const emit = defineEmits<{
   (e: 'task-drop', taskId: string, columnId: string): void
 }>()
 
+const STATUS_MOTIF: Record<string, string> = {
+  pending: 'quiet',     todo:  'quiet',
+  in_progress: 'focus', doing: 'focus',
+  done: 'calm',
+  skipped: 'dusk',      skip:  'dusk',
+  blocked: 'energy',    block: 'energy',
+}
+
+const columnMotif = computed(() => {
+  const matchStatus = (props.column.match_rules as { status?: unknown } | null)?.status
+  const entryStatus = (props.column.entry_rules as { set_status?: unknown } | null)?.set_status
+  const status = (typeof matchStatus === 'string' && matchStatus)
+    || (typeof entryStatus === 'string' && entryStatus)
+  return (status && STATUS_MOTIF[status]) || 'anchor'
+})
+
 async function onTaskUpdate(task: Task) {
   // Patch via API — status change, text change, etc.
   await api(`/api/tasks/${task.id}`, {
@@ -129,7 +145,8 @@ function onColumnDrop(evt: DragEvent) {
 </script>
 
 <template>
-  <div class="flex flex-col min-w-[320px] max-w-[380px] bg-[--bg-elev-1] border border-[--border-1] rounded-xl flex-shrink-0 min-h-0">
+  <div :data-motif="columnMotif" class="relative flex flex-col min-w-[320px] max-w-[380px] bg-[--bg-elev-1] border border-[--border-1] rounded-xl flex-shrink-0 min-h-0">
+    <div class="absolute left-0 top-2 bottom-2 w-0.5 rounded-full pointer-events-none" :style="{ background: 'var(--m)' }" />
     <!-- Column header (fixed, does not scroll) -->
     <div class="flex items-center gap-2 px-3 py-2.5 border-b border-[--border-1] bg-[--bg-elev-2] flex-shrink-0">
       <span v-if="column.color" class="w-2.5 h-2.5 rounded-full flex-shrink-0" :style="{ background: column.color }" />

--- a/frontend/src/components/__tests__/KanbanColumn.test.ts
+++ b/frontend/src/components/__tests__/KanbanColumn.test.ts
@@ -74,3 +74,40 @@ describe('KanbanColumn drop target', () => {
     expect(body.classes()).not.toContain('ring-2')
   })
 })
+
+describe('KanbanColumn motif', () => {
+  function mountWith(rules: Partial<Pick<KanbanColumnType, 'match_rules' | 'entry_rules'>>) {
+    setActivePinia(createPinia())
+    return mount(KanbanColumn, {
+      props: {
+        column: { ...testColumn, match_rules: {}, entry_rules: {}, ...rules },
+        tasks: [],
+      },
+    })
+  }
+
+  const cases: Array<[string, string]> = [
+    ['pending', 'quiet'],
+    ['in_progress', 'focus'],
+    ['done', 'calm'],
+    ['skipped', 'dusk'],
+    ['blocked', 'energy'],
+  ]
+
+  for (const [status, expected] of cases) {
+    it(`maps match_rules.status="${status}" to motif="${expected}"`, () => {
+      const w = mountWith({ match_rules: { status } })
+      expect(w.find('[data-motif]').attributes('data-motif')).toBe(expected)
+    })
+  }
+
+  it('falls back to entry_rules.set_status when match_rules has none', () => {
+    const w = mountWith({ match_rules: {}, entry_rules: { set_status: 'done' } })
+    expect(w.find('[data-motif]').attributes('data-motif')).toBe('calm')
+  })
+
+  it('falls back to "anchor" when no status rule is present', () => {
+    const w = mountWith({ match_rules: { plan_date: 'not_null' }, entry_rules: {} })
+    expect(w.find('[data-motif]').attributes('data-motif')).toBe('anchor')
+  })
+})


### PR DESCRIPTION
## Summary
Each Kanban column gets a thin left-edge motif rail driven by the column's status, mirroring how `AnchorBlock` already exposes anchor identity. Default mapping only — no editing UI.

- `KanbanColumn.vue` root gains `:data-motif="columnMotif"` + `relative`, plus a new first-child absolute rail (`w-0.5 top-2 bottom-2 rounded-full pointer-events-none`) painted with `var(--m)`.
- `columnMotif` derives from `column.match_rules.status`, falls back to `column.entry_rules.set_status`, then to `'anchor'` for columns without a status filter (context-grouped, etc.).
- Mapping (canonical status + alias both supported): pending/todo → quiet · in_progress/doing → focus · done → calm · skipped/skip → dusk · blocked/block → energy.
- `top-2 bottom-2` inset chosen so the rail doesn't visually clip into the column's `rounded-xl` corners; `pointer-events-none` preserves drop-target hit-testing.

## Test plan
- [x] `vue-tsc --noEmit` clean
- [x] `pr-review-toolkit:code-reviewer` pass — no findings
- [ ] CI — vitest (local Node 18 can't run rolldown ≥20.12; new motif test cases run on CI)
- [ ] On Kanban view, verify each column shows the expected motif color in its left rail
- [ ] Verify a context-grouped (no-status) column falls back to `anchor`