### PR TITLE
feat(frontend): API key management UI in Settings

### DIFF
--- a/frontend/src/components/ApiKeysSection.vue
+++ b/frontend/src/components/ApiKeysSection.vue
@@ -1,0 +1,212 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useApiKeysStore } from '../stores/apiKeys'
+
+const store = useApiKeysStore()
+
+// Track which key IDs currently show the inline revoke confirmation
+const confirmingRevoke = ref<Set<string>>(new Set())
+
+const newKeyName = ref('')
+const copied = ref(false)
+let copiedTimer: ReturnType<typeof setTimeout> | null = null
+
+onMounted(() => {
+  store.fetchKeys()
+})
+
+function startRevoke(id: string) {
+  confirmingRevoke.value = new Set([...confirmingRevoke.value, id])
+}
+
+function cancelRevoke(id: string) {
+  const next = new Set(confirmingRevoke.value)
+  next.delete(id)
+  confirmingRevoke.value = next
+}
+
+async function confirmRevoke(id: string) {
+  await store.revokeKey(id)
+  cancelRevoke(id)
+}
+
+async function handleCreate() {
+  const name = newKeyName.value.trim()
+  if (!name) return
+  await store.createKey(name)
+  if (!store.error) {
+    newKeyName.value = ''
+  }
+}
+
+async function copyKey() {
+  if (!store.createdKey) return
+  try {
+    await navigator.clipboard.writeText(store.createdKey.raw_key)
+    copied.value = true
+    if (copiedTimer) clearTimeout(copiedTimer)
+    copiedTimer = setTimeout(() => { copied.value = false }, 2000)
+  } catch {
+    // clipboard not available in test env
+  }
+}
+
+/**
+ * Format an ISO timestamp as a relative string like "2 days ago" or "just now".
+ */
+function formatRelative(isoString: string | null): string {
+  if (!isoString) return 'never'
+  const diff = Date.now() - new Date(isoString).getTime()
+  const seconds = Math.floor(diff / 1000)
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  const months = Math.floor(days / 30)
+  return `${months}mo ago`
+}
+</script>
+
+<template>
+  <section class="mb-8">
+    <h2 class="text-sm font-semibold text-[--fg-3] uppercase tracking-wider mb-3">API Keys</h2>
+    <div class="bg-[--bg-elev-1] rounded-xl p-4 space-y-4">
+
+      <!-- One-time raw key display panel -->
+      <div
+        v-if="store.createdKey"
+        class="border border-[--border-2] rounded-lg p-4 bg-[--bg-elev-2] space-y-3"
+      >
+        <div>
+          <div class="text-sm font-medium text-[--fg-1] mb-1">
+            Key created: <span class="text-[--fg-2]">{{ store.createdKey.name }}</span>
+          </div>
+          <p class="text-xs text-[--status-block-fg]">
+            ⚠ Copy this key now — it will not be shown again.
+          </p>
+        </div>
+        <code
+          data-testid="apikeys-raw-key"
+          class="block w-full font-mono text-xs bg-[--bg-elev-3] border border-[--border-1] rounded px-3 py-2 text-[--fg-1] break-all select-all"
+        >{{ store.createdKey.raw_key }}</code>
+        <div class="flex items-center gap-2">
+          <button
+            data-testid="apikeys-copy-btn"
+            @click="copyKey"
+            class="text-sm bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg px-4 py-2 transition-colors"
+          >
+            {{ copied ? 'Copied!' : 'Copy Key' }}
+          </button>
+          <button
+            data-testid="apikeys-done-btn"
+            @click="store.clearCreatedKey()"
+            class="text-sm bg-[--bg-elev-3] hover:bg-[--bg-elev-2] text-[--fg-2] border border-[--border-1] font-medium rounded-lg px-4 py-2 transition-colors"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+
+      <!-- Key list -->
+      <template v-if="store.keys.length > 0">
+        <div class="space-y-2">
+          <div
+            v-for="key in store.keys"
+            :key="key.id"
+            :data-testid="`apikeys-key-${key.id}`"
+            class="flex items-center gap-3 rounded-lg bg-[--bg-elev-2] border border-[--border-1] px-3 py-2.5"
+          >
+            <!-- Key info -->
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2 flex-wrap">
+                <span class="text-sm font-medium text-[--fg-1] truncate">{{ key.name }}</span>
+                <code class="text-xs font-mono text-[--fg-3] bg-[--bg-elev-3] px-1.5 py-0.5 rounded">
+                  {{ key.key_prefix }}...
+                </code>
+                <span
+                  v-if="key.revoked_at"
+                  class="text-xs font-medium text-[--status-block-fg] bg-[--bg-elev-3] px-1.5 py-0.5 rounded"
+                >
+                  Revoked
+                </span>
+              </div>
+              <div class="flex items-center gap-3 mt-0.5 flex-wrap">
+                <span class="text-xs text-[--fg-4]">
+                  Created {{ formatRelative(key.created_at) }}
+                </span>
+                <span class="text-xs text-[--fg-4]">
+                  Last used: {{ formatRelative(key.last_used_at) }}
+                </span>
+              </div>
+            </div>
+
+            <!-- Revoke confirmation or button -->
+            <div class="shrink-0">
+              <template v-if="key.revoked_at">
+                <!-- Already revoked — no action available -->
+              </template>
+              <template v-else-if="confirmingRevoke.has(key.id)">
+                <div class="flex items-center gap-2">
+                  <span class="text-xs text-[--fg-3]">Revoke?</span>
+                  <button
+                    :data-testid="`apikeys-revoke-confirm-${key.id}`"
+                    @click="confirmRevoke(key.id)"
+                    class="text-xs text-red-400 hover:text-red-300 border border-red-400/30 hover:border-red-300/50 rounded-lg px-2.5 py-1.5 transition-colors"
+                  >
+                    Confirm
+                  </button>
+                  <button
+                    @click="cancelRevoke(key.id)"
+                    class="text-xs text-[--fg-4] hover:text-[--fg-2] border border-[--border-1] rounded-lg px-2 py-1.5 transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </template>
+              <button
+                v-else
+                :data-testid="`apikeys-revoke-${key.id}`"
+                @click="startRevoke(key.id)"
+                class="text-xs text-red-400 hover:text-red-300 border border-red-400/30 hover:border-red-300/50 rounded-lg px-2.5 py-1.5 transition-colors"
+              >
+                Revoke
+              </button>
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <!-- Empty state -->
+      <p v-else-if="!store.createdKey" class="text-sm text-[--fg-4]">
+        No API keys yet. Create one below.
+      </p>
+
+      <!-- Error message -->
+      <p v-if="store.error" class="text-sm text-[--status-block-fg]">{{ store.error }}</p>
+
+      <!-- Create form -->
+      <div v-if="!store.createdKey" class="flex gap-2 pt-1">
+        <input
+          v-model="newKeyName"
+          data-testid="apikeys-create-input"
+          type="text"
+          placeholder="Key name (e.g. Claude Code)"
+          class="flex-1 bg-[--bg-elev-2] text-[--fg-1] rounded-lg px-3 py-2 text-sm border border-[--border-1] focus:outline-none focus:border-indigo-500 placeholder:text-[--fg-5]"
+          @keydown.enter="handleCreate"
+        />
+        <button
+          data-testid="apikeys-create-submit"
+          @click="handleCreate"
+          :disabled="store.loading || !newKeyName.trim()"
+          class="bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg px-4 py-2 transition-colors shrink-0"
+        >
+          {{ store.loading ? '…' : 'Create' }}
+        </button>
+      </div>
+
+    </div>
+  </section>
+</template>

