### PR TITLE
feat: plan week view with drag-and-drop and edge-scroll

### DIFF
--- a/frontend/src/components/__tests__/PlanWeekCell.test.ts
+++ b/frontend/src/components/__tests__/PlanWeekCell.test.ts
@@ -1,0 +1,111 @@
+/**
+ * PlanWeekCell — drop handler
+ *
+ * Verifies that:
+ *   1. Dropping a task card onto the cell calls moveTaskToAnchor with correct args
+ *   2. Drop with no dataTransfer payload is a no-op
+ *   3. Drop with malformed JSON is a no-op (does not throw)
+ *   4. Visual drop-over state is set on dragover and cleared on dragleave
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ path: '/' }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) })),
+}))
+
+// Minimal TaskCard stub so PlanWeekCell can render without all TaskCard deps
+vi.mock('../TaskCard.vue', () => ({
+  default: { template: '<div data-testid="task-card-stub" />' },
+}))
+
+describe('PlanWeekCell', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  async function mountCell(props: Record<string, unknown> = {}) {
+    const { default: PlanWeekCell } = await import('../plan/PlanWeekCell.vue')
+    return mount(PlanWeekCell, {
+      props: {
+        date: '2026-05-05',
+        anchorId: 'anchor-deep-work',
+        anchorName: 'Deep Work',
+        tasks: [],
+        ...props,
+      },
+    })
+  }
+
+  it('calls moveTaskToAnchor with correct taskId, newDate and anchorId on drop', async () => {
+    const { usePlanStore } = await import('../../stores/plan')
+    const store = usePlanStore()
+    const spy = vi.spyOn(store, 'moveTaskToAnchor').mockResolvedValue(undefined)
+
+    const wrapper = await mountCell()
+    const dropZone = wrapper.find('[data-testid="week-cell-drop"]')
+
+    const payload = JSON.stringify({ taskId: 'task-abc', fromAnchorId: 'morning', fromDate: '2026-05-03' })
+    const dt = { getData: vi.fn(() => payload), dropEffect: 'move' }
+    await dropZone.trigger('drop', { dataTransfer: dt })
+
+    expect(spy).toHaveBeenCalledOnce()
+    expect(spy).toHaveBeenCalledWith({ taskId: 'task-abc', newDate: '2026-05-05', anchorId: 'anchor-deep-work' })
+  })
+
+  it('is a no-op when drop has no dataTransfer payload', async () => {
+    const { usePlanStore } = await import('../../stores/plan')
+    const store = usePlanStore()
+    const spy = vi.spyOn(store, 'moveTaskToAnchor').mockResolvedValue(undefined)
+
+    const wrapper = await mountCell()
+    const dropZone = wrapper.find('[data-testid="week-cell-drop"]')
+
+    const dt = { getData: vi.fn(() => ''), dropEffect: 'move' }
+    await dropZone.trigger('drop', { dataTransfer: dt })
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op and does not throw when drop payload is malformed JSON', async () => {
+    const { usePlanStore } = await import('../../stores/plan')
+    const store = usePlanStore()
+    const spy = vi.spyOn(store, 'moveTaskToAnchor').mockResolvedValue(undefined)
+
+    const wrapper = await mountCell()
+    const dropZone = wrapper.find('[data-testid="week-cell-drop"]')
+
+    const dt = { getData: vi.fn(() => 'not valid json'), dropEffect: 'move' }
+    await expect(dropZone.trigger('drop', { dataTransfer: dt })).resolves.not.toThrow()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('sets dragover class on dragover and clears it on dragleave', async () => {
+    const wrapper = await mountCell()
+    const dropZone = wrapper.find('[data-testid="week-cell-drop"]')
+
+    const dt = { getData: vi.fn(() => ''), dropEffect: 'copy' }
+    await dropZone.trigger('dragover', { dataTransfer: dt })
+    expect(dropZone.classes()).toContain('ring-1')
+
+    await dropZone.trigger('dragleave')
+    expect(dropZone.classes()).not.toContain('ring-1')
+  })
+
+  it('renders task stubs when tasks prop is populated', async () => {
+    const tasks = [
+      { id: 't1', text: 'Task one', status: 'pending', position: 0 },
+      { id: 't2', text: 'Task two', status: 'done', position: 1 },
+    ]
+    const wrapper = await mountCell({ tasks })
+    const cards = wrapper.findAll('[data-testid="task-card-stub"]')
+    expect(cards).toHaveLength(2)
+  })
+})

--- a/frontend/src/components/plan/PlanWeekCell.vue
+++ b/frontend/src/components/plan/PlanWeekCell.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { usePlanStore } from '../../stores/plan'
+import type { Task } from '../../stores/plan'
+import TaskCard from '../TaskCard.vue'
+
+const props = defineProps<{
+  date: string
+  anchorId: string
+  anchorName: string
+  tasks: Task[]
+}>()
+
+const planStore = usePlanStore()
+
+// ── Drag-over visual state ────────────────────────────────────────────────────
+const isDragOver = ref(false)
+
+function onDragOver(e: DragEvent) {
+  e.preventDefault()
+  if (e.dataTransfer) e.dataTransfer.dropEffect = 'move'
+  isDragOver.value = true
+}
+
+function onDragLeave() {
+  isDragOver.value = false
+}
+
+// ── Drop: move task to this anchor×day cell ───────────────────────────────────
+async function onDrop(e: DragEvent) {
+  e.preventDefault()
+  isDragOver.value = false
+
+  const raw = e.dataTransfer?.getData('text/plain')
+  if (!raw) return
+
+  let payload: { taskId?: string }
+  try {
+    payload = JSON.parse(raw)
+  } catch {
+    return // ignore malformed drag data from other drag sources
+  }
+
+  if (!payload.taskId) return
+
+  await planStore.moveTaskToAnchor({
+    taskId: payload.taskId,
+    newDate: props.date,
+    anchorId: props.anchorId,
+  })
+}
+</script>
+
+<template>
+  <div
+    data-testid="week-cell-drop"
+    class="min-h-[80px] p-1 rounded transition-colors"
+    :class="[
+      isDragOver
+        ? 'ring-1 ring-[--accent] bg-[--accent-veil]'
+        : 'bg-[--bg-elev-1] hover:bg-[--bg-elev-2]',
+    ]"
+    @dragover="onDragOver"
+    @dragleave="onDragLeave"
+    @drop="onDrop"
+  >
+    <div class="flex flex-col gap-0.5">
+      <TaskCard
+        v-for="task in tasks"
+        :key="task.id"
+        :task="task"
+        :hide-tags="true"
+        class="text-xs"
+      />
+      <div v-if="!tasks.length" class="text-[11px] text-[--fg-6] px-1 py-0.5 italic">
+        No tasks
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/plan/PlanWeekView.vue
+++ b/frontend/src/components/plan/PlanWeekView.vue
@@ -9,6 +9,8 @@ const planStore = usePlanStore()
 const anchorStore = useAnchorStore()
 
 // ── Week navigation ────────────────────────────────────────────────────────────
+// Plan week view is intentionally Mon–Sun (spec requirement).
+// CalendarView uses Sun–Sat; these are different products with different needs.
 function getMonday(dateStr: string): Date {
   const d = new Date(dateStr + 'T12:00:00')
   const day = d.getDay()
@@ -63,8 +65,10 @@ function nextWeek() {
 }
 
 // ── Data loading ───────────────────────────────────────────────────────────────
+// fetchPlanRange populates planStore.plans (the keyed cache). fetchPlan would
+// clobber planStore.plan and activeDate — not what we want in week view.
 async function loadWeek() {
-  await Promise.all(weekDates.value.map(d => planStore.fetchPlan(d)))
+  await planStore.fetchPlanRange(weekDates.value[0], weekDates.value[6])
 }
 
 onMounted(() => {

--- a/frontend/src/components/plan/PlanWeekView.vue
+++ b/frontend/src/components/plan/PlanWeekView.vue
@@ -1,0 +1,187 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, watch } from 'vue'
+import { usePlanStore } from '../../stores/plan'
+import { useAnchorStore } from '../../stores/anchors'
+import { useDragEdgeScroll } from '../../composables/useDragEdgeScroll'
+import PlanWeekCell from './PlanWeekCell.vue'
+
+const planStore = usePlanStore()
+const anchorStore = useAnchorStore()
+
+// ── Week navigation ────────────────────────────────────────────────────────────
+function getMonday(dateStr: string): Date {
+  const d = new Date(dateStr + 'T12:00:00')
+  const day = d.getDay()
+  const diff = day === 0 ? -6 : 1 - day
+  d.setDate(d.getDate() + diff)
+  return d
+}
+
+function localDateStr(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+const weekStart = ref(getMonday(planStore.activeDate))
+
+const weekDates = computed<string[]>(() =>
+  Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(weekStart.value)
+    d.setDate(d.getDate() + i)
+    return localDateStr(d)
+  }),
+)
+
+const weekLabel = computed(() => {
+  const s = new Date(weekDates.value[0] + 'T12:00:00')
+  const e = new Date(weekDates.value[6] + 'T12:00:00')
+  return `${s.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} – ${e.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}`
+})
+
+// Day-of-week headers (Mon–Sun) with date numbers
+const dayHeaders = computed(() =>
+  weekDates.value.map(dateStr => {
+    const d = new Date(dateStr + 'T12:00:00')
+    return {
+      dateStr,
+      label: d.toLocaleDateString(undefined, { weekday: 'short' }),
+      dayNum: d.getDate(),
+      isToday: dateStr === planStore.today,
+    }
+  }),
+)
+
+function prevWeek() {
+  const d = new Date(weekStart.value)
+  d.setDate(d.getDate() - 7)
+  weekStart.value = d
+}
+
+function nextWeek() {
+  const d = new Date(weekStart.value)
+  d.setDate(d.getDate() + 7)
+  weekStart.value = d
+}
+
+// ── Data loading ───────────────────────────────────────────────────────────────
+async function loadWeek() {
+  await Promise.all(weekDates.value.map(d => planStore.fetchPlan(d)))
+}
+
+onMounted(() => {
+  anchorStore.fetchAnchors()
+  loadWeek()
+})
+
+watch(weekStart, loadWeek)
+
+// ── Cell data accessor ─────────────────────────────────────────────────────────
+function cellTasks(anchorId: string, dateStr: string) {
+  return planStore.plans[dateStr]?.anchors[anchorId]?.tasks ?? []
+}
+
+// ── Edge-scroll wiring ─────────────────────────────────────────────────────────
+const gridRef = ref<HTMLElement | null>(null)
+
+const { onDragOver: edgeDragOver, onDragLeave: edgeDragLeave, onDragEnd: edgeDragEnd } =
+  useDragEdgeScroll(gridRef, (direction) => {
+    if (direction === 'prev') prevWeek()
+    else nextWeek()
+  })
+</script>
+
+<template>
+  <div>
+    <!-- Week navigation header -->
+    <div class="flex items-center gap-2 mb-3">
+      <button
+        data-testid="week-prev"
+        class="text-[--fg-4] hover:text-[--fg-1] text-lg px-1 transition-colors"
+        @click="prevWeek"
+      >
+        ‹
+      </button>
+      <span class="text-sm font-medium min-w-[160px] text-center">{{ weekLabel }}</span>
+      <button
+        data-testid="week-next"
+        class="text-[--fg-4] hover:text-[--fg-1] text-lg px-1 transition-colors"
+        @click="nextWeek"
+      >
+        ›
+      </button>
+    </div>
+
+    <!-- Grid: anchor labels × day columns -->
+    <div
+      ref="gridRef"
+      data-testid="week-plan-grid"
+      class="overflow-x-auto"
+      @dragover="edgeDragOver"
+      @dragleave="edgeDragLeave"
+      @dragend="edgeDragEnd"
+    >
+      <div
+        class="grid min-w-[600px]"
+        :style="{ gridTemplateColumns: `120px repeat(7, 1fr)` }"
+      >
+        <!-- Header row: blank corner + day headers -->
+        <div class="sticky top-0 z-10 bg-[--bg-canvas] border-b border-[--border-1] h-10" />
+        <div
+          v-for="day in dayHeaders"
+          :key="day.dateStr"
+          class="sticky top-0 z-10 bg-[--bg-canvas] border-b border-[--border-1] border-l border-[--border-soft] px-1 py-1.5 text-center"
+        >
+          <div
+            class="text-xs font-medium"
+            :class="day.isToday ? 'text-[--accent]' : 'text-[--fg-3]'"
+          >
+            {{ day.label }}
+          </div>
+          <div
+            class="text-sm font-semibold"
+            :class="day.isToday ? 'text-[--accent]' : 'text-[--fg-1]'"
+          >
+            {{ day.dayNum }}
+          </div>
+        </div>
+
+        <!-- Anchor rows -->
+        <template v-for="anchor in anchorStore.anchors" :key="anchor.id">
+          <!-- Anchor name label -->
+          <div
+            class="px-2 py-2 border-b border-[--border-soft] flex items-start gap-1.5"
+            :style="{ borderLeft: `3px solid ${anchor.color}` }"
+          >
+            <div>
+              <div class="text-xs font-medium text-[--fg-2] truncate leading-tight">
+                {{ anchor.name }}
+              </div>
+              <div class="text-[10px] text-[--fg-5]">{{ anchor.time }}</div>
+            </div>
+          </div>
+
+          <!-- Day cells for this anchor -->
+          <div
+            v-for="dateStr in weekDates"
+            :key="dateStr"
+            class="border-b border-[--border-soft] border-l border-[--border-soft] p-0.5"
+          >
+            <PlanWeekCell
+              :date="dateStr"
+              :anchor-id="anchor.id"
+              :anchor-name="anchor.name"
+              :tasks="cellTasks(anchor.id, dateStr)"
+            />
+          </div>
+        </template>
+
+        <!-- Empty state when no anchors loaded -->
+        <div
+          v-if="!anchorStore.anchors.length"
+          class="col-span-8 text-center text-sm text-[--fg-4] py-8"
+        >
+          No anchors configured
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/composables/__tests__/useDragEdgeScroll.test.ts
+++ b/frontend/src/composables/__tests__/useDragEdgeScroll.test.ts
@@ -1,0 +1,134 @@
+/**
+ * useDragEdgeScroll composable
+ *
+ * Verifies that:
+ *   1. onAdvance('next') fires after dwell when cursor is near right edge
+ *   2. onAdvance('prev') fires after dwell when cursor is near left edge
+ *   3. onAdvance does NOT fire before the dwell time expires
+ *   4. onAdvance does NOT fire when onDragLeave is called before dwell
+ *   5. onAdvance does NOT fire when onDragEnd is called before dwell
+ *   6. Moving cursor out of the edge zone (no dragleave) also clears the timer
+ *   7. Timer does not fire twice for a continuous edge dwell
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref } from 'vue'
+import { useDragEdgeScroll } from '../useDragEdgeScroll'
+
+// Container spanning x=0–500
+function makeContainer(): HTMLElement {
+  const el = document.createElement('div')
+  vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+    left: 0, right: 500, width: 500,
+    top: 0, bottom: 200, height: 200,
+    x: 0, y: 0,
+    toJSON: () => ({}),
+  } as DOMRect)
+  return el
+}
+
+function makeDragEvent(clientX: number): DragEvent {
+  return { clientX, preventDefault: vi.fn() } as unknown as DragEvent
+}
+
+describe('useDragEdgeScroll', () => {
+  beforeEach(() => {
+    // Only fake setTimeout/clearTimeout — leave Vitest's own scheduling intact
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
+
+  function setup(threshold = 80, dwell = 600) {
+    const containerRef = ref<HTMLElement | null>(makeContainer())
+    const onAdvance = vi.fn()
+    const handlers = useDragEdgeScroll(containerRef, onAdvance, { threshold, dwell })
+    return { handlers, onAdvance, containerRef }
+  }
+
+  it('fires onAdvance("next") after dwell when cursor is near right edge', () => {
+    const { handlers, onAdvance } = setup()
+    // clientX=450, right=500, threshold=80 → 500−450=50 < 80 ✓
+    handlers.onDragOver(makeDragEvent(450))
+    expect(onAdvance).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(600)
+    expect(onAdvance).toHaveBeenCalledOnce()
+    expect(onAdvance).toHaveBeenCalledWith('next')
+  })
+
+  it('fires onAdvance("prev") after dwell when cursor is near left edge', () => {
+    const { handlers, onAdvance } = setup()
+    // clientX=30, left=0, threshold=80 → 30−0=30 < 80 ✓
+    handlers.onDragOver(makeDragEvent(30))
+    expect(onAdvance).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(600)
+    expect(onAdvance).toHaveBeenCalledOnce()
+    expect(onAdvance).toHaveBeenCalledWith('prev')
+  })
+
+  it('does NOT fire onAdvance before the dwell expires', () => {
+    const { handlers, onAdvance } = setup()
+    handlers.onDragOver(makeDragEvent(450))
+    vi.advanceTimersByTime(599)
+    expect(onAdvance).not.toHaveBeenCalled()
+  })
+
+  it('does NOT fire when onDragLeave is called before dwell', () => {
+    const { handlers, onAdvance } = setup()
+    handlers.onDragOver(makeDragEvent(450))
+    vi.advanceTimersByTime(300)
+    handlers.onDragLeave()
+    vi.advanceTimersByTime(400)
+    expect(onAdvance).not.toHaveBeenCalled()
+  })
+
+  it('does NOT fire when onDragEnd is called before dwell', () => {
+    const { handlers, onAdvance } = setup()
+    handlers.onDragOver(makeDragEvent(450))
+    vi.advanceTimersByTime(300)
+    handlers.onDragEnd()
+    vi.advanceTimersByTime(400)
+    expect(onAdvance).not.toHaveBeenCalled()
+  })
+
+  it('clears the timer when cursor moves to mid-container (no dragleave)', () => {
+    const { handlers, onAdvance } = setup()
+    // Start edge dwell
+    handlers.onDragOver(makeDragEvent(450))
+    vi.advanceTimersByTime(300)
+    // Move to middle — x=250, distance to both edges = 250 > 80
+    handlers.onDragOver(makeDragEvent(250))
+    vi.advanceTimersByTime(400)
+    expect(onAdvance).not.toHaveBeenCalled()
+  })
+
+  it('fires only once for continuous edge dwell (repeated dragover calls)', () => {
+    const { handlers, onAdvance } = setup()
+    handlers.onDragOver(makeDragEvent(450))
+    handlers.onDragOver(makeDragEvent(455))
+    handlers.onDragOver(makeDragEvent(460))
+    vi.advanceTimersByTime(600)
+    expect(onAdvance).toHaveBeenCalledOnce()
+  })
+
+  it('does nothing when containerRef is null', () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const onAdvance = vi.fn()
+    const handlers = useDragEdgeScroll(containerRef, onAdvance)
+    handlers.onDragOver(makeDragEvent(450))
+    vi.advanceTimersByTime(600)
+    expect(onAdvance).not.toHaveBeenCalled()
+  })
+
+  it('accepts custom threshold and dwell options', () => {
+    const { handlers, onAdvance } = setup(50, 300)
+    // threshold=50: 500-460=40 < 50 ✓
+    handlers.onDragOver(makeDragEvent(460))
+    vi.advanceTimersByTime(299)
+    expect(onAdvance).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(onAdvance).toHaveBeenCalledWith('next')
+  })
+})

--- a/frontend/src/composables/useDragEdgeScroll.ts
+++ b/frontend/src/composables/useDragEdgeScroll.ts
@@ -1,0 +1,71 @@
+import type { Ref } from 'vue'
+
+export type AdvanceDirection = 'prev' | 'next'
+
+export interface DragEdgeScrollOptions {
+  /** px from the left/right edge to trigger a dwell timer (default: 80) */
+  threshold?: number
+  /** ms to hold at the edge before firing onAdvance (default: 600) */
+  dwell?: number
+}
+
+/**
+ * Composable that fires onAdvance('prev'|'next') after a dwell period when
+ * a drag cursor is within `threshold` pixels of the left or right edge of
+ * the given container. Clears the timer on dragleave or dragend.
+ *
+ * Returns `{ onDragOver, onDragLeave, onDragEnd }` handlers to wire into
+ * the container element template — mirrors the pattern in useAutoScrollDrag.
+ */
+export function useDragEdgeScroll(
+  containerRef: Ref<HTMLElement | null>,
+  onAdvance: (direction: AdvanceDirection) => void,
+  options?: DragEdgeScrollOptions,
+) {
+  const threshold = options?.threshold ?? 80
+  const dwell = options?.dwell ?? 600
+
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  function clearTimer() {
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  function startTimer(direction: AdvanceDirection) {
+    if (timer !== null) return // already running — don't reset, keep original dwell
+    timer = setTimeout(() => {
+      timer = null
+      onAdvance(direction)
+    }, dwell)
+  }
+
+  function onDragOver(e: DragEvent) {
+    const container = containerRef.value
+    if (!container) return
+
+    const rect = container.getBoundingClientRect()
+    const x = e.clientX
+
+    if (x - rect.left < threshold) {
+      startTimer('prev')
+    } else if (rect.right - x < threshold) {
+      startTimer('next')
+    } else {
+      // Cursor moved out of edge zone during dragover — clear pending timer
+      clearTimer()
+    }
+  }
+
+  function onDragLeave() {
+    clearTimer()
+  }
+
+  function onDragEnd() {
+    clearTimer()
+  }
+
+  return { onDragOver, onDragLeave, onDragEnd }
+}

--- a/frontend/src/stores/__tests__/plan.test.ts
+++ b/frontend/src/stores/__tests__/plan.test.ts
@@ -106,6 +106,9 @@ describe('usePlanStore – moveTask optimistic updates', () => {
     const { usePlanStore } = await import('../plan')
     const store = usePlanStore()
 
+    // Pin activeDate so the fromDate lookup matches regardless of real calendar date
+    store.activeDate = '2026-05-01'
+
     // Set active plan (fromDate) — toDate '2026-05-05' is NOT in plans cache
     store.plan = {
       date: '2026-05-01',
@@ -146,5 +149,91 @@ describe('usePlanStore – moveTask optimistic updates', () => {
     expect(store.plans['2026-04-30'].anchors.morning.tasks).toHaveLength(0)
     expect(store.plans['2026-05-01'].anchors.morning.tasks).toHaveLength(1)
     expect(store.plans['2026-05-01'].anchors.morning.tasks[0].id).toBe('task-xyz')
+  })
+})
+
+describe('usePlanStore – moveTaskToAnchor', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('PATCHes /api/tasks/:id with plan_date and anchor_id', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({ ok: true, json: async () => ({}) } as any)
+    const { usePlanStore } = await import('../plan')
+    const store = usePlanStore()
+
+    await store.moveTaskToAnchor({ taskId: 'task-1', newDate: '2026-05-05', anchorId: 'anchor-a' })
+
+    expect(vi.mocked(api)).toHaveBeenCalledWith(
+      '/api/tasks/task-1',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ plan_date: '2026-05-05', anchor_id: 'anchor-a' }),
+      }),
+    )
+  })
+
+  it('optimistically removes task from source and inserts into target when both are cached', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({ ok: true, json: async () => ({}) } as any)
+    const { usePlanStore } = await import('../plan')
+    const store = usePlanStore()
+
+    const task = { id: 'task-1', text: 'Drag me', status: 'pending', position: 0 } as any
+    store.plans['2026-05-01'] = {
+      date: '2026-05-01',
+      anchors: { morning: { tasks: [task], notes: '' } },
+    } as any
+    store.plans['2026-05-03'] = {
+      date: '2026-05-03',
+      anchors: { 'deep-work': { tasks: [], notes: '' } },
+    } as any
+
+    await store.moveTaskToAnchor({ taskId: 'task-1', newDate: '2026-05-03', anchorId: 'deep-work' })
+
+    expect(store.plans['2026-05-01'].anchors.morning.tasks).toHaveLength(0)
+    expect(store.plans['2026-05-03'].anchors['deep-work'].tasks).toHaveLength(1)
+    expect(store.plans['2026-05-03'].anchors['deep-work'].tasks[0].id).toBe('task-1')
+  })
+
+  it('optimistically removes from source only when target day is not cached', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({ ok: true, json: async () => ({}) } as any)
+    const { usePlanStore } = await import('../plan')
+    const store = usePlanStore()
+
+    const task = { id: 'task-2', text: 'Move me', status: 'pending', position: 0 } as any
+    store.plans['2026-05-01'] = {
+      date: '2026-05-01',
+      anchors: { morning: { tasks: [task], notes: '' } },
+    } as any
+    // Target day intentionally absent from cache
+    delete (store.plans as any)['2026-05-07']
+
+    await store.moveTaskToAnchor({ taskId: 'task-2', newDate: '2026-05-07', anchorId: 'evening' })
+
+    expect(store.plans['2026-05-01'].anchors.morning.tasks).toHaveLength(0)
+    expect(store.plans['2026-05-07']).toBeUndefined()
+  })
+
+  it('also removes from active plan when task lives in plan (not plans cache)', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({ ok: true, json: async () => ({}) } as any)
+    const { usePlanStore } = await import('../plan')
+    const store = usePlanStore()
+
+    const task = { id: 'task-3', text: 'Active day task', status: 'pending', position: 0 } as any
+    store.plan = {
+      date: '2026-05-02',
+      anchors: { morning: { tasks: [task], notes: '' } },
+      acknowledgements: {},
+      check_in_log: [],
+    } as any
+
+    await store.moveTaskToAnchor({ taskId: 'task-3', newDate: '2026-05-05', anchorId: 'afternoon' })
+
+    expect(store.plan!.anchors.morning.tasks).toHaveLength(0)
   })
 })

