### PR TITLE
fix(frontend): restore DnD + fix move-task reactivity from detail panel

### DIFF
--- a/frontend/src/components/AnchorBlock.vue
+++ b/frontend/src/components/AnchorBlock.vue
@@ -197,6 +197,7 @@ function onDrop(evt: DragEvent, toIndex: number) {
           <template v-for="mg in ctx.milestoneGroups" :key="mg.milestone.id">
             <div v-for="{ task, index: i } in mg.tasks" :key="task.id || i"
                  :data-task-id="task.id"
+                 draggable="true"
                  @dragstart="onDragStart($event, task)"
                  @dragover.prevent
                  @drop.stop.prevent="onDrop($event, i)">
@@ -206,6 +207,7 @@ function onDrop(evt: DragEvent, toIndex: number) {
           </template>
           <div v-for="{ task, index: i } in ctx.ungrouped" :key="task.id || i"
                :data-task-id="task.id"
+               draggable="true"
                @dragstart="onDragStart($event, task)"
                @dragover.prevent
                @drop.stop.prevent="onDrop($event, i)">
@@ -240,6 +242,7 @@ function onDrop(evt: DragEvent, toIndex: number) {
             <template v-if="mg.tasks.length === 1">
               <div v-for="{ task, index: i } in mg.tasks" :key="task.id || i"
                    :data-task-id="task.id"
+                   draggable="true"
                    @dragstart="onDragStart($event, task)"
                    @dragover.prevent
                    @drop.stop.prevent="onDrop($event, i)">
@@ -256,6 +259,7 @@ function onDrop(evt: DragEvent, toIndex: number) {
               @header-click="pushPanel({ kind: 'milestone', entityId: mg.milestone.id })">
               <div v-for="{ task, index: i } in mg.tasks" :key="task.id || i"
                    :data-task-id="task.id"
+                   draggable="true"
                    @dragstart="onDragStart($event, task)"
                    @dragover.prevent
                    @drop.stop.prevent="onDrop($event, i)">
@@ -273,6 +277,7 @@ function onDrop(evt: DragEvent, toIndex: number) {
           <!-- Ungrouped tasks within this context -->
           <div v-for="{ task, index: i } in ctx.ungrouped" :key="task.id || i"
                :data-task-id="task.id"
+               draggable="true"
                @dragstart="onDragStart($event, task)"
                @dragover.prevent
                @drop.stop.prevent="onDrop($event, i)">

--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -202,7 +202,9 @@ async function onRescheduleDate(e: Event) {
   const newDate = (e.target as HTMLInputElement).value
   if (!newDate || newDate === taskPlanDate.value) return
   await planStore.moveTask(props.taskId, taskPlanDate.value, anchorId.value, newDate, anchorId.value)
-  await planStore.fetchPlan(newDate)
+  // Refresh the current day (no arg) — passing newDate would change activeDate and
+  // cause AnchorBlock to show the destination day's content under the wrong URL.
+  await planStore.fetchPlan()
 }
 
 // Delete

--- a/frontend/src/components/__tests__/AnchorBlock.test.ts
+++ b/frontend/src/components/__tests__/AnchorBlock.test.ts
@@ -56,4 +56,24 @@ describe('AnchorBlock', () => {
     const w = await mountBlock({ isLast: false })
     expect(w.find('[data-testid="anchor-line"]').exists()).toBe(true)
   })
+
+  it('task wrapper divs have draggable="true" so DnD can initiate', async () => {
+    // Seed the plan store with one task in the target anchor
+    const { usePlanStore } = await import('../../stores/plan')
+    const store = usePlanStore()
+    store.plan = {
+      date: '2026-05-01',
+      anchors: {
+        a1: {
+          tasks: [{ id: 'task-1', text: 'Draggable task', status: 'pending', position: 0 } as any],
+          notes: '',
+        },
+      },
+    } as any
+
+    const w = await mountBlock()
+    const wrapper = w.find('[data-task-id="task-1"]')
+    expect(wrapper.exists()).toBe(true)
+    expect(wrapper.attributes('draggable')).toBe('true')
+  })
 })

--- a/frontend/src/stores/__tests__/plan.test.ts
+++ b/frontend/src/stores/__tests__/plan.test.ts
@@ -1,16 +1,20 @@
 /**
- * plan store — patchTaskFields action
+ * plan store — patchTaskFields + moveTask actions
  *
  * Verifies that patchTaskFields:
  *   1. PATCHes /api/tasks/:id with the given fields
  *   2. Applies an optimistic update to the in-memory plan
  *   3. Returns true on success, false on API error
+ *
+ * Verifies that moveTask:
+ *   4. Removes task from in-memory plan even when toDate is not cached
+ *   5. Inserts into toDate when it's in plans cache, even if fromDay is not the active plan
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 
 vi.mock('../../lib/api', () => ({
-  api: vi.fn(() => Promise.resolve({ ok: false, json: async () => ({}) })),
+  api: vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) })),
 }))
 
 describe('usePlanStore – patchTaskFields', () => {
@@ -89,5 +93,58 @@ describe('usePlanStore – patchTaskFields', () => {
     const result = await store.patchTaskFields('task-abc', { status: 'done' })
     expect(result).toBe(false)
     expect(store.plan!.anchors.morning.tasks[0].status).toBe('pending')
+  })
+})
+
+describe('usePlanStore – moveTask optimistic updates', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('removes task from in-memory plan even when toDate is not cached', async () => {
+    const { usePlanStore } = await import('../plan')
+    const store = usePlanStore()
+
+    // Set active plan (fromDate) — toDate '2026-05-05' is NOT in plans cache
+    store.plan = {
+      date: '2026-05-01',
+      anchors: {
+        morning: {
+          tasks: [{ id: 'task-xyz', text: 'Move me', status: 'pending', position: 0 } as any],
+          notes: '',
+        },
+      },
+    } as any
+    // Ensure toDate is absent from range cache
+    delete (store.plans as any)['2026-05-05']
+
+    await store.moveTask('task-xyz', '2026-05-01', 'morning', '2026-05-05', 'morning')
+
+    // Task must be removed from the active day's anchor even though toDate wasn't cached
+    expect(store.plan!.anchors.morning.tasks).toHaveLength(0)
+  })
+
+  it('inserts task into toDate when it is in plans cache, even if fromDay is not active', async () => {
+    const { usePlanStore } = await import('../plan')
+    const store = usePlanStore()
+
+    // fromDate is in range cache (not the active plan)
+    const fromTask = { id: 'task-xyz', text: 'Move me', status: 'pending', position: 0 } as any
+    store.plans['2026-04-30'] = {
+      date: '2026-04-30',
+      anchors: { morning: { tasks: [fromTask], notes: '' } },
+    } as any
+    // toDate is also in range cache
+    store.plans['2026-05-01'] = {
+      date: '2026-05-01',
+      anchors: { morning: { tasks: [], notes: '' } },
+    } as any
+
+    await store.moveTask('task-xyz', '2026-04-30', 'morning', '2026-05-01', 'morning')
+
+    expect(store.plans['2026-04-30'].anchors.morning.tasks).toHaveLength(0)
+    expect(store.plans['2026-05-01'].anchors.morning.tasks).toHaveLength(1)
+    expect(store.plans['2026-05-01'].anchors.morning.tasks[0].id).toBe('task-xyz')
   })
 })

--- a/frontend/src/stores/plan.ts
+++ b/frontend/src/stores/plan.ts
@@ -93,17 +93,18 @@ export const usePlanStore = defineStore('plan', () => {
     toDate: string, toAnchor: string,
     position?: number,
   ) {
-    // Optimistic update in plans cache
+    // Optimistic update in plans cache — each side is independent so that
+    // moving to an uncached date still removes the task from the visible plan.
     const fromDay = plans.value[fromDate] ?? (fromDate === activeDate.value ? plan.value : null)
-    const toDay = plans.value[toDate] ?? (toDate === activeDate.value ? plan.value : null)
-    if (fromDay && toDay) {
-      const task = fromDay.anchors[fromAnchor]?.tasks.find(t => t.id === taskUuid)
-      if (task) {
-        fromDay.anchors[fromAnchor].tasks = fromDay.anchors[fromAnchor].tasks.filter(t => t.id !== taskUuid)
-        if (!toDay.anchors[toAnchor]) toDay.anchors[toAnchor] = { tasks: [], notes: '' }
-        const pos = position ?? toDay.anchors[toAnchor].tasks.length
-        toDay.anchors[toAnchor].tasks.splice(pos, 0, { ...task, position: pos })
-      }
+    const toDay   = plans.value[toDate]   ?? (toDate   === activeDate.value ? plan.value : null)
+    const task = fromDay?.anchors[fromAnchor]?.tasks.find(t => t.id === taskUuid)
+    if (fromDay && task) {
+      fromDay.anchors[fromAnchor].tasks = fromDay.anchors[fromAnchor].tasks.filter(t => t.id !== taskUuid)
+    }
+    if (toDay && task) {
+      if (!toDay.anchors[toAnchor]) toDay.anchors[toAnchor] = { tasks: [], notes: '' }
+      const pos = position ?? toDay.anchors[toAnchor].tasks.length
+      toDay.anchors[toAnchor].tasks.splice(pos, 0, { ...task, position: pos })
     }
     await api(`/api/tasks/${taskUuid}/move`, {
       method: 'PUT',


### PR DESCRIPTION
## Summary

- **Bug 1 — Move-task reactivity:** When rescheduling a task from the detail panel to a different date, the current day's plan list now immediately removes the task. Also fixed `fetchPlan(newDate)` → `fetchPlan()` in `onRescheduleDate` — the old call was silently changing `planStore.activeDate`, causing `AnchorBlock` to render the destination day's content under the wrong URL.
- **Bug 2 — DnD regression:** Added `draggable="true"` to all 5 task wrapper divs in `AnchorBlock.vue`. The `@dragstart`/`@dragover`/`@drop` handlers were wired up but the HTML attribute required to initiate a drag gesture was missing — a regression from the motif/borderless-cards commit that removed the dedicated drag handle.

## Root causes

| Bug | File | Root cause |
|-----|------|-----------|
| Move-task reactivity | `stores/plan.ts` | `if (fromDay && toDay)` guard required both endpoints to be cached; moving to an uncached date meant the optimistic removal was also skipped |
| Wrong-day flicker | `components/TaskDetailPanel.vue` | `fetchPlan(newDate)` mutates `planStore.activeDate`, causing the plan view to show the destination day under the old URL |
| DnD broken | `components/AnchorBlock.vue` | `draggable` attribute absent from task wrapper divs |

## Test plan

- [x] `plan.test.ts`: `moveTask removes task from in-memory plan even when toDate is not cached`
- [x] `plan.test.ts`: `moveTask inserts into toDate when it's in plans cache, even if fromDay is not active`
- [x] `AnchorBlock.test.ts`: `task wrapper divs have draggable="true" so DnD can initiate`
- [x] All 396 tests pass (`npx vitest run`)
- [x] Zero TypeScript errors (`npm run build`)
- [x] Code review (pr-review-toolkit:code-reviewer) — no HIGH or MEDIUM findings