### PR TITLE
fix: move MiniCalendar from persistent sidebar to dropdown popover

### DIFF
--- a/frontend/src/components/plan/MiniCalendar.vue
+++ b/frontend/src/components/plan/MiniCalendar.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
 import { usePlanStore } from '../../stores/plan'
-import { useAnchorStore } from '../../stores/anchors'
 import MiniCalendarDay from './MiniCalendarDay.vue'
 
 const planStore = usePlanStore()
-const anchorStore = useAnchorStore()
+
+const emit = defineEmits<{
+  (e: 'day-click', date: string): void
+}>()
 
 function localDateStr(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
@@ -49,7 +51,7 @@ function taskCount(date: string): number {
   return Object.values(day.anchors).reduce((sum, a) => sum + a.tasks.length, 0)
 }
 
-// Load plan data for visible dates when month changes
+// Load plan data for visible dates when month changes (for task count dots)
 async function loadMonth() {
   const dates = calendarDates.value
   await planStore.fetchPlanRange(dates[0], dates[41])
@@ -57,17 +59,6 @@ async function loadMonth() {
 
 onMounted(loadMonth)
 watch(viewDate, loadMonth)
-
-async function onTaskDropped(payload: { taskId: string; date: string; fromAnchorId?: string }) {
-  // Pick the first anchor as default when we don't have context
-  const defaultAnchorId = anchorStore.anchors[0]?.id ?? ''
-  const anchorId = payload.fromAnchorId ?? defaultAnchorId
-  await planStore.moveTaskToAnchor({
-    taskId: payload.taskId,
-    newDate: payload.date,
-    anchorId,
-  })
-}
 </script>
 
 <template>
@@ -96,7 +87,7 @@ async function onTaskDropped(payload: { taskId: string; date: string; fromAnchor
       >{{ dow }}</span>
     </div>
 
-    <!-- Calendar grid — MiniCalendarDay handles drop zone per cell -->
+    <!-- Calendar grid -->
     <div class="grid grid-cols-7 gap-px">
       <MiniCalendarDay
         v-for="date in calendarDates"
@@ -104,7 +95,7 @@ async function onTaskDropped(payload: { taskId: string; date: string; fromAnchor
         :date="date"
         :task-count="taskCount(date)"
         :is-today="date === today"
-        @task-dropped="onTaskDropped"
+        @day-click="emit('day-click', $event)"
       />
     </div>
   </div>

--- a/frontend/src/components/plan/MiniCalendarDay.vue
+++ b/frontend/src/components/plan/MiniCalendarDay.vue
@@ -1,43 +1,20 @@
 <script setup lang="ts">
-import { useDropZone } from '../../composables/useDropZone'
-import type { DropPayload } from '../../composables/useDropZone'
-
-const props = defineProps<{
+defineProps<{
   date: string
   taskCount: number
   isToday: boolean
 }>()
 
 const emit = defineEmits<{
-  (e: 'task-dropped', payload: { taskId: string; date: string; fromAnchorId?: string }): void
+  (e: 'day-click', date: string): void
 }>()
-
-// Each day cell is its own drop target — calling useDropZone at setup level
-// (not inside v-for) is the correct Vue 3 composable pattern.
-const { isOver, dropHandlers } = useDropZone({
-  onDrop(payload: DropPayload) {
-    const p = payload as { taskId?: string; fromAnchorId?: string }
-    if (!p.taskId) return
-    emit('task-dropped', {
-      taskId: p.taskId,
-      date: props.date,
-      fromAnchorId: p.fromAnchorId,
-    })
-  },
-})
 </script>
 
 <template>
   <div
     :data-date="date"
-    class="relative flex flex-col items-center justify-start p-0.5 rounded cursor-default min-h-[28px] transition-colors select-none"
-    :class="[
-      isOver ? 'ring-1 ring-[--accent] bg-[--accent-veil]' : 'hover:bg-[--bg-elev-2]',
-    ]"
-    @dragenter="dropHandlers.onDragEnter"
-    @dragover="dropHandlers.onDragOver"
-    @dragleave="dropHandlers.onDragLeave"
-    @drop="dropHandlers.onDrop"
+    class="relative flex flex-col items-center justify-start p-0.5 rounded cursor-pointer min-h-[28px] transition-colors select-none hover:bg-[--bg-elev-2]"
+    @click="emit('day-click', date)"
   >
     <!-- Day number -->
     <span

--- a/frontend/src/components/plan/__tests__/MiniCalendar.test.ts
+++ b/frontend/src/components/plan/__tests__/MiniCalendar.test.ts
@@ -1,6 +1,7 @@
 /**
- * MiniCalendar — compact month sidebar for plan view
- * Day cells are drop targets via MiniCalendarDay child component (one useDropZone per cell).
+ * MiniCalendar — compact month navigation popover
+ * Clicking a day emits 'day-click' up to PlanView for navigation.
+ * No drag-and-drop — MiniCalendar is navigation-only.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
@@ -20,7 +21,7 @@ vi.mock('../MiniCalendarDay.vue', () => ({
   default: {
     props: ['date', 'taskCount', 'isToday'],
     template: '<div :data-testid="\'day-\' + date" :data-date="date" />',
-    emits: ['task-dropped'],
+    emits: ['day-click'],
   },
 }))
 
@@ -56,7 +57,7 @@ describe('MiniCalendar — rendering', () => {
   })
 })
 
-describe('MiniCalendar — drop delegation', () => {
+describe('MiniCalendar — day-click navigation', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
@@ -67,16 +68,8 @@ describe('MiniCalendar — drop delegation', () => {
     return mount(MiniCalendar, {})
   }
 
-  it('calls planStore.moveTaskToAnchor when a task-dropped event is emitted from a day cell', async () => {
-    const { usePlanStore } = await import('../../../stores/plan')
-    const store = usePlanStore()
-    const spy = vi.spyOn(store, 'moveTaskToAnchor').mockResolvedValue(undefined)
-
+  it('emits day-click with the date when a day cell emits day-click', async () => {
     const w = await mountCalendar()
-
-    // Use findAllComponents to get Vue component wrappers (not DOM wrappers).
-    // trigger('task-dropped') fires a native DOM event — Vue's @task-dropped listener
-    // only fires when the child component calls emit(). We need vm.$emit() here.
     const { default: MiniCalendarDayStub } = await import('../MiniCalendarDay.vue')
     const dayWrappers = w.findAllComponents(MiniCalendarDayStub)
     expect(dayWrappers).toHaveLength(42)
@@ -84,14 +77,10 @@ describe('MiniCalendar — drop delegation', () => {
     const targetWrapper = dayWrappers[10]
     const targetDate = targetWrapper.props('date') as string
 
-    // Emit via Vue's component emit — propagates to parent's @task-dropped listener
-    await targetWrapper.vm.$emit('task-dropped', { taskId: 'task-xyz', date: targetDate, fromAnchorId: 'morning' })
+    await targetWrapper.vm.$emit('day-click', targetDate)
     await w.vm.$nextTick()
 
-    // MiniCalendar handles the event and calls the store
-    expect(spy).toHaveBeenCalledOnce()
-    const call = spy.mock.calls[0][0]
-    expect(call.taskId).toBe('task-xyz')
-    expect(call.newDate).toBe(targetDate)
+    expect(w.emitted('day-click')).toBeTruthy()
+    expect(w.emitted('day-click')![0][0]).toBe(targetDate)
   })
 })

--- a/frontend/src/components/plan/__tests__/MiniCalendarDay.test.ts
+++ b/frontend/src/components/plan/__tests__/MiniCalendarDay.test.ts
@@ -1,39 +1,20 @@
 /**
- * MiniCalendarDay — individual day cell with useDropZone drop target
+ * MiniCalendarDay — individual day cell for navigation
+ * Clicking a cell emits 'day-click' with the date string.
+ * No drop-target behavior — MiniCalendar is navigation-only.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
-import { ref } from 'vue'
 
 vi.mock('../../../lib/api', () => ({
   api: vi.fn(() => Promise.resolve({ ok: true, json: async () => [] })),
 }))
 
-const mockIsOver = ref(false)
-let capturedOnDrop: ((payload: unknown, ctx: unknown) => void) | null = null
-
-vi.mock('../../../composables/useDropZone', () => ({
-  useDropZone: vi.fn((opts: any) => {
-    capturedOnDrop = opts.onDrop
-    return {
-      isOver: mockIsOver,
-      dropHandlers: {
-        onDragEnter: vi.fn(),
-        onDragOver: vi.fn(),
-        onDragLeave: vi.fn(),
-        onDrop: vi.fn(),
-      },
-    }
-  }),
-}))
-
-describe('MiniCalendarDay — drop zone', () => {
+describe('MiniCalendarDay — navigation', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
-    mockIsOver.value = false
-    capturedOnDrop = null
   })
 
   async function mountDay(props: Record<string, unknown> = {}) {
@@ -53,40 +34,15 @@ describe('MiniCalendarDay — drop zone', () => {
     expect(w.find('[data-date="2026-05-15"]').exists()).toBe(true)
   })
 
-  it('applies highlight class when isOver is true', async () => {
-    const w = await mountDay()
-    const cell = w.find('[data-date="2026-05-15"]')
-
-    mockIsOver.value = true
-    await w.vm.$nextTick()
-
-    expect(cell.classes()).toContain('ring-1')
-  })
-
-  it('emits task-dropped with taskId and date when a task payload is dropped', async () => {
-    const w = await mountDay({ date: '2026-06-01' })
-
-    capturedOnDrop!({ type: 'task', taskId: 'task-abc', fromAnchorId: 'morning' }, undefined)
-    await w.vm.$nextTick()
-
-    expect(w.emitted('task-dropped')).toBeTruthy()
-    const event = w.emitted('task-dropped')![0][0] as any
-    expect(event.taskId).toBe('task-abc')
-    expect(event.date).toBe('2026-06-01')
-    expect(event.fromAnchorId).toBe('morning')
-  })
-
-  it('does not emit task-dropped when payload has no taskId', async () => {
-    const w = await mountDay()
-
-    capturedOnDrop!({ type: 'task' }, undefined)
-
-    expect(w.emitted('task-dropped')).toBeFalsy()
+  it('emits day-click with the date when the cell is clicked', async () => {
+    const w = await mountDay({ date: '2026-06-10' })
+    await w.find('[data-date="2026-06-10"]').trigger('click')
+    expect(w.emitted('day-click')).toBeTruthy()
+    expect(w.emitted('day-click')![0][0]).toBe('2026-06-10')
   })
 
   it('highlights today cell with today styling', async () => {
     const w = await mountDay({ isToday: true })
-    // text-[--accent] is on the day-number span, not the root cell div
     const daySpan = w.find('[data-date="2026-05-15"] span')
     expect(daySpan.classes()).toContain('text-[--accent]')
   })

--- a/frontend/src/views/PlanView.vue
+++ b/frontend/src/views/PlanView.vue
@@ -49,11 +49,35 @@ onMounted(() => {
   anchorStore.fetchAnchors()
   milestoneStore.fetchAll()
   clockTimer = setInterval(() => { now.value = new Date() }, 60_000)
+  document.addEventListener('click', onDocumentClick)
 })
 
 onUnmounted(() => {
   if (clockTimer) clearInterval(clockTimer)
+  document.removeEventListener('click', onDocumentClick)
 })
+
+// MiniCalendar popover toggle
+const miniCalOpen = ref(false)
+
+function toggleMiniCal() {
+  miniCalOpen.value = !miniCalOpen.value
+}
+
+function onMiniCalDayClick(date: string) {
+  goToDate(date)
+  miniCalOpen.value = false
+}
+
+function onDocumentClick(e: MouseEvent) {
+  const popover = document.getElementById('mini-cal-popover')
+  const toggle = document.querySelector('[data-testid="mini-cal-toggle"]')
+  if (!popover || !toggle) return
+  if (!popover.contains(e.target as Node) && !toggle.contains(e.target as Node)) {
+    miniCalOpen.value = false
+  }
+}
+
 
 function offsetDate(base: string, days: number): string {
   const d = new Date(base + 'T12:00:00')
@@ -139,6 +163,25 @@ async function onAnchorColumnDrop(e: DragEvent) {
         </div>
       </div>
       <div class="flex items-center gap-3">
+        <!-- Mini calendar popover toggle -->
+        <div class="relative">
+          <button
+            data-testid="mini-cal-toggle"
+            class="text-[--fg-4] hover:text-[--fg-1] transition-colors px-1.5 py-1 rounded text-sm"
+            :class="miniCalOpen ? 'text-[--fg-1] bg-[--bg-elev-2]' : ''"
+            title="Jump to date"
+            @click.stop="toggleMiniCal"
+          >📅</button>
+          <div
+            v-if="miniCalOpen"
+            id="mini-cal-popover"
+            class="absolute right-0 top-full mt-1 z-50"
+            @click.stop
+          >
+            <MiniCalendar @day-click="onMiniCalDayClick" />
+          </div>
+        </div>
+
         <!-- Zoom controls -->
         <div class="flex gap-1 bg-[--bg-elev-1] rounded-lg p-0.5">
           <router-link :to="'/plan/day/' + activeDate"
@@ -160,54 +203,43 @@ async function onAnchorColumnDrop(e: DragEvent) {
       </div>
     </div>
 
-    <!-- Month view: full-width, no sidebar -->
+    <!-- Month view -->
     <MonthView v-if="props.view === 'month'" />
 
-    <!-- Week + Day views: shared flex layout with MiniCalendar sidebar -->
-    <div v-else class="flex gap-4 items-start">
-      <!-- Mini calendar sidebar — reschedule tasks by dropping onto a day -->
-      <div class="flex-shrink-0">
-        <MiniCalendar />
-      </div>
+    <!-- Week view -->
+    <PlanWeekView v-else-if="props.view === 'week'" />
 
-      <!-- Main view content -->
-      <div class="flex-1 min-w-0">
-        <!-- Week view: anchor rows × day columns grid -->
-        <PlanWeekView v-if="props.view === 'week'" />
-
-        <!-- Day view: two-column layout -->
-        <template v-else>
-          <div v-if="planStore.loading" class="text-[--fg-4]">Loading...</div>
-          <!-- Two-column: anchor blocks left, day timeline right -->
-          <div v-else class="grid grid-cols-[1fr_320px] gap-4 items-start">
-            <!-- Left: anchor blocks -->
-            <div
-              class="flex flex-col"
-              @dragover.prevent
-              @drop="onAnchorColumnDrop"
-            >
-              <AnchorBlock
-                v-for="(anchor, i) in anchorStore.anchors"
-                :key="anchor.id"
-                :anchor-id="anchor.id"
-                :anchor-name="anchor.name"
-                :time="anchor.time"
-                :color="anchor.color"
-                :motif="anchor.motif"
-                :is-now="anchorStates.get(anchor.id) === 'now'"
-                :is-past="anchorStates.get(anchor.id) === 'past'"
-                :is-last="i === anchorStore.anchors.length - 1" />
-            </div>
-            <!-- Right: day timeline -->
-            <DayTimeline
-              :date="activeDate"
-              @create-at="onCreateAt"
-              @open-event="onOpenEvent"
-            />
-          </div>
-        </template>
+    <!-- Day view: two-column layout -->
+    <template v-else>
+      <div v-if="planStore.loading" class="text-[--fg-4]">Loading...</div>
+      <!-- Two-column: anchor blocks left, day timeline right -->
+      <div v-else class="grid grid-cols-[1fr_320px] gap-4 items-start">
+        <!-- Left: anchor blocks -->
+        <div
+          class="flex flex-col"
+          @dragover.prevent
+          @drop="onAnchorColumnDrop"
+        >
+          <AnchorBlock
+            v-for="(anchor, i) in anchorStore.anchors"
+            :key="anchor.id"
+            :anchor-id="anchor.id"
+            :anchor-name="anchor.name"
+            :time="anchor.time"
+            :color="anchor.color"
+            :motif="anchor.motif"
+            :is-now="anchorStates.get(anchor.id) === 'now'"
+            :is-past="anchorStates.get(anchor.id) === 'past'"
+            :is-last="i === anchorStore.anchors.length - 1" />
+        </div>
+        <!-- Right: day timeline -->
+        <DayTimeline
+          :date="activeDate"
+          @create-at="onCreateAt"
+          @open-event="onOpenEvent"
+        />
       </div>
-    </div>
+    </template>
 
     <!-- Child route detail panels -->
     <router-view />

--- a/frontend/src/views/__tests__/PlanView.minicalendar.test.ts
+++ b/frontend/src/views/__tests__/PlanView.minicalendar.test.ts
@@ -1,0 +1,121 @@
+/**
+ * PlanView — MiniCalendar dropdown/popover integration
+ * A calendar icon button near the D/W/M tabs toggles the MiniCalendar.
+ * Clicking a day navigates to that date in the current view.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+const mockPush = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useRoute: () => ({ path: '/plan/day/2026-05-15' }),
+  RouterLink: { template: '<a><slot /></a>', props: ['to'] },
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: true, json: async () => [] })),
+}))
+
+// Stub heavy child components
+vi.mock('../../components/AnchorBlock.vue', () => ({
+  default: { template: '<div data-testid="anchor-block" />' },
+}))
+vi.mock('../../components/plan/PlanWeekView.vue', () => ({
+  default: { template: '<div data-testid="plan-week-view" />' },
+}))
+vi.mock('../../components/MonthView.vue', () => ({
+  default: { template: '<div data-testid="month-view" />' },
+}))
+vi.mock('../../components/DayTimeline.vue', () => ({
+  default: { template: '<div data-testid="day-timeline" />', props: ['date'], emits: ['create-at', 'open-event'] },
+}))
+vi.mock('../../components/plan/MiniCalendar.vue', () => ({
+  default: {
+    template: '<div data-testid="mini-calendar" />',
+    emits: ['day-click'],
+  },
+}))
+
+describe('PlanView — MiniCalendar popover', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  async function mountView(view = 'day', date = '2026-05-15') {
+    const { default: PlanView } = await import('../PlanView.vue')
+    return mount(PlanView, {
+      props: { view, date },
+      global: { stubs: { RouterLink: { template: '<a><slot /></a>', props: ['to'] } } },
+    })
+  }
+
+  it('renders a mini-calendar toggle button near the view tabs', async () => {
+    const w = await mountView()
+    expect(w.find('[data-testid="mini-cal-toggle"]').exists()).toBe(true)
+  })
+
+  it('MiniCalendar is hidden by default', async () => {
+    const w = await mountView()
+    expect(w.find('[data-testid="mini-calendar"]').exists()).toBe(false)
+  })
+
+  it('clicking the toggle button shows the MiniCalendar', async () => {
+    const w = await mountView()
+    await w.find('[data-testid="mini-cal-toggle"]').trigger('click')
+    expect(w.find('[data-testid="mini-calendar"]').exists()).toBe(true)
+  })
+
+  it('clicking the toggle button again hides the MiniCalendar', async () => {
+    const w = await mountView()
+    await w.find('[data-testid="mini-cal-toggle"]').trigger('click')
+    await w.find('[data-testid="mini-cal-toggle"]').trigger('click')
+    expect(w.find('[data-testid="mini-calendar"]').exists()).toBe(false)
+  })
+
+  it('day-click from MiniCalendar navigates to that date in the current view', async () => {
+    const w = await mountView('day', '2026-05-15')
+    await w.find('[data-testid="mini-cal-toggle"]').trigger('click')
+
+    const { default: MiniCalendarStub } = await import('../../components/plan/MiniCalendar.vue')
+    const cal = w.findComponent(MiniCalendarStub)
+    await cal.vm.$emit('day-click', '2026-06-03')
+    await w.vm.$nextTick()
+
+    expect(mockPush).toHaveBeenCalledWith('/plan/day/2026-06-03')
+  })
+
+  it('day-click in week view navigates to the week route', async () => {
+    const w = await mountView('week', '2026-05-15')
+    await w.find('[data-testid="mini-cal-toggle"]').trigger('click')
+
+    const { default: MiniCalendarStub } = await import('../../components/plan/MiniCalendar.vue')
+    const cal = w.findComponent(MiniCalendarStub)
+    await cal.vm.$emit('day-click', '2026-06-03')
+    await w.vm.$nextTick()
+
+    expect(mockPush).toHaveBeenCalledWith('/plan/week/2026-06-03')
+  })
+
+  it('day-click closes the popover after navigating', async () => {
+    const w = await mountView('day', '2026-05-15')
+    await w.find('[data-testid="mini-cal-toggle"]').trigger('click')
+    expect(w.find('[data-testid="mini-calendar"]').exists()).toBe(true)
+
+    const { default: MiniCalendarStub } = await import('../../components/plan/MiniCalendar.vue')
+    const cal = w.findComponent(MiniCalendarStub)
+    await cal.vm.$emit('day-click', '2026-06-03')
+    await w.vm.$nextTick()
+
+    expect(w.find('[data-testid="mini-calendar"]').exists()).toBe(false)
+  })
+
+  it('MiniCalendar is shown in week view too', async () => {
+    const w = await mountView('week')
+    await w.find('[data-testid="mini-cal-toggle"]').trigger('click')
+    expect(w.find('[data-testid="mini-calendar"]').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- **MiniCalendarDay**: Stripped `useDropZone` entirely — navigation-only; drop targets on a 28px cell are too small to be useful
- **MiniCalendar**: Removed drop delegation (`moveTaskToAnchor`), now emits `day-click` upward for PlanView to handle navigation
- **PlanView**: Removed persistent left sidebar layout; added `📅` toggle button next to D/W/M tabs; clicking opens MiniCalendar as an absolute-positioned popover; day-click navigates to that date in the current view and closes the popover; click-outside closes via document listener (cleaned up in `onUnmounted`)

## Test plan

- [ ] 501 tests pass, zero TS errors
- [ ] `📅` button appears next to D/W/M tabs in day and week plan views
- [ ] Clicking button opens month grid popover
- [ ] Clicking a day navigates to `/plan/<view>/<date>` and closes the popover
- [ ] Clicking outside the popover closes it
- [ ] Day view still shows AnchorBlocks + DayTimeline with no layout change
- [ ] Week view still shows PlanWeekView with no layout change