### PR TITLE
fix: prevent duplicate slide-over panel on calendar event click

### DIFF
--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -185,7 +185,6 @@ const calendarEventStyle = computed(() => {
     :draggable="isSelfDraggable || undefined"
     @dragstart="dragHandlers.onDragStart"
     @dragend="dragHandlers.onDragEnd"
-    @click.stop="navigable && task.id && pushPanel({ kind: 'task', entityId: task.id })"
   >
     <div class="flex items-center gap-1 truncate pointer-events-none">
       <!-- gcal badge — shown when the event is from an external calendar -->

--- a/frontend/src/components/__tests__/TaskCardCalendarEvent.test.ts
+++ b/frontend/src/components/__tests__/TaskCardCalendarEvent.test.ts
@@ -9,7 +9,8 @@
  *   3. Renders recurring indicator (↻) when is_recurring or is_occurrence
  *   4. Uses resolvedColor prop for background/border; falls back to defaultColor()
  *   5. Has draggable="true" and dragstart payload includes fromStartTime + durationMs
- *   6. Click opens event panel via pushPanel
+ *   6. Click panel navigation is handled by CalendarView via @click fallthrough —
+ *      TaskCard itself does NOT call pushPanel on click (avoids duplicate panel bug)
  *   7. Hides itself (v-show=false) when isDragging is true
  *   8. Does NOT render plan-mode elements (status controls) in calendar-event mode
  */
@@ -173,13 +174,17 @@ describe('TaskCard – mode="calendar-event"', () => {
     expect(payload.durationMs).toBe(1_800_000)   // 30 min in ms
   })
 
-  it('click opens event panel via pushPanel with task entityId', async () => {
+  it('click does NOT call pushPanel directly — panel navigation is delegated to CalendarView via @click fallthrough', async () => {
+    // TaskCard in calendar-event mode intentionally has no own @click handler.
+    // The parent (CalendarView) provides @click="openEventPanel" which Vue 3 merges as
+    // a fallthrough attribute onto the root element. Having both would cause two pushPanel
+    // calls per click (the duplicate panel bug).
     const { default: TaskCard } = await import('../TaskCard.vue')
     const wrapper = mount(TaskCard, {
       props: { task: mockTask, mode: 'calendar-event', event: mockEvent, heightPx: 60, topPx: 0 },
     })
     await wrapper.find('[data-testid="task-card-calendar-event"]').trigger('click')
-    expect(mockPushPanel).toHaveBeenCalledWith({ kind: 'task', entityId: 'task-1' })
+    expect(mockPushPanel).not.toHaveBeenCalled()
   })
 
   it('is hidden (v-show=false) while drag is active', async () => {

--- a/frontend/src/views/__tests__/CalendarView.event-click.test.ts
+++ b/frontend/src/views/__tests__/CalendarView.event-click.test.ts
@@ -1,0 +1,138 @@
+/**
+ * CalendarView — event block click navigation
+ *
+ * Regression test for duplicate panel bug:
+ *   Clicking a calendar event used to call pushPanel twice because
+ *   TaskCard's own @click.stop AND CalendarView's @click="openEventPanel"
+ *   (a Vue 3 fallthrough attribute) both fired on the same root element.
+ *   stopPropagation prevents bubbling, not same-element merged listeners.
+ *
+ * These tests verify:
+ *   1. Clicking a task-backed event pushes exactly one panel with kind:'task'
+ *   2. Clicking a standalone event (no task_id) pushes exactly one panel with kind:'event'
+ */
+import { describe, it, expect, vi, beforeEach, defineComponent } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { nextTick } from 'vue'
+import { resetFocusedDay } from '../../composables/useCalendarFocus'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const replaceMock = vi.fn()
+const pushPanelMock = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), replace: replaceMock }),
+  useRoute: () => ({ path: '/calendar', query: {} }),
+  RouterLink: {
+    props: ['to'],
+    template: '<a><slot /></a>',
+  },
+  RouterView: { template: '<div />' },
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: true, json: async () => [] })),
+}))
+
+// Mock useSlideOver so both CalendarView and TaskCard share the same push spy.
+vi.mock('../../composables/useSlideOver', () => ({
+  useSlideOver: () => ({
+    stack: { value: [] },
+    push: pushPanelMock,
+    pop: vi.fn(),
+    close: vi.fn(),
+    restoreFromUrl: vi.fn(),
+  }),
+  resetSlideOverStack: vi.fn(),
+}))
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function localDateString(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+const TODAY = localDateString(new Date())
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('CalendarView — calendar event block click', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    resetFocusedDay()
+    pushPanelMock.mockReset()
+    replaceMock.mockReset()
+  })
+
+  it('clicking a task-backed event block calls pushPanel exactly once with kind:task', async () => {
+    const { useEventStore } = await import('../../stores/events')
+    const { default: CalendarView } = await import('../CalendarView.vue')
+
+    const wrapper = mount(CalendarView)
+    await flushPromises()
+
+    useEventStore().events.push({
+      id: 'ev-task1',
+      title: 'My Task Event',
+      start_time: `${TODAY}T09:00:00`,
+      end_time: `${TODAY}T10:00:00`,
+      source: 'tether',
+      external_id: null,
+      task_id: 'task-abc',
+      anchor_id: null,
+      color: null,
+      is_recurring: false,
+      is_occurrence: false,
+      is_all_day: false,
+      rrule: null,
+      context_subject: null,
+    })
+    await nextTick()
+
+    const eventBlock = wrapper.find('[data-testid="task-card-calendar-event"]')
+    expect(eventBlock.exists()).toBe(true)
+
+    await eventBlock.trigger('click')
+
+    // Must be called exactly once — the bug causes it to be called twice
+    expect(pushPanelMock).toHaveBeenCalledTimes(1)
+    expect(pushPanelMock).toHaveBeenCalledWith({ kind: 'task', entityId: 'task-abc' })
+  })
+
+  it('clicking a standalone event block (no task_id) calls pushPanel once with kind:event', async () => {
+    const { useEventStore } = await import('../../stores/events')
+    const { default: CalendarView } = await import('../CalendarView.vue')
+
+    const wrapper = mount(CalendarView)
+    await flushPromises()
+
+    useEventStore().events.push({
+      id: 'ev-standalone',
+      title: 'Standalone GCal Event',
+      start_time: `${TODAY}T14:00:00`,
+      end_time: `${TODAY}T15:00:00`,
+      source: 'google_calendar',
+      external_id: 'gcal-xyz',
+      task_id: null,
+      anchor_id: null,
+      color: null,
+      is_recurring: false,
+      is_occurrence: false,
+      is_all_day: false,
+      rrule: null,
+      context_subject: null,
+    })
+    await nextTick()
+
+    const eventBlock = wrapper.find('[data-testid="task-card-calendar-event"]')
+    expect(eventBlock.exists()).toBe(true)
+
+    await eventBlock.trigger('click')
+
+    // Standalone events must use kind:'event', not kind:'task'
+    expect(pushPanelMock).toHaveBeenCalledTimes(1)
+    expect(pushPanelMock).toHaveBeenCalledWith({ kind: 'event', entityId: 'ev-standalone' })
+  })
+})

