### PR TITLE
fix: DnD bugs A-D — timeline drops over events, per-anchor demotion, sidebar task moves

### DIFF
--- a/frontend/src/components/DayTimeline.vue
+++ b/frontend/src/components/DayTimeline.vue
@@ -227,6 +227,49 @@ async function onSlotDrop(e: DragEvent, i: number) {
   } catch { /* ignore malformed payload */ }
 }
 
+// --- Container-level DnD handlers (Bug B fix) ---
+// TaskCards are rendered after slot divs in the DOM and sit above them in z-order.
+// When a drag passes over a TaskCard block, dragover fires on the card but the card
+// doesn't call preventDefault, so the browser marks that position as no-drop.
+// The container-level handlers catch those events (dragover bubbles up from TaskCard)
+// and compute the target slot from clientY, enabling drops anywhere in the timed area.
+
+/** Map clientY to the nearest 15-min slot index, accounting for scroll offset. */
+function slotIndexFromClientY(clientY: number): number {
+  if (!timedAreaEl.value) return 0
+  const rect = timedAreaEl.value.getBoundingClientRect()
+  const relY = Math.max(0, clientY - rect.top + timedAreaEl.value.scrollTop)
+  return Math.max(0, Math.min(SLOT_COUNT - 1, Math.floor(relY / (15 * PX_PER_MINUTE))))
+}
+
+function onTimedAreaDragOver(e: DragEvent) {
+  e.preventDefault()
+  if (e.dataTransfer) e.dataTransfer.dropEffect = 'move'
+  // Slot divs handle their own highlight via onSlotDragOver — skip when the event
+  // originates from a slot div (it bubbles up here but overSlotIndex is already correct).
+  if ((e.target as HTMLElement).hasAttribute('data-time-slot')) return
+  overSlotIndex.value = slotIndexFromClientY(e.clientY)
+}
+
+function onTimedAreaDragLeave(e: DragEvent) {
+  const related = e.relatedTarget as Node | null
+  if (related && (e.currentTarget as HTMLElement).contains(related)) return
+  overSlotIndex.value = null
+}
+
+async function onTimedAreaDrop(e: DragEvent) {
+  e.preventDefault()
+  overSlotIndex.value = null
+  const rawJson = e.dataTransfer?.getData('application/json')
+  const rawText = e.dataTransfer?.getData('text/plain')
+  const raw = rawJson || rawText
+  if (!raw) return
+  const i = slotIndexFromClientY(e.clientY)
+  try {
+    await handleSlotDrop(JSON.parse(raw), slotTime(i))
+  } catch { /* ignore malformed payload */ }
+}
+
 // Array used purely for v-for slot grid rendering
 const slotIndices = Array.from({ length: SLOT_COUNT }, (_, i) => i)
 
