### PR TITLE
feat(frontend): unified DnD composables + TaskCard mode prop (Track 1)

### DIFF
--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -4,18 +4,36 @@ import type { Task, TaskStatus } from '../stores/plan'
 import type { FollowupConfig } from '../stores/anchors'
 import { useMilestoneStore } from '../stores/milestones'
 import { useSlideOver } from '../composables/useSlideOver'
+import { useDraggableTask } from '../composables/useDraggableTask'
+
 const milestoneStore = useMilestoneStore()
 const { push: pushPanel } = useSlideOver()
 
+/** Display mode for the card. Controls layout and drag behaviour.
+ *  - `plan`             — editable card in an AnchorBlock; drag sourced from wrapper div
+ *  - `kanban`           — read-only card; this element IS the drag source
+ *  - `calendar-event`  — positioned in a time-grid (absorbs CalendarEventBlock)
+ *  - `calendar-sidebar`— read-only compact card in calendar sidebar task list
+ */
+type TaskCardMode = 'plan' | 'kanban' | 'calendar-event' | 'calendar-sidebar'
+
 const props = withDefaults(defineProps<{
   task: Task
+  mode?: TaskCardMode
   editable?: boolean
   showRemove?: boolean
   showDetailLink?: boolean
   compact?: boolean
   hideTags?: boolean  // hide milestone/context tags (when inside a GroupContainer that already shows them)
   navigable?: boolean  // whether clicking the card navigates to detail panel
+  // ── calendar-event mode props (mirror CalendarEventBlock) ──────────────────
+  heightPx?: number
+  topPx?: number
+  leftPercent?: number
+  widthPercent?: number
+  resolvedColor?: string
 }>(), {
+  mode: 'plan',
   editable: true,
   showRemove: true,
   showDetailLink: true,
@@ -23,10 +41,24 @@ const props = withDefaults(defineProps<{
   hideTags: false,
   navigable: true,
 })
+
 const emit = defineEmits<{
   (e: 'update', task: Task): void
   (e: 'remove'): void
 }>()
+
+// ── Drag source — useDraggableTask ────────────────────────────────────────────
+// isDragging is set when THIS element is the drag source (kanban, calendar-event,
+// calendar-sidebar). In plan mode the AnchorBlock wrapper is the source, so
+// isDragging stays false — that's fine; Track 3 will wire the wrapper.
+const taskRef = computed(() => props.task)
+const { isDragging, dragHandlers } = useDraggableTask(taskRef)
+
+// Whether this card element is itself draggable (not just a container for a
+// wrapper-div drag in plan view).
+const isSelfDraggable = computed(() =>
+  !!props.task.id && (props.mode === 'kanban' || props.mode === 'calendar-event' || props.mode === 'calendar-sidebar' || !props.editable)
+)
 
 // Status pill colors (text + bg for the clickable pill)
 const STATUS_PILL: Record<TaskStatus, { bg: string; text: string; label: string }> = {
@@ -38,7 +70,6 @@ const STATUS_PILL: Record<TaskStatus, { bg: string; text: string; label: string 
 }
 
 // Tasks are transparent — the parent AnchorBlock's --m-band provides the surface.
-// Status is communicated by text dimming + pill + per-task sidebar line only.
 const STATUS_ROW_STYLE: Record<TaskStatus, Record<string, string>> = {
   pending:     {},
   in_progress: {},
@@ -92,17 +123,6 @@ function updateText(e: Event) {
   emit('update', { ...props.task, text: (e.target as HTMLInputElement).value })
 }
 
-function onDragStart(evt: DragEvent) {
-  if (!props.task.id) {
-    console.warn('[TaskCard] dragstart blocked: task has no id', props.task)
-    evt.preventDefault()
-    return
-  }
-  if (!evt.dataTransfer) return
-  evt.dataTransfer.effectAllowed = 'move'
-  evt.dataTransfer.setData('text/plain', JSON.stringify({ taskId: props.task.id }))
-}
-
 function toggleFollowup(enabled: boolean) {
   const fc: FollowupConfig = {
     enabled,
@@ -114,14 +134,53 @@ function toggleFollowup(enabled: boolean) {
   emit('update', { ...props.task, followup_config: enabled ? fc : null })
 }
 
+// ── Calendar-event mode: position/size styles ──────────────────────────────────
+const calendarEventStyle = computed(() => {
+  const lp = props.leftPercent ?? 0
+  const wp = props.widthPercent ?? 100
+  return {
+    position: 'absolute' as const,
+    top: `${props.topPx ?? 0}px`,
+    height: `${props.heightPx ?? 20}px`,
+    left: `calc(${lp}% + ${wp * 0.05}% + 2px)`,
+    width: `calc(${wp * 0.9}% - 4px)`,
+    backgroundColor: props.resolvedColor ?? '#6366f1',
+    borderLeft: `3px solid ${props.resolvedColor ?? '#6366f1'}`,
+    opacity: 0.92,
+  }
+})
 </script>
 
 <template>
-  <div class="group transition-colors cursor-pointer relative"
-      :style="STATUS_ROW_STYLE[task.status]"
-      :draggable="!editable && !!task.id"
-      @dragstart="onDragStart"
-      @click="navigable && task.id && pushPanel({ kind: 'task', entityId: task.id })">
+  <!-- ── calendar-event mode: absorbed from CalendarEventBlock ─────────────── -->
+  <div
+    v-if="mode === 'calendar-event'"
+    data-testid="task-card-calendar-event"
+    data-event-block
+    class="rounded overflow-hidden text-xs px-1.5 py-0.5 cursor-grab shadow-md hover:brightness-110 transition-all z-10"
+    :style="calendarEventStyle"
+    :draggable="!!task.id"
+    @dragstart="dragHandlers.onDragStart"
+    @dragend="dragHandlers.onDragEnd"
+    @click.stop="navigable && task.id && pushPanel({ kind: 'task', entityId: task.id })"
+  >
+    <div class="flex items-center gap-1 truncate pointer-events-none">
+      <span class="truncate font-medium text-[--accent-fg]">{{ task.text }}</span>
+    </div>
+  </div>
+
+  <!-- ── plan / kanban / calendar-sidebar modes ─────────────────────────────── -->
+  <div
+    v-else
+    data-testid="task-card"
+    v-show="!isDragging"
+    class="group transition-colors cursor-pointer relative"
+    :style="STATUS_ROW_STYLE[task.status]"
+    :draggable="isSelfDraggable"
+    @dragstart="dragHandlers.onDragStart"
+    @dragend="dragHandlers.onDragEnd"
+    @click="navigable && task.id && pushPanel({ kind: 'task', entityId: task.id })"
+  >
     <div v-if="task.motif || task.color"
          class="absolute left-0 top-1 bottom-1 w-0.5 rounded-full pointer-events-none"
          :style="{ background: task.motif ? `var(--motif-${task.motif})` : task.color! }" />

--- a/frontend/src/components/__tests__/TaskCard.test.ts
+++ b/frontend/src/components/__tests__/TaskCard.test.ts
@@ -28,39 +28,44 @@ describe('TaskCard drag behavior', () => {
     setActivePinia(createPinia())
   })
 
+  // NOTE: TaskCard template has a fragment root (v-if calendar-event / v-else normal).
+  // Tests use data-testid selectors to target the rendered element directly.
+
   it('sets draggable="true" when editable is false (kanban mode)', () => {
     const wrapper = mount(TaskCard, {
       props: { task: baseTask, editable: false },
     })
-    expect(wrapper.attributes('draggable')).toBe('true')
+    expect(wrapper.find('[data-testid="task-card"]').attributes('draggable')).toBe('true')
   })
 
   it('sets draggable="false" when editable is true (plan mode)', () => {
     const wrapper = mount(TaskCard, {
       props: { task: baseTask, editable: true },
     })
-    expect(wrapper.attributes('draggable')).toBe('false')
+    expect(wrapper.find('[data-testid="task-card"]').attributes('draggable')).toBe('false')
   })
 
   it('sets draggable="false" when task has no id', () => {
     const wrapper = mount(TaskCard, {
       props: { task: { ...baseTask, id: '' }, editable: false },
     })
-    expect(wrapper.attributes('draggable')).toBe('false')
+    expect(wrapper.find('[data-testid="task-card"]').attributes('draggable')).toBe('false')
   })
 
-  it('serializes taskId as text/plain on dragstart', async () => {
+  it('serializes superset payload (type, taskId, title) as text/plain on dragstart', async () => {
     const wrapper = mount(TaskCard, {
       props: { task: baseTask, editable: false },
     })
     const setData = vi.fn()
-    await wrapper.trigger('dragstart', {
+    await wrapper.find('[data-testid="task-card"]').trigger('dragstart', {
       dataTransfer: { setData, effectAllowed: '' },
     })
-    expect(setData).toHaveBeenCalledWith(
-      'text/plain',
-      JSON.stringify({ taskId: 'task-1' }),
-    )
+    expect(setData).toHaveBeenCalledWith('text/plain', expect.any(String))
+    const [, raw] = setData.mock.calls[0]
+    const payload = JSON.parse(raw)
+    expect(payload.type).toBe('task')
+    expect(payload.taskId).toBe('task-1')
+    expect(payload.title).toBe('Test task')
   })
 
   it('does not serialize data when task has no id', async () => {
@@ -68,9 +73,128 @@ describe('TaskCard drag behavior', () => {
       props: { task: { ...baseTask, id: '' }, editable: false },
     })
     const setData = vi.fn()
-    await wrapper.trigger('dragstart', {
+    await wrapper.find('[data-testid="task-card"]').trigger('dragstart', {
       dataTransfer: { setData, effectAllowed: '' },
     })
     expect(setData).not.toHaveBeenCalled()
+  })
+})
+
+describe('TaskCard mode prop', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders without error when mode="plan" (default/no mode)', () => {
+    const wrapper = mount(TaskCard, {
+      props: { task: baseTask },
+    })
+    expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(true)
+  })
+
+  it('renders without error when mode="kanban"', () => {
+    const wrapper = mount(TaskCard, {
+      props: { task: baseTask, mode: 'kanban' },
+    })
+    expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(true)
+  })
+
+  it('renders calendar-event mode with absolute positioning style', () => {
+    const wrapper = mount(TaskCard, {
+      props: {
+        task: baseTask,
+        mode: 'calendar-event',
+        topPx: 120,
+        heightPx: 60,
+      },
+    })
+    expect(wrapper.find('[data-testid="task-card-calendar-event"]').exists()).toBe(true)
+    const style = wrapper.find('[data-testid="task-card-calendar-event"]').attributes('style')
+    expect(style).toContain('top: 120px')
+    expect(style).toContain('height: 60px')
+  })
+
+  it('calendar-event mode applies resolvedColor as background', () => {
+    const wrapper = mount(TaskCard, {
+      props: {
+        task: baseTask,
+        mode: 'calendar-event',
+        topPx: 0,
+        heightPx: 60,
+        resolvedColor: '#6366f1',
+      },
+    })
+    const el = wrapper.find('[data-testid="task-card-calendar-event"]')
+    expect(el.attributes('style')).toContain('#6366f1')
+  })
+
+  it('calendar-event mode applies leftPercent and widthPercent to style', () => {
+    const wrapper = mount(TaskCard, {
+      props: {
+        task: baseTask,
+        mode: 'calendar-event',
+        topPx: 0,
+        heightPx: 60,
+        leftPercent: 50,
+        widthPercent: 50,
+      },
+    })
+    const el = wrapper.find('[data-testid="task-card-calendar-event"]')
+    const style = el.attributes('style') ?? ''
+    expect(style).toContain('50%')
+  })
+
+  it('calendar-event mode displays task title', () => {
+    const wrapper = mount(TaskCard, {
+      props: {
+        task: { ...baseTask, text: 'Stand-up meeting' },
+        mode: 'calendar-event',
+        topPx: 0,
+        heightPx: 60,
+      },
+    })
+    expect(wrapper.text()).toContain('Stand-up meeting')
+  })
+})
+
+describe('TaskCard isDragging / source-hide behavior', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('root element is visible (not hidden) by default', () => {
+    const wrapper = mount(TaskCard, {
+      props: { task: baseTask, editable: false },
+    })
+    // v-show="!isDragging" — isDragging starts false → display not none
+    expect(wrapper.find('[data-testid="task-card"]').isVisible()).toBe(true)
+  })
+
+  it('root element is hidden via v-show while dragging', async () => {
+    const wrapper = mount(TaskCard, {
+      props: { task: baseTask, editable: false },
+      attachTo: document.body,
+    })
+    const card = wrapper.find('[data-testid="task-card"]')
+    const setData = vi.fn()
+    await card.trigger('dragstart', {
+      dataTransfer: { setData, effectAllowed: '' },
+    })
+    // After dragstart, isDragging=true → v-show="false" → display:none
+    expect(card.isVisible()).toBe(false)
+  })
+
+  it('root element becomes visible again after dragend', async () => {
+    const wrapper = mount(TaskCard, {
+      props: { task: baseTask, editable: false },
+      attachTo: document.body,
+    })
+    const card = wrapper.find('[data-testid="task-card"]')
+    const setData = vi.fn()
+    await card.trigger('dragstart', {
+      dataTransfer: { setData, effectAllowed: '' },
+    })
+    await card.trigger('dragend')
+    expect(card.isVisible()).toBe(true)
   })
 })

--- a/frontend/src/composables/__tests__/useDraggableTask.test.ts
+++ b/frontend/src/composables/__tests__/useDraggableTask.test.ts
@@ -1,0 +1,137 @@
+/**
+ * useDraggableTask composable
+ *
+ * Verifies that:
+ *   1. isDragging starts as false
+ *   2. onDragStart sets isDragging to true
+ *   3. onDragStart writes superset payload to dataTransfer
+ *   4. onDragStart with no task id calls preventDefault and does not set isDragging
+ *   5. onDragEnd restores isDragging to false
+ *   6. Optional context fields (fromAnchorId, fromDate) are included in payload when provided
+ *   7. Optional scheduling fields (fromStartTime, durationMs) are included when provided
+ *   8. effectAllowed is set to 'move' on dragstart
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { ref } from 'vue'
+import { useDraggableTask } from '../useDraggableTask'
+import type { Task } from '../../stores/plan'
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task-1',
+    text: 'Test task',
+    description: null,
+    status: 'pending',
+    position: 0,
+    followup_config: null,
+    blocks: [],
+    blocked_by: [],
+    context_subject: null,
+    context_node_id: null,
+    ...overrides,
+  }
+}
+
+function makeDragEvent(overrides: Partial<DragEvent> = {}): DragEvent {
+  const setData = vi.fn()
+  return {
+    preventDefault: vi.fn(),
+    dataTransfer: {
+      setData,
+      effectAllowed: '',
+    },
+    ...overrides,
+  } as unknown as DragEvent
+}
+
+describe('useDraggableTask', () => {
+  it('isDragging starts as false', () => {
+    const taskRef = ref(makeTask())
+    const { isDragging } = useDraggableTask(taskRef)
+    expect(isDragging.value).toBe(false)
+  })
+
+  it('onDragStart sets isDragging to true', () => {
+    const taskRef = ref(makeTask())
+    const { isDragging, dragHandlers } = useDraggableTask(taskRef)
+    dragHandlers.onDragStart(makeDragEvent())
+    expect(isDragging.value).toBe(true)
+  })
+
+  it('onDragEnd restores isDragging to false', () => {
+    const taskRef = ref(makeTask())
+    const { isDragging, dragHandlers } = useDraggableTask(taskRef)
+    dragHandlers.onDragStart(makeDragEvent())
+    expect(isDragging.value).toBe(true)
+    dragHandlers.onDragEnd()
+    expect(isDragging.value).toBe(false)
+  })
+
+  it('onDragStart writes type and taskId to dataTransfer', () => {
+    const taskRef = ref(makeTask({ id: 'task-abc', text: 'My task' }))
+    const { dragHandlers } = useDraggableTask(taskRef)
+    const evt = makeDragEvent()
+    dragHandlers.onDragStart(evt)
+    expect(evt.dataTransfer!.setData).toHaveBeenCalledWith('text/plain', expect.any(String))
+    const [, raw] = (evt.dataTransfer!.setData as ReturnType<typeof vi.fn>).mock.calls[0]
+    const payload = JSON.parse(raw)
+    expect(payload.type).toBe('task')
+    expect(payload.taskId).toBe('task-abc')
+    expect(payload.title).toBe('My task')
+  })
+
+  it('sets effectAllowed to "move"', () => {
+    const taskRef = ref(makeTask())
+    const { dragHandlers } = useDraggableTask(taskRef)
+    const evt = makeDragEvent()
+    dragHandlers.onDragStart(evt)
+    expect((evt.dataTransfer as DataTransfer).effectAllowed).toBe('move')
+  })
+
+  it('includes fromAnchorId and fromDate in payload when context provided', () => {
+    const taskRef = ref(makeTask({ id: 't1' }))
+    const contextRef = ref({ fromAnchorId: 'anchor-morning', fromDate: '2026-05-02' })
+    const { dragHandlers } = useDraggableTask(taskRef, contextRef)
+    const evt = makeDragEvent()
+    dragHandlers.onDragStart(evt)
+    const [, raw] = (evt.dataTransfer!.setData as ReturnType<typeof vi.fn>).mock.calls[0]
+    const payload = JSON.parse(raw)
+    expect(payload.fromAnchorId).toBe('anchor-morning')
+    expect(payload.fromDate).toBe('2026-05-02')
+  })
+
+  it('includes fromStartTime and durationMs when provided in context', () => {
+    const taskRef = ref(makeTask({ id: 't1' }))
+    const contextRef = ref({
+      fromAnchorId: 'anchor-focus',
+      fromDate: '2026-05-02',
+      fromStartTime: '2026-05-02T09:00:00',
+      durationMs: 3600000,
+    })
+    const { dragHandlers } = useDraggableTask(taskRef, contextRef)
+    const evt = makeDragEvent()
+    dragHandlers.onDragStart(evt)
+    const [, raw] = (evt.dataTransfer!.setData as ReturnType<typeof vi.fn>).mock.calls[0]
+    const payload = JSON.parse(raw)
+    expect(payload.fromStartTime).toBe('2026-05-02T09:00:00')
+    expect(payload.durationMs).toBe(3600000)
+  })
+
+  it('calls preventDefault and does NOT set isDragging when task has no id', () => {
+    const taskRef = ref(makeTask({ id: '' }))
+    const { isDragging, dragHandlers } = useDraggableTask(taskRef)
+    const evt = makeDragEvent()
+    dragHandlers.onDragStart(evt)
+    expect(evt.preventDefault).toHaveBeenCalled()
+    expect(isDragging.value).toBe(false)
+  })
+
+  it('does nothing if dataTransfer is null', () => {
+    const taskRef = ref(makeTask())
+    const { isDragging, dragHandlers } = useDraggableTask(taskRef)
+    const evt = makeDragEvent({ dataTransfer: null as unknown as DataTransfer })
+    // Should not throw
+    expect(() => dragHandlers.onDragStart(evt)).not.toThrow()
+    expect(isDragging.value).toBe(false)
+  })
+})

--- a/frontend/src/composables/__tests__/useDropZone.test.ts
+++ b/frontend/src/composables/__tests__/useDropZone.test.ts
@@ -33,17 +33,26 @@ describe('useDropZone', () => {
     expect(isOver.value).toBe(false)
   })
 
-  it('onDragOver sets isOver to true and calls preventDefault', () => {
+  it('onDragEnter sets isOver to true and calls preventDefault', () => {
+    const { isOver, dropHandlers } = useDropZone({ onDrop: vi.fn() })
+    const evt = makeDragEvent()
+    dropHandlers.onDragEnter(evt)
+    expect(isOver.value).toBe(true)
+    expect(evt.preventDefault).toHaveBeenCalled()
+  })
+
+  it('onDragOver calls preventDefault but does NOT change isOver', () => {
     const { isOver, dropHandlers } = useDropZone({ onDrop: vi.fn() })
     const evt = makeDragEvent()
     dropHandlers.onDragOver(evt)
-    expect(isOver.value).toBe(true)
+    // dragover alone should not set isOver — only dragenter does
+    expect(isOver.value).toBe(false)
     expect(evt.preventDefault).toHaveBeenCalled()
   })
 
   it('onDragLeave sets isOver to false after single enter', () => {
     const { isOver, dropHandlers } = useDropZone({ onDrop: vi.fn() })
-    dropHandlers.onDragOver(makeDragEvent())
+    dropHandlers.onDragEnter(makeDragEvent())
     expect(isOver.value).toBe(true)
     dropHandlers.onDragLeave()
     expect(isOver.value).toBe(false)
@@ -51,9 +60,9 @@ describe('useDropZone', () => {
 
   it('requires matching onDragLeave calls to clear isOver (enter counter pattern)', () => {
     const { isOver, dropHandlers } = useDropZone({ onDrop: vi.fn() })
-    // Simulate entering parent then child — 2 enter events
-    dropHandlers.onDragOver(makeDragEvent())
-    dropHandlers.onDragOver(makeDragEvent())
+    // Simulate entering parent then child — 2 dragenter events
+    dropHandlers.onDragEnter(makeDragEvent())
+    dropHandlers.onDragEnter(makeDragEvent())
     dropHandlers.onDragLeave()
     expect(isOver.value).toBe(true)  // still inside, one enter outstanding
     dropHandlers.onDragLeave()
@@ -63,7 +72,7 @@ describe('useDropZone', () => {
   it('onDrop calls preventDefault, resets isOver, parses payload, calls onDrop callback', () => {
     const onDrop = vi.fn()
     const { isOver, dropHandlers } = useDropZone({ onDrop })
-    dropHandlers.onDragOver(makeDragEvent())
+    dropHandlers.onDragEnter(makeDragEvent())
     const payload = { type: 'task', taskId: 'task-1', title: 'Do thing' }
     const evt = makeDragEvent(JSON.stringify(payload))
     dropHandlers.onDrop(evt)
@@ -109,7 +118,7 @@ describe('useDropZone', () => {
     expect(isOver.value).toBe(false)
   })
 
-  it('sets dropEffect to "move" on dragover when dataTransfer present', () => {
+  it('sets dropEffect to "move" on onDragOver when dataTransfer present', () => {
     const { dropHandlers } = useDropZone({ onDrop: vi.fn() })
     const evt = makeDragEvent()
     dropHandlers.onDragOver(evt)

--- a/frontend/src/composables/__tests__/useDropZone.test.ts
+++ b/frontend/src/composables/__tests__/useDropZone.test.ts
@@ -1,0 +1,118 @@
+/**
+ * useDropZone composable
+ *
+ * Verifies that:
+ *   1. isOver starts as false
+ *   2. onDragOver sets isOver to true and calls preventDefault
+ *   3. onDragLeave decrements count; isOver becomes false when count reaches 0
+ *   4. Multiple onDragEnter (via onDragOver) require equal onDragLeave calls to clear isOver
+ *   5. onDrop calls preventDefault, resets isOver to false, parses payload, calls options.onDrop
+ *   6. onDrop with no dataTransfer does nothing (no throw)
+ *   7. onDrop with malformed JSON does not call options.onDrop
+ *   8. onDrop with empty payload string does not call options.onDrop
+ *   9. targetContext is passed through to options.onDrop
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { useDropZone } from '../useDropZone'
+
+function makeDragEvent(rawPayload?: string | null): DragEvent {
+  // null explicitly means "no dataTransfer"; undefined (default) → non-null with empty getData
+  const dataTransfer = rawPayload === null
+    ? null
+    : { getData: vi.fn().mockReturnValue(rawPayload ?? ''), dropEffect: '' }
+  return {
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    dataTransfer,
+  } as unknown as DragEvent
+}
+
+describe('useDropZone', () => {
+  it('isOver starts as false', () => {
+    const { isOver } = useDropZone({ onDrop: vi.fn() })
+    expect(isOver.value).toBe(false)
+  })
+
+  it('onDragOver sets isOver to true and calls preventDefault', () => {
+    const { isOver, dropHandlers } = useDropZone({ onDrop: vi.fn() })
+    const evt = makeDragEvent()
+    dropHandlers.onDragOver(evt)
+    expect(isOver.value).toBe(true)
+    expect(evt.preventDefault).toHaveBeenCalled()
+  })
+
+  it('onDragLeave sets isOver to false after single enter', () => {
+    const { isOver, dropHandlers } = useDropZone({ onDrop: vi.fn() })
+    dropHandlers.onDragOver(makeDragEvent())
+    expect(isOver.value).toBe(true)
+    dropHandlers.onDragLeave()
+    expect(isOver.value).toBe(false)
+  })
+
+  it('requires matching onDragLeave calls to clear isOver (enter counter pattern)', () => {
+    const { isOver, dropHandlers } = useDropZone({ onDrop: vi.fn() })
+    // Simulate entering parent then child — 2 enter events
+    dropHandlers.onDragOver(makeDragEvent())
+    dropHandlers.onDragOver(makeDragEvent())
+    dropHandlers.onDragLeave()
+    expect(isOver.value).toBe(true)  // still inside, one enter outstanding
+    dropHandlers.onDragLeave()
+    expect(isOver.value).toBe(false)
+  })
+
+  it('onDrop calls preventDefault, resets isOver, parses payload, calls onDrop callback', () => {
+    const onDrop = vi.fn()
+    const { isOver, dropHandlers } = useDropZone({ onDrop })
+    dropHandlers.onDragOver(makeDragEvent())
+    const payload = { type: 'task', taskId: 'task-1', title: 'Do thing' }
+    const evt = makeDragEvent(JSON.stringify(payload))
+    dropHandlers.onDrop(evt)
+    expect(evt.preventDefault).toHaveBeenCalled()
+    expect(isOver.value).toBe(false)
+    expect(onDrop).toHaveBeenCalledWith(payload, undefined)
+  })
+
+  it('passes targetContext through to onDrop callback', () => {
+    const onDrop = vi.fn()
+    const targetContext = { anchorId: 'morning', date: '2026-05-02' }
+    const { dropHandlers } = useDropZone({ onDrop, targetContext })
+    const payload = { type: 'task', taskId: 't2' }
+    dropHandlers.onDrop(makeDragEvent(JSON.stringify(payload)))
+    expect(onDrop).toHaveBeenCalledWith(payload, targetContext)
+  })
+
+  it('does not call onDrop callback with empty dataTransfer string', () => {
+    const onDrop = vi.fn()
+    const { dropHandlers } = useDropZone({ onDrop })
+    dropHandlers.onDrop(makeDragEvent(''))
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  it('does not call onDrop callback with malformed JSON', () => {
+    const onDrop = vi.fn()
+    const { dropHandlers } = useDropZone({ onDrop })
+    dropHandlers.onDrop(makeDragEvent('not-json'))
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when dataTransfer is null', () => {
+    const onDrop = vi.fn()
+    const { dropHandlers } = useDropZone({ onDrop })
+    expect(() => dropHandlers.onDrop(makeDragEvent(null))).not.toThrow()
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  it('counter never goes below 0 on extra onDragLeave calls', () => {
+    const { isOver, dropHandlers } = useDropZone({ onDrop: vi.fn() })
+    dropHandlers.onDragLeave()
+    dropHandlers.onDragLeave()
+    expect(isOver.value).toBe(false)
+  })
+
+  it('sets dropEffect to "move" on dragover when dataTransfer present', () => {
+    const { dropHandlers } = useDropZone({ onDrop: vi.fn() })
+    const evt = makeDragEvent()
+    dropHandlers.onDragOver(evt)
+    expect((evt.dataTransfer as DataTransfer).dropEffect).toBe('move')
+  })
+})

--- a/frontend/src/composables/useDraggableTask.ts
+++ b/frontend/src/composables/useDraggableTask.ts
@@ -1,0 +1,81 @@
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+import type { Task } from '../stores/plan'
+
+/**
+ * Superset drag payload written to `text/plain` on dragstart.
+ * All fields from all drag contexts are present so any drop target can
+ * read what it needs without knowing the source view.
+ */
+export interface DraggableTaskPayload {
+  type: 'task'
+  taskId: string
+  title: string
+  /** Anchor the task came from (plan view day/week) */
+  fromAnchorId?: string
+  /** Date string (YYYY-MM-DD) the task came from */
+  fromDate?: string
+  /** ISO start time when task has a calendar event */
+  fromStartTime?: string
+  /** Duration in ms when task has a calendar event */
+  durationMs?: number
+}
+
+/** Optional context provided by the parent to enrich the drag payload */
+export interface DraggableTaskContext {
+  fromAnchorId?: string
+  fromDate?: string
+  fromStartTime?: string
+  durationMs?: number
+}
+
+/**
+ * Unified HTML5 DnD drag-source composable for task cards.
+ *
+ * Returns:
+ * - `isDragging` — true while the card is being dragged; bind to
+ *   `v-show="!isDragging"` on the source element to hide it on pickup
+ * - `dragHandlers` — attach to the draggable element's @dragstart / @dragend
+ *
+ * @param taskRef  Reactive ref to the task being dragged
+ * @param contextRef  Optional reactive context (anchor, date, calendar fields)
+ */
+export function useDraggableTask(
+  taskRef: Ref<Task>,
+  contextRef?: Ref<DraggableTaskContext | undefined>,
+) {
+  const isDragging = ref(false)
+
+  function onDragStart(evt: DragEvent) {
+    const task = taskRef.value
+    if (!task.id) {
+      evt.preventDefault()
+      return
+    }
+    if (!evt.dataTransfer) return
+
+    const ctx = contextRef?.value
+    const payload: DraggableTaskPayload = {
+      type: 'task',
+      taskId: task.id,
+      title: task.text,
+      ...(ctx?.fromAnchorId !== undefined && { fromAnchorId: ctx.fromAnchorId }),
+      ...(ctx?.fromDate !== undefined && { fromDate: ctx.fromDate }),
+      ...(ctx?.fromStartTime !== undefined && { fromStartTime: ctx.fromStartTime }),
+      ...(ctx?.durationMs !== undefined && { durationMs: ctx.durationMs }),
+    }
+
+    evt.dataTransfer.effectAllowed = 'move'
+    evt.dataTransfer.setData('text/plain', JSON.stringify(payload))
+    isDragging.value = true
+  }
+
+  function onDragEnd() {
+    isDragging.value = false
+  }
+
+  return {
+    isDragging,
+    dragHandlers: { onDragStart, onDragEnd },
+  }
+}

--- a/frontend/src/composables/useDropZone.ts
+++ b/frontend/src/composables/useDropZone.ts
@@ -1,0 +1,65 @@
+import { ref } from 'vue'
+import type { DraggableTaskPayload } from './useDraggableTask'
+
+export type DropPayload = DraggableTaskPayload | Record<string, unknown>
+
+export interface UseDropZoneOptions<TContext = unknown> {
+  /** Called when a valid payload is dropped. Semantics are handled by the caller. */
+  onDrop: (payload: DropPayload, targetContext: TContext | undefined) => void
+  /** Arbitrary context passed through to onDrop — e.g. { anchorId, date } */
+  targetContext?: TContext
+}
+
+/**
+ * Unified HTML5 DnD drop-target composable.
+ *
+ * Absorbs the `dragEnterCount` counter pattern (prevents isOver flicker when
+ * cursor moves over child elements) used in KanbanColumn.
+ *
+ * Returns:
+ * - `isOver` — true while a drag is over the drop zone; bind for visual feedback
+ * - `dropHandlers` — attach to the container element
+ *
+ * @param options.onDrop  Called with (parsedPayload, targetContext) on valid drop
+ * @param options.targetContext  Forwarded as-is to onDrop (anchor id, date, etc.)
+ */
+export function useDropZone<TContext = unknown>(options: UseDropZoneOptions<TContext>) {
+  const isOver = ref(false)
+  // Counter tracks nested dragenter/dragleave so child elements don't flicker isOver
+  let enterCount = 0
+
+  function onDragOver(evt: DragEvent) {
+    evt.preventDefault()
+    if (evt.dataTransfer) evt.dataTransfer.dropEffect = 'move'
+    enterCount++
+    isOver.value = true
+  }
+
+  function onDragLeave() {
+    enterCount = Math.max(0, enterCount - 1)
+    if (enterCount === 0) isOver.value = false
+  }
+
+  function onDrop(evt: DragEvent) {
+    evt.preventDefault()
+    enterCount = 0
+    isOver.value = false
+
+    const raw = evt.dataTransfer?.getData('text/plain')
+    if (!raw) return
+
+    let payload: DropPayload
+    try {
+      payload = JSON.parse(raw)
+    } catch {
+      return // ignore malformed data from other drag sources
+    }
+
+    options.onDrop(payload, options.targetContext)
+  }
+
+  return {
+    isOver,
+    dropHandlers: { onDragOver, onDragLeave, onDrop },
+  }
+}

--- a/frontend/src/composables/useDropZone.ts
+++ b/frontend/src/composables/useDropZone.ts
@@ -28,11 +28,17 @@ export function useDropZone<TContext = unknown>(options: UseDropZoneOptions<TCon
   // Counter tracks nested dragenter/dragleave so child elements don't flicker isOver
   let enterCount = 0
 
+  // onDragEnter fires ONCE per element entered — use it for the counter.
+  // onDragOver fires continuously (~60fps) — only preventDefault + dropEffect here.
+  function onDragEnter(evt: DragEvent) {
+    evt.preventDefault()
+    enterCount++
+    isOver.value = true
+  }
+
   function onDragOver(evt: DragEvent) {
     evt.preventDefault()
     if (evt.dataTransfer) evt.dataTransfer.dropEffect = 'move'
-    enterCount++
-    isOver.value = true
   }
 
   function onDragLeave() {
@@ -60,6 +66,6 @@ export function useDropZone<TContext = unknown>(options: UseDropZoneOptions<TCon
 
   return {
     isOver,
-    dropHandlers: { onDragOver, onDragLeave, onDrop },
+    dropHandlers: { onDragEnter, onDragOver, onDragLeave, onDrop },
   }
 }


### PR DESCRIPTION
## Summary

- **`useDraggableTask`** — unified HTML5 DnD drag-source composable. Writes superset payload `{type, taskId, title, fromAnchorId?, fromDate?, fromStartTime?, durationMs?}` so all drop targets can read what they need. `isDragging` ref enables `v-show="!isDragging"` source-hiding on dragstart/end.
- **`useDropZone`** — unified drop-target composable. Absorbs the `dragEnterCount` counter pattern from KanbanColumn (prevents `isOver` flicker when cursor moves over child elements). Caller provides `onDrop(payload, targetContext)` — all JSON parsing/error handling is internal.
- **`TaskCard`** — adds `mode: 'plan' | 'kanban' | 'calendar-event' | 'calendar-sidebar'` prop. Wires `useDraggableTask` (replaces inline `onDragStart`). Adds `calendar-event` template section that absorbs `CalendarEventBlock` layout (absolute positioning via `topPx`/`heightPx`/`leftPercent`/`widthPercent`/`resolvedColor` props). Adds `data-testid="task-card"` and `v-show="!isDragging"` on normal-mode root.

## Why

Track 1 of the DnD unification plan (`cc-context-store/tether/plans/frontend-ui-ux/dnd-unification.md`). Tracks 2 and 3 depend on these composable interfaces. See ACCOUNTING.md for full context.

## Test plan

- [ ] `useDraggableTask`: 9 tests — payload shape, effectAllowed, isDragging lifecycle, no-id guard, null dataTransfer guard
- [ ] `useDropZone`: 10 tests — isOver lifecycle, dragEnterCount counter, onDrop parsing, targetContext pass-through, empty/malformed/null guards, dropEffect
- [ ] `TaskCard`: 14 tests — draggable binding, superset payload, no-id guard, mode prop, calendar-event styling, isDragging v-show
- [ ] Full suite: 443 tests passing
- [ ] `npm run build`: zero type errors