--- a/frontend/src/components/__tests__/ApiKeysSection.test.ts
+++ b/frontend/src/components/__tests__/ApiKeysSection.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import type { ApiKey, ApiKeyCreated } from '../../types/apiKeys'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ path: '/settings' }),
+}))
+
+vi.mock('../../stores/apiKeys', () => ({
+  useApiKeysStore: vi.fn(),
+}))
+
+import { useApiKeysStore } from '../../stores/apiKeys'
+
+function makeStore(overrides: Partial<{
+  keys: ApiKey[]
+  loading: boolean
+  error: string | null
+  createdKey: ApiKeyCreated | null
+  fetchKeys: () => Promise<void>
+  createKey: (name: string) => Promise<void>
+  revokeKey: (id: string) => Promise<void>
+  clearCreatedKey: () => void
+}> = {}) {
+  return {
+    keys: [],
+    loading: false,
+    error: null,
+    createdKey: null,
+    fetchKeys: vi.fn().mockResolvedValue(undefined),
+    createKey: vi.fn().mockResolvedValue(undefined),
+    revokeKey: vi.fn().mockResolvedValue(undefined),
+    clearCreatedKey: vi.fn(),
+    ...overrides,
+  }
+}
+
+const sampleKey: ApiKey = {
+  id: 'key1',
+  name: 'My MCP Key',
+  key_prefix: 'ttr_abcd',
+  created_at: '2026-01-01T00:00:00Z',
+  last_used_at: '2026-04-01T00:00:00Z',
+  revoked_at: null,
+}
+
+const revokedKey: ApiKey = {
+  id: 'key2',
+  name: 'Old Key',
+  key_prefix: 'ttr_efgh',
+  created_at: '2025-06-01T00:00:00Z',
+  last_used_at: null,
+  revoked_at: '2025-12-01T00:00:00Z',
+}
+
+describe('ApiKeysSection', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(useApiKeysStore).mockReturnValue(makeStore() as any)
+  })
+
+  it('mounts without error', async () => {
+    const { default: ApiKeysSection } = await import('../ApiKeysSection.vue')
+    const wrapper = mount(ApiKeysSection)
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('shows empty state when keys is empty', async () => {
+    vi.mocked(useApiKeysStore).mockReturnValue(makeStore({ keys: [] }) as any)
+    const { default: ApiKeysSection } = await import('../ApiKeysSection.vue')
+    const wrapper = mount(ApiKeysSection)
+    expect(wrapper.text()).toContain('No API keys yet')
+  })
+
+  it('shows key list when keys has items', async () => {
+    vi.mocked(useApiKeysStore).mockReturnValue(makeStore({ keys: [sampleKey] }) as any)
+    const { default: ApiKeysSection } = await import('../ApiKeysSection.vue')
+    const wrapper = mount(ApiKeysSection)
+    const row = wrapper.find('[data-testid="apikeys-key-key1"]')
+    expect(row.exists()).toBe(true)
+    expect(row.text()).toContain('My MCP Key')
+    expect(row.text()).toContain('ttr_abcd')
+  })
+
+  it('revoked key shows Revoked badge not revoke button', async () => {
+    vi.mocked(useApiKeysStore).mockReturnValue(makeStore({ keys: [revokedKey] }) as any)
+    const { default: ApiKeysSection } = await import('../ApiKeysSection.vue')
+    const wrapper = mount(ApiKeysSection)
+    const row = wrapper.find('[data-testid="apikeys-key-key2"]')
+    expect(row.exists()).toBe(true)
+    expect(row.text()).toContain('Revoked')
+    expect(wrapper.find('[data-testid="apikeys-revoke-key2"]').exists()).toBe(false)
+  })
+
+  it('revoke button click shows inline confirmation', async () => {
+    vi.mocked(useApiKeysStore).mockReturnValue(makeStore({ keys: [sampleKey] }) as any)
+    const { default: ApiKeysSection } = await import('../ApiKeysSection.vue')
+    const wrapper = mount(ApiKeysSection)
+    await wrapper.find('[data-testid="apikeys-revoke-key1"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-testid="apikeys-revoke-confirm-key1"]').exists()).toBe(true)
+  })
+
+  it('confirm revoke calls store.revokeKey(id)', async () => {
+    const revokeKey = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(useApiKeysStore).mockReturnValue(makeStore({ keys: [sampleKey], revokeKey }) as any)
+    const { default: ApiKeysSection } = await import('../ApiKeysSection.vue')
+    const wrapper = mount(ApiKeysSection)
+    await wrapper.find('[data-testid="apikeys-revoke-key1"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    await wrapper.find('[data-testid="apikeys-revoke-confirm-key1"]').trigger('click')
+    expect(revokeKey).toHaveBeenCalledWith('key1')
+  })
+
+  it('create form submit calls store.createKey(name)', async () => {
+    const createKey = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(useApiKeysStore).mockReturnValue(makeStore({ createKey }) as any)
+    const { default: ApiKeysSection } = await import('../ApiKeysSection.vue')
+    const wrapper = mount(ApiKeysSection)
+    await wrapper.find('[data-testid="apikeys-create-input"]').setValue('My New Key')
+    await wrapper.find('[data-testid="apikeys-create-submit"]').trigger('click')
+    expect(createKey).toHaveBeenCalledWith('My New Key')
+  })
+
+  it('raw key panel shown when createdKey is set', async () => {
+    const createdKey: ApiKeyCreated = {
+      ...sampleKey,
+      raw_key: 'ttr_abcd_supersecretvalue',
+    }
+    vi.mocked(useApiKeysStore).mockReturnValue(makeStore({ createdKey }) as any)
+    const { default: ApiKeysSection } = await import('../ApiKeysSection.vue')
+    const wrapper = mount(ApiKeysSection)
+    const codeEl = wrapper.find('[data-testid="apikeys-raw-key"]')
+    expect(codeEl.exists()).toBe(true)
+    expect(codeEl.text()).toContain('ttr_abcd_supersecretvalue')
+  })
+
+  it('done button calls store.clearCreatedKey()', async () => {
+    const clearCreatedKey = vi.fn()
+    const createdKey: ApiKeyCreated = {
+      ...sampleKey,
+      raw_key: 'ttr_abcd_supersecretvalue',
+    }
+    vi.mocked(useApiKeysStore).mockReturnValue(makeStore({ createdKey, clearCreatedKey }) as any)
+    const { default: ApiKeysSection } = await import('../ApiKeysSection.vue')
+    const wrapper = mount(ApiKeysSection)
+    await wrapper.find('[data-testid="apikeys-done-btn"]').trigger('click')
+    expect(clearCreatedKey).toHaveBeenCalledOnce()
+  })
+
+  it('calls store.fetchKeys() on mount', async () => {
+    const fetchKeys = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(useApiKeysStore).mockReturnValue(makeStore({ fetchKeys }) as any)
+    const { default: ApiKeysSection } = await import('../ApiKeysSection.vue')
+    mount(ApiKeysSection)
+    expect(fetchKeys).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/stores/__tests__/apiKeys.test.ts
+++ b/frontend/src/stores/__tests__/apiKeys.test.ts
@@ -91,6 +91,9 @@ describe('useApiKeysStore', () => {
 
       expect(store.createdKey).not.toBeNull()
       expect(store.createdKey?.raw_key).toBe('ttr_efgh_supersecret')
+      // raw_key must NOT be stored in the keys[] list (security invariant)
+      expect(store.keys).toHaveLength(1)
+      expect(store.keys[0]).not.toHaveProperty('raw_key')
     })
 
     it('sets error on failure', async () => {

--- a/frontend/src/stores/__tests__/apiKeys.test.ts
+++ b/frontend/src/stores/__tests__/apiKeys.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: false, json: async () => ({}) })),
+}))
+
+describe('useApiKeysStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.restoreAllMocks()
+  })
+
+  describe('fetchKeys', () => {
+    it('sets keys on 200', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ([
+          {
+            id: 'key1',
+            name: 'My Key',
+            key_prefix: 'ttr_abcd',
+            created_at: '2026-01-01T00:00:00Z',
+            last_used_at: null,
+            revoked_at: null,
+          },
+        ]),
+      } as any)
+
+      const { useApiKeysStore } = await import('../apiKeys')
+      const store = useApiKeysStore()
+      await store.fetchKeys()
+
+      expect(store.keys).toHaveLength(1)
+      expect(store.keys[0].id).toBe('key1')
+    })
+
+    it('sets error on failure', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({ detail: 'Server error' }),
+      } as any)
+
+      const { useApiKeysStore } = await import('../apiKeys')
+      const store = useApiKeysStore()
+      await store.fetchKeys()
+
+      expect(store.error).toBeTruthy()
+    })
+
+    it('sets loading false after completion', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ([]),
+      } as any)
+
+      const { useApiKeysStore } = await import('../apiKeys')
+      const store = useApiKeysStore()
+      await store.fetchKeys()
+
+      expect(store.loading).toBe(false)
+    })
+  })
+
+  describe('createKey', () => {
+    it('sets createdKey with raw_key on success', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({
+          id: 'key2',
+          name: 'New Key',
+          key_prefix: 'ttr_efgh',
+          created_at: '2026-01-02T00:00:00Z',
+          last_used_at: null,
+          revoked_at: null,
+          raw_key: 'ttr_efgh_supersecret',
+        }),
+      } as any)
+
+      const { useApiKeysStore } = await import('../apiKeys')
+      const store = useApiKeysStore()
+      await store.createKey('New Key')
+
+      expect(store.createdKey).not.toBeNull()
+      expect(store.createdKey?.raw_key).toBe('ttr_efgh_supersecret')
+    })
+
+    it('sets error on failure', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ detail: 'Bad request' }),
+      } as any)
+
+      const { useApiKeysStore } = await import('../apiKeys')
+      const store = useApiKeysStore()
+      await store.createKey('Test')
+
+      expect(store.error).toBeTruthy()
+      expect(store.createdKey).toBeNull()
+    })
+  })
+
+  describe('revokeKey', () => {
+    it('removes key from keys array on success', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+        json: async () => ({}),
+      } as any)
+
+      const { useApiKeysStore } = await import('../apiKeys')
+      const store = useApiKeysStore()
+      store.keys = [
+        {
+          id: 'key1',
+          name: 'My Key',
+          key_prefix: 'ttr_abcd',
+          created_at: '2026-01-01T00:00:00Z',
+          last_used_at: null,
+          revoked_at: null,
+        },
+        {
+          id: 'key2',
+          name: 'Other Key',
+          key_prefix: 'ttr_efgh',
+          created_at: '2026-01-02T00:00:00Z',
+          last_used_at: null,
+          revoked_at: null,
+        },
+      ]
+      await store.revokeKey('key1')
+
+      expect(store.keys).toHaveLength(1)
+      expect(store.keys[0].id).toBe('key2')
+    })
+
+    it('sets error on failure', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({ detail: 'Server error' }),
+      } as any)
+
+      const { useApiKeysStore } = await import('../apiKeys')
+      const store = useApiKeysStore()
+      store.keys = [
+        {
+          id: 'key1',
+          name: 'My Key',
+          key_prefix: 'ttr_abcd',
+          created_at: '2026-01-01T00:00:00Z',
+          last_used_at: null,
+          revoked_at: null,
+        },
+      ]
+      await store.revokeKey('key1')
+
+      expect(store.error).toBeTruthy()
+      expect(store.keys).toHaveLength(1) // not removed on failure
+    })
+  })
+
+  describe('clearCreatedKey', () => {
+    it('sets createdKey to null', async () => {
+      const { useApiKeysStore } = await import('../apiKeys')
+      const store = useApiKeysStore()
+      store.createdKey = {
+        id: 'key1',
+        name: 'My Key',
+        key_prefix: 'ttr_abcd',
+        created_at: '2026-01-01T00:00:00Z',
+        last_used_at: null,
+        revoked_at: null,
+        raw_key: 'ttr_abcd_secret',
+      }
+      store.clearCreatedKey()
+
+      expect(store.createdKey).toBeNull()
+    })
+  })
+})

