### PR TITLE
fix(anthropic-oauth): extract token from setup-token stdout, propagate as env var

### DIFF
--- a/api/credentials_vault.py
+++ b/api/credentials_vault.py
@@ -1,20 +1,18 @@
-"""Credentials vault — encrypt/decrypt per-user credentials blobs.
+"""Credentials vault — encrypt/decrypt per-user OAuth tokens.
 
-Stores Anthropic OAuth credentials as Fernet-encrypted bytes in the
-user_integrations.credentials_blob column. On use, decrypts to a temp
-directory, yields the path, then reads back and re-persists if the content
-changed (i.e. token was refreshed by the caller).
+Stores Anthropic OAuth credentials as a Fernet-encrypted JSON blob in the
+``user_integrations.credentials_blob`` column. On use, decrypts the blob and
+yields an env dict suitable for spawning ``claude-code`` (or the agent SDK,
+which spawns claude-code internally) — the CLI reads ``CLAUDE_CODE_OAUTH_TOKEN``
+before falling back to a credentials file on disk, so we never need to write
+one.
 """
 from __future__ import annotations
 
 import asyncio
 import json
 import logging
-import os
-import secrets
-import shutil
 from contextlib import asynccontextmanager
-from pathlib import Path
 from typing import AsyncIterator
 
 from cryptography.fernet import Fernet
@@ -28,11 +26,6 @@ from db.pg_queries.integrations import (
 
 logger = logging.getLogger(__name__)
 
-# Default runtime directory for materialized credentials.
-# systemd RuntimeDirectory=tether/creds creates /run/tether/creds owned by the
-# service user. Dockerfile / CI must create this directory or set creds_dir.
-_DEFAULT_CREDS_DIR = Path("/run/tether/creds")
-
 
 class CredentialsVault:
     """Fernet-encrypted credentials store backed by Postgres."""
@@ -41,62 +34,42 @@ class CredentialsVault:
     # reconstructed vault still serialises correctly within the same process.
     _locks: dict[str, asyncio.Lock] = {}
 
-    def __init__(
-        self,
-        pool,
-        encryption_key: bytes,
-        *,
-        creds_dir: Path = _DEFAULT_CREDS_DIR,
-    ) -> None:
+    def __init__(self, pool, encryption_key: bytes) -> None:
         self._pool = pool
         self._fernet = Fernet(encryption_key)
-        self._creds_dir = creds_dir
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 
     @asynccontextmanager
-    async def materialize(self, user_id: str) -> AsyncIterator[Path]:
-        """Decrypt credentials_blob → temp dir → yield → persist if changed → rmtree.
+    async def materialize(self, user_id: str) -> AsyncIterator[dict[str, str]]:
+        """Decrypt credentials_blob → yield env dict for claude-code subprocess.
 
-        The temp directory is always removed in the finally block, even if an
-        exception is raised inside the `async with` block.
+        The yielded dict is intended to be merged into the env passed to
+        ``ClaudeAgentOptions(env=...)`` or ``subprocess.Popen``. The CLI reads
+        ``CLAUDE_CODE_OAUTH_TOKEN`` before consulting the on-disk credentials
+        file, so the token never needs to touch the filesystem.
         """
-        self._creds_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        async with db_pg.get_conn(self._pool, user_id=user_id) as conn:
+            blob = await get_credentials_blob(conn, user_id)
 
-        subdir_name = secrets.token_hex(16)
-        subdir = self._creds_dir / subdir_name
-        subdir.mkdir(mode=0o700)
+        if blob is None:
+            raise ValueError(f"No credentials found for user {user_id}")
 
-        creds_file = subdir / ".credentials.json"
-
+        plaintext = self._fernet.decrypt(blob)
         try:
-            # Decrypt and write credentials
-            async with db_pg.get_conn(self._pool, user_id=user_id) as conn:
-                blob = await get_credentials_blob(conn, user_id)
+            data = json.loads(plaintext.decode())
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            raise ValueError(f"Malformed credentials blob for user {user_id}") from e
 
-            if blob is None:
-                raise ValueError(f"No credentials_blob found for user {user_id}")
+        token = data.get("oauth_token") if isinstance(data, dict) else None
+        if not token:
+            raise ValueError(
+                f"Credentials blob for user {user_id} missing 'oauth_token' field"
+            )
 
