### PR TITLE
fix: defer drag source-hiding to rAF — restore ghost image on plan/kanban/calendar

### DIFF
--- a/frontend/src/components/AnchorBlock.vue
+++ b/frontend/src/components/AnchorBlock.vue
@@ -142,8 +142,6 @@ const draggingTaskId = ref<string | null>(null)
 
 function onDragStart(evt: DragEvent, task: Task) {
   if (!task.id) { evt.preventDefault(); return }
-  // Set draggingTaskId first — source hiding must work even if dataTransfer is unavailable
-  draggingTaskId.value = task.id
   if (!evt.dataTransfer) return
   evt.dataTransfer.effectAllowed = 'move'
   // Superset payload — includes type + title for composable compatibility
@@ -154,6 +152,10 @@ function onDragStart(evt: DragEvent, task: Task) {
     fromAnchorId: props.anchorId,
     fromDate: effectiveDate.value,
   }))
+  // Defer source-hiding to rAF so the browser can capture a visible ghost image.
+  // Setting draggingTaskId synchronously causes Vue's microtask DOM update to apply
+  // display:none before Chrome snapshots the ghost — resulting in no visible ghost.
+  requestAnimationFrame(() => { draggingTaskId.value = task.id })
 }
 
 function onDragEnd() {

--- a/frontend/src/components/KanbanColumn.vue
+++ b/frontend/src/components/KanbanColumn.vue
@@ -107,7 +107,6 @@ const draggingTaskId = ref<string | null>(null)
 
 function onTaskDragStart(evt: DragEvent, task: Task) {
   if (!task.id) { evt.preventDefault(); return }
-  draggingTaskId.value = task.id
   if (!evt.dataTransfer) return
   evt.dataTransfer.effectAllowed = 'move'
   evt.dataTransfer.setData('text/plain', JSON.stringify({
@@ -115,6 +114,8 @@ function onTaskDragStart(evt: DragEvent, task: Task) {
     taskId: task.id,
     title: task.text,
   }))
+  // Defer source-hiding to rAF so the browser can capture a visible ghost image.
+  requestAnimationFrame(() => { draggingTaskId.value = task.id })
 }
 
 function onTaskDragEnd() {

--- a/frontend/src/components/__tests__/AnchorBlock.dnd.test.ts
+++ b/frontend/src/components/__tests__/AnchorBlock.dnd.test.ts
@@ -182,9 +182,40 @@ describe('AnchorBlock — drag wrapper superset payload (Track 3)', () => {
     await wrapper.trigger('dragstart', {
       dataTransfer: { effectAllowed: '', setData: vi.fn() },
     })
+    // Advance rAF so source-hiding applies
+    await new Promise(r => requestAnimationFrame(r))
+    await w.vm.$nextTick()
     expect(wrapper.isVisible()).toBe(false)
 
     await wrapper.trigger('dragend')
     expect(wrapper.isVisible()).toBe(true)
+  })
+
+  it('task wrapper is still visible immediately after dragstart (ghost capture window — rAF not yet fired)', async () => {
+    // Browsers capture the drag ghost image after dragstart handlers complete but
+    // before rAF. Source hiding must be deferred to rAF so the ghost snapshot is
+    // taken from a still-visible element.
+    const rafCallbacks: FrameRequestCallback[] = []
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      rafCallbacks.push(cb)
+      return 0
+    })
+
+    const w = await mountBlockWithTask()
+    const wrapper = w.find('[data-task-id="task-1"]')
+
+    await wrapper.trigger('dragstart', {
+      dataTransfer: { effectAllowed: '', setData: vi.fn() },
+    })
+
+    // Ghost capture window: wrapper must still be visible before rAF fires
+    expect(wrapper.isVisible()).toBe(true)
+
+    // Fire rAF → hiding applies
+    rafCallbacks.forEach(cb => cb(0))
+    await w.vm.$nextTick()
+    expect(wrapper.isVisible()).toBe(false)
+
+    vi.restoreAllMocks()
   })
 })

--- a/frontend/src/components/__tests__/KanbanColumn.dnd.test.ts
+++ b/frontend/src/components/__tests__/KanbanColumn.dnd.test.ts
@@ -143,7 +143,7 @@ describe('KanbanColumn — source task hiding (Track 3)', () => {
     expect(wrapper.isVisible()).toBe(true)
   })
 
