### PR TITLE
feat(frontend): continuous tether line + anchor focus widget

### DIFF
--- a/frontend/src/components/AnchorBlock.vue
+++ b/frontend/src/components/AnchorBlock.vue
@@ -19,6 +19,9 @@ const props = defineProps<{
   color: string
   date?: string
   motif?: string | null
+  isNow?: boolean
+  isPast?: boolean
+  isLast?: boolean
 }>()
 
 const store = usePlanStore()
@@ -161,9 +164,27 @@ function onDrop(evt: DragEvent, toIndex: number) {
 </script>
 
 <template>
-  <div :data-motif="motif ?? 'anchor'" class="relative">
-    <div class="absolute left-0 top-0 bottom-0 w-1 rounded-full pointer-events-none" :style="{ background: 'var(--m)' }" />
-    <div class="pl-3">
+  <div :data-motif="motif ?? 'anchor'" class="anchor-row">
+    <!-- Rail: dot + connecting line -->
+    <div class="anchor-rail">
+      <div
+        data-testid="anchor-dot"
+        class="anchor-dot"
+        :class="{
+          'anchor-dot--now': isNow,
+          'anchor-dot--past': isPast,
+          'anchor-dot--upcoming': !isNow && !isPast,
+        }"
+      />
+      <div
+        v-if="!isLast"
+        data-testid="anchor-line"
+        class="anchor-line"
+      />
+    </div>
+
+    <!-- Card content -->
+    <div class="min-w-0">
   <GroupContainer :label="`${anchorName} · ${time}`" :collapsible="true" :level="0">
     <template #header-right>
       <span class="text-xs text-[--fg-5]">{{ anchorPlan.tasks.length }}</span>
@@ -272,6 +293,84 @@ function onDrop(evt: DragEvent, toIndex: number) {
     <button type="button" @click="onAddNewTask()"
             class="mt-2 text-xs text-[--fg-4] hover:text-[--fg-2]">+ Add task</button>
   </GroupContainer>
-    </div>
-  </div>
+    </div><!-- end card content -->
+  </div><!-- end anchor-row -->
 </template>
+
+<style scoped>
+/* ── Anchor row: rail column + card column ── */
+.anchor-row {
+  display: grid;
+  grid-template-columns: 24px 1fr;
+  gap: 12px;
+  padding-bottom: 8px; /* matches gap between rows */
+}
+
+/* Rail: vertically stacked dot + line */
+.anchor-rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 10px;
+  position: relative;
+  overflow: visible;
+}
+
+/* Connecting line */
+.anchor-line {
+  flex: 1;
+  width: var(--line-strength, 2px);
+  background: var(--m, var(--line-color));
+  opacity: 0.55;
+  margin-top: 4px;
+  /* Extend 8px past the component to bridge the padding-bottom gap */
+  margin-bottom: -8px;
+  min-height: 16px;
+}
+
+/* Base dot */
+.anchor-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--m, var(--line-color));
+  flex-shrink: 0;
+  position: relative;
+  z-index: 1;
+}
+
+/* Now: larger with glow ring */
+.anchor-dot--now {
+  width: 16px;
+  height: 16px;
+  box-shadow:
+    0 0 0 4px var(--bg-canvas),
+    0 0 0 6px var(--m-line, var(--line-glow)),
+    0 0 14px 2px var(--m-line, var(--line-glow));
+}
+
+/* Past: faded */
+.anchor-dot--past {
+  opacity: 0.35;
+}
+
+/* Upcoming: slightly faded */
+.anchor-dot--upcoming {
+  opacity: 0.55;
+}
+
+/* Terminal theme: square nodes + dashed line */
+[data-theme="terminal"] .anchor-dot {
+  border-radius: 2px;
+  border: 1px solid var(--m, rgba(80, 250, 123, 0.5));
+  background: var(--bg-canvas);
+}
+[data-theme="terminal"] .anchor-dot--now {
+  background: var(--m, var(--accent));
+}
+[data-theme="terminal"] .anchor-line {
+  background: none;
+  border-left: 1.5px dashed var(--m, rgba(80, 250, 123, 0.35));
+  width: 0;
+}
+</style>