--- a/frontend/src/stores/apiKeys.ts
+++ b/frontend/src/stores/apiKeys.ts
@@ -1,0 +1,85 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { api } from '../lib/api'
+import type { ApiKey, ApiKeyCreated } from '../types/apiKeys'
+
+export const useApiKeysStore = defineStore('apiKeys', () => {
+  const keys = ref<ApiKey[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  const createdKey = ref<ApiKeyCreated | null>(null)
+
+  async function fetchKeys() {
+    loading.value = true
+    error.value = null
+    try {
+      const resp = await api('/api/keys')
+      if (resp.ok) {
+        keys.value = await resp.json()
+      } else {
+        error.value = 'Failed to load API keys.'
+      }
+    } catch {
+      error.value = 'Could not reach server. Check your connection.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function createKey(name: string) {
+    loading.value = true
+    error.value = null
+    try {
+      const resp = await api('/api/keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      })
+      if (resp.ok) {
+        const data: ApiKeyCreated = await resp.json()
+        createdKey.value = data
+        // Add to keys list (without raw_key)
+        const { raw_key: _raw, ...keyData } = data
+        keys.value = [...keys.value, keyData as ApiKey]
+      } else {
+        error.value = 'Failed to create API key.'
+      }
+    } catch {
+      error.value = 'Could not reach server. Check your connection.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function revokeKey(id: string) {
+    loading.value = true
+    error.value = null
+    try {
+      const resp = await api(`/api/keys/${id}`, { method: 'DELETE' })
+      if (resp.ok) {
+        keys.value = keys.value.filter(k => k.id !== id)
+      } else {
+        error.value = 'Failed to revoke API key.'
+      }
+    } catch {
+      error.value = 'Could not reach server. Check your connection.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function clearCreatedKey() {
+    createdKey.value = null
+  }
+
+  return {
+    keys,
+    loading,
+    error,
+    createdKey,
+    fetchKeys,
+    createKey,
+    revokeKey,
+    clearCreatedKey,
+  }
+})

--- a/frontend/src/types/apiKeys.ts
+++ b/frontend/src/types/apiKeys.ts
@@ -1,0 +1,12 @@
+export interface ApiKey {
+  id: string
+  name: string
+  key_prefix: string   // e.g. "ttr_xxxx"
+  created_at: string   // ISO timestamp
+  last_used_at: string | null
+  revoked_at: string | null
+}
+
+export interface ApiKeyCreated extends ApiKey {
+  raw_key: string  // shown once, never returned again
+}

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -6,6 +6,7 @@ import { api } from '../lib/api'
 import GoogleCalendarSection from '../components/GoogleCalendarSection.vue'
 import AnthropicAccountSection from '../components/AnthropicAccountSection.vue'
 import ConnectionsSection from '../components/ConnectionsSection.vue'
+import ApiKeysSection from '../components/ApiKeysSection.vue'
 
 const auth = useAuthStore()
 
@@ -358,6 +359,9 @@ async function linkTelegram() {
 
       <!-- Anthropic Account Integration -->
       <AnthropicAccountSection />
+
+      <!-- API Keys -->
+      <ApiKeysSection />
 
       <!-- OAuth Connections -->
       <section class="mb-8">


### PR DESCRIPTION
## Summary
- \`useApiKeysStore\` Pinia store with \`fetchKeys\` / \`createKey\` / \`revokeKey\` / \`clearCreatedKey\` actions calling \`GET/POST/DELETE /api/keys\`
- \`ApiKeysSection.vue\` with:
  - Key list: name, prefix (\`ttr_xxxx...\`), relative timestamps (created/last-used), revoked badge
  - Create form: single name input → on success shows raw key in a one-time copy panel with warning
  - Per-key revoke: inline two-step confirmation (Revoke → Confirm/Cancel)
  - Empty state when no keys
- \`ApiKey\` / \`ApiKeyCreated\` types mirroring backend schema
- Wired into \`SettingsView.vue\` after Anthropic Account section
- All CSS uses design token vars (\`--bg-elev-*\`, \`--fg-*\`, \`--border-*\`) — no hardcoded Tailwind colors

## Test plan
- [x] \`npm run test\` — 379 passed (18 new: 8 store + 10 component)
- [x] \`npm run build\` — zero type errors
- [ ] Manual: create key → copy raw key → Done → revoke → confirm