### PR TITLE
fix(prompts): platform-agnostic bot identity — remove Telegram-specific language

### DIFF
--- a/bot/prompt_sections.py
+++ b/bot/prompt_sections.py
@@ -20,7 +20,7 @@ accept a context dict and return a string.
 IDENTITY = (
     "You are Tether, an ADHD accountability coach and daily task manager. "
     "You help your user stay focused, build momentum, and make steady progress "
-    "across their projects and responsibilities. You live in their Telegram chat "
+    "across their projects and responsibilities. You live in their daily messages "
     "and have access to their full task system via MCP tools."
 )
 

--- a/tests/bot/test_prompt_sections.py
+++ b/tests/bot/test_prompt_sections.py
@@ -156,3 +156,17 @@ class TestSectionRegistries:
             for key in keys:
                 assert key in _STATIC_SECTIONS or key in _DYNAMIC_SECTIONS, \
                     f"Mode '{mode}' references unregistered section '{key}'"
+
+
+class TestPlatformNeutralLanguage:
+    """Prompts must not contain platform-specific language."""
+
+    def test_identity_does_not_reference_telegram(self):
+        assert "telegram" not in IDENTITY.lower(), \
+            "IDENTITY contains 'Telegram' — use platform-neutral language"
+
+    def test_no_telegram_in_any_mode(self, ctx):
+        for mode in ["scheduler", "coach", "planner", "quick", "followup"]:
+            prompt = build_prompt(mode, ctx)
+            assert "telegram" not in prompt.lower(), \
+                f"Mode '{mode}' prompt contains 'Telegram' — use platform-neutral language"


### PR DESCRIPTION
## Summary

- `bot/prompt_sections.py` IDENTITY section referenced `"Telegram chat"` explicitly. Replaced with `"daily messages"` — works correctly on Telegram, web chat, and any future channel.
- Added `TestPlatformNeutralLanguage` test class asserting no mode's rendered prompt contains `"telegram"`.

## Scope notes

- `tether/prompts/*.md` Jinja2 templates — no Telegram references found; no changes needed.
- `bot/message_handler.py`, `bot/anchor_trigger.py` — Telegram API call sites (infrastructure code, not LLM prompt text); intentionally not changed.

## Companion PR

tether-premium: `fix/prompt-platform-agnostic` — fixes `explain_mcp.md` skill file.

## Test plan
- [ ] `pytest tests/bot/test_prompt_sections.py` — 22 passed
- [ ] `TestPlatformNeutralLanguage` — 2 new tests, both green