@@ -294,12 +337,20 @@ function anchorBandStyle(anchor: { color: string; id: string }) {
     </div>
 
     <!-- Timed area -->
+    <!-- Container-level DnD: catches drops over TaskCard blocks (Bug B fix).
+         TaskCards render after slot divs in DOM order, sitting above them in z-order.
+         When a drag passes over a TaskCard, dragover fires on it but the card doesn't
+         call preventDefault, so the browser marks that zone as no-drop. Since dragover
+         bubbles, the outer container catches it and enables drops anywhere in the area. -->
     <div
       ref="timedAreaEl"
       data-testid="timed-area"
       class="relative flex overflow-y-auto"
       :style="{ height: 'calc(100vh - 200px)' }"
       @click="onTimedAreaClick"
+      @dragover="onTimedAreaDragOver"
+      @dragleave="onTimedAreaDragLeave"
+      @drop="onTimedAreaDrop"
     >
       <!-- Hour grid + labels -->
       <div class="relative flex-shrink-0 w-10" :style="{ height: `${AXIS_TOTAL_PX}px` }">
@@ -344,6 +395,8 @@ function anchorBandStyle(anchor: { color: string; id: string }) {
         />
 
         <!-- 15-min slot drop targets -- transparent absolute divs at each 15-min interval -->
+        <!-- @drop.stop: prevents the drop from bubbling to the container-level handler -->
+        <!-- (container handles drops that land on TaskCard blocks, which sit above these divs) -->
         <div
           v-for="i in slotIndices"
           :key="'slot-' + i"
@@ -358,7 +411,7 @@ function anchorBandStyle(anchor: { color: string; id: string }) {
           }"
           @dragover="(e) => onSlotDragOver(e, i)"
           @dragleave="(e) => onSlotDragLeave(e, i)"
-          @drop="(e) => onSlotDrop(e, i)"
+          @drop.stop="(e) => onSlotDrop(e, i)"
         />
 
         <!-- Timed event blocks -- TaskCard in calendar-event mode -->

--- a/frontend/src/components/__tests__/DayTimelineDropZone.test.ts
+++ b/frontend/src/components/__tests__/DayTimelineDropZone.test.ts
@@ -237,4 +237,25 @@ describe('DayTimeline – 15-min slot drop targets', () => {
     expect(mockMoveEvent).toHaveBeenCalled()
     expect(mockPromoteTask).not.toHaveBeenCalled()
   })
+
+  // ── Bug B: drops that land on a TaskCard (above slot divs in z-order) must still work ──
+  it('dropping a task payload onto the timed-area container (over an event block) promotes it correctly', async () => {
+    // Bug B: TaskCards sit above slot divs in DOM/z-order. Drops over them bubble up
+    // to the timed-area container. The container must handle them via clientY computation.
+    const { default: DayTimeline } = await import('../DayTimeline.vue')
+    const wrapper = mount(DayTimeline, { props: { date: '2024-06-10' } })
+    const timedArea = wrapper.find('[data-testid="timed-area"]')
+    expect(timedArea.exists()).toBe(true)
+    const payload = { type: 'task', taskId: 'task-99', title: 'Dropped over event block' }
+    await timedArea.trigger('drop', {
+      dataTransfer: { getData: (t: string) => t === 'text/plain' ? JSON.stringify(payload) : '' },
+    })
+    // task-99 has no existing event → promoteTask
+    expect(mockPromoteTask).toHaveBeenCalledWith(
+      'task-99',
+      expect.any(String),
+      expect.any(String),
+      'Dropped over event block',
+    )
+  })
 })

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -621,19 +621,27 @@ async function onColumnDrop(e: DragEvent, dayIndex: number) {
   }
 }
 
-// ─── Sidebar anchor drop — demote calendar event back to task ─
+// ─── Sidebar anchor drop — demote event OR move task between anchors ──────────
 async function onSidebarAnchorDrop(e: DragEvent, anchorId: string) {
   const raw = e.dataTransfer?.getData('application/json') || e.dataTransfer?.getData('text/plain')
   if (!raw) return
   try {
     const data = JSON.parse(raw)
-    if (data.type === 'task' && data.taskId && data.fromStartTime) {
+    if (data.type === 'task' && data.taskId) {
       const taskId = data.taskId as string
-      const ev = eventStore.events.find(e => e.task_id === taskId)
-        ?? eventStore.events.find(e => e.id === taskId)
-      if (!ev) return
-      await eventStore.demoteEvent(ev.id, anchorId, focusedDay.value)
-      await planStore.fetchPlanRange(dayKeys.value[0], dayKeys.value[6])
+      if (data.fromStartTime) {
+        // Demotion path: calendar event dragged back to the sidebar (Bug C/E fix)
+        // focusedDay.value is intentional — user intent is "put this on today's plan"
+        const ev = eventStore.events.find(e => e.task_id === taskId)
+          ?? eventStore.events.find(e => e.id === taskId)
+        if (!ev) return
+        await eventStore.demoteEvent(ev.id, anchorId, focusedDay.value)
+        await planStore.fetchPlanRange(dayKeys.value[0], dayKeys.value[6])
+      } else if (data.fromAnchorId && data.fromDate) {
+        // Task→task move: dragging a sidebar task to a different anchor (Bug A/D fix)
+        await planStore.moveTask(taskId, data.fromDate as string, data.fromAnchorId as string, focusedDay.value, anchorId)
+        await planStore.fetchPlanRange(dayKeys.value[0], dayKeys.value[6])
+      }
     }
   } catch { /* ignore malformed */ }
 }
@@ -763,7 +771,13 @@ const { onDragOver: calendarEdgeDragOver, onDragLeave: calendarEdgeDragLeave, on
               @dragstart="(e: DragEvent) => {
                 if (e.dataTransfer) {
                   e.dataTransfer.effectAllowed = 'move'
-                  e.dataTransfer.setData('text/plain', JSON.stringify({ type: 'task', taskId: task.id, title: task.text }))
+                  e.dataTransfer.setData('text/plain', JSON.stringify({
+                    type: 'task',
+                    taskId: task.id,
+                    title: task.text,
+                    fromAnchorId: anchor.id,
+                    fromDate: focusedDay,
+                  }))
                 }
               }"
             >

--- a/frontend/src/views/PlanView.vue
+++ b/frontend/src/views/PlanView.vue
@@ -119,8 +119,12 @@ function onOpenEvent(event: CalendarEvent) {
   }
 }
 