--- a/frontend/src/components/AnchorFocusWidget.vue
+++ b/frontend/src/components/AnchorFocusWidget.vue
@@ -1,0 +1,198 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useAnchorStore, computeAnchorStates } from '../stores/anchors'
+import type { Anchor } from '../stores/anchors'
+
+const anchorStore = useAnchorStore()
+
+// Reactive clock — widget auto-shifts as anchors change
+const now = ref(new Date())
+let clockTimer: ReturnType<typeof setInterval> | null = null
+
+onMounted(() => {
+  clockTimer = setInterval(() => { now.value = new Date() }, 60_000)
+})
+onUnmounted(() => {
+  if (clockTimer) clearInterval(clockTimer)
+})
+
+const sorted = computed<Anchor[]>(() =>
+  [...anchorStore.anchors].sort((a, b) => a.time.localeCompare(b.time))
+)
+
+const states = computed(() => computeAnchorStates(sorted.value, now.value))
+
+const currentIndex = computed(() =>
+  sorted.value.findIndex(a => states.value.get(a.id) === 'now')
+)
+
+const prevAnchor = computed<Anchor | null>(() =>
+  currentIndex.value > 0 ? sorted.value[currentIndex.value - 1] : null
+)
+const currentAnchor = computed<Anchor | null>(() =>
+  currentIndex.value >= 0 ? sorted.value[currentIndex.value] : null
+)
+const nextAnchor = computed<Anchor | null>(() =>
+  currentIndex.value >= 0 && currentIndex.value < sorted.value.length - 1
+    ? sorted.value[currentIndex.value + 1]
+    : null
+)
+</script>
+
+<template>
+  <div class="anchor-focus-widget" data-testid="anchor-focus-widget">
+    <!-- Previous anchor -->
+    <div
+      v-if="prevAnchor"
+      data-testid="anchor-focus-prev"
+      class="anchor-focus-row anchor-focus-row--subdued"
+    >
+      <div
+        class="anchor-focus-dot anchor-focus-dot--past"
+        :style="prevAnchor.motif ? { background: `var(--motif-${prevAnchor.motif})` } : {}"
+      />
+      <div class="anchor-focus-content">
+        <span class="anchor-focus-name">{{ prevAnchor.name }}</span>
+        <span class="anchor-focus-time">{{ prevAnchor.time }}</span>
+      </div>
+    </div>
+
+    <!-- Current anchor -->
+    <div
+      v-if="currentAnchor"
+      data-testid="anchor-focus-current"
+      class="anchor-focus-row anchor-focus-row--current"
+    >
+      <div
+        class="anchor-focus-dot anchor-focus-dot--now"
+        :style="currentAnchor.motif
+          ? {
+              background: `var(--motif-${currentAnchor.motif})`,
+              boxShadow: `0 0 0 4px var(--bg-canvas), 0 0 0 6px var(--motif-${currentAnchor.motif}-veil, var(--line-glow))`,
+            }
+          : {}"
+      />
+      <div class="anchor-focus-content">
+        <div class="anchor-focus-name-row">
+          <span class="anchor-focus-name anchor-focus-name--current">{{ currentAnchor.name }}</span>
+          <span class="anchor-focus-badge">now</span>
+        </div>
+        <span class="anchor-focus-time">{{ currentAnchor.time }}</span>
+      </div>
+    </div>
+
+    <!-- Next anchor -->
+    <div
+      v-if="nextAnchor"
+      data-testid="anchor-focus-next"
+      class="anchor-focus-row anchor-focus-row--subdued"
+    >
+      <div
+        class="anchor-focus-dot anchor-focus-dot--upcoming"
+        :style="nextAnchor.motif ? { background: `var(--motif-${nextAnchor.motif})` } : {}"
+      />
+      <div class="anchor-focus-content">
+        <span class="anchor-focus-name">{{ nextAnchor.name }}</span>
+        <span class="anchor-focus-time">{{ nextAnchor.time }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.anchor-focus-widget {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.anchor-focus-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.anchor-focus-row--subdued {
+  opacity: 0.5;
+}
+
+.anchor-focus-row--current {
+  opacity: 1;
+}
+
+/* Dots */
+.anchor-focus-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--line-color);
+}
+
+.anchor-focus-dot--now {
+  width: 12px;
+  height: 12px;
+  background: var(--node-now);
+  box-shadow:
+    0 0 0 3px var(--bg-canvas),
+    0 0 0 5px var(--line-glow);
+}
+
+.anchor-focus-dot--past {
+  background: var(--node-done);
+  opacity: 0.6;
+}
+
+.anchor-focus-dot--upcoming {
+  background: var(--node-fill);
+  border: 1.5px solid var(--line-color);
+}
+
+/* Content */
+.anchor-focus-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.anchor-focus-name-row {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.anchor-focus-name {
+  font-size: 12px;
+  color: var(--fg-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.anchor-focus-name--current {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--fg-1);
+  letter-spacing: -0.01em;
+}
+
+.anchor-focus-badge {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  padding: 2px 5px;
+  border-radius: 2px;
+  background: var(--node-now);
+  color: var(--bg-canvas);
+  flex-shrink: 0;
+}
+
+.anchor-focus-time {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  color: var(--fg-4);
+}
+</style>

--- a/frontend/src/components/DayView.vue
+++ b/frontend/src/components/DayView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { usePlanStore } from '../stores/plan'
-import { useAnchorStore } from '../stores/anchors'
+import { useAnchorStore, computeAnchorStates } from '../stores/anchors'
 import { useAuthStore } from '../stores/auth'
 import AnchorBlock from './AnchorBlock.vue'
 import AnchorEditor from './AnchorEditor.vue'
@@ -14,6 +14,12 @@ const anchorStore = useAnchorStore()
 const authStore = useAuthStore()
 const tab = ref<'plan' | 'context' | 'anchors'>('plan')
 const zoom = ref<'d' | 'w' | 'm'>('d')
+
+// Reactive clock for anchor state updates (refreshes every minute)
+const now = ref(new Date())
+let clockTimer: ReturnType<typeof setInterval> | null = null
+
+const anchorStates = computed(() => computeAnchorStates(anchorStore.anchors, now.value))
 
 const isToday = computed(() => planStore.activeDate === planStore.today)
 
@@ -33,6 +39,11 @@ onMounted(() => {
   planStore.fetchPlan()
   planStore.connectWebSocket()
   anchorStore.fetchAnchors()
+  clockTimer = setInterval(() => { now.value = new Date() }, 60_000)
+})
+
+onUnmounted(() => {
+  if (clockTimer) clearInterval(clockTimer)
 })
 </script>
 
@@ -105,15 +116,18 @@ onMounted(() => {
     <template v-else>
       <div v-if="tab === 'plan'">
         <div v-if="planStore.loading" class="text-white/40">Loading...</div>
-        <div v-else class="flex flex-col gap-2">
+        <div v-else class="flex flex-col">
           <AnchorBlock
-            v-for="anchor in anchorStore.anchors"
+            v-for="(anchor, i) in anchorStore.anchors"
             :key="anchor.id"
             :anchor-id="anchor.id"
             :anchor-name="anchor.name"
             :time="anchor.time"
             :color="anchor.color"
-            :motif="anchor.motif" />
+            :motif="anchor.motif"
+            :is-now="anchorStates.get(anchor.id) === 'now'"
+            :is-past="anchorStates.get(anchor.id) === 'past'"
+            :is-last="i === anchorStore.anchors.length - 1" />
         </div>
       </div>
 

--- a/frontend/src/components/__tests__/AnchorBlock.test.ts
+++ b/frontend/src/components/__tests__/AnchorBlock.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ path: '/' }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: true, json: async () => [] })),
+}))
+
+describe('AnchorBlock', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  async function mountBlock(props: Record<string, unknown> = {}) {
+    const { default: AnchorBlock } = await import('../AnchorBlock.vue')
+    return mount(AnchorBlock, {
+      props: {
+        anchorId: 'a1',
+        anchorName: 'Morning',
+        time: '08:00',
+        color: '#fff',
+        ...props,
+      },
+    })
+  }
+
+  it('renders an anchor dot', async () => {
+    const w = await mountBlock()
+    expect(w.find('[data-testid="anchor-dot"]').exists()).toBe(true)
+  })
+
+  it('applies anchor-dot--now class when isNow is true', async () => {
+    const w = await mountBlock({ isNow: true })
+    const dot = w.find('[data-testid="anchor-dot"]')
+    expect(dot.classes()).toContain('anchor-dot--now')
+  })
+
+  it('applies anchor-dot--past class when isPast is true', async () => {
+    const w = await mountBlock({ isPast: true })
+    const dot = w.find('[data-testid="anchor-dot"]')
+    expect(dot.classes()).toContain('anchor-dot--past')
+  })
+
+  it('hides the tether line when isLast is true', async () => {
+    const w = await mountBlock({ isLast: true })
+    expect(w.find('[data-testid="anchor-line"]').exists()).toBe(false)
+  })
+
+  it('shows the tether line when isLast is false', async () => {
+    const w = await mountBlock({ isLast: false })
+    expect(w.find('[data-testid="anchor-line"]').exists()).toBe(true)
+  })
+})