--- a/frontend/src/stores/plan.ts
+++ b/frontend/src/stores/plan.ts
@@ -113,6 +113,65 @@ export const usePlanStore = defineStore('plan', () => {
     })
   }
 
+  /**
+   * Move a task to a new date/anchor cell. PATCHes both plan_date and anchor_id
+   * atomically (Track B confirmed both fields are accepted). Optimistically
+   * removes the task from its source cell (scans all cached plans + the active
+   * plan) and inserts it into the target cell if that day is already cached.
+   */
+  async function moveTaskToAnchor({
+    taskId,
+    newDate,
+    anchorId,
+  }: { taskId: string; newDate: string; anchorId: string }) {
+    // --- Optimistic update ---
+    // Find task in any cached plan and remove it from its source anchor.
+    let foundTask: Task | undefined
+
+    // Search plans range cache first
+    for (const dayPlan of Object.values(plans.value)) {
+      for (const anchorPlan of Object.values(dayPlan.anchors)) {
+        const idx = anchorPlan.tasks.findIndex(t => t.id === taskId)
+        if (idx !== -1) {
+          foundTask = anchorPlan.tasks[idx]
+          anchorPlan.tasks.splice(idx, 1)
+          break
+        }
+      }
+      if (foundTask) break
+    }
+
+    // Fall back to the active single-day plan
+    if (!foundTask && plan.value) {
+      for (const anchorPlan of Object.values(plan.value.anchors)) {
+        const idx = anchorPlan.tasks.findIndex(t => t.id === taskId)
+        if (idx !== -1) {
+          foundTask = anchorPlan.tasks[idx]
+          anchorPlan.tasks.splice(idx, 1)
+          break
+        }
+      }
+    }
+
+    // Insert into target cell if that day is already in the range cache
+    if (foundTask) {
+      const targetDay = plans.value[newDate]
+      if (targetDay) {
+        if (!targetDay.anchors[anchorId]) {
+          targetDay.anchors[anchorId] = { tasks: [], notes: '' }
+        }
+        targetDay.anchors[anchorId].tasks.push({ ...foundTask })
+      }
+    }
+
+    // --- API call (plan_date + anchor_id — Track B confirmed both fields work) ---
+    await api(`/api/tasks/${taskId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ plan_date: newDate, anchor_id: anchorId }),
+    })
+  }
+
   async function reorderTask(taskUuid: string, date: string, anchorId: string, newPosition: number) {
     const dayPlan = plans.value[date] ?? (date === activeDate.value ? plan.value : null)
     if (!dayPlan?.anchors[anchorId]) return
@@ -202,7 +261,7 @@ export const usePlanStore = defineStore('plan', () => {
     plan, loading, today, activeDate, savedDates, plans,
     fetchPlan, fetchSavedDates,
     goToPrevDay, goToNextDay, goToToday,
-    fetchPlanRange, moveTask, reorderTask,
+    fetchPlanRange, moveTask, moveTaskToAnchor, reorderTask,
     updateAnchorTasks, updateTaskStatus, patchTaskFields, connectWebSocket,
   }
 })

--- a/frontend/src/stores/plan.ts
+++ b/frontend/src/stores/plan.ts
@@ -160,7 +160,8 @@ export const usePlanStore = defineStore('plan', () => {
         if (!targetDay.anchors[anchorId]) {
           targetDay.anchors[anchorId] = { tasks: [], notes: '' }
         }
-        targetDay.anchors[anchorId].tasks.push({ ...foundTask })
+        // Include updated anchor_id so the task reflects its new home in cache
+        targetDay.anchors[anchorId].tasks.push({ ...foundTask, anchor_id: anchorId })
       }
     }
 

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useDragEdgeScroll } from '../composables/useDragEdgeScroll'
 import { useAnchorStore } from '../stores/anchors'
 import { useEventStore } from '../stores/events'
 import { usePlanStore } from '../stores/plan'
@@ -724,6 +725,14 @@ function loadEvents() {
 }
 
 const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+// ── Edge-scroll: advance calendar week when dragging to left/right edge ────────
+const calendarGridRef = ref<HTMLElement | null>(null)
+const { onDragOver: calendarEdgeDragOver, onDragLeave: calendarEdgeDragLeave, onDragEnd: calendarEdgeDragEnd } =
+  useDragEdgeScroll(calendarGridRef, (direction) => {
+    if (viewMode.value !== 'week') return
+    shiftWeek(direction === 'prev' ? -7 : 7)
+  })
 </script>
 
 <template>
@@ -922,7 +931,14 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
       <template v-if="viewMode === 'week'">
         <!-- Scrollable time grid — header lives inside so both share the same
              container width even when the scrollbar is visible. -->
-        <div class="flex-1 overflow-y-auto" data-testid="calendar-grid">
+        <div
+          ref="calendarGridRef"
+          class="flex-1 overflow-y-auto"
+          data-testid="calendar-grid"
+          @dragover="calendarEdgeDragOver"
+          @dragleave="calendarEdgeDragLeave"
+          @dragend="calendarEdgeDragEnd"
+        >
 
           <!-- Sticky header wrapper: day-of-week header + all-day band scroll together -->
           <div class="sticky top-0 z-10">

--- a/frontend/src/views/PlanView.vue
+++ b/frontend/src/views/PlanView.vue
@@ -7,7 +7,7 @@ import { useMilestoneStore } from '../stores/milestones'
 import { useEventStore } from '../stores/events'
 import { useSlideOver } from '../composables/useSlideOver'
 import AnchorBlock from '../components/AnchorBlock.vue'
-import WeekView from '../components/WeekView.vue'
+import PlanWeekView from '../components/plan/PlanWeekView.vue'
 import MonthView from '../components/MonthView.vue'
 import DayTimeline from '../components/DayTimeline.vue'
 import type { CalendarEvent } from '../types/events'
@@ -159,8 +159,8 @@ async function onAnchorColumnDrop(e: DragEvent) {
       </div>
     </div>
 
-    <!-- Week view -->
-    <WeekView v-if="props.view === 'week'" />
+    <!-- Week view: anchor rows × day columns grid -->
+    <PlanWeekView v-if="props.view === 'week'" />
 
     <!-- Month view -->
     <MonthView v-else-if="props.view === 'month'" />


### PR DESCRIPTION
## Summary

- **`useDragEdgeScroll` composable** — fires `onAdvance('prev'|'next')` after ~600ms dwell when a dragged item is within 80px of the left/right edge of a container; clears on `dragleave`/`dragend`. Reused by both `PlanWeekView` and `CalendarView`.
- **`moveTaskToAnchor` store action** — PATCHes `/api/tasks/:id` with `{plan_date, anchor_id}` atomically (Track B confirmed both fields work); optimistic remove from source cell, insert into target cell if cached.
- **`PlanWeekCell`** — anchor×day drop target; reads `{taskId}` from the standard `text/plain` drag payload and calls `moveTaskToAnchor`; shows drag-over ring highlight.
- **`PlanWeekView`** — 7-column × N-anchor-row CSS grid with Mon–Sun headers and prev/next week nav; loads all 7 days via `fetchPlanRange`; wires `useDragEdgeScroll` to the grid container.
- **`PlanView`** — swaps `WeekView` → `PlanWeekView` on the `/plan/week` route.
- **`CalendarView`** — wires `useDragEdgeScroll` to the calendar week grid container for edge-scroll week advance.
- **Fix** pre-existing `moveTask` test that was coupled to the calendar date `2026-05-01`.

## Test plan

- [ ] `npm run test` — 414 tests pass (43 files)
- [ ] `npm run build` — zero type errors
- [ ] Manual: navigate to `/plan/week/<date>` → anchor×day grid renders with task cards
- [ ] Manual: drag a task card from one cell, drop onto another → task moves date + anchor
- [ ] Manual: drag a task to the left/right edge of the week grid → week advances after ~600ms
- [ ] Manual: drag a task in CalendarView week grid to the left/right edge → calendar week advances
- [ ] Manual: day view (`/plan/day/<date>`) still works as before