-/** Handle drop of a calendar event onto the anchor column — demotes it back to a plain task. */
-async function onAnchorColumnDrop(e: DragEvent) {
+/**
+ * Handle drop of a calendar event onto a specific anchor — demotes it back to a plain task.
+ * Bug C fix: each AnchorBlock wrapper gets its own drop zone so the targeted anchor id is
+ * always known exactly, rather than falling back to ev.anchor_id ?? anchors[0].
+ */
+async function onAnchorDrop(e: DragEvent, anchorId: string) {
   const rawJson = e.dataTransfer?.getData('application/json')
   const rawText = e.dataTransfer?.getData('text/plain')
   const raw = rawJson || rawText
@@ -134,7 +138,6 @@ async function onAnchorColumnDrop(e: DragEvent) {
       const ev = eventStore.events.find(e => e.task_id === taskId)
         ?? eventStore.events.find(e => e.id === taskId)
       if (!ev) return
-      const anchorId = ev.anchor_id ?? anchorStore.anchors[0]?.id ?? ''
       await eventStore.demoteEvent(ev.id, anchorId, activeDate.value)
       await planStore.fetchPlan(activeDate.value)
     }
@@ -217,23 +220,27 @@ async function onAnchorColumnDrop(e: DragEvent) {
       <div v-if="planStore.loading" class="text-[--fg-4]">Loading...</div>
       <!-- Two-column: anchor blocks left, day timeline right -->
       <div v-else class="grid grid-cols-[1fr_320px] gap-4 items-start">
-        <!-- Left: anchor blocks -->
-        <div
-          class="flex flex-col"
-          @dragover.prevent
-          @drop="onAnchorColumnDrop"
-        >
-          <AnchorBlock
+        <!-- Left: anchor blocks — each wrapped in its own drop zone (Bug C fix) -->
+        <!-- Per-anchor @drop means the exact targeted anchor id is always known,
+             preventing demotion from always landing on the first anchor. -->
+        <div class="flex flex-col">
+          <div
             v-for="(anchor, i) in anchorStore.anchors"
             :key="anchor.id"
-            :anchor-id="anchor.id"
-            :anchor-name="anchor.name"
-            :time="anchor.time"
-            :color="anchor.color"
-            :motif="anchor.motif"
-            :is-now="anchorStates.get(anchor.id) === 'now'"
-            :is-past="anchorStates.get(anchor.id) === 'past'"
-            :is-last="i === anchorStore.anchors.length - 1" />
+            data-anchor-drop-zone
+            @dragover.prevent
+            @drop="(e) => onAnchorDrop(e, anchor.id)"
+          >
+            <AnchorBlock
+              :anchor-id="anchor.id"
+              :anchor-name="anchor.name"
+              :time="anchor.time"
+              :color="anchor.color"
+              :motif="anchor.motif"
+              :is-now="anchorStates.get(anchor.id) === 'now'"
+              :is-past="anchorStates.get(anchor.id) === 'past'"
+              :is-last="i === anchorStore.anchors.length - 1" />
+          </div>
         </div>
         <!-- Right: day timeline -->
         <DayTimeline

--- a/frontend/src/views/__tests__/CalendarViewDnD.test.ts
+++ b/frontend/src/views/__tests__/CalendarViewDnD.test.ts
@@ -84,12 +84,15 @@ vi.mock('../../stores/anchors', () => ({
   }),
 }))
 
+const mockMoveTask = vi.fn()
+
 vi.mock('../../stores/plan', () => ({
   usePlanStore: () => ({
     plan: null,
     plans: {},
     fetchPlan: vi.fn(),
     fetchPlanRange: mockFetchPlanRange,
+    moveTask: mockMoveTask,
   }),
 }))
 
@@ -141,6 +144,7 @@ describe('CalendarView – HTML5 DnD refactor', () => {
     mockPushPanel.mockReset()
     mockCreateTaskAndPromote.mockReset()
     mockCreateTaskAndPromote.mockResolvedValue('new-task-id')
+    mockMoveTask.mockReset()
   })
 
   // ── KEY FAILING TEST #1 ────────────────────────────────────────────────────
@@ -310,6 +314,44 @@ describe('CalendarView – HTML5 DnD refactor', () => {
     })
     await flushPromises()
     expect(mockDemoteEvent).toHaveBeenCalled()
+    expect(mockFetchPlanRange).toHaveBeenCalled()
+  })
+
+  // ── Bug A/D: sidebar task→task move between anchors ───────────────────────
+  it('onSidebarAnchorDrop with task payload (no fromStartTime) calls planStore.moveTask', async () => {
+    // Bug A/D: dropping a sidebar task onto another anchor should move the task,
+    // not silently do nothing. Requires fromAnchorId + fromDate in the payload.
+    const { default: CalendarView } = await import('../CalendarView.vue')
+    const wrapper = mount(CalendarView)
+    await flushPromises()
+
+    const vm = wrapper.vm as unknown as Record<string, unknown>
+    expect(typeof vm.onSidebarAnchorDrop).toBe('function')
+
+    const payload = {
+      type: 'task',
+      taskId: 'task-99',
+      fromAnchorId: 'anchor-morning',
+      fromDate: todayStr,
+    }
+    const fakeEvent = {
+      dataTransfer: {
+        getData: (t: string) => t === 'text/plain' ? JSON.stringify(payload) : '',
+      },
+    }
+    await (vm.onSidebarAnchorDrop as (e: unknown, id: string) => Promise<void>)(
+      fakeEvent,
+      'anchor-afternoon',
+    )
+    await flushPromises()
+
+    expect(mockMoveTask).toHaveBeenCalledWith(
+      'task-99',
+      todayStr,
+      'anchor-morning',
+      todayStr,
+      'anchor-afternoon',
+    )
     expect(mockFetchPlanRange).toHaveBeenCalled()
   })
 