--- a/frontend/src/components/__tests__/AnchorFocusWidget.test.ts
+++ b/frontend/src/components/__tests__/AnchorFocusWidget.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { nextTick } from 'vue'
+
+import AnchorFocusWidget from '../AnchorFocusWidget.vue'
+import { useAnchorStore } from '../../stores/anchors'
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: true, json: async () => [] })),
+}))
+
+/**
+ * Build three anchors bracketing the real current time so no fake timers
+ * are needed. We place one 2 h before now, one 1 h before now (= "now"),
+ * and one 1 h after now. Edge-case: clamp to [00,23].
+ */
+function makeRealTimeAnchors() {
+  const h = new Date().getHours()
+  const fmt = (n: number) => `${String(Math.min(23, Math.max(0, n))).padStart(2, '0')}:00`
+  return [
+    { id: 'a-prev', name: 'Morning',   time: fmt(h - 2), duration_minutes: 60, flexibility: 'flexible', strictness: 1, color: '#aaa', position: 0, followup_config: null, motif: null },
+    { id: 'a-now',  name: 'Deep Work', time: fmt(h - 1), duration_minutes: 60, flexibility: 'flexible', strictness: 1, color: '#bbb', position: 1, followup_config: null, motif: null },
+    { id: 'a-next', name: 'Wind Down', time: fmt(h + 1), duration_minutes: 60, flexibility: 'flexible', strictness: 1, color: '#ccc', position: 2, followup_config: null, motif: null },
+  ]
+}
+
+describe('AnchorFocusWidget', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  async function mountWidget(anchors = makeRealTimeAnchors()) {
+    const store = useAnchorStore()
+    store.anchors = anchors as typeof store.anchors
+    const wrapper = mount(AnchorFocusWidget)
+    await nextTick()
+    return wrapper
+  }
+
+  it('shows current anchor name when it is the active block', async () => {
+    const w = await mountWidget()
+    const current = w.find('[data-testid="anchor-focus-current"]')
+    expect(current.exists()).toBe(true)
+    expect(current.text()).toContain('Deep Work')
+  })
+
+  it('shows prev anchor at reduced opacity', async () => {
+    const w = await mountWidget()
+    const prev = w.find('[data-testid="anchor-focus-prev"]')
+    expect(prev.exists()).toBe(true)
+    expect(prev.text()).toContain('Morning')
+    expect(prev.classes()).toContain('anchor-focus-row--subdued')
+  })
+
+  it('shows next anchor at reduced opacity', async () => {
+    const w = await mountWidget()
+    const next = w.find('[data-testid="anchor-focus-next"]')
+    expect(next.exists()).toBe(true)
+    expect(next.text()).toContain('Wind Down')
+    expect(next.classes()).toContain('anchor-focus-row--subdued')
+  })
+
+  it('does not show prev when first anchor is current', async () => {
+    const h = new Date().getHours()
+    const fmt = (n: number) => `${String(Math.min(23, Math.max(0, n))).padStart(2, '0')}:00`
+    // Only two anchors: current (before now) + next (after now) — no prior anchor
+    const anchors = [
+      { id: 'a-now',  name: 'First Block', time: fmt(h - 1), duration_minutes: 60, flexibility: 'flexible', strictness: 1, color: '#bbb', position: 0, followup_config: null, motif: null },
+      { id: 'a-next', name: 'Next Block',  time: fmt(h + 1), duration_minutes: 60, flexibility: 'flexible', strictness: 1, color: '#ccc', position: 1, followup_config: null, motif: null },
+    ]
+    const w = await mountWidget(anchors)
+    expect(w.find('[data-testid="anchor-focus-prev"]').exists()).toBe(false)
+    expect(w.find('[data-testid="anchor-focus-current"]').text()).toContain('First Block')
+  })
+
+  it('does not show next when last anchor is current', async () => {
+    const h = new Date().getHours()
+    const fmt = (n: number) => `${String(Math.min(23, Math.max(0, n))).padStart(2, '0')}:00`
+    // Only two anchors: prev (before now) + current (before now, last) — no future anchor
+    const anchors = [
+      { id: 'a-prev', name: 'Prev Block', time: fmt(h - 2), duration_minutes: 60, flexibility: 'flexible', strictness: 1, color: '#aaa', position: 0, followup_config: null, motif: null },
+      { id: 'a-now',  name: 'Last Block', time: fmt(h - 1), duration_minutes: 60, flexibility: 'flexible', strictness: 1, color: '#bbb', position: 1, followup_config: null, motif: null },
+    ]
+    const w = await mountWidget(anchors)
+    expect(w.find('[data-testid="anchor-focus-next"]').exists()).toBe(false)
+    expect(w.find('[data-testid="anchor-focus-current"]').text()).toContain('Last Block')
+  })
+})

