### PR TITLE
Wave 2: kanban/calendar reactivity, sticky bgs, chip contrast

### DIFF
--- a/frontend/src/components/GroupContainer.vue
+++ b/frontend/src/components/GroupContainer.vue
@@ -34,9 +34,12 @@ const stickyTop = computed(() => {
     <div class="absolute left-0 top-1 bottom-0 w-px"
          :style="{ background: railColor, opacity: 0.55 }" />
 
-    <!-- Pill heading (sticky below nav bar) -->
+    <!-- Pill heading (sticky below nav bar). Explicit opaque bg so scrolled
+         content beneath the pill doesn't bleed through. --bg-elev-1 matches
+         the kanban column surface (flush) and reads as a subtle header rail
+         on canvas-level surfaces like PlanView. -->
     <div
-      class="flex items-center gap-2 select-none sticky z-10 py-0.5"
+      class="flex items-center gap-2 select-none sticky z-10 py-0.5 bg-[--bg-elev-1]"
       :class="[collapsed ? '' : 'mb-1']"
       :style="{ top: stickyTop }">
       <span class="text-xs font-medium uppercase tracking-wide"

--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -12,6 +12,7 @@ import { useAnchorStore } from '../stores/anchors'
 import { useBacklogStore } from '../stores/backlog'
 import { useEventStore } from '../stores/events'
 import { useTasksStore } from '../stores/tasks'
+import { useKanbanStore } from '../stores/kanban'
 import { useSubtasks } from '../composables/useSubtasks'
 import { useLinks } from '../composables/useLinks'
 import { useDependencies } from '../composables/useDependencies'
@@ -29,6 +30,7 @@ const anchorStore = useAnchorStore()
 const backlogStore = useBacklogStore()
 const eventStore = useEventStore()
 const tasksStore = useTasksStore()
+const kanbanStore = useKanbanStore()
 
 // Calendar event linked to this task, OR the event itself when props.taskId is an event ID
 // (standalone events opened via kind:'event' in SlideOverStack pass event.id as taskId).
@@ -122,6 +124,9 @@ async function patchTask(fields: Record<string, unknown>) {
   } else {
     await planStore.fetchPlan()
   }
+  // Mirror the patch into the kanban store so the kanban view re-renders
+  // when fields like motif/color/text are edited from the detail panel.
+  if (resp.ok) kanbanStore.applyTaskPatch(props.taskId, fields)
 }
 
 // Text editing

--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -115,8 +115,16 @@ async function patchTask(fields: Record<string, unknown>) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(fields),
   })