--- a/frontend/src/views/__tests__/PlanViewDnD.test.ts
+++ b/frontend/src/views/__tests__/PlanViewDnD.test.ts
@@ -1,0 +1,146 @@
+/**
+ * PlanView — DnD bug fixes
+ *
+ * Bug C: Demoting a calendar event to the anchor column must land in the
+ *        TARGETED anchor, not always the first one.
+ *
+ * Previously the whole anchor column was a single drop zone; the anchorId was
+ * derived from ev.anchor_id ?? anchors[0].id, which always picks the first
+ * anchor when the event has no stored anchor_id.
+ *
+ * Fix: each AnchorBlock wrapper gets its own @drop="(e) => onAnchorDrop(e, anchor.id)"
+ * so the correct anchor is always passed.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { defineComponent, h } from 'vue'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useRoute: () => ({
+    params: { view: 'day', date: '2024-06-10' },
+    path: '/plan/day/2024-06-10',
+    query: {},
+  }),
+  RouterLink: defineComponent({
+    props: ['to'],
+    setup(_p, { slots }) { return () => h('a', {}, slots.default?.()) },
+  }),
+  RouterView: defineComponent({ template: '<div />' }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) })),
+}))
+
+const mockDemoteEvent = vi.fn()
+const mockFetchPlan = vi.fn()
+
+vi.mock('../../stores/events', () => ({
+  useEventStore: () => ({
+    events: [
+      {
+        id: 'ev-1',
+        title: 'Meeting',
+        task_id: 'task-1',
+        start_time: '2024-06-10T09:00:00',
+        end_time: '2024-06-10T09:30:00',
+        source: 'tether',
+        external_id: null,
+        anchor_id: null,  // null → previously always fell back to anchors[0]
+        color: null,
+        is_recurring: false,
+        is_occurrence: false,
+        rrule: null,
+        is_all_day: false,
+        context_subject: null,
+      },
+    ],
+    fetchEvents: vi.fn(),
+    demoteEvent: mockDemoteEvent,
+    promoteTask: vi.fn(),
+    moveEvent: vi.fn(),
+    createTaskAndPromote: vi.fn(),
+    deleteEvent: vi.fn(),
+    removeEventsForTask: vi.fn(),
+  }),
+}))
+
+vi.mock('../../stores/anchors', () => ({
+  useAnchorStore: () => ({
+    anchors: [
+      { id: 'anchor-morning', name: 'Morning', time: '08:00', color: '#3b82f6', motif: null, duration_minutes: 240 },
+      { id: 'anchor-afternoon', name: 'Afternoon', time: '13:00', color: '#f59e0b', motif: null, duration_minutes: 240 },
+    ],
+    fetchAnchors: vi.fn(),
+  }),
+  computeAnchorStates: vi.fn(() => new Map()),
+}))
+
+vi.mock('../../stores/plan', () => ({
+  usePlanStore: () => ({
+    plan: { date: '2024-06-10', anchors: {}, acknowledgements: {}, check_in_log: [] },
+    loading: false,
+    today: '2024-06-10',
+    fetchPlan: mockFetchPlan,
+    plans: {},
+    activeDate: '2024-06-10',
+  }),
+}))
+
+vi.mock('../../stores/milestones', () => ({
+  useMilestoneStore: () => ({ all: [], fetchAll: vi.fn(), taskMilestones: {} }),
+}))
+
+vi.mock('../../composables/useSlideOver', () => ({
+  useSlideOver: () => ({
+    push: vi.fn(),
+    pop: vi.fn(),
+    stack: { value: [] },
+    close: vi.fn(),
+    restoreFromUrl: vi.fn(),
+  }),
+}))
+
+describe('PlanView — Bug C: per-anchor demotion drop', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockDemoteEvent.mockReset()
+    mockFetchPlan.mockReset()
+  })
+
+  it('renders one drop zone per anchor (not a single column drop zone)', async () => {
+    const { default: PlanView } = await import('../PlanView.vue')
+    const wrapper = mount(PlanView, { props: { view: 'day', date: '2024-06-10' } })
+    await flushPromises()
+    const dropZones = wrapper.findAll('[data-anchor-drop-zone]')
+    expect(dropZones.length).toBe(2)
+  })
+
+  it('dropping a calendar event onto the second anchor calls demoteEvent with that anchor id', async () => {
+    const { default: PlanView } = await import('../PlanView.vue')
+    const wrapper = mount(PlanView, { props: { view: 'day', date: '2024-06-10' } })
+    await flushPromises()
+
+    const dropZones = wrapper.findAll('[data-anchor-drop-zone]')
+    expect(dropZones.length).toBe(2)
+    const afternoonZone = dropZones[1]  // anchor-afternoon
+
+    const payload = {
+      type: 'task',
+      taskId: 'task-1',
+      fromStartTime: '2024-06-10T09:00:00',
+    }
+    await afternoonZone.trigger('drop', {
+      dataTransfer: {
+        getData: (t: string) => t === 'text/plain' ? JSON.stringify(payload) : '',
+      },
+    })
+    await flushPromises()
+
+    // Must target anchor-afternoon specifically, not anchor-morning (the first one)
+    expect(mockDemoteEvent).toHaveBeenCalledWith('ev-1', 'anchor-afternoon', '2024-06-10')
+    expect(mockDemoteEvent).not.toHaveBeenCalledWith('ev-1', 'anchor-morning', expect.any(String))
+  })
+})


### PR DESCRIPTION
## Summary

Fixes four DnD bugs on the plan and calendar views:

- **Bug B (DayTimeline):** TaskCards are rendered after slot divs in the DOM, sitting above them in z-order and absorbing `dragover` events without `preventDefault`. Drops over existing calendar event blocks silently failed. Fix: add container-level `@dragover`/`@drop` to the timed-area div that catches bubbled events from TaskCard blocks and computes the target slot from `clientY`. Slot divs get `@drop.stop` to prevent double-firing.

- **Bug C (PlanView):** The entire anchor column was one drop zone, so `demoteEvent` always used `ev.anchor_id ?? anchors[0].id` — landing every calendar-event demotion on the first anchor regardless of where the user dropped. Fix: each AnchorBlock now has its own `@drop="(e) => onAnchorDrop(e, anchor.id)"` wrapper div.

- **Bugs A+D (CalendarView sidebar):** Sidebar `<li>` dragstart omitted `fromAnchorId`/`fromDate`, and `onSidebarAnchorDrop` only handled `fromStartTime` payloads. Task→task moves between sidebar anchors silently did nothing. Fix: include `fromAnchorId` and `fromDate` in sidebar dragstart; `onSidebarAnchorDrop` now handles both demotion (`fromStartTime` present) and task moves (`fromAnchorId` + `fromDate` present).

## Test plan

- [ ] All new tests green (`DayTimelineDropZone`, `PlanViewDnD`, `CalendarViewDnD`)
- [ ] Full suite passes (only pre-existing `AnchorFocusWidget` failures remain)
- [ ] `npm run build` zero TypeScript errors
- [ ] Manually verify: drag calendar event to second anchor in PlanView → lands on correct anchor
- [ ] Manually verify: drag task between sidebar anchors in CalendarView → task moves
- [ ] Manually verify: drag task from anchor onto DayTimeline event block area → event created at correct time