--- a/frontend/src/stores/__tests__/anchorStates.test.ts
+++ b/frontend/src/stores/__tests__/anchorStates.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { computeAnchorStates } from '../anchors'
+import type { Anchor } from '../anchors'
+
+function makeAnchor(time: string, id: string): Anchor {
+  return {
+    id,
+    name: `Anchor ${id}`,
+    time,
+    duration_minutes: 60,
+    flexibility: 'flexible',
+    strictness: 1,
+    color: '#fff',
+    position: 0,
+    followup_config: null,
+    motif: null,
+  }
+}
+
+const anchors: Anchor[] = [
+  makeAnchor('08:00', 'a1'),
+  makeAnchor('12:00', 'a2'),
+  makeAnchor('17:00', 'a3'),
+]
+
+describe('computeAnchorStates', () => {
+  it('marks first anchor as now when time is before all anchor times', () => {
+    const now = new Date()
+    now.setHours(6, 0, 0, 0)
+    const states = computeAnchorStates(anchors, now)
+    expect(states.get('a1')).toBe('now')
+    expect(states.get('a2')).toBe('future')
+    expect(states.get('a3')).toBe('future')
+  })
+
+  it('marks last anchor as now when time is after all anchor times', () => {
+    const now = new Date()
+    now.setHours(20, 0, 0, 0)
+    const states = computeAnchorStates(anchors, now)
+    expect(states.get('a1')).toBe('past')
+    expect(states.get('a2')).toBe('past')
+    expect(states.get('a3')).toBe('now')
+  })
+
+  it('marks the correct anchor as now for mid-day time', () => {
+    const now = new Date()
+    now.setHours(14, 0, 0, 0)
+    const states = computeAnchorStates(anchors, now)
+    expect(states.get('a1')).toBe('past')
+    expect(states.get('a2')).toBe('now')
+    expect(states.get('a3')).toBe('future')
+  })
+
+  it('marks all anchors past current as future', () => {
+    const now = new Date()
+    now.setHours(9, 0, 0, 0)
+    const states = computeAnchorStates(anchors, now)
+    expect(states.get('a1')).toBe('now')
+    expect(states.get('a2')).toBe('future')
+    expect(states.get('a3')).toBe('future')
+  })
+})

