### PR TITLE
fix(calendar): motif color reactivity — live planStore ref in taskFromEvent

### DIFF
--- a/frontend/src/stores/plan.ts
+++ b/frontend/src/stores/plan.ts
@@ -238,10 +238,21 @@ export const usePlanStore = defineStore('plan', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(fields),
     })
-    if (resp.ok && plan.value) {
-      for (const anchor of Object.values(plan.value.anchors)) {
-        const task = anchor.tasks.find(t => t.id === taskId)
-        if (task) { Object.assign(task, fields); break }
+    if (resp.ok) {
+      // Update task in single-day plan (plan view)
+      if (plan.value?.anchors) {
+        for (const anchor of Object.values(plan.value.anchors)) {
+          const task = anchor.tasks.find(t => t.id === taskId)
+          if (task) { Object.assign(task, fields); break }
+        }
+      }
+      // Update task in range cache (CalendarView uses plans for multi-day display)
+      for (const dayPlan of Object.values(plans.value)) {
+        if (!dayPlan?.anchors) continue
+        for (const anchor of Object.values(dayPlan.anchors)) {
+          const task = anchor.tasks.find(t => t.id === taskId)
+          if (task) { Object.assign(task, fields); break }
+        }
       }
     }
     return resp.ok

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -639,9 +639,28 @@ async function onColumnDrop(e: DragEvent, dayIndex: number) {
 }
 
 // ─── Synthetic Task from CalendarEvent ────────────────────────
-// TaskCard mode="calendar-event" needs a Task prop. Build a minimal one from
-// the event so the drag payload and click handler have the right ids/title.
+// TaskCard mode="calendar-event" needs a Task prop. For task-linked events,
+// return the LIVE task object from planStore so motif / status mutations from
+// patchTaskFields propagate reactively to the calendar card. Only fall back to
+// a synthetic object for standalone events (no task_id).
 function taskFromEvent(event: CalendarEvent): Task {
+  if (event.task_id) {
+    // Search range cache first (populated by fetchPlanRange, used by CalendarView)
+    for (const dayPlan of Object.values(planStore.plans)) {
+      for (const anchor of Object.values(dayPlan.anchors)) {
+        const t = anchor.tasks.find(t => t.id === event.task_id)
+        if (t) return t
+      }
+    }
+    // Fallback: single-day plan (e.g. focused day loaded separately)
+    if (planStore.plan?.anchors) {
+      for (const anchor of Object.values(planStore.plan.anchors)) {
+        const t = anchor.tasks.find(t => t.id === event.task_id)
+        if (t) return t
+      }
+    }
+  }
+  // Standalone event or task not yet in any loaded plan — synthesise minimal Task
   return {
     id: event.task_id ?? event.id,
     text: event.title,

--- a/frontend/src/views/__tests__/CalendarView.test.ts
+++ b/frontend/src/views/__tests__/CalendarView.test.ts
@@ -447,4 +447,153 @@ describe('CalendarView', () => {
     expect(updatedBlock.attributes('data-motif')).toBe('anchor')
     expect(updatedBlock.attributes('style')).not.toContain('#ff0000')
   })
+
+  // ── Reactivity: taskFromEvent must return live planStore ref ──────────────────
+  // Bug: taskFromEvent() always built a fresh synthetic Task with no motif, so
+  // data-motif was always "anchor" regardless of what patchTaskFields set.
+  // Fix: look up the live task from planStore.plans / planStore.plan and return it
+  // directly — Vue reactivity will then propagate motif mutations to the card.
+
+  it('task motif change in planStore.plans propagates reactively to calendar card data-motif', async () => {
+    const { usePlanStore } = await import('../../stores/plan')
+    const { useEventStore } = await import('../../stores/events')
+    const { default: CalendarView } = await import('../CalendarView.vue')
+    const wrapper = mount(CalendarView)
+    await flushPromises()
+
+    const d = new Date()
+    const TODAY = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+
+    const planStore = usePlanStore()
+    const eventStore = useEventStore()
+
+    // Seed a task in the plans range cache (mirrors what fetchPlanRange populates)
+    planStore.plans[TODAY] = {
+      date: TODAY,
+      anchors: {
+        morning: {
+          tasks: [
+            {
+              id: 'task-live-motif',
+              text: 'Live Motif Task',
+              description: null,
+              status: 'pending',
+              position: 0,
+              followup_config: null,
+              blocks: [],
+              blocked_by: [],
+              context_subject: null,
+              context_node_id: null,
+              anchor_id: 'morning',
+              motif: null,
+            },
+          ],
+          notes: '',
+        },
+      },
+      acknowledgements: {},
+      check_in_log: [],
+    }
+
+    // Seed event that links to the plan task
+    eventStore.events.push({
+      id: 'ev-live-motif',
+      title: 'Live Motif Task',
+      start_time: `${TODAY}T10:00:00`,
+      end_time: `${TODAY}T11:00:00`,
+      source: 'tether',
+      external_id: null,
+      task_id: 'task-live-motif',
+      anchor_id: 'morning',
+      color: null,
+      is_recurring: false,
+      is_occurrence: false,
+      is_all_day: false,
+      rrule: null,
+      context_subject: null,
+    })
+    await nextTick()
+
+    const block = wrapper.find('[data-event-block]')
+    expect(block.exists()).toBe(true)
+    // Initial: no motif → falls back to 'anchor'
+    expect(block.attributes('data-motif')).toBe('anchor')
+
+    // Simulate patchTaskFields mutating the live task object in plans cache
+    const liveTask = planStore.plans[TODAY].anchors['morning'].tasks[0]
+    Object.assign(liveTask, { motif: 'focus' })
+    await nextTick()
+
+    // FAILS before fix: taskFromEvent returns a stale synthetic copy, not the live ref
+    expect(wrapper.find('[data-event-block]').attributes('data-motif')).toBe('focus')
+  })
+
+  it('patchTaskFields updates task in plans range cache so calendar card reacts', async () => {
+    // Integration test: exercises the real patchTaskFields → plans mutation path.
+    // Verifies the production workflow: MotifPicker → patchTaskFields → CalendarView.
+    // Default api mock already returns { ok: true } — sufficient for PATCH to apply.
+    const { usePlanStore } = await import('../../stores/plan')
+    const { useEventStore } = await import('../../stores/events')
+    const { default: CalendarView } = await import('../CalendarView.vue')
+
+    const wrapper = mount(CalendarView)
+    await flushPromises()
+
+    const d = new Date()
+    const TODAY = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+
+    const planStore = usePlanStore()
+    const eventStore = useEventStore()
+
+    // Seed a task in BOTH plan (single-day) and plans (range cache)
+    const taskObj = {
+      id: 'task-patch-motif',
+      text: 'Patch Motif Task',
+      description: null,
+      status: 'pending' as const,
+      position: 0,
+      followup_config: null,
+      blocks: [],
+      blocked_by: [],
+      context_subject: null,
+      context_node_id: null,
+      anchor_id: 'morning',
+      motif: null,
+    }
+    planStore.plans[TODAY] = {
+      date: TODAY,
+      anchors: { morning: { tasks: [taskObj], notes: '' } },
+      acknowledgements: {},
+      check_in_log: [],
+    }
+
+    eventStore.events.push({
+      id: 'ev-patch-motif',
+      title: 'Patch Motif Task',
+      start_time: `${TODAY}T10:00:00`,
+      end_time: `${TODAY}T11:00:00`,
+      source: 'tether',
+      external_id: null,
+      task_id: 'task-patch-motif',
+      anchor_id: 'morning',
+      color: null,
+      is_recurring: false,
+      is_occurrence: false,
+      is_all_day: false,
+      rrule: null,
+      context_subject: null,
+    })
+    await nextTick()
+
+    const block = wrapper.find('[data-event-block]')
+    expect(block.exists()).toBe(true)
+    expect(block.attributes('data-motif')).toBe('anchor')
+
+    // Call patchTaskFields — the same action MotifPicker calls
+    await planStore.patchTaskFields('task-patch-motif', { motif: 'focus' })
+    await nextTick()
+
+    // FAILS before fix: patchTaskFields only updates plan.value, not plans.value
+    expect(wrapper.find('[data-event-block]').attributes('data-motif')).toBe('focus')
+  })
 })


### PR DESCRIPTION
## Summary

- **Bug:** After PR #272, changing a task's motif via `MotifPicker` in `TaskDetailPanel` did not update the calendar card background reactively. The card always showed the `anchor` motif color regardless of the saved motif.
- **Root cause (1):** `taskFromEvent()` in `CalendarView.vue` always built a fresh synthetic `Task` object with no `motif` field. Even though `patchTaskFields` correctly mutated the live task in `planStore.plan`, the calendar card held a reference to a stale snapshot — Vue had nothing to track.
- **Root cause (2):** `patchTaskFields` only updated `plan.value` (single-day plan), never `plans.value` (range cache). CalendarView reads tasks from the range cache populated by `fetchPlanRange`, so motif changes were invisible to it.

## Fixes

**`CalendarView.vue` — `taskFromEvent`:** Now searches `planStore.plans` (range cache) then `planStore.plan` (single-day fallback) for the live task object. Returns it directly so Vue's reactivity system tracks mutations. Falls back to synthetic object only for standalone events (`task_id == null`).

**`stores/plan.ts` — `patchTaskFields`:** Also walks `plans.value` (range cache) and mutates the matching task alongside `plan.value`, keeping both caches in sync.

## Tests

Two new failing-first tests added to `CalendarView.test.ts`:
1. **Direct mutation path** — seeds task in `planStore.plans`, mutates `motif` directly, asserts `data-motif` updates.
2. **`patchTaskFields` path** — calls `planStore.patchTaskFields(...)` and asserts the calendar card `data-motif` updates (the production MotifPicker flow).

All 522 tests pass. Zero TypeScript errors.