### PR TITLE
Migrate DayTimeline events to TaskCard drag pattern, remove legacy calendar-event payload

### DIFF
--- a/frontend/src/components/DayTimeline.vue
+++ b/frontend/src/components/DayTimeline.vue
@@ -4,7 +4,10 @@ import { useEventStore } from '../stores/events'
 import { useAnchorStore } from '../stores/anchors'
 import { useMilestoneStore } from '../stores/milestones'
 import { useContextStore } from '../stores/context'
+import { usePlanStore } from '../stores/plan'
+import type { Task } from '../stores/plan'
 import RecurrenceEditDialog from './RecurrenceEditDialog.vue'
+import TaskCard from './TaskCard.vue'
 import {
   eventTopPx,
   eventHeightPx,
@@ -35,9 +38,36 @@ const eventStore = useEventStore()
 const anchorStore = useAnchorStore()
 const milestoneStore = useMilestoneStore()
 const contextStore = useContextStore()
+const planStore = usePlanStore()
 
 function resolveColor(ev: CalendarEvent): string {
   return resolveEventColor(ev, milestoneStore.all, contextStore.nodes)
+}
+
+function taskFromEvent(ev: CalendarEvent): Task {
+  // For task-linked events, return live Task from planStore for reactive motif/status
+  if (ev.task_id && planStore.plan?.anchors) {
+    for (const anchor of Object.values(planStore.plan.anchors)) {
+      const t = anchor.tasks.find(t => t.id === ev.task_id)
+      if (t) return t
+    }
+  }
+  // Standalone event or task not in today's plan — synthesise minimal Task
+  return {
+    id: ev.task_id ?? ev.id,
+    text: ev.title,
+    description: null,
+    status: 'pending',
+    position: 0,
+    followup_config: null,
+    blocks: [],
+    blocked_by: [],
+    context_subject: ev.context_subject,
+    context_node_id: null,
+    anchor_id: ev.anchor_id,
+    color: null,
+    motif: null,
+  }
 }
 
 // --- Date parsing ---
@@ -136,7 +166,7 @@ function onRecurrenceCancel() {
 
 // --- 15-min slot drop zones ---
 
-const SLOT_COUNT = (AXIS_END_HOUR - AXIS_START_HOUR) * 4  // e.g. 18h × 4 = 72
+const SLOT_COUNT = (AXIS_END_HOUR - AXIS_START_HOUR) * 4  // e.g. 18h x 4 = 72
 
 /** Format slot index as 'HH:MM'. Slot 0 = AXIS_START_HOUR:00. */
 function slotTime(i: number): string {
@@ -150,29 +180,21 @@ async function handleSlotDrop(payload: DropPayload, time: string) {
   const slotStart = `${props.date}T${time}:00`
   const slotStartMs = new Date(slotStart).getTime()
 
-  if (payload.type === 'calendar-event') {
-    // Reposition existing event, preserving its duration.
-    const p = payload as { eventId?: string; durationMs?: number }
-    const dur = p.durationMs ?? 30 * 60_000
-    const newEnd = toLocalIso(new Date(slotStartMs + dur))
-    const ev = eventStore.events.find(e => e.id === p.eventId)
-    if (!ev) return
-    await handleEventMove(ev, slotStart, newEnd)
+  // type === 'task' handles both plan-view promotions AND calendar-event repositions
+  // (useDraggableTask always writes type:'task'; fromStartTime present <-> calendar event)
+  const taskId = (payload as { taskId?: string }).taskId
+  if (!taskId) return
+  const title = (payload as { title?: string }).title ?? taskId
+  // Dual lookup: task_id for task-linked events; id for standalone events
+  const existing = eventStore.events.find(e => e.task_id === taskId)
+    ?? eventStore.events.find(e => e.id === taskId)
+  if (existing) {
+    const dur = new Date(existing.end_time).getTime() - new Date(existing.start_time).getTime()
+    const newEnd = toLocalIso(new Date(slotStartMs + (dur || 30 * 60_000)))
+    await handleEventMove(existing, slotStart, newEnd)
   } else {
-    // type === 'task' (or legacy AnchorBlock format with taskId field)
-    const taskId = (payload as { taskId?: string }).taskId
-    if (!taskId) return
-    const title = (payload as { title?: string }).title ?? taskId
-    // Check if this task is already promoted to avoid creating a duplicate event.
-    const existing = eventStore.events.find(e => e.task_id === taskId)
-    if (existing) {
-      const dur = new Date(existing.end_time).getTime() - new Date(existing.start_time).getTime()
-      const newEnd = toLocalIso(new Date(slotStartMs + (dur || 30 * 60_000)))
-      await eventStore.moveEvent(existing.id, slotStart, newEnd)
-    } else {
-      const endISO = toLocalIso(new Date(slotStartMs + 30 * 60_000))
-      await eventStore.promoteTask(taskId, slotStart, endISO, title)
-    }
+    const endISO = toLocalIso(new Date(slotStartMs + 30 * 60_000))
+    await eventStore.promoteTask(taskId, slotStart, endISO, title)
   }
 }
 
@@ -203,35 +225,6 @@ async function onSlotDrop(e: DragEvent, i: number) {
   } catch { /* ignore malformed payload */ }
 }
 
-// --- Calendar-event drag source ---
-
-/** ID of the event being dragged (used to hide the source element via v-show). */
-const draggingEventId = ref<string | null>(null)
-
-function onEventDragStart(evt: DragEvent, ev: CalendarEvent) {
-  if (evt.dataTransfer) {
-    const durationMs = new Date(ev.end_time).getTime() - new Date(ev.start_time).getTime()
-    const payload = JSON.stringify({
-      type: 'calendar-event',
-      eventId: ev.id,
-      taskId: ev.task_id,
-      title: ev.title,
-      anchorId: ev.anchor_id,
-      fromStartTime: ev.start_time,
-      durationMs,
-    })
-    evt.dataTransfer.effectAllowed = 'move'
-    evt.dataTransfer.setData('application/json', payload)
-    evt.dataTransfer.setData('text/plain', payload)
-  }
-  // Set synchronously (consistent with useDraggableTask pattern).
-  draggingEventId.value = ev.id
-}
-
-function onEventDragEnd() {
-  draggingEventId.value = null
-}
-
 // Array used purely for v-for slot grid rendering
 const slotIndices = Array.from({ length: SLOT_COUNT }, (_, i) => i)
 
@@ -255,7 +248,7 @@ function onTimedAreaClick(e: MouseEvent) {
 
 // --- Time formatting helpers ---
 
-/** Format a Date as local-naive ISO (YYYY-MM-DDTHH:MM) — no timezone offset. */
+/** Format a Date as local-naive ISO (YYYY-MM-DDTHH:MM) -- no timezone offset. */
 function toLocalIso(d: Date): string {
   const year = d.getFullYear()
   const mo = String(d.getMonth() + 1).padStart(2, '0')
@@ -264,9 +257,6 @@ function toLocalIso(d: Date): string {
   const mm = String(d.getMinutes()).padStart(2, '0')
   return `${year}-${mo}-${day}T${hh}:${mm}`
 }
-
-// Note: drag of calendar-event blocks is now handled by TaskCard mode="calendar-event".
-// onDrop for task promotion is now handled by slot-level useDropZone instances.
 
 // --- Anchor color helper ---
 
@@ -279,18 +269,6 @@ function anchorBandStyle(anchor: { color: string; id: string }) {
     height: `${anchorBandHeightPx(anchor as Parameters<typeof anchorBandHeightPx>[0], dateObj.value)}px`,
     left: `${layout.leftPercent}%`,
     width: `${layout.widthPercent}%`,
-  }
-}
-
-// --- Event block helpers ---
-
-function timedEventStyle(event: CalendarEvent) {
-  const layout = overlapLayout.value[event.id]
-  const leftPct = layout?.leftPercent ?? 0
-  const widthPct = layout?.widthPercent ?? 100
-  return {
-    left: `${leftPct}%`,
-    width: `calc(${widthPct}% - 4px)`,
   }
 }
 </script>
@@ -346,7 +324,7 @@ function timedEventStyle(event: CalendarEvent) {
           :style="anchorBandStyle(anchor)"
         />
 
-        <!-- Overlap background bands — light tint indicating simultaneous events -->
+        <!-- Overlap background bands -- light tint indicating simultaneous events -->
         <div
           v-for="(band, bi) in overlapBands"
           :key="'overlap-' + bi"
@@ -363,7 +341,7 @@ function timedEventStyle(event: CalendarEvent) {
           :style="{ top: `${(hour - AXIS_START_HOUR) * 60 * PX_PER_MINUTE}px` }"
         />
 
-        <!-- 15-min slot drop targets — transparent absolute divs at each 15-min interval -->
+        <!-- 15-min slot drop targets -- transparent absolute divs at each 15-min interval -->
         <div
           v-for="i in slotIndices"
           :key="'slot-' + i"
@@ -381,55 +359,21 @@ function timedEventStyle(event: CalendarEvent) {
           @drop="(e) => onSlotDrop(e, i)"
         />
 
-        <!--
-          Timed event blocks — inline CalendarEventBlock-equivalent (CalendarEventBlock absorbed).
-          The wrapper div owns: absolute positioning, HTML5 drag source, click-to-open, v-show.
-          This avoids needing TaskCard here and lets us write the 'calendar-event' payload
-          (with eventId + durationMs) instead of the 'task' payload that useDraggableTask writes.
-        -->
-        <div
+        <!-- Timed event blocks -- TaskCard in calendar-event mode -->
+        <TaskCard
           v-for="ev in timedEvents"
           :key="ev.id"
-          :data-event-id="ev.id"
-          v-show="draggingEventId !== ev.id"
-          draggable="true"
-          class="absolute z-10 cursor-grab"
-          :style="{
-            top: `${eventTopPx(ev.start_time)}px`,
-            left: timedEventStyle(ev).left,
-            width: timedEventStyle(ev).width,
-            height: `${eventHeightPx(ev.start_time, ev.end_time)}px`,
-          }"
-          @dragstart="(e) => onEventDragStart(e, ev)"
-          @dragend="onEventDragEnd"
+          :task="taskFromEvent(ev)"
+          mode="calendar-event"
+          :event="ev"
+          :top-px="eventTopPx(ev.start_time)"
+          :height-px="eventHeightPx(ev.start_time, ev.end_time)"
+          :left-percent="overlapLayout[ev.id]?.leftPercent ?? 0"
+          :width-percent="overlapLayout[ev.id]?.widthPercent ?? 100"
+          :resolved-color="resolveColor(ev)"
+          data-event-block
           @click.stop="emit('open-event', ev)"
-        >
-          <!-- Event visual: absorbs CalendarEventBlock.vue template -->
-          <div
-            class="absolute inset-0 rounded overflow-hidden text-xs px-1.5 py-0.5 shadow-md hover:brightness-110 transition-all"
-            :style="{
-              backgroundColor: resolveColor(ev),
-              borderLeft: '3px solid ' + resolveColor(ev),
-              opacity: ev.source !== 'tether' ? 0.75 : 0.92,
-            }"
-          >
-            <div class="flex items-center gap-1 truncate pointer-events-none">
-              <span
-                v-if="ev.source !== 'tether'"
-                data-testid="gcal-badge"
-                class="text-[9px] bg-black/20 rounded px-0.5 flex-shrink-0"
-                :title="ev.source === 'google_calendar' ? 'Synced from Google Calendar' : 'Synced from external source'"
-              >{{ ev.source === 'google_calendar' ? 'G' : '↗' }}</span>
-              <span
-                v-if="ev.is_recurring || ev.is_occurrence"
-                data-testid="recurring-indicator"
-                class="text-[9px] flex-shrink-0 opacity-80"
-                title="Recurring event"
-              >↻</span>
-              <span class="truncate font-medium text-[--accent-fg]">{{ ev.title }}</span>
-            </div>
-          </div>
-        </div>
+        />
       </div>
     </div>
 

--- a/frontend/src/components/__tests__/DayTimeline.test.ts
+++ b/frontend/src/components/__tests__/DayTimeline.test.ts
@@ -27,6 +27,26 @@ vi.mock('../../lib/api', () => ({
   api: vi.fn(() => Promise.resolve({ ok: true, json: async () => [] })),
 }))
 
+vi.mock('../../stores/plan', () => ({
+  usePlanStore: () => ({
+    plan: null,
+    plans: {},
+    fetchPlan: vi.fn(),
+    today: '2024-06-10',
+    activeDate: { value: '2024-06-10' },
+  }),
+}))
+
+vi.mock('../../composables/useSlideOver', () => ({
+  useSlideOver: () => ({
+    stack: { value: [] },
+    push: vi.fn(),
+    pop: vi.fn(),
+    close: vi.fn(),
+    restoreFromUrl: vi.fn(),
+  }),
+}))
+
 // Mock stores so we can control their output
 const mockAnchors: Anchor[] = [
   {
@@ -317,17 +337,16 @@ describe('DayTimeline component', () => {
     await expect(timedArea.trigger('drop')).resolves.not.toThrow()
   })
 
-  it('event wrapper div is the drag source and contains the event title', async () => {
-    // New HTML5 DnD design: the wrapper div (data-event-id) is draggable="true"
-    // and contains the event title inline — no separate "grip strip".
+  it('timed events render as TaskCard in calendar-event mode (draggable)', async () => {
     const { default: DayTimeline } = await import('../DayTimeline.vue')
     const wrapper = mount(DayTimeline, { props: { date: '2024-06-10' } })
-    // Event wrapper divs should be draggable
-    const eventWrapper = wrapper.find('[data-event-id="ev-timed"]')
-    expect(eventWrapper.exists()).toBe(true)
-    expect(eventWrapper.attributes('draggable')).toBe('true')
-    // The wrapper IS the visual element so it contains the title
-    expect(eventWrapper.text()).toContain('Team standup')
+    // After migration: TaskCard renders [data-testid="task-card-calendar-event"] for each timed event
+    const card = wrapper.find('[data-testid="task-card-calendar-event"]')
+    expect(card.exists()).toBe(true)
+    expect(card.attributes('draggable')).toBe('true')
+    expect(card.text()).toContain('Team standup')
+    // Old data-event-id selector must NOT exist
+    expect(wrapper.find('[data-event-id="ev-timed"]').exists()).toBe(false)
     // Time-slot drop targets should NOT be draggable
     const slots = wrapper.findAll('[data-time-slot]')
     for (const slot of slots) {

--- a/frontend/src/components/__tests__/DayTimelineDropZone.test.ts
+++ b/frontend/src/components/__tests__/DayTimelineDropZone.test.ts
@@ -85,6 +85,26 @@ vi.mock('../../stores/context', () => ({
   }),
 }))
 
+vi.mock('../../stores/plan', () => ({
+  usePlanStore: () => ({
+    plan: null,
+    plans: {},
+    fetchPlan: vi.fn(),
+    today: '2024-06-10',
+    activeDate: { value: '2024-06-10' },
+  }),
+}))
+
+vi.mock('../../composables/useSlideOver', () => ({
+  useSlideOver: () => ({
+    stack: { value: [] },
+    push: vi.fn(),
+    pop: vi.fn(),
+    close: vi.fn(),
+    restoreFromUrl: vi.fn(),
+  }),
+}))
+
 // Expected total 15-min slots
 const TOTAL_SLOTS = (AXIS_END_HOUR - AXIS_START_HOUR) * 4  // 72
 
@@ -128,15 +148,16 @@ describe('DayTimeline – 15-min slot drop targets', () => {
     )
   })
 
-  it('dropping a calendar-event payload moves the event preserving duration (PATCH /api/events/:id)', async () => {
+  it('dropping a task payload with fromStartTime moves the event preserving duration (PATCH /api/events/:id)', async () => {
     const { default: DayTimeline } = await import('../DayTimeline.vue')
     const wrapper = mount(DayTimeline, { props: { date: '2024-06-10' } })
     const slot = wrapper.find('[data-time="10:00"]')
     expect(slot.exists()).toBe(true)
     const durationMs = 30 * 60_000  // 30 min
+    // After migration: TaskCard writes type:'task' not type:'calendar-event'
     const payload = {
-      type: 'calendar-event',
-      eventId: 'ev-timed',
+      type: 'task',
+      taskId: 'task-1',  // mockTimedEvent.task_id = 'task-1'
       title: 'Team standup',
       fromStartTime: '2024-06-10T09:00:00',
       durationMs,
@@ -151,30 +172,32 @@ describe('DayTimeline – 15-min slot drop targets', () => {
 
   it('source event block is hidden (v-show=false) while its drag is active', async () => {
     const { default: DayTimeline } = await import('../DayTimeline.vue')
-    // attachTo: document.body required for v-show to propagate in jsdom
     const wrapper = mount(DayTimeline, { props: { date: '2024-06-10' }, attachTo: document.body })
-    // Find the event wrapper (has data-event-id)
-    const eventWrapper = wrapper.find(`[data-event-id="${mockTimedEvent.id}"]`)
-    expect(eventWrapper.exists()).toBe(true)
-    // Initially visible
-    expect(eventWrapper.isVisible()).toBe(true)
-    // Trigger dragstart on the event element
-    await eventWrapper.trigger('dragstart')
+    const card = wrapper.find('[data-testid="task-card-calendar-event"]')
+    expect(card.exists()).toBe(true)
+    expect(card.isVisible()).toBe(true)
+    await card.trigger('dragstart', {
+      dataTransfer: { setData: vi.fn(), effectAllowed: '' },
+    })
+    // useDraggableTask defers isDragging=true to rAF for ghost-image capture
+    await new Promise(r => requestAnimationFrame(r))
     await wrapper.vm.$nextTick()
-    expect(eventWrapper.isVisible()).toBe(false)
+    expect(card.isVisible()).toBe(false)
     wrapper.unmount()
   })
 
   it('source event block is restored (v-show=true) on dragend with no valid drop', async () => {
     const { default: DayTimeline } = await import('../DayTimeline.vue')
     const wrapper = mount(DayTimeline, { props: { date: '2024-06-10' }, attachTo: document.body })
-    const eventWrapper = wrapper.find(`[data-event-id="${mockTimedEvent.id}"]`)
-    await eventWrapper.trigger('dragstart')
+    const card = wrapper.find('[data-testid="task-card-calendar-event"]')
+    await card.trigger('dragstart', {
+      dataTransfer: { setData: vi.fn(), effectAllowed: '' },
+    })
+    await new Promise(r => requestAnimationFrame(r))
     await wrapper.vm.$nextTick()
-    // Now fire dragend
-    await eventWrapper.trigger('dragend')
+    await card.trigger('dragend')
     await wrapper.vm.$nextTick()
-    expect(eventWrapper.isVisible()).toBe(true)
+    expect(card.isVisible()).toBe(true)
     wrapper.unmount()
   })
 

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -590,25 +590,6 @@ async function onColumnDrop(e: DragEvent, dayIndex: number) {
     startDate = new Date(dayKey + 'T12:00:00')
   }
 
-  if (payload.type === 'calendar-event' && payload.eventId) {
-    // Move event preserving duration (fromStartTime + durationMs from payload)
-    const durationMs = (payload.durationMs as number) || 30 * 60_000
-    const endDate = new Date(startDate.getTime() + durationMs)
-    const existing = eventStore.events.find(ev => ev.id === payload.eventId)
-    if (existing?.is_occurrence) {
-      pendingRecurrence.value = {
-        kind: 'event-move',
-        eventId: payload.eventId as string,
-        startTime: startDate.toISOString(),
-        endTime: endDate.toISOString(),
-        originalStartTime: payload.fromStartTime as string,
-      }
-      return
-    }
-    await eventStore.moveEvent(payload.eventId as string, startDate.toISOString(), endDate.toISOString())
-    return
-  }
-
   if (payload.type === 'task' && payload.taskId) {
     const taskId = payload.taskId as string
     // Look up by task_id first; fall back to event.id for standalone/synced events

--- a/frontend/src/views/PlanView.vue
+++ b/frontend/src/views/PlanView.vue
@@ -121,17 +121,21 @@ function onOpenEvent(event: CalendarEvent) {
 
 /** Handle drop of a calendar event onto the anchor column — demotes it back to a plain task. */
 async function onAnchorColumnDrop(e: DragEvent) {
-  // DayTimeline writes both application/json and text/plain; prefer application/json
   const rawJson = e.dataTransfer?.getData('application/json')
   const rawText = e.dataTransfer?.getData('text/plain')
   const raw = rawJson || rawText
   if (!raw) return
   try {
     const data = JSON.parse(raw)
-    // type: 'task' with fromStartTime = calendar event being demoted back to plan
-    if (data.type === 'task' && data.fromStartTime && data.id) {
-      const anchorId = data.anchorId ?? anchorStore.anchors[0]?.id ?? ''
-      await eventStore.demoteEvent(data.id, anchorId, activeDate.value)
+    // type:'task' with fromStartTime = calendar event being demoted back to anchor
+    if (data.type === 'task' && data.taskId && data.fromStartTime) {
+      const taskId = data.taskId as string
+      // Dual lookup: task_id for task-linked events; id for standalone events
+      const ev = eventStore.events.find(e => e.task_id === taskId)
+        ?? eventStore.events.find(e => e.id === taskId)
+      if (!ev) return
+      const anchorId = ev.anchor_id ?? anchorStore.anchors[0]?.id ?? ''
+      await eventStore.demoteEvent(ev.id, anchorId, activeDate.value)
       await planStore.fetchPlan(activeDate.value)
     }
   } catch {

--- a/frontend/src/views/PlanView.vue
+++ b/frontend/src/views/PlanView.vue
@@ -128,11 +128,10 @@ async function onAnchorColumnDrop(e: DragEvent) {
   if (!raw) return
   try {
     const data = JSON.parse(raw)
-    if (data.type === 'calendar-event' && data.eventId) {
-      // Use the event's original anchor if available; fall back to first anchor
+    // type: 'task' with fromStartTime = calendar event being demoted back to plan
+    if (data.type === 'task' && data.fromStartTime && data.id) {
       const anchorId = data.anchorId ?? anchorStore.anchors[0]?.id ?? ''
-      await eventStore.demoteEvent(data.eventId, anchorId, activeDate.value)
-      // Refresh plan so the demoted task appears in anchor blocks
+      await eventStore.demoteEvent(data.id, anchorId, activeDate.value)
       await planStore.fetchPlan(activeDate.value)
     }
   } catch {

--- a/frontend/src/views/__tests__/CalendarViewDnD.test.ts
+++ b/frontend/src/views/__tests__/CalendarViewDnD.test.ts
@@ -151,11 +151,9 @@ describe('CalendarView – HTML5 DnD refactor', () => {
     expect(wrapper.find('[data-testid="task-card-calendar-event"]').exists()).toBe(true)
   })
 
-  // ── KEY FAILING TEST #2 ────────────────────────────────────────────────────
-  // Current CalendarView only handles task promotions in onDrop; calendar-event
-  // payloads (type:'calendar-event') are ignored. After refactor, handleColumnDrop
-  // routes these to eventStore.moveEvent with preserved duration.
-  it('dropping a calendar-event payload onto a day column calls eventStore.moveEvent with preserved duration', async () => {
+  // After migration: type:'task' with fromStartTime handles calendar-event repositions
+  // (useDraggableTask always writes type:'task'; fromStartTime present signals it's a calendar event)
+  it('dropping a task payload with fromStartTime onto a day column calls eventStore.moveEvent with preserved duration', async () => {
     const { default: CalendarView } = await import('../CalendarView.vue')
     const wrapper = mount(CalendarView)
     await flushPromises()
@@ -164,9 +162,11 @@ describe('CalendarView – HTML5 DnD refactor', () => {
     expect(todayCol.exists()).toBe(true)
 
     const durationMs = 30 * 60_000  // 30 min
+    // After migration: TaskCard writes type:'task' not type:'calendar-event'
+    // mockTimedEvent.task_id = 'task-1', so lookup via task_id finds ev-today
     const payload = {
-      type: 'calendar-event',
-      eventId: 'ev-today',
+      type: 'task',
+      taskId: 'task-1',
       title: 'Team meeting',
       fromStartTime: `${todayStr}T10:00:00`,
       durationMs,


### PR DESCRIPTION
## Summary

- Replaces inline draggable `<div>` blocks in `DayTimeline.vue` with `TaskCard mode="calendar-event"`, unifying the plan-view embedded calendar with CalendarView's drag pattern
- Removes the legacy `type:'calendar-event'` drag payload from all three sites where it was produced or consumed — it is now dead code
- Updates `PlanView.onAnchorColumnDrop` to handle the canonical `type:'task'` payload (with `fromStartTime` as the signal that a calendar event is being demoted back to an anchor)
- Adds dual event lookup (`task_id === taskId` then `id === taskId`) to handle both task-linked and standalone events throughout

## Files changed

| File | Change |
|------|--------|
| `frontend/src/components/DayTimeline.vue` | Replace inline drag divs with TaskCard; add `taskFromEvent`; remove `draggingEventId`/`onEventDragStart`/`onEventDragEnd`; simplify `handleSlotDrop` to single `type:'task'` path with dual lookup |
| `frontend/src/views/PlanView.vue` | `onAnchorColumnDrop` now handles `type:'task'` + `fromStartTime` |
| `frontend/src/views/CalendarView.vue` | Remove unreachable `type:'calendar-event'` branch from `onColumnDrop` |
| `frontend/src/components/__tests__/DayTimeline.test.ts` | Add plan/slideOver mocks; update drag-source test to check `[data-testid="task-card-calendar-event"]` |
| `frontend/src/components/__tests__/DayTimelineDropZone.test.ts` | Add plan/slideOver mocks; update drag-hide tests (rAF flush); update drop payload to `type:'task'` |
| `frontend/src/views/__tests__/CalendarViewDnD.test.ts` | Update drop payload test to `type:'task'` matching unified format |

## Test plan

- [x] 525/525 tests passing (`npm run test`)
- [x] `npm run build` — zero type errors
- [x] Verify timed events in plan day-view are draggable and can be repositioned by dropping onto a 15-min slot
- [x] Verify dragging a timed event from the plan day-view onto the anchor column demotes it back to a task