--- a/frontend/src/stores/anchors.ts
+++ b/frontend/src/stores/anchors.ts
@@ -23,6 +23,36 @@ export interface Anchor {
   motif?: string | null
 }
 
+export type AnchorState = 'past' | 'now' | 'future'
+
+/**
+ * Pure helper — given a list of anchors and a reference time, returns a map of
+ * anchorId → 'past' | 'now' | 'future'.
+ *
+ * Algorithm: sort by time, find the last anchor whose HH:MM ≤ now — that's "now".
+ * Everything before it is "past", everything after is "future". If now is before
+ * the first anchor, the first anchor is still "now" (no prior block active).
+ */
+export function computeAnchorStates(anchors: Anchor[], now: Date): Map<string, AnchorState> {
+  const sorted = [...anchors].sort((a, b) => a.time.localeCompare(b.time))
+  const nowMinutes = now.getHours() * 60 + now.getMinutes()
+
+  let currentIndex = 0
+  for (let i = 0; i < sorted.length; i++) {
+    const [h, m] = sorted[i].time.split(':').map(Number)
+    if (h * 60 + m <= nowMinutes) currentIndex = i
+    else break
+  }
+
+  const result = new Map<string, AnchorState>()
+  sorted.forEach((a, i) => {
+    if (i < currentIndex) result.set(a.id, 'past')
+    else if (i === currentIndex) result.set(a.id, 'now')
+    else result.set(a.id, 'future')
+  })
+  return result
+}
+
 export const useAnchorStore = defineStore('anchors', () => {
   const anchors = ref<Anchor[]>([])
 

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -6,6 +6,7 @@ import { useAnchorStore } from '../stores/anchors'
 import { useMilestoneStore } from '../stores/milestones'
 import { useEventStore } from '../stores/events'
 import TaskCard from '../components/TaskCard.vue'
+import AnchorFocusWidget from '../components/AnchorFocusWidget.vue'
 
 const planStore = usePlanStore()
 const anchorStore = useAnchorStore()
@@ -98,10 +99,8 @@ const dayStats = computed(() => {
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
       <!-- Now Box -->
       <div class="bg-[--bg-elev-2] border border-[--border-1] rounded-xl p-4">
-        <div class="flex items-center gap-2 mb-3">
-          <div v-if="currentAnchor" class="w-3 h-3 rounded-full" :style="{ background: currentAnchor.color }" />
-          <h2 class="font-semibold text-lg">{{ currentAnchor?.name ?? 'No active block' }}</h2>
-          <span class="text-[--fg-4] text-sm ml-auto">{{ currentAnchor?.time }}</span>
+        <div class="mb-3">
+          <AnchorFocusWidget />
         </div>
         <div v-if="allDayEventsToday.length" class="flex flex-wrap gap-1 mb-2">
           <div v-for="ev in allDayEventsToday" :key="ev.id"

--- a/frontend/src/views/PlanView.vue
+++ b/frontend/src/views/PlanView.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { computed, watch, onMounted } from 'vue'
+import { computed, watch, onMounted, onUnmounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { usePlanStore } from '../stores/plan'
-import { useAnchorStore } from '../stores/anchors'
+import { useAnchorStore, computeAnchorStates } from '../stores/anchors'
 import { useMilestoneStore } from '../stores/milestones'
 import { useEventStore } from '../stores/events'
 import { useSlideOver } from '../composables/useSlideOver'
@@ -16,6 +16,11 @@ const props = defineProps<{ view: string; date?: string }>()
 const router = useRouter()
 const planStore = usePlanStore()
 const anchorStore = useAnchorStore()
+
+// Reactive clock — drives current/past/future dot states
+const now = ref(new Date())
+let clockTimer: ReturnType<typeof setInterval> | null = null
+const anchorStates = computed(() => computeAnchorStates(anchorStore.anchors, now.value))
 const milestoneStore = useMilestoneStore()
 const eventStore = useEventStore()
 const { push: pushPanel } = useSlideOver()
@@ -42,6 +47,11 @@ watch(activeDate, (d) => planStore.fetchPlan(d), { immediate: true })
 onMounted(() => {
   anchorStore.fetchAnchors()
   milestoneStore.fetchAll()
+  clockTimer = setInterval(() => { now.value = new Date() }, 60_000)
+})
+
+onUnmounted(() => {
+  if (clockTimer) clearInterval(clockTimer)
 })
 
 function offsetDate(base: string, days: number): string {
@@ -162,18 +172,21 @@ async function onAnchorColumnDrop(e: DragEvent) {
       <div v-else class="grid grid-cols-[1fr_320px] gap-4 items-start">
         <!-- Left: anchor blocks -->
         <div
-          class="flex flex-col gap-2"
+          class="flex flex-col"
           @dragover.prevent
           @drop="onAnchorColumnDrop"
         >
           <AnchorBlock
-            v-for="anchor in anchorStore.anchors"
+            v-for="(anchor, i) in anchorStore.anchors"
             :key="anchor.id"
             :anchor-id="anchor.id"
             :anchor-name="anchor.name"
             :time="anchor.time"
             :color="anchor.color"
-            :motif="anchor.motif" />
+            :motif="anchor.motif"
+            :is-now="anchorStates.get(anchor.id) === 'now'"
+            :is-past="anchorStates.get(anchor.id) === 'past'"
+            :is-last="i === anchorStore.anchors.length - 1" />
         </div>
         <!-- Right: day timeline -->
         <DayTimeline


### PR DESCRIPTION
## Summary

- **Continuous tether line:** `AnchorBlock` now uses a 24px rail column with a themed dot + connecting line instead of a flat colored bar. Dots scale (14px normal / 16px now with glow) and fade by state (past 35%, upcoming 55%). The line bridges the gap between rows via `margin-bottom: -8px` so it reads as one continuous thread. Terminal theme gets square nodes + dashed line.
- **`computeAnchorStates` helper:** Pure exported function in `anchors.ts` — classifies each anchor as `past | now | future` given a `Date`. Used by `DayView`, `PlanView`, and the new widget. Reactive per-minute clock in each parent drives live updates.
- **`AnchorFocusWidget`:** New component showing prev/current/next anchors with the current one foregrounded (name at 16px/600, "now" badge, glow dot) and neighbours subdued (50% opacity). Wired into the Dashboard Now Box, updating every minute.

## Test plan

- [ ] 354 Vitest tests pass (`npm run test` in worktree frontend)
- [ ] Zero TS errors (`npm run build`)
- [ ] `anchorStates.test.ts` — 4 cases covering boundary conditions of `computeAnchorStates`
- [ ] `AnchorBlock.test.ts` — 5 cases: dot renders, now/past classes, line shown/hidden
- [ ] `AnchorFocusWidget.test.ts` — 5 cases: prev/current/next visibility and subdued states
- [ ] Verify visually in DayView, PlanView, and Dashboard with different themes/motifs