### PR TITLE
fix(TaskCard): omit draggable attribute when not self-draggable

### DIFF
--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -182,7 +182,7 @@ const calendarEventStyle = computed(() => {
     data-event-block
     class="rounded overflow-hidden text-xs px-1.5 py-0.5 cursor-grab shadow-md hover:brightness-110 transition-all z-10"
     :style="calendarEventStyle"
-    :draggable="isSelfDraggable"
+    :draggable="isSelfDraggable || undefined"
     @dragstart="dragHandlers.onDragStart"
     @dragend="dragHandlers.onDragEnd"
     @click.stop="navigable && task.id && pushPanel({ kind: 'task', entityId: task.id })"
@@ -213,7 +213,7 @@ const calendarEventStyle = computed(() => {
     v-show="!isDragging"
     class="group transition-colors cursor-pointer relative"
     :style="STATUS_ROW_STYLE[task.status]"
-    :draggable="isSelfDraggable"
+    :draggable="isSelfDraggable || undefined"
     @dragstart="dragHandlers.onDragStart"
     @dragend="dragHandlers.onDragEnd"
     @click="navigable && task.id && pushPanel({ kind: 'task', entityId: task.id })"

--- a/frontend/src/components/__tests__/TaskCard.test.ts
+++ b/frontend/src/components/__tests__/TaskCard.test.ts
@@ -38,18 +38,21 @@ describe('TaskCard drag behavior', () => {
     expect(wrapper.find('[data-testid="task-card"]').attributes('draggable')).toBe('true')
   })
 
-  it('sets draggable="false" when editable is true (plan mode)', () => {
+  it('omits draggable attribute when editable is true (plan mode — lets parent wrapper govern)', () => {
+    // HTML5 DnD: explicit draggable="false" on a child hard-blocks the parent's draggable="true".
+    // When TaskCard is not the drag source (plan mode), the attribute must be absent so
+    // AnchorBlock's outer wrapper div can own drag initiation.
     const wrapper = mount(TaskCard, {
       props: { task: baseTask, editable: true },
     })
-    expect(wrapper.find('[data-testid="task-card"]').attributes('draggable')).toBe('false')
+    expect(wrapper.find('[data-testid="task-card"]').attributes('draggable')).toBeUndefined()
   })
 
-  it('sets draggable="false" when task has no id', () => {
+  it('omits draggable attribute when task has no id', () => {
     const wrapper = mount(TaskCard, {
       props: { task: { ...baseTask, id: '' }, editable: false },
     })
-    expect(wrapper.find('[data-testid="task-card"]').attributes('draggable')).toBe('false')
+    expect(wrapper.find('[data-testid="task-card"]').attributes('draggable')).toBeUndefined()
   })
 
   it('serializes superset payload (type, taskId, title) as text/plain on dragstart', async () => {


### PR DESCRIPTION
## Summary

- **Bug:** `TaskCard` was rendering `draggable="false"` in the DOM when `mode='plan'` + `editable=true` (the default). In HTML5 DnD, an explicit `draggable="false"` on a child **hard-blocks** the parent's `draggable="true"` — the browser does not walk up to the wrapper div. `AnchorBlock` wraps every `<TaskCard>` in a `draggable="true"` div, but the inner attribute was silently cancelling all `dragstart` events on the plan page after the DnD unification (PR #265) merged.

- **Fix (one line):** `:draggable="isSelfDraggable || undefined"` — Vue omits the HTML attribute entirely when the value is `undefined`, letting the parent wrapper govern. When `isSelfDraggable=true` (kanban, calendar-event, calendar-sidebar modes) it still renders `draggable="true"` as before.

- **Tests:** Updated 2 existing assertions from `toBe('false')` → `toBeUndefined()` with inline comments explaining the HTML5 DnD blocking behaviour. 501/501 tests passing, zero type errors.

## Test plan

- [ ] Plan day view: tasks drag and drop between anchors again
- [ ] Kanban: task cards still draggable (mode='kanban' / editable=false path unchanged)
- [ ] Calendar-event mode: event blocks still draggable
- [ ] Full suite: 501 tests passing, `npm run build` zero TS errors