-            plaintext = self._fernet.decrypt(blob)
-            # Write with mode 0o600 — credentials must not be world-readable
-            fd = os.open(str(creds_file), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-            with os.fdopen(fd, "wb") as f:
-                f.write(plaintext)
-            original_bytes = plaintext
-
-            yield subdir
-
-            # Read back — persist if content changed
-            if creds_file.exists():
-                current_bytes = creds_file.read_bytes()
-                if current_bytes != original_bytes:
-                    new_blob = self._fernet.encrypt(current_bytes)
-                    async with db_pg.get_conn(self._pool, user_id=user_id) as conn:
-                        await store_credentials_blob(conn, user_id, new_blob)
-        finally:
-            shutil.rmtree(subdir, ignore_errors=True)
+        yield {"CLAUDE_CODE_OAUTH_TOKEN": token}
 
     async def is_connected(self, user_id: str) -> bool:
         """True if user has a non-null credentials_blob for the anthropic provider."""

--- a/api/routes/integrations.py
+++ b/api/routes/integrations.py
@@ -17,10 +17,8 @@ Anthropic OAuth vault endpoints:
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import os
-import pathlib
 import re
 import shutil
 import tempfile
@@ -72,6 +70,11 @@ _ANTHROPIC_URL_RE = re.compile(r"https://\S+")
 # Note: does not strip OSC8 hyperlinks (\x1b]8;;URL\x07...\x1b]8;;\x07) — if
 # claude setup-token ever uses them, extend this regex or post-process the URL.
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+# `claude setup-token` prints a long-lived OAuth token to stdout (sk-ant-oat-…)
+# rather than writing a credentials file. The trailing run is URL-safe base64
+# plus dashes/underscores; we capture the longest such run after the prefix.
+_OAUTH_TOKEN_RE = re.compile(r"sk-ant-[A-Za-z0-9_-]+")
 _ANTHROPIC_URL_SCHEME = "https"
 # claude setup-token may emit URLs on either domain depending on version.
 _VALID_ANTHROPIC_NETLOCS = {"console.anthropic.com", "claude.com"}
@@ -207,7 +210,8 @@ def _complete_pexpect_sync(child, code: str) -> str:
     try:
         child.expect(pexpect.EOF, timeout=30)
         post_output = _ANSI_ESCAPE_RE.sub("", child.before.decode(errors="replace") if child.before else "")
-        logger.debug("anthropic/complete: child output after code submission: %r", post_output[-500:])
+        safe_output = _OAUTH_TOKEN_RE.sub("sk-ant-***REDACTED***", post_output)
+        logger.debug("anthropic/complete: child output after code submission: %r", safe_output[-500:])
     except pexpect.TIMEOUT:
         logger.warning("anthropic/complete: pexpect timed out waiting for EOF after code submission")
         return "timeout"
@@ -675,27 +679,32 @@ async def anthropic_complete(
         logger.warning("anthropic/complete: setup process reported failure for user_id=%s", user_id)
         return {"ok": False, "error": "setup failed"}
 
-    # result == "ok"
-    creds_file = pathlib.Path(temp_dir) / ".credentials.json"
-    logger.debug("anthropic/complete: checking for credentials file at %s", creds_file)
-    if not creds_file.exists():
+    # result == "ok": extract the OAuth token printed to stdout by
+    # `claude setup-token`. The CLI does not write a credentials file — it
+    # prints a long-lived sk-ant-oat-… token, which we persist as the only
+    # field in the credentials blob.
+    raw_after_code = child.before.decode(errors="replace") if getattr(child, "before", None) else ""
+    cleaned = _ANSI_ESCAPE_RE.sub("", raw_after_code)
+    match = _OAUTH_TOKEN_RE.search(cleaned)
+    if not match:
+        safe_tail = _OAUTH_TOKEN_RE.sub("sk-ant-***REDACTED***", cleaned)
         logger.error(
-            "anthropic/complete: process exited 0 but credentials file missing at %s; "
-            "temp_dir contents: %s",
-            creds_file,
-            list(pathlib.Path(temp_dir).iterdir()),
+            "anthropic/complete: process exited 0 but no OAuth token found in output for user_id=%s; "
+            "tail=%r",
+            user_id,
+            safe_tail[-500:],
         )
         shutil.rmtree(temp_dir, ignore_errors=True)
-        return {"ok": False, "error": "credentials file not found"}
+        return {"ok": False, "error": "OAuth token not found in setup output"}
 
-    blob_dict = json.loads(creds_file.read_text())
-    logger.debug("anthropic/complete: credentials file found, keys=%s", list(blob_dict.keys()))
+    token = match.group(0)
+    logger.debug("anthropic/complete: OAuth token extracted (len=%d)", len(token))
 
     vault = request.app.state.vault
     if vault is None:
         logger.error("anthropic/complete: vault is None — credentials cannot be persisted for user_id=%s", user_id)
     else:
-        await vault.store_initial(user_id, blob_dict)
+        await vault.store_initial(user_id, {"oauth_token": token})
         logger.info("anthropic/complete: credentials stored in vault for user_id=%s", user_id)
 
     shutil.rmtree(temp_dir, ignore_errors=True)

--- a/bot/llm.py
+++ b/bot/llm.py
@@ -16,11 +16,12 @@ import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 
-# Per-request credentials directory — set by handle_message() when a vault is
-# provided so that all LLM calls in the same request use the correct per-user
-# Claude config. Never set this at module level; always use .set()/.reset().
-_llm_creds_dir: contextvars.ContextVar[str | None] = contextvars.ContextVar(
-    "_llm_creds_dir", default=None
+# Per-request env extras — set by handle_message() when a vault is provided so
+# that all LLM calls in the same request inherit per-user credentials (typically
+# {"CLAUDE_CODE_OAUTH_TOKEN": "<oauth-token>"}). Never set this at module
+# level; always use .set()/.reset().
+_llm_env_extras: contextvars.ContextVar[dict[str, str] | None] = contextvars.ContextVar(
+    "_llm_env_extras", default=None
 )
 
 logger = logging.getLogger(__name__)
@@ -95,9 +96,9 @@ class PipelineBackend(LLMBackend):
         prompt = "\n".join(prompt_parts)
 
         env: dict[str, str] = {}
-        creds_dir_val = _llm_creds_dir.get()
-        if creds_dir_val:
-            env["CLAUDE_CONFIG_DIR"] = creds_dir_val
+        extras = _llm_env_extras.get()
+        if extras:
+            env.update(extras)
 
         opts = ClaudeAgentOptions(
             model=model,

--- a/bot/message_handler.py
+++ b/bot/message_handler.py
@@ -214,12 +214,12 @@ def get_model(role: str) -> str:
 async def call_claude(prompt: str, timeout: int = 180, model_role: str | None = None,
                       stage: str = "") -> str:
     from claude_agent_sdk import query, ClaudeAgentOptions, AssistantMessage, TextBlock
-    from bot.llm import _llm_creds_dir
+    from bot.llm import _llm_env_extras
 
     env: dict[str, str] = {}
-    creds_dir_val = _llm_creds_dir.get()
-    if creds_dir_val:
-        env["CLAUDE_CONFIG_DIR"] = creds_dir_val
+    extras = _llm_env_extras.get()
+    if extras:
+        env.update(extras)
 
     model = get_model(model_role) if model_role is not None else None
     opts = ClaudeAgentOptions(
@@ -1159,22 +1159,24 @@ async def _handle_message_body(text: str, send_fn: Callable[[str], None], pool, 
 async def handle_message(text: str, send_fn: Callable[[str], None], pool, user_id: str,
                          vault=None) -> None:
     """Public entry point. When a vault is provided, acquires the per-user lock
-    and materializes credentials into a temp directory before calling the pipeline.
+    and materialises credentials into an env dict that downstream LLM calls
+    merge into the spawned claude-code subprocess.
 
     Vault is a duck-typed object with:
       - with_lock(user_id) -> async context manager
-      - materialize(user_id) -> async context manager yielding a creds_dir path
+      - materialize(user_id) -> async context manager yielding a dict[str, str]
+        of env vars (e.g. {"CLAUDE_CODE_OAUTH_TOKEN": "..."})
     """
-    from bot.llm import _llm_creds_dir
+    from bot.llm import _llm_env_extras
 
     if vault is not None:
         async with vault.with_lock(user_id):
-            async with vault.materialize(user_id) as creds_dir:
-                token = _llm_creds_dir.set(str(creds_dir))
+            async with vault.materialize(user_id) as env_extras:
+                token = _llm_env_extras.set(dict(env_extras))
                 try:
                     await _handle_message_body(text, send_fn, pool, user_id)
                 finally:
-                    _llm_creds_dir.reset(token)
+                    _llm_env_extras.reset(token)
     else:
         await _handle_message_body(text, send_fn, pool, user_id)
 

--- a/tests/api/test_anthropic_integrations.py
+++ b/tests/api/test_anthropic_integrations.py
@@ -111,18 +111,21 @@ async def test_start_no_url_returns_502(auth_app_client):
 
 @pytest.mark.asyncio
 async def test_complete_success(auth_app_client, tmp_path):
-    """Stash a fake pending entry; complete succeeds and calls vault.store_initial."""
+    """Stash a fake pending entry; complete extracts token from child.before and persists it."""
     import api.routes.integrations as ant_routes
     client, mock_vault, app = auth_app_client
 
-    # Create a fake credentials.json in a temp dir
-    creds_data = {"api_key": "sk-ant-test", "type": "oauth"}
-    creds_file = tmp_path / ".credentials.json"
-    creds_file.write_text(json.dumps(creds_data))
-
+    fake_token = "sk-ant-oat01-FAKETOKEN_abc123"
     mock_child = MagicMock()
+    # `claude setup-token` prints the OAuth token to stdout after the code is
+    # accepted. pexpect captures all post-sendline output in child.before.
+    mock_child.before = (
+        b"\x1b[2K\x1b[1Gpasted code\n"
+        b"OAuth token created!\n"
+        + fake_token.encode()
+        + b"\n"
+    )
 
-    # Stash fake pending entry for TEST_USER_ID
     ant_routes._pending_setups[TEST_USER_ID] = {
         "child": mock_child,
         "temp_dir": str(tmp_path),
@@ -139,11 +142,80 @@ async def test_complete_success(auth_app_client, tmp_path):
         )
 
     assert resp.status_code == 200
-    data = resp.json()
-    assert data["ok"] is True
+    assert resp.json()["ok"] is True
     mock_vault.store_initial.assert_called_once()
-    call_args = mock_vault.store_initial.call_args
-    assert call_args[0][0] == TEST_USER_ID  # first positional arg is user_id
+    args = mock_vault.store_initial.call_args.args
+    assert args[0] == TEST_USER_ID
+    assert args[1] == {"oauth_token": fake_token}
+
+
+@pytest.mark.asyncio
+async def test_complete_no_token_in_output_returns_error(auth_app_client, tmp_path):
+    """If the setup process exits 0 but no sk-ant-… token is in stdout, surface an error."""
+    import api.routes.integrations as ant_routes
+    client, mock_vault, app = auth_app_client
+
+    mock_child = MagicMock()
+    mock_child.before = b"some unexpected output without any token\n"
+
+    ant_routes._pending_setups[TEST_USER_ID] = {
+        "child": mock_child,
+        "temp_dir": str(tmp_path),
+        "started_at": time.time(),
+    }
+
+    with patch(
+        "api.routes.integrations._complete_pexpect_sync",
+        return_value="ok",
+    ):
+        resp = await client.post(
+            "/api/integrations/anthropic/complete",
+            json={"code": "auth_code_123"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is False
+    assert "token" in body["error"].lower()
+    mock_vault.store_initial.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_complete_success_does_not_log_token(auth_app_client, tmp_path, caplog):
+    """The OAuth token must never appear in any log output, even at DEBUG level."""
+    import logging
+    import api.routes.integrations as ant_routes
+    client, mock_vault, app = auth_app_client
+
+    fake_token = "sk-ant-oat01-SECRET_TOKEN_value_xyz789"
+    mock_child = MagicMock()
+    mock_child.before = (
+        b"\x1b[2K\x1b[1Gpasted code\n"
+        b"OAuth token created!\n"
+        + fake_token.encode()
+        + b"\n"
+    )
+
+    ant_routes._pending_setups[TEST_USER_ID] = {
+        "child": mock_child,
+        "temp_dir": str(tmp_path),
+        "started_at": time.time(),
+    }
+
+    caplog.set_level(logging.DEBUG, logger="api.routes.integrations")
+    with patch(
+        "api.routes.integrations._complete_pexpect_sync",
+        return_value="ok",
+    ):
+        resp = await client.post(
+            "/api/integrations/anthropic/complete",
+            json={"code": "auth_code_123"},
+        )
+    assert resp.status_code == 200
+
+    for record in caplog.records:
+        msg = record.getMessage()
+        assert fake_token not in msg, f"token leaked in log record: {record.name} {msg!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -306,19 +378,14 @@ async def test_complete_broken_pipe_returns_502(auth_app_client, tmp_path):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_cfg_vault_key_roundtrip(tmp_path, monkeypatch):
+async def test_cfg_vault_key_roundtrip(monkeypatch):
     """A key from Fernet.generate_key().decode() round-trips through cfg → CredentialsVault."""
     from cryptography.fernet import Fernet
     from contextlib import asynccontextmanager
-    from unittest.mock import patch
 
-    raw_key = Fernet.generate_key()           # bytes: URL-safe base64, 44 chars
-    key_str = raw_key.decode()                # str: what operator puts in TETHER_VAULT_KEY
+    raw_key = Fernet.generate_key()
+    monkeypatch.setenv("TETHER_VAULT_KEY", raw_key.decode())
 
-    monkeypatch.setenv("TETHER_VAULT_KEY", key_str)
-
-    # Reset the config singleton's cache so it re-resolves placeholders from env,
-    # then reload api.config so VAULT_KEY is recomputed with the new value.
     from config import loader as config_loader
     config_loader.config._cfg = None
 
@@ -326,13 +393,12 @@ async def test_cfg_vault_key_roundtrip(tmp_path, monkeypatch):
     import api.config as cfg
     importlib.reload(cfg)
 
-    assert cfg.VAULT_KEY is not None, "VAULT_KEY should be set"
+    assert cfg.VAULT_KEY is not None
 
     from api.credentials_vault import CredentialsVault
 
-    vault = CredentialsVault(pool=None, encryption_key=cfg.VAULT_KEY, creds_dir=tmp_path)
+    vault = CredentialsVault(pool=None, encryption_key=cfg.VAULT_KEY)
 
-    original = {"token": "test-roundtrip"}
     stored: list[bytes] = []
 
     async def fake_store(conn, user_id, blob):
@@ -350,9 +416,6 @@ async def test_cfg_vault_key_roundtrip(tmp_path, monkeypatch):
          patch("api.credentials_vault.get_credentials_blob", side_effect=fake_get), \
          patch("api.credentials_vault.db_pg.get_conn", fake_get_conn):
 
-        await vault.store_initial("user1", original)
-        async with vault.materialize("user1") as creds_dir:
-            import json
-            loaded = json.loads((creds_dir / ".credentials.json").read_text())
-
-    assert loaded == original
+        await vault.store_initial("user1", {"oauth_token": "sk-ant-oat01-roundtrip"})
+        async with vault.materialize("user1") as env:
+            assert env == {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-roundtrip"}

--- a/tests/api/test_credentials_vault.py
+++ b/tests/api/test_credentials_vault.py
@@ -1,53 +1,18 @@
-"""Unit tests for CredentialsVault — no live database required.
+"""Unit tests for CredentialsVault — env-dict materialize() contract.
 
-TDD: written before implementation, confirmed to fail for the right reason
-(ModuleNotFoundError / ImportError) before api/credentials_vault.py exists.
+`materialize()` decrypts the stored credentials blob and yields an env dict
+suitable for spawning claude-code as a subprocess. The Anthropic SDK / CLI
+reads ``CLAUDE_CODE_OAUTH_TOKEN`` before falling back to the credentials file.
 """
 from __future__ import annotations
 
 import asyncio
 import json
-import os
-import tempfile
 from contextlib import asynccontextmanager
-from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch, call
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from cryptography.fernet import Fernet
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _make_vault(pool=None, creds_dir: Path | None = None):
-    """Return a CredentialsVault with a fresh Fernet key and optional creds_dir."""
-    from api.credentials_vault import CredentialsVault
-
-    key = Fernet.generate_key()
-    kwargs = {}
-    if creds_dir is not None:
-        kwargs["creds_dir"] = creds_dir
-    return CredentialsVault(pool, key, **kwargs)
-
-
-@asynccontextmanager
-async def _fake_get_conn(blob: bytes | None):
-    """Context manager that fakes db.postgres.get_conn and returns a mock conn
-    whose fetchrow returns a record-like dict for credentials_blob."""
-    conn = AsyncMock()
-
-    async def fake_fetchrow(query, *args):
-        if blob is None:
-            return None
-        # Return something with __getitem__ for ['credentials_blob']
-        row = {"credentials_blob": blob}
-        return row
-
-    conn.fetchrow = fake_fetchrow
-    conn.execute = AsyncMock(return_value=None)
-    yield conn
 
 
 # ---------------------------------------------------------------------------
@@ -56,13 +21,10 @@ async def _fake_get_conn(blob: bytes | None):
 
 @pytest.mark.asyncio
 async def test_fernet_roundtrip():
-    """Encrypt then decrypt a known blob dict, verify identity."""
-    from cryptography.fernet import Fernet
-
     key = Fernet.generate_key()
     f = Fernet(key)
 
-    original = {"api_key": "sk-ant-abc123", "refreshed": True}
+    original = {"oauth_token": "sk-ant-oat01-abc123", "refreshed": True}
     plaintext = json.dumps(original).encode()
     encrypted = f.encrypt(plaintext)
     decrypted = json.loads(f.decrypt(encrypted).decode())
@@ -71,18 +33,17 @@ async def test_fernet_roundtrip():
 
 
 # ---------------------------------------------------------------------------
-# 2. store_initial + materialize roundtrip (mocked DB)
+# 2. store_initial + materialize roundtrip — yields env dict
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_store_and_retrieve_roundtrip(tmp_path):
-    """store_initial encrypts the blob; materialize decrypts it back."""
+async def test_store_and_materialize_yields_env_dict():
+    """materialize yields {'CLAUDE_CODE_OAUTH_TOKEN': <token>} from stored blob."""
     from api.credentials_vault import CredentialsVault
 
     key = Fernet.generate_key()
-    vault = CredentialsVault(pool=None, encryption_key=key, creds_dir=tmp_path)
+    vault = CredentialsVault(pool=None, encryption_key=key)
 
-    original = {"anthropic_api_key": "sk-ant-test", "user": "u1"}
     stored_blob: list[bytes] = []
 
     async def fake_store(conn, user_id, blob):
@@ -93,198 +54,79 @@ async def test_store_and_retrieve_roundtrip(tmp_path):
 
     @asynccontextmanager
     async def fake_get_conn(pool, user_id=None):
-        conn = AsyncMock()
-        yield conn
+        yield AsyncMock()
 
     with patch("api.credentials_vault.store_credentials_blob", side_effect=fake_store), \
          patch("api.credentials_vault.get_credentials_blob", side_effect=fake_get), \
          patch("api.credentials_vault.db_pg.get_conn", fake_get_conn):
 
-        await vault.store_initial("user1", original)
-        assert len(stored_blob) == 1
+        await vault.store_initial("user1", {"oauth_token": "sk-ant-oat01-XYZ"})
 
-        # Now materialize and verify the decrypted JSON matches
-        async with vault.materialize("user1") as creds_dir:
-            creds_file = creds_dir / ".credentials.json"
-            assert creds_file.exists()
-            loaded = json.loads(creds_file.read_text())
-
-    assert loaded == original
+        async with vault.materialize("user1") as env:
+            assert isinstance(env, dict)
+            assert env == {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-XYZ"}
 
 
 # ---------------------------------------------------------------------------
-# 3. materialize persists when file content changed
+# 3. materialize raises when blob is missing
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_materialize_persists_when_changed(tmp_path):
-    """If the credentials file is modified inside materialize, vault re-encrypts and stores."""
+async def test_materialize_raises_when_blob_missing():
     from api.credentials_vault import CredentialsVault
-    from cryptography.fernet import Fernet
 
-    key = Fernet.generate_key()
-    vault = CredentialsVault(pool=None, encryption_key=key, creds_dir=tmp_path)
-
-    original = {"token": "old_token"}
-    f = Fernet(key)
-    original_blob = f.encrypt(json.dumps(original).encode())
-
-    stored_calls: list[bytes] = []
+    vault = CredentialsVault(pool=None, encryption_key=Fernet.generate_key())
 
     async def fake_get(conn, user_id):
-        return original_blob
-
-    async def fake_store(conn, user_id, blob):
-        stored_calls.append(blob)
+        return None
 
     @asynccontextmanager
     async def fake_get_conn(pool, user_id=None):
         yield AsyncMock()
 
     with patch("api.credentials_vault.get_credentials_blob", side_effect=fake_get), \
-         patch("api.credentials_vault.store_credentials_blob", side_effect=fake_store), \
          patch("api.credentials_vault.db_pg.get_conn", fake_get_conn):
-
-        async with vault.materialize("user1") as creds_dir:
-            creds_file = creds_dir / ".credentials.json"
-            # Modify the file — simulate token refresh
-            updated = {"token": "new_token"}
-            creds_file.write_text(json.dumps(updated))
-
-    # store should have been called once with new encrypted bytes
-    assert len(stored_calls) == 1
-    decrypted = json.loads(f.decrypt(stored_calls[0]).decode())
-    assert decrypted == updated
+        with pytest.raises(ValueError, match="No credentials"):
+            async with vault.materialize("user1"):
+                pass
 
 
 # ---------------------------------------------------------------------------
-# 4. materialize does NOT persist when file unchanged
+# 4. materialize raises when blob is malformed (no oauth_token field)
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_materialize_no_persist_when_unchanged(tmp_path):
-    """If credentials file is not modified, store_credentials_blob is NOT called."""
+async def test_materialize_raises_on_missing_oauth_token_field():
     from api.credentials_vault import CredentialsVault
-    from cryptography.fernet import Fernet
 
     key = Fernet.generate_key()
-    vault = CredentialsVault(pool=None, encryption_key=key, creds_dir=tmp_path)
+    vault = CredentialsVault(pool=None, encryption_key=key)
 
-    original = {"token": "unchanged"}
-    f = Fernet(key)
-    original_blob = f.encrypt(json.dumps(original).encode())
-
-    stored_calls: list = []
+    bad_blob = Fernet(key).encrypt(json.dumps({"unrelated": "data"}).encode())
 
     async def fake_get(conn, user_id):
-        return original_blob
-
-    async def fake_store(conn, user_id, blob):
-        stored_calls.append(blob)
+        return bad_blob
 
     @asynccontextmanager
     async def fake_get_conn(pool, user_id=None):
         yield AsyncMock()
 
     with patch("api.credentials_vault.get_credentials_blob", side_effect=fake_get), \
-         patch("api.credentials_vault.store_credentials_blob", side_effect=fake_store), \
          patch("api.credentials_vault.db_pg.get_conn", fake_get_conn):
-
-        async with vault.materialize("user1") as creds_dir:
-            # Do NOT modify the file
-            pass
-
-    assert len(stored_calls) == 0
+        with pytest.raises(ValueError, match="oauth_token"):
+            async with vault.materialize("user1"):
+                pass
 
 
 # ---------------------------------------------------------------------------
-# 5. materialize rmtree on exception
+# 5. disconnect
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_materialize_rmtree_on_exception(tmp_path):
-    """Even if an exception is raised inside materialize, the temp dir is cleaned up."""
-    from api.credentials_vault import CredentialsVault
-    from cryptography.fernet import Fernet
-
-    key = Fernet.generate_key()
-    vault = CredentialsVault(pool=None, encryption_key=key, creds_dir=tmp_path)
-
-    original = {"token": "abc"}
-    f = Fernet(key)
-    original_blob = f.encrypt(json.dumps(original).encode())
-
-    captured_dir: list[Path] = []
-
-    async def fake_get(conn, user_id):
-        return original_blob
-
-    @asynccontextmanager
-    async def fake_get_conn(pool, user_id=None):
-        yield AsyncMock()
-
-    with patch("api.credentials_vault.get_credentials_blob", side_effect=fake_get), \
-         patch("api.credentials_vault.store_credentials_blob", new=AsyncMock()), \
-         patch("api.credentials_vault.db_pg.get_conn", fake_get_conn):
-
-        with pytest.raises(ValueError, match="intentional"):
-            async with vault.materialize("user1") as creds_dir:
-                captured_dir.append(creds_dir)
-                raise ValueError("intentional error")
-
-    # The subdir should be gone
-    assert len(captured_dir) == 1
-    assert not captured_dir[0].exists()
-
-
-# ---------------------------------------------------------------------------
-# 5b. materialize writes credentials file with mode 0o600
-# ---------------------------------------------------------------------------
-
-@pytest.mark.asyncio
-async def test_materialize_credentials_file_mode(tmp_path):
-    """Materialized .credentials.json must be owner-read-write only (0o600)."""
-    from api.credentials_vault import CredentialsVault
-    from cryptography.fernet import Fernet
-
-    key = Fernet.generate_key()
-    vault = CredentialsVault(pool=None, encryption_key=key, creds_dir=tmp_path)
-
-    original = {"token": "secret"}
-    f = Fernet(key)
-    original_blob = f.encrypt(json.dumps(original).encode())
-
-    async def fake_get(conn, user_id):
-        return original_blob
-
-    @asynccontextmanager
-    async def fake_get_conn(pool, user_id=None):
-        yield AsyncMock()
-
-    captured_file: list[Path] = []
-
-    with patch("api.credentials_vault.get_credentials_blob", side_effect=fake_get), \
-         patch("api.credentials_vault.store_credentials_blob", new=AsyncMock()), \
-         patch("api.credentials_vault.db_pg.get_conn", fake_get_conn):
-
-        async with vault.materialize("user1") as creds_dir:
-            creds_file = creds_dir / ".credentials.json"
-            captured_file.append(creds_file)
-            mode = creds_file.stat().st_mode & 0o777
-            assert mode == 0o600, f"Expected 0o600, got 0o{mode:o}"
-
-
-# ---------------------------------------------------------------------------
-# 6. disconnect calls delete_credentials_blob
-# ---------------------------------------------------------------------------
-
-@pytest.mark.asyncio
-async def test_disconnect_calls_delete(tmp_path):
-    """vault.disconnect calls delete_credentials_blob with correct user_id."""
+async def test_disconnect_calls_delete():
     from api.credentials_vault import CredentialsVault
 
-    key = Fernet.generate_key()
-    vault = CredentialsVault(pool=None, encryption_key=key, creds_dir=tmp_path)
+    vault = CredentialsVault(pool=None, encryption_key=Fernet.generate_key())
 
     deleted: list[str] = []
 
@@ -303,16 +145,14 @@ async def test_disconnect_calls_delete(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# 7. with_lock serializes concurrent access
+# 6. with_lock serializes
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_with_lock_serializes(tmp_path):
-    """Two concurrent coroutines acquiring the same user lock run sequentially."""
+async def test_with_lock_serializes():
     from api.credentials_vault import CredentialsVault
 
-    key = Fernet.generate_key()
-    vault = CredentialsVault(pool=None, encryption_key=key, creds_dir=tmp_path)
+    vault = CredentialsVault(pool=None, encryption_key=Fernet.generate_key())
 
     order: list[str] = []
 
@@ -330,8 +170,50 @@ async def test_with_lock_serializes(tmp_path):
 
     await asyncio.gather(task_a(), task_b())
 
-    # Either a runs completely before b, or vice versa — they must NOT interleave
     assert order in [
         ["a_enter", "a_exit", "b_enter", "b_exit"],
         ["b_enter", "b_exit", "a_enter", "a_exit"],
     ]
+
+
+# ---------------------------------------------------------------------------
+# 7. cfg.VAULT_KEY roundtrip — operator-supplied key works through full pipeline
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cfg_vault_key_roundtrip(monkeypatch):
+    raw_key = Fernet.generate_key()
+    monkeypatch.setenv("TETHER_VAULT_KEY", raw_key.decode())
+
+    from config import loader as config_loader
+    config_loader.config._cfg = None
+
+    import importlib
+    import api.config as cfg
+    importlib.reload(cfg)
+
+    assert cfg.VAULT_KEY is not None
+
+    from api.credentials_vault import CredentialsVault
+
+    vault = CredentialsVault(pool=None, encryption_key=cfg.VAULT_KEY)
+
+    stored: list[bytes] = []
+
+    async def fake_store(conn, user_id, blob):
+        stored.append(blob)
+
+    async def fake_get(conn, user_id):
+        return stored[-1] if stored else None
+
+    @asynccontextmanager
+    async def fake_get_conn(pool, user_id=None):
+        yield AsyncMock()
+
+    with patch("api.credentials_vault.store_credentials_blob", side_effect=fake_store), \
+         patch("api.credentials_vault.get_credentials_blob", side_effect=fake_get), \
+         patch("api.credentials_vault.db_pg.get_conn", fake_get_conn):
+
+        await vault.store_initial("user1", {"oauth_token": "sk-ant-oat01-roundtrip"})
+        async with vault.materialize("user1") as env:
+            assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "sk-ant-oat01-roundtrip"

--- a/tests/bot/test_llm.py
+++ b/tests/bot/test_llm.py
@@ -106,8 +106,8 @@ class TestPipelineBackendSDKMigration:
         assert not subprocess_called
 
     @pytest.mark.asyncio
-    async def test_complete_passes_creds_dir_in_env(self, tmp_path):
-        from bot.llm import PipelineBackend, _llm_creds_dir
+    async def test_complete_passes_env_extras_in_env(self):
+        from bot.llm import PipelineBackend, _llm_env_extras
         from claude_agent_sdk import AssistantMessage, TextBlock, ClaudeAgentOptions
         from unittest.mock import patch
 
@@ -121,8 +121,8 @@ class TestPipelineBackendSDKMigration:
             )
             yield msg
 
-        creds_path = str(tmp_path / "mycreds")
-        token = _llm_creds_dir.set(creds_path)
+        extras = {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-pipeline"}
+        token = _llm_env_extras.set(extras)
         try:
             b = PipelineBackend()
             with patch("claude_agent_sdk.query", side_effect=_fake_query):
@@ -132,10 +132,10 @@ class TestPipelineBackendSDKMigration:
                     model="claude-haiku-4-5-20251001",
                 )
         finally:
-            _llm_creds_dir.reset(token)
+            _llm_env_extras.reset(token)
 
         assert len(captured) == 1
-        assert captured[0].env.get("CLAUDE_CONFIG_DIR") == creds_path
+        assert captured[0].env.get("CLAUDE_CODE_OAUTH_TOKEN") == "sk-ant-oat01-pipeline"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/bot/test_message_handler.py
+++ b/tests/bot/test_message_handler.py
@@ -67,10 +67,10 @@ async def test_call_claude_returns_text_from_sdk():
 
 
 @pytest.mark.asyncio
-async def test_call_claude_passes_creds_dir_to_sdk_env(tmp_path):
-    """When _llm_creds_dir ContextVar is set, call_claude passes CLAUDE_CONFIG_DIR in env."""
+async def test_call_claude_passes_env_extras_to_sdk_env():
+    """When _llm_env_extras is set, call_claude merges it into the SDK env."""
     from bot.message_handler import call_claude
-    from bot.llm import _llm_creds_dir
+    from bot.llm import _llm_env_extras
     from claude_agent_sdk import AssistantMessage, TextBlock, ClaudeAgentOptions
 
     captured_opts: list[ClaudeAgentOptions] = []
@@ -83,23 +83,23 @@ async def test_call_claude_passes_creds_dir_to_sdk_env(tmp_path):
         )
         yield msg
 
-    creds_dir = str(tmp_path / "creds")
-    token = _llm_creds_dir.set(creds_dir)
+    extras = {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-XYZ"}
+    token = _llm_env_extras.set(extras)
     try:
         with patch("claude_agent_sdk.query", side_effect=_fake_query):
             await call_claude("prompt")
     finally:
-        _llm_creds_dir.reset(token)
+        _llm_env_extras.reset(token)
 
     assert len(captured_opts) == 1
-    assert captured_opts[0].env.get("CLAUDE_CONFIG_DIR") == creds_dir
+    assert captured_opts[0].env.get("CLAUDE_CODE_OAUTH_TOKEN") == "sk-ant-oat01-XYZ"
 
 
 @pytest.mark.asyncio
-async def test_call_claude_no_creds_dir_no_env_key():
-    """When _llm_creds_dir is not set, CLAUDE_CONFIG_DIR is not added to env."""
+async def test_call_claude_no_env_extras_no_token():
+    """When _llm_env_extras is None, no per-user env vars leak through."""
     from bot.message_handler import call_claude
-    from bot.llm import _llm_creds_dir
+    from bot.llm import _llm_env_extras
     from claude_agent_sdk import AssistantMessage, TextBlock, ClaudeAgentOptions
 
     captured_opts: list[ClaudeAgentOptions] = []
@@ -112,15 +112,15 @@ async def test_call_claude_no_creds_dir_no_env_key():
         )
         yield msg
 
-    token = _llm_creds_dir.set(None)
+    token = _llm_env_extras.set(None)
     try:
         with patch("claude_agent_sdk.query", side_effect=_fake_query):
             await call_claude("prompt")
     finally:
-        _llm_creds_dir.reset(token)
+        _llm_env_extras.reset(token)
 
-    assert len(captured_opts) == 1, "query() should have been called exactly once"
-    assert "CLAUDE_CONFIG_DIR" not in captured_opts[0].env
+    assert len(captured_opts) == 1
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in captured_opts[0].env
 
 
 @pytest.mark.asyncio
@@ -179,18 +179,16 @@ async def test_handle_message_acquires_vault_lock(tmp_path, monkeypatch):
         @asynccontextmanager
         async def materialize(self, user_id: str):
             self.materialized_for.append(user_id)
-            yield str(tmp_path / "creds")
+            yield {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-stub"}
 
     vault = StubVault()
 
-    # Capture ContextVar value observed inside _handle_message_body
-    from bot.llm import _llm_creds_dir
-    observed_creds_dir: list[str | None] = []
+    from bot.llm import _llm_env_extras
+    observed: list[dict | None] = []
 
     async def _body_spy(*args, **kwargs):
-        observed_creds_dir.append(_llm_creds_dir.get())
+        observed.append(_llm_env_extras.get())
 
-    # Patch away all DB and LLM calls
     with patch("bot.message_handler._handle_message_body", side_effect=_body_spy) as mock_body:
         from bot.message_handler import handle_message
         await handle_message("hi", lambda m: None, object(), "user-123", vault=vault)
@@ -198,9 +196,7 @@ async def test_handle_message_acquires_vault_lock(tmp_path, monkeypatch):
     assert "user-123" in vault.lock_acquired_for
     assert "user-123" in vault.materialized_for
     mock_body.assert_called_once()
-    # Verify _llm_creds_dir ContextVar was set to the materialized creds path inside the body
-    assert len(observed_creds_dir) == 1
-    assert observed_creds_dir[0] == str(tmp_path / "creds")
+    assert observed == [{"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-stub"}]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `claude setup-token` does NOT write `~/.claude/.credentials.json`; it prints an `sk-ant-oat-…` long-lived OAuth token to stdout. The previous flow tried to copy a non-existent file, so `result == "ok"` silently produced empty vault rows and the agent SDK had no credentials.
- Extract the token from ANSI-stripped `child.before` via `_OAUTH_TOKEN_RE = re.compile(r"sk-ant-[A-Za-z0-9_-]+")` and persist `{"oauth_token": token}` via `vault.store_initial`.
- Switch per-user credential propagation from on-disk creds-dir → `CLAUDE_CODE_OAUTH_TOKEN` env var. `CredentialsVault.materialize()` is now an `@asynccontextmanager` yielding `{"CLAUDE_CODE_OAUTH_TOKEN": token}`. `bot/llm.py` + `bot/message_handler.py`: ContextVar `_llm_creds_dir` → `_llm_env_extras: dict[str, str] | None`, merged into `ClaudeAgentOptions(env=...)`. Credentials never touch disk.

## Security

`pr-review-toolkit:code-reviewer` flagged that `_complete_pexpect_sync` logged `post_output[-500:]` at DEBUG, which would leak the full token at `TETHER_LOG_LEVEL=DEBUG`. Both that log and the no-token error log now run output through `_OAUTH_TOKEN_RE.sub("sk-ant-***REDACTED***", ...)`. New caplog regression test asserts the token never appears in logs on a successful flow at DEBUG level.

## Test plan

- [x] `pytest tests/api tests/bot` — **240 passed, 206 skipped, 0 failed**
- [x] `tests/api/test_credentials_vault.py` — Fernet roundtrip, env-dict yield, missing-blob raises ValueError, missing-`oauth_token`-field raises ValueError, disconnect calls delete, `with_lock` serialises, `cfg.VAULT_KEY` env-dict roundtrip
- [x] `tests/api/test_anthropic_integrations.py::test_complete_success` — token extracted from `child.before`, persisted as `{"oauth_token": token}`
- [x] `tests/api/test_anthropic_integrations.py::test_complete_no_token_in_output_returns_error` — returns `{"ok": false, "error": "OAuth token not found in setup output"}`
- [x] `tests/api/test_anthropic_integrations.py::test_complete_success_does_not_log_token` — caplog at DEBUG, asserts token never in any log record
- [x] `tests/bot/test_llm.py::test_complete_passes_env_extras_in_env` — `ClaudeAgentOptions.env["CLAUDE_CODE_OAUTH_TOKEN"]` populated
- [x] `tests/bot/test_message_handler.py::test_call_claude_passes_env_extras_to_sdk_env` + `test_handle_message_acquires_vault_lock` — `_llm_env_extras` ContextVar propagation through vault lock + materialize
- [ ] On Pi: re-run `claude setup-token`, complete the OAuth code flow, confirm `is_connected` returns true and a bot message reaches Anthropic.

## Out of scope / follow-up

- `tether-premium/.worktrees/bot-oauth-migration` — `Session.__init__(creds_dir=...)` → `env_extras: dict[str, str] | None`, update `register.py`. Deferred until this PR merges.