### PR TITLE
fix(calendar): load full week plan range so non-focused-day task motifs resolve

### DIFF
--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -690,6 +690,9 @@ function openEventPanel(event: CalendarEvent) {
 // ─── Data loading ──────────────────────────────────────────────
 function loadEvents() {
   eventStore.fetchEvents(dayKeys.value[0], dayKeys.value[6])
+  // Populate planStore.plans for the full visible week so taskFromEvent() returns
+  // live reactive task objects (with motif) for every day — not just the focused day.
+  planStore.fetchPlanRange(dayKeys.value[0], dayKeys.value[6])
 }
 
 const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']

--- a/frontend/src/views/__tests__/CalendarView.test.ts
+++ b/frontend/src/views/__tests__/CalendarView.test.ts
@@ -596,4 +596,74 @@ describe('CalendarView', () => {
     // FAILS before fix: patchTaskFields only updates plan.value, not plans.value
     expect(wrapper.find('[data-event-block]').attributes('data-motif')).toBe('focus')
   })
+
+  // ── fetchPlanRange coverage ────────────────────────────────────────────────────
+  // Bug: CalendarView fetched events for a full 7-day week but never called
+  // fetchPlanRange, so planStore.plans was always empty. taskFromEvent() fell
+  // through to planStore.plan (focused day only) — events on non-focused days
+  // always returned a synthetic motifless object.
+  // Fix: loadEvents() must call fetchPlanRange for the same week range.
+
+  it('calls planStore.fetchPlanRange for the visible week on mount', async () => {
+    const { usePlanStore } = await import('../../stores/plan')
+    const { default: CalendarView } = await import('../CalendarView.vue')
+
+    const planStore = usePlanStore()
+    const spy = vi.spyOn(planStore, 'fetchPlanRange').mockResolvedValue(undefined)
+
+    mount(CalendarView)
+    await flushPromises()
+
+    // FAILS before fix: loadEvents() only calls eventStore.fetchEvents, never fetchPlanRange
+    expect(spy).toHaveBeenCalledOnce()
+
+    // The range must span exactly 6 days (Sun→Sat inclusive = 6-day diff)
+    const [start, end] = spy.mock.calls[0] as [string, string]
+    const diff =
+      (new Date(end + 'T12:00:00').getTime() - new Date(start + 'T12:00:00').getTime()) /
+      86_400_000
+    expect(diff).toBe(6)
+  })
+
+  it('calls planStore.fetchPlanRange again when navigating to next week', async () => {
+    const { usePlanStore } = await import('../../stores/plan')
+    const { default: CalendarView } = await import('../CalendarView.vue')
+
+    const planStore = usePlanStore()
+    const spy = vi.spyOn(planStore, 'fetchPlanRange').mockResolvedValue(undefined)
+
+    const wrapper = mount(CalendarView)
+    await flushPromises()
+    spy.mockClear()
+
+    const buttons = wrapper.findAll('button')
+    const nextBtn = buttons.find(b => b.text() === '›')
+    expect(nextBtn).toBeDefined()
+    await nextBtn!.trigger('click')
+    await flushPromises()
+
+    // FAILS before fix: shiftWeek → loadEvents() never calls fetchPlanRange
+    expect(spy).toHaveBeenCalledOnce()
+  })
+
+  it('calls planStore.fetchPlanRange again when navigating to previous week', async () => {
+    const { usePlanStore } = await import('../../stores/plan')
+    const { default: CalendarView } = await import('../CalendarView.vue')
+
+    const planStore = usePlanStore()
+    const spy = vi.spyOn(planStore, 'fetchPlanRange').mockResolvedValue(undefined)
+
+    const wrapper = mount(CalendarView)
+    await flushPromises()
+    spy.mockClear()
+
+    const buttons = wrapper.findAll('button')
+    const prevBtn = buttons.find(b => b.text() === '‹')
+    expect(prevBtn).toBeDefined()
+    await prevBtn!.trigger('click')
+    await flushPromises()
+
+    // FAILS before fix: shiftWeek → loadEvents() never calls fetchPlanRange
+    expect(spy).toHaveBeenCalledOnce()
+  })
 })


### PR DESCRIPTION
## Summary

- `CalendarView` called `eventStore.fetchEvents(week range)` but only `planStore.fetchPlan(single day)` — leaving `planStore.plans` always empty
- `taskFromEvent()` searched `planStore.plans` (empty) then fell back to `planStore.plan` (focused day only); events on the other 6 days always returned a synthetic `{ motif: undefined }` object
- This caused `data-motif="anchor"` on every non-focused-day event regardless of the task's actual motif — persisting even after hard refresh

**Fix:** add `planStore.fetchPlanRange(dayKeys[0], dayKeys[6])` to `loadEvents()`. This covers all 4 call sites (mount, prev/next week, today, month→week click). `patchTaskFields` already updates `plans.value` in-place, so the reactive chain is now complete for every visible day.

## Test plan

- [x] 3 new tests: `fetchPlanRange` called on mount with 6-day range, called again on next-week nav, called again on prev-week nav
- [x] All 525 tests pass (`npm run test`)
- [x] Zero type errors (`npm run build`)
- [ ] Runtime: open CalendarView on a week with promoted tasks on non-focused days; set a motif in TaskDetailPanel; verify card background changes immediately