+  // Optimistic in-place merge: mutate the object task.value points to so
+  // the controlled MotifPicker/text/status inputs in this panel reflect
+  // the change immediately, regardless of which store owns the object.
+  // Without this, a calendar event whose task lives on a non-focused
+  // day's plan would never update — fetchPlan() refetches the focused
+  // day, leaving the panel's task ref stale.
+  if (resp.ok && task.value) {
+    Object.assign(task.value, fields)
+  }
   if (isBacklog.value) {
-    // Update standalone task from response if applicable
     if (resp.ok && standaloneTask.value) {
       standaloneTask.value = await resp.json()
     }

--- a/frontend/src/components/__tests__/MotifPicker.test.ts
+++ b/frontend/src/components/__tests__/MotifPicker.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import MotifPicker from '../MotifPicker.vue'
 
-const SLOTS = ['anchor','focus','calm','energy','care','flow','dusk','quiet']
+const SLOTS = ['anchor','focus','calm','energy','care','flow','dusk','quiet','light','dark']
 
 describe('MotifPicker', () => {
-  it('renders 8 motif dots', () => {
+  it('renders 10 motif dots', () => {
     const wrapper = mount(MotifPicker, { props: { modelValue: null } })
     const dots = wrapper.findAll('[data-testid="motif-dot"]')
-    expect(dots).toHaveLength(8)
+    expect(dots).toHaveLength(10)
     expect(dots.map(d => d.attributes('data-slot'))).toEqual(SLOTS)
   })
 

--- a/frontend/src/composables/useTextOnColor.ts
+++ b/frontend/src/composables/useTextOnColor.ts
@@ -1,0 +1,47 @@
+/**
+ * Pick a foreground color (light or dark) that contrasts a given hex bg.
+ *
+ * Used for chips whose background is a user/motif/event color and therefore
+ * not theme-bound — `text-white` looks great on saturated dark bgs but fails
+ * on lighter motif palettes (notably Paper). WCAG relative luminance with a
+ * 0.5 threshold is the cheap, reliable heuristic.
+ *
+ * Returns `#0a0a0a` (near-black) for light bgs, `#ffffff` for dark bgs, and
+ * `#ffffff` for unparseable inputs (e.g. `var(--motif-anchor)`) — the same
+ * default the chips had before.
+ */
+
+interface RGB { r: number; g: number; b: number }
+
+function parseHex(input: string): RGB | null {
+  const m = input.trim().match(/^#([\da-f]{3}|[\da-f]{6})$/i)
+  if (!m) return null
+  const hex = m[1]
+  if (hex.length === 3) {
+    return {
+      r: parseInt(hex[0] + hex[0], 16),
+      g: parseInt(hex[1] + hex[1], 16),
+      b: parseInt(hex[2] + hex[2], 16),
+    }
+  }
+  return {
+    r: parseInt(hex.slice(0, 2), 16),
+    g: parseInt(hex.slice(2, 4), 16),
+    b: parseInt(hex.slice(4, 6), 16),
+  }
+}
+
+function relativeLuminance({ r, g, b }: RGB): number {
+  const ch = (c: number) => {
+    const cs = c / 255
+    return cs <= 0.03928 ? cs / 12.92 : ((cs + 0.055) / 1.055) ** 2.4
+  }
+  return 0.2126 * ch(r) + 0.7152 * ch(g) + 0.0722 * ch(b)
+}
+
+export function textOnColor(bg: string | null | undefined): string {
+  if (!bg) return '#ffffff'
+  const rgb = parseHex(bg)
+  if (!rgb) return '#ffffff'
+  return relativeLuminance(rgb) > 0.5 ? '#0a0a0a' : '#ffffff'
+}

--- a/frontend/src/stores/kanban.ts
+++ b/frontend/src/stores/kanban.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { api } from '../lib/api'
+import type { Task } from './plan'
 
 export interface KanbanColumn {
   id: string
@@ -12,9 +13,16 @@ export interface KanbanColumn {
   created_by: string | null
 }
 
+export interface KanbanTask extends Task {
+  plan_date: string | null
+  anchor_id: string | null
+}
+
 export const useKanbanStore = defineStore('kanban', () => {
   const columns = ref<KanbanColumn[]>([])
+  const allTasks = ref<KanbanTask[]>([])
   const loading = ref(false)
+  const tasksLoading = ref(false)
   const error = ref<string | null>(null)
 
   async function fetchColumns() {
@@ -34,5 +42,38 @@ export const useKanbanStore = defineStore('kanban', () => {
     }
   }
 
-  return { columns, loading, error, fetchColumns }
+  async function fetchAllTasks() {
+    tasksLoading.value = true
+    try {
+      const resp = await api('/api/tasks/all')
+      if (!resp.ok) throw new Error(`${resp.status}`)
+      allTasks.value = await resp.json()
+    } catch (e) {
+      console.error('fetchAllTasks error:', e)
+    } finally {
+      tasksLoading.value = false
+    }
+  }
+
+  /**
+   * Merge a partial PATCH into the local task copy so views holding
+   * `allTasks` re-render immediately after a detail-panel edit.
+   * No-op if the task isn't in the local list (e.g. kanban not loaded yet).
+   */
+  function applyTaskPatch(taskId: string, patch: Partial<KanbanTask>) {
+    const i = allTasks.value.findIndex(t => t.id === taskId)
+    if (i === -1) return
+    allTasks.value[i] = { ...allTasks.value[i], ...patch }
+  }
+
+  return {
+    columns,
+    allTasks,
+    loading,
+    tasksLoading,
+    error,
+    fetchColumns,
+    fetchAllTasks,
+    applyTaskPatch,
+  }
 })

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -945,8 +945,10 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
               </div>
             </div>
 
-            <!-- All-day band — one row above the timed grid, one chip per is_all_day event -->
-            <div data-testid="all-day-band" class="sticky flex border-b border-[--border-1] bg-[--bg-canvas-veil] pl-12">
+            <!-- All-day band — one row above the timed grid, one chip per is_all_day event.
+                 Use opaque --bg-canvas (not the 80% veil) so timed-grid events scrolling
+                 underneath don't bleed through this sticky band. -->
+            <div data-testid="all-day-band" class="sticky flex border-b border-[--border-1] bg-[--bg-canvas] pl-12">
             <div
               v-for="(_, i) in days"
               :key="dayKeys[i]"

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -13,6 +13,7 @@ import CalendarFilterPanel from '../components/CalendarFilterPanel.vue'
 import RecurrenceEditDialog from '../components/RecurrenceEditDialog.vue'
 import type { RecurrenceEditScope, PendingRecurrence } from '../types/recurrence'
 import { resolveEventColor } from '../composables/useColorResolver'
+import { textOnColor } from '../composables/useTextOnColor'
 import { computeOverlapLayout, computeOverlapBands, type EventLayout, type OverlapBand } from '../composables/useOverlapLayout'
 import type { CalendarEvent } from '../types/events'
 import type { Anchor } from '../stores/anchors'
@@ -901,8 +902,8 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
               <div
                 v-for="ev in eventsForDay(date).slice(0, 3)"
                 :key="ev.id"
-                class="rounded text-[10px] px-1 py-0.5 truncate font-medium text-white leading-none"
-                :style="{ backgroundColor: resolveColor(ev) }"
+                class="rounded text-[10px] px-1 py-0.5 truncate font-medium leading-none"
+                :style="{ backgroundColor: resolveColor(ev), color: textOnColor(resolveColor(ev)) }"
               >
                 {{ ev.title }}
               </div>
@@ -957,8 +958,8 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
               <div
                 v-for="ev in allDayEventsByDay[dayKeys[i]]"
                 :key="ev.id"
-                class="rounded text-[10px] px-1 py-0.5 truncate font-medium text-white leading-none cursor-pointer"
-                :style="{ backgroundColor: resolveColor(ev) }"
+                class="rounded text-[10px] px-1 py-0.5 truncate font-medium leading-none cursor-pointer"
+                :style="{ backgroundColor: resolveColor(ev), color: textOnColor(resolveColor(ev)) }"
                 data-event-block
                 @click="openEventPanel(ev)"
                 @mousedown.stop="(e: MouseEvent) => onEventMousedown(e, ev)"

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -7,6 +7,7 @@ import { useMilestoneStore } from '../stores/milestones'
 import { useEventStore } from '../stores/events'
 import TaskCard from '../components/TaskCard.vue'
 import AnchorFocusWidget from '../components/AnchorFocusWidget.vue'
+import { textOnColor } from '../composables/useTextOnColor'
 
 const planStore = usePlanStore()
 const anchorStore = useAnchorStore()
@@ -105,8 +106,8 @@ const dayStats = computed(() => {
         <div v-if="allDayEventsToday.length" class="flex flex-wrap gap-1 mb-2">
           <div v-for="ev in allDayEventsToday" :key="ev.id"
                data-testid="all-day-event-chip"
-               class="text-xs px-2 py-0.5 rounded text-white font-medium"
-               :style="{ backgroundColor: ev.color ?? '#6366f1' }">
+               class="text-xs px-2 py-0.5 rounded font-medium"
+               :style="{ backgroundColor: ev.color ?? '#6366f1', color: textOnColor(ev.color ?? '#6366f1') }">
             {{ ev.title }}
           </div>
         </div>

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -1,41 +1,20 @@
 <script setup lang="ts">
-import { onMounted, computed, ref } from 'vue'
+import { onMounted, computed } from 'vue'
 import KanbanColumn from '../components/KanbanColumn.vue'
-import { useKanbanStore } from '../stores/kanban'
+import { useKanbanStore, type KanbanTask } from '../stores/kanban'
 import { useMilestoneStore } from '../stores/milestones'
-import type { Task, TaskStatus } from '../stores/plan'
+import type { TaskStatus } from '../stores/plan'
 import { api } from '../lib/api'
 import { useSlideOver } from '../composables/useSlideOver'
-
-interface KanbanTask extends Task {
-  plan_date: string | null
-  anchor_id: string | null
-}
 
 const { push: pushPanel } = useSlideOver()
 const kanbanStore = useKanbanStore()
 const milestoneStore = useMilestoneStore()
 
-const allTasks = ref<KanbanTask[]>([])
-const tasksLoading = ref(false)
-
-async function fetchAllTasks() {
-  tasksLoading.value = true
-  try {
-    const resp = await api('/api/tasks/all')
-    if (!resp.ok) throw new Error(`${resp.status}`)
-    allTasks.value = await resp.json()
-  } catch (e) {
-    console.error('fetchAllTasks error:', e)
-  } finally {
-    tasksLoading.value = false
-  }
-}
-
 onMounted(() => {
   kanbanStore.fetchColumns()
   milestoneStore.fetchAll()
-  fetchAllTasks()
+  kanbanStore.fetchAllTasks()
 })
 
 async function onAddTask(columnId: string, opts: { context_subject?: string; milestone_id?: string }) {
@@ -55,7 +34,7 @@ async function onAddTask(columnId: string, opts: { context_subject?: string; mil
     })
     if (!resp.ok) throw new Error(`${resp.status}`)
     const task = await resp.json()
-    await fetchAllTasks()
+    await kanbanStore.fetchAllTasks()
     pushPanel({ kind: 'task', entityId: task.id })
   } catch (e) {
     console.error('Failed to create task:', e)
@@ -71,7 +50,7 @@ async function onTaskDrop(taskId: string, columnId: string) {
   const column = kanbanStore.columns.find(c => c.id === columnId)
   if (!column) return
 
-  const task = allTasks.value.find(t => t.id === taskId)
+  const task = kanbanStore.allTasks.find(t => t.id === taskId)
   if (!task) return
 
   const rules = column.entry_rules
@@ -110,7 +89,7 @@ async function onTaskDrop(taskId: string, columnId: string) {
     console.error('Failed to update task:', e)
     task.status = oldStatus
     task.plan_date = oldPlanDate
-    await fetchAllTasks()
+    await kanbanStore.fetchAllTasks()
   } finally {
     pendingDrops.delete(taskId)
   }
@@ -124,7 +103,7 @@ const columnTasks = computed(() => {
     result[col.id] = []
   }
 
-  for (const task of allTasks.value) {
+  for (const task of kanbanStore.allTasks) {
     for (const col of cols) {
       if (matchesRules(task, col.match_rules)) {
         result[col.id].push(task)
@@ -161,7 +140,7 @@ function matchesRules(task: KanbanTask, rules: Record<string, unknown>): boolean
   <div class="h-screen bg-gray-900 text-white p-6 flex flex-col overflow-hidden">
     <h1 class="text-2xl font-bold mb-4 flex-shrink-0">Kanban</h1>
 
-    <div v-if="kanbanStore.loading || tasksLoading" class="text-white/40 text-sm">Loading...</div>
+    <div v-if="kanbanStore.loading || kanbanStore.tasksLoading" class="text-white/40 text-sm">Loading...</div>
     <div v-else-if="kanbanStore.error" class="text-red-400 text-sm">{{ kanbanStore.error }}</div>
 
     <div v-else class="flex gap-4 overflow-x-auto flex-1 min-h-0">


### PR DESCRIPTION
## Summary

Wave 2 frontend bug fixes plus the text-readability pass. Five commits, all stacked on `origin/main`.

- **`00a3ac0`** — Kanban TaskCard fields update reactively from the detail panel. `KanbanView`'s local `allTasks` ref hoisted into `kanbanStore`; new `applyTaskPatch(taskId, patch)` lets the detail panel mirror patches into the in-memory copy. Fixes the bug where changing a task's motif updated PlanView's sidebar but not the kanban column.
- **`44aed16`** — Motif/text/status edits update the detail panel UI immediately. `Object.assign(task.value, fields)` after a successful PATCH so the controlled `MotifPicker` reflects the new value regardless of whether `task` resolves through plan / backlog / standalone. Fixes the Bug 2 symptom: motif palette clicks on calendar event panels did nothing — `planStore.fetchPlan()` without a date arg refetches the focused day, leaving cross-day calendar-event tasks visually stale.
- **`92218cb`** — Sticky headers get explicit opaque backgrounds. `GroupContainer` pill bumped to `bg-[--bg-elev-1]` (matches kanban column flush; subtle header rail on canvas-level surfaces); calendar all-day band switched from `--bg-canvas-veil` (80% transparent) to `--bg-canvas`. Stops scrolled content from bleeding through sticky headers.
- **`656e32f`** — Contrast-aware text color on event chips. New `useTextOnColor` composable (WCAG relative luminance, 0.5 threshold) picks `#0a0a0a` for light bgs and `#ffffff` for dark. Applied to CalendarView month/week pills and DashboardView all-day chips so light motif palettes don't render white-on-pale chip text.
- **`e4a5d84`** — MotifPicker test slot count 8 → 10 (upstream design-tokens PR added `light`/`dark` neutrals; test was stale and breaking CI).

Out of scope (explicitly deferred per team-lead): motif-driving-event-color (feature add, not a bug), recurring color cascade (need concrete repro first).

## Test plan

- [x] `npm run build` — vue-tsc + vite clean
- [x] `npm run test` — 347/347 pass
- [x] `pr-review-toolkit:code-reviewer` — no high-confidence findings
- [ ] CI green
- [ ] Manual: edit task motif from a calendar event panel whose task is on a non-focused day → palette visually shifts and event sidebar updates immediately
- [ ] Manual: scroll a long context group in PlanView → sticky pill stays opaque, no bleed-through
- [ ] Manual: switch to Paper theme → event chip text remains readable (dark text on light chips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)