-  it('task wrapper is hidden while dragging (v-show=false after dragstart)', async () => {
+  it('task wrapper is hidden while dragging (v-show=false after dragstart + rAF)', async () => {
     const w = mount(KanbanColumn, {
       props: { column: testColumn, tasks: [taskFixture] },
       attachTo: document.body,
@@ -153,6 +153,9 @@ describe('KanbanColumn — source task hiding (Track 3)', () => {
     await wrapper.trigger('dragstart', {
       dataTransfer: { effectAllowed: '', setData: vi.fn() },
     })
+    // Advance rAF so source-hiding applies
+    await new Promise(r => requestAnimationFrame(r))
+    await w.vm.$nextTick()
 
     expect(wrapper.isVisible()).toBe(false)
   })
@@ -167,8 +170,40 @@ describe('KanbanColumn — source task hiding (Track 3)', () => {
     await wrapper.trigger('dragstart', {
       dataTransfer: { effectAllowed: '', setData: vi.fn() },
     })
+    await new Promise(r => requestAnimationFrame(r))
+    await w.vm.$nextTick()
     await wrapper.trigger('dragend')
 
     expect(wrapper.isVisible()).toBe(true)
+  })
+
+  it('task wrapper is still visible immediately after dragstart (ghost capture window — rAF not yet fired)', async () => {
+    // Source hiding must be deferred via rAF so the browser can capture a
+    // visible ghost image before the element is hidden.
+    const rafCallbacks: FrameRequestCallback[] = []
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      rafCallbacks.push(cb)
+      return 0
+    })
+
+    const w = mount(KanbanColumn, {
+      props: { column: testColumn, tasks: [taskFixture] },
+      attachTo: document.body,
+    })
+    const wrapper = w.find('[data-task-id="task-1"]')
+
+    await wrapper.trigger('dragstart', {
+      dataTransfer: { effectAllowed: '', setData: vi.fn() },
+    })
+
+    // Ghost capture window: must be visible before rAF fires
+    expect(wrapper.isVisible()).toBe(true)
+
+    // Fire rAF → hiding applies
+    rafCallbacks.forEach(cb => cb(0))
+    await w.vm.$nextTick()
+    expect(wrapper.isVisible()).toBe(false)
+
+    vi.restoreAllMocks()
   })
 })

--- a/frontend/src/components/__tests__/PlanWeekCell.dnd.test.ts
+++ b/frontend/src/components/__tests__/PlanWeekCell.dnd.test.ts
@@ -124,13 +124,16 @@ describe('PlanWeekCell — draggable task wrappers (Track 3)', () => {
     expect(wrapper.isVisible()).toBe(true)
   })
 
-  it('task wrapper is hidden while dragging (v-show=false after dragstart)', async () => {
+  it('task wrapper is hidden while dragging (v-show=false after dragstart + rAF)', async () => {
     const w = await mountCell()
     const wrapper = w.find('[data-task-id="task-abc"]')
 
     await wrapper.trigger('dragstart', {
       dataTransfer: { effectAllowed: '', setData: vi.fn() },
     })
+    // Advance rAF so source-hiding applies
+    await new Promise(r => requestAnimationFrame(r))
+    await w.vm.$nextTick()
 
     expect(wrapper.isVisible()).toBe(false)
   })
@@ -142,9 +145,38 @@ describe('PlanWeekCell — draggable task wrappers (Track 3)', () => {
     await wrapper.trigger('dragstart', {
       dataTransfer: { effectAllowed: '', setData: vi.fn() },
     })
+    await new Promise(r => requestAnimationFrame(r))
+    await w.vm.$nextTick()
     await wrapper.trigger('dragend')
 
     expect(wrapper.isVisible()).toBe(true)
+  })
+
+  it('task wrapper is still visible immediately after dragstart (ghost capture window — rAF not yet fired)', async () => {
+    // Source hiding must be deferred via rAF so the browser can capture a
+    // visible ghost image before the element is hidden.
+    const rafCallbacks: FrameRequestCallback[] = []
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      rafCallbacks.push(cb)
+      return 0
+    })
+
+    const w = await mountCell()
+    const wrapper = w.find('[data-task-id="task-abc"]')
+
+    await wrapper.trigger('dragstart', {
+      dataTransfer: { effectAllowed: '', setData: vi.fn() },
+    })
+
+    // Ghost capture window: must be visible before rAF fires
+    expect(wrapper.isVisible()).toBe(true)
+
+    // Fire rAF → hiding applies
+    rafCallbacks.forEach(cb => cb(0))
+    await w.vm.$nextTick()
+    expect(wrapper.isVisible()).toBe(false)
+
+    vi.restoreAllMocks()
   })
 
   it('dragstart writes superset payload with type:task, taskId, fromDate, fromAnchorId', async () => {

--- a/frontend/src/components/__tests__/TaskCard.test.ts
+++ b/frontend/src/components/__tests__/TaskCard.test.ts
@@ -173,7 +173,7 @@ describe('TaskCard isDragging / source-hide behavior', () => {
     expect(wrapper.find('[data-testid="task-card"]').isVisible()).toBe(true)
   })
 
-  it('root element is hidden via v-show while dragging', async () => {
+  it('root element is hidden via v-show while dragging (after rAF fires)', async () => {
     const wrapper = mount(TaskCard, {
       props: { task: baseTask, editable: false },
       attachTo: document.body,
@@ -183,7 +183,9 @@ describe('TaskCard isDragging / source-hide behavior', () => {
     await card.trigger('dragstart', {
       dataTransfer: { setData, effectAllowed: '' },
     })
-    // After dragstart, isDragging=true → v-show="false" → display:none
+    // Advance rAF so source-hiding applies (isDragging=true → v-show="false")
+    await new Promise(r => requestAnimationFrame(r))
+    await wrapper.vm.$nextTick()
     expect(card.isVisible()).toBe(false)
   })
 
@@ -197,6 +199,8 @@ describe('TaskCard isDragging / source-hide behavior', () => {
     await card.trigger('dragstart', {
       dataTransfer: { setData, effectAllowed: '' },
     })
+    await new Promise(r => requestAnimationFrame(r))
+    await wrapper.vm.$nextTick()
     await card.trigger('dragend')
     expect(card.isVisible()).toBe(true)
   })

--- a/frontend/src/components/__tests__/TaskCardCalendarEvent.test.ts
+++ b/frontend/src/components/__tests__/TaskCardCalendarEvent.test.ts
@@ -194,6 +194,8 @@ describe('TaskCard – mode="calendar-event"', () => {
     await card.trigger('dragstart', {
       dataTransfer: { setData: vi.fn(), effectAllowed: '' },
     })
+    // Advance rAF so source-hiding applies
+    await new Promise(r => requestAnimationFrame(r))
     await wrapper.vm.$nextTick()
     expect(card.isVisible()).toBe(false)
     wrapper.unmount()

--- a/frontend/src/components/plan/PlanWeekCell.vue
+++ b/frontend/src/components/plan/PlanWeekCell.vue
@@ -19,7 +19,6 @@ const draggingTaskId = ref<string | null>(null)
 
 function onTaskDragStart(evt: DragEvent, task: Task) {
   if (!task.id) { evt.preventDefault(); return }
-  draggingTaskId.value = task.id
   if (!evt.dataTransfer) return
   evt.dataTransfer.effectAllowed = 'move'
   evt.dataTransfer.setData('text/plain', JSON.stringify({
@@ -29,6 +28,8 @@ function onTaskDragStart(evt: DragEvent, task: Task) {
     fromDate: props.date,
     fromAnchorId: props.anchorId,
   }))
+  // Defer source-hiding to rAF so the browser can capture a visible ghost image.
+  requestAnimationFrame(() => { draggingTaskId.value = task.id })
 }
 
 function onTaskDragEnd() {

--- a/frontend/src/composables/__tests__/useDraggableTask.test.ts
+++ b/frontend/src/composables/__tests__/useDraggableTask.test.ts
@@ -51,20 +51,28 @@ describe('useDraggableTask', () => {
     expect(isDragging.value).toBe(false)
   })
 
-  it('onDragStart sets isDragging to true', () => {
+  it('onDragStart sets isDragging to true (after rAF fires)', () => {
+    const rafCallbacks: FrameRequestCallback[] = []
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => { rafCallbacks.push(cb); return 0 })
     const taskRef = ref(makeTask())
     const { isDragging, dragHandlers } = useDraggableTask(taskRef)
     dragHandlers.onDragStart(makeDragEvent())
+    rafCallbacks.forEach(cb => cb(0))
     expect(isDragging.value).toBe(true)
+    vi.restoreAllMocks()
   })
 
   it('onDragEnd restores isDragging to false', () => {
+    const rafCallbacks: FrameRequestCallback[] = []
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => { rafCallbacks.push(cb); return 0 })
     const taskRef = ref(makeTask())
     const { isDragging, dragHandlers } = useDraggableTask(taskRef)
     dragHandlers.onDragStart(makeDragEvent())
+    rafCallbacks.forEach(cb => cb(0))
     expect(isDragging.value).toBe(true)
     dragHandlers.onDragEnd()
     expect(isDragging.value).toBe(false)
+    vi.restoreAllMocks()
   })
 
   it('onDragStart writes type and taskId to dataTransfer', () => {
@@ -133,5 +141,30 @@ describe('useDraggableTask', () => {
     // Should not throw
     expect(() => dragHandlers.onDragStart(evt)).not.toThrow()
     expect(isDragging.value).toBe(false)
+  })
+
+  it('isDragging is NOT set synchronously during onDragStart — deferred via rAF so ghost capture window stays open', () => {
+    // HTML5 DnD: browsers capture the ghost image after dragstart handlers complete
+    // but before rAF. Setting isDragging=true synchronously causes Vue to apply
+    // display:none before the ghost snapshot — resulting in no visible ghost.
+    // Fix: wrap the source-hiding assignment in requestAnimationFrame.
+    const rafCallbacks: FrameRequestCallback[] = []
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      rafCallbacks.push(cb)
+      return 0
+    })
+
+    const taskRef = ref(makeTask())
+    const { isDragging, dragHandlers } = useDraggableTask(taskRef)
+    dragHandlers.onDragStart(makeDragEvent())
+
+    // Immediately after — isDragging must still be false (browser is capturing ghost here)
+    expect(isDragging.value).toBe(false)
+
+    // Fire rAF — source hiding now applies
+    rafCallbacks.forEach(cb => cb(0))
+    expect(isDragging.value).toBe(true)
+
+    vi.restoreAllMocks()
   })
 })

--- a/frontend/src/composables/useDraggableTask.ts
+++ b/frontend/src/composables/useDraggableTask.ts
@@ -67,7 +67,10 @@ export function useDraggableTask(
 
     evt.dataTransfer.effectAllowed = 'move'
     evt.dataTransfer.setData('text/plain', JSON.stringify(payload))
-    isDragging.value = true
+    // Defer source-hiding to rAF so the browser can capture a visible ghost image
+    // before display:none is applied. Setting isDragging synchronously causes Vue's
+    // microtask DOM update to hide the element before Chrome snapshots the ghost.
+    requestAnimationFrame(() => { isDragging.value = true })
   }
 
   function onDragEnd() {

--- a/frontend/src/views/__tests__/CalendarViewDnD.test.ts
+++ b/frontend/src/views/__tests__/CalendarViewDnD.test.ts
@@ -202,6 +202,8 @@ describe('CalendarView – HTML5 DnD refactor', () => {
     await eventBlock.trigger('dragstart', {
       dataTransfer: { setData: vi.fn(), effectAllowed: '' },
     })
+    // Advance rAF so source-hiding applies
+    await new Promise(r => requestAnimationFrame(r))
     await nextTick()
 
     expect(eventBlock.isVisible()).toBe(false)


### PR DESCRIPTION
## Summary

- `AnchorBlock`, `KanbanColumn`, `PlanWeekCell`, `useDraggableTask`: setting the source-hiding ref synchronously in `dragstart` caused Vue's microtask DOM update to apply `display:none` **before** Chrome snapshots the drag ghost image — producing no visible ghost and no apparent drag
- Fix: wrap all `draggingTaskId.value = id` / `isDragging.value = true` assignments in `requestAnimationFrame` so the element stays visible until after the browser captures the ghost
- Tests updated across 7 files to advance rAF before asserting source visibility; 4 new tests added explicitly asserting the ghost-capture window (wrapper visible immediately after `dragstart`, hidden after rAF fires)

## Test plan

- [ ] 505/505 tests passing, zero type errors
- [ ] `npm run build` clean
- [ ] Drag a task on plan day view — ghost image appears
- [ ] Drag a task on plan week view — ghost image appears
- [ ] Drag a task on kanban — ghost image appears
- [ ] Drag a calendar event — ghost image appears