--- a/frontend/src/views/__tests__/CalendarView.event-click.test.ts
+++ b/frontend/src/views/__tests__/CalendarView.event-click.test.ts
@@ -11,7 +11,7 @@
  *   1. Clicking a task-backed event pushes exactly one panel with kind:'task'
  *   2. Clicking a standalone event (no task_id) pushes exactly one panel with kind:'event'
  */
-import { describe, it, expect, vi, beforeEach, defineComponent } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { nextTick } from 'vue'


### PR DESCRIPTION
## Summary

- **Bug:** Clicking a calendar event opened 2 stacked slide-over panels. Clicking away closed one, then clicking away again closed the second.
- **Root cause:** `TaskCard` in `calendar-event` mode had its own `@click.stop` calling `pushPanel`. CalendarView also had `@click="openEventPanel"` on the `<TaskCard>` component tag — since `click` is not in TaskCard's `emits`, Vue 3 treated it as a **fallthrough attribute** and merged it onto the same root DOM element as a second listener. `stopPropagation` stops DOM bubbling but not co-registered same-element listeners, so both fired on every click.
- **Fix:** Removed the `@click.stop` from TaskCard's `calendar-event` template. CalendarView's `openEventPanel` (via fallthrough) is now the sole handler and correctly distinguishes task-backed events (`kind:'task'`) from standalone events (`kind:'event'`).

## Test plan

- [x] Added `CalendarView.event-click.test.ts` — 2 regression tests:
  - Task-backed event: `pushPanel` called exactly once with `kind:'task'`
  - Standalone event (no `task_id`): `pushPanel` called exactly once with `kind:'event'`
- [x] Updated `TaskCardCalendarEvent.test.ts` — old test expected TaskCard to call `pushPanel` directly; updated to document the delegation pattern
- [x] All 507 tests pass
- [x] Zero TypeScript errors (`tsc --noEmit`)