### PR TITLE
fix: anchor pings ON CONFLICT + cron env vars

### DIFF
--- a/bot/crontab.py
+++ b/bot/crontab.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import os
 import subprocess
 from pathlib import Path
 
@@ -9,10 +10,26 @@ MARKER_START = "# TETHER_START"
 MARKER_END = "# TETHER_END"
 _VENV_PYTHON = Path.home() / "tether" / ".venv" / "bin" / "python"
 
+# Path to the env file sourced before each anchor trigger cron job.
+# Must contain at minimum: DATABASE_URL, TETHER_USER_ID
+# Uses the same file as systemd EnvironmentFile= (bare KEY=VALUE lines, no `export`).
+# Override with TETHER_CRON_ENV_FILE env var or set bot.cron_env_file in config yaml.
+_ENV_FILE: str = os.environ.get(
+    "TETHER_CRON_ENV_FILE",
+    str(Path.home() / ".tether-config" / "env"),
+)
+
 
 def _anchor_to_cron(anchor: dict) -> str:
     h, m = map(int, anchor["time"].split(":"))
-    return f"{m} {h} * * * {_VENV_PYTHON} -m bot.anchor_trigger {anchor['id']}"
+    # Use `set -a; . /env/file; set +a` so bare KEY=VALUE lines are auto-exported
+    # to child processes.  Plain `. file` does not export vars; systemd's
+    # EnvironmentFile= injects them directly and doesn't require this workaround.
+    return (
+        f"{m} {h} * * * "
+        f"set -a; . {_ENV_FILE}; set +a; "
+        f"{_VENV_PYTHON} -m bot.anchor_trigger {anchor['id']}"
+    )
 
 
 async def sync_crontab(pool, user_id: str) -> None:

--- a/db/pg_queries/followup.py
+++ b/db/pg_queries/followup.py
@@ -26,7 +26,7 @@ async def init_followup_state(
             (user_id, date, anchor_id, task_id, sequence_started_at)
         VALUES
             (current_setting('app.current_user_id', true)::uuid, $1, $2, $3, $4)
-        ON CONFLICT (user_id, date, anchor_id, task_id) DO NOTHING
+        ON CONFLICT (user_id, date, task_id) DO NOTHING
         """,
         date,
         anchor_id,

--- a/tests/bot/test_crontab_env.py
+++ b/tests/bot/test_crontab_env.py
@@ -1,0 +1,109 @@
+"""Regression test — cron entries must source env file for DATABASE_URL + TETHER_USER_ID.
+
+After the Postgres migration, anchor_trigger.py requires DATABASE_URL and
+TETHER_USER_ID.  Cron does not inherit systemd's EnvironmentFile vars, so
+the cron entry must explicitly source an env file.
+
+The env file uses bare KEY=VALUE format (same as systemd EnvironmentFile=),
+so we must use `set -a; . /file; set +a` to export vars to child processes.
+"""
+from __future__ import annotations
+
+import pytest
+from contextlib import asynccontextmanager
+from unittest.mock import patch, AsyncMock
+
+from bot.crontab import sync_crontab, MARKER_START, MARKER_END, _anchor_to_cron
+
+ANCHORS = [
+    {"id": "00000000-0000-0000-0000-000000000010", "name": "The Grind", "time": "08:00"},
+]
+
+
+async def _run_sync(existing_crontab=""):
+    """Run sync_crontab with mocked DB and subprocess; return written crontab."""
+    written = []
+    mock_pool = AsyncMock()
+    mock_conn = AsyncMock()
+
+    @asynccontextmanager
+    async def mock_get_conn(pool, user_id=None):
+        yield mock_conn
+
+    def fake_run(cmd, **kwargs):
+        class R:
+            pass
+        r = R()
+        if cmd == ["crontab", "-l"]:
+            r.stdout = existing_crontab
+            r.returncode = 0 if existing_crontab else 1
+        else:
+            written.append(kwargs.get("input", ""))
+            r.returncode = 0
+        return r
+
+    with patch("bot.crontab.pg.get_conn", mock_get_conn), \
+         patch("bot.crontab.get_anchors", AsyncMock(return_value=ANCHORS)), \
+         patch("bot.crontab.subprocess.run", side_effect=fake_run):
+        await sync_crontab(mock_pool, "00000000-0000-0000-0000-000000000001")
+
+    return written[0] if written else ""
+
+
+# ---------------------------------------------------------------------------
+# Bug B: cron entries must source env file so DATABASE_URL is available
+# ---------------------------------------------------------------------------
+
+def test_anchor_to_cron_includes_env_file_sourcing():
+    """_anchor_to_cron must produce an entry that sources an env file.
+
+    Without this, anchor_trigger.py raises KeyError: 'DATABASE_URL' because
+    cron does not inherit systemd EnvironmentFile vars.
+    """
+    anchor = {"id": "00000000-0000-0000-0000-000000000010", "time": "08:00"}
+    entry = _anchor_to_cron(anchor)
+
+    # Entry must contain set -a to auto-export sourced vars (KEY=VALUE format)
+    assert "set -a" in entry, (
+        f"Cron entry must use 'set -a' to export vars from the env file.\n"
+        f"Got: {entry!r}"
+    )
+    # Entry must source some env file
+    assert ". /" in entry or ". ~" in entry or "source /" in entry, (
+        f"Cron entry must source an env file ('. /path/to/env').\n"
+        f"Got: {entry!r}"
+    )
+
+
+def test_anchor_to_cron_env_file_path_is_configurable():
+    """The env file path must be configurable, not hardcoded."""
+    import bot.crontab as crontab_mod
+
+    anchor = {"id": "00000000-0000-0000-0000-000000000010", "time": "08:00"}
+
+    with patch.object(crontab_mod, "_ENV_FILE", "/custom/path/env"):
+        entry = _anchor_to_cron(anchor)
+
+    assert "/custom/path/env" in entry, (
+        f"Cron entry must use the configured env file path.\n"
+        f"Got: {entry!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_crontab_entries_source_env_file():
+    """End-to-end: written crontab must include env file sourcing in each tether entry."""
+    result = await _run_sync()
+    lines = result.splitlines()
+
+    tether_lines = [
+        l for l in lines
+        if "bot.anchor_trigger" in l
+    ]
+    assert tether_lines, "Expected at least one anchor_trigger line in crontab"
+
+    for line in tether_lines:
+        assert "set -a" in line, (
+            f"Each anchor trigger cron line must source env with 'set -a'.\n"
+            f"Got: {line!r}"
+        )

--- a/tests/db/test_followup_state.py
+++ b/tests/db/test_followup_state.py
@@ -1,0 +1,54 @@
+"""Tests for db/pg_queries/followup.py — ON CONFLICT clause bug regression."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timezone
+
+
+# ---------------------------------------------------------------------------
+# Bug A: ON CONFLICT must use (user_id, date, task_id) — not anchor_id
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_init_followup_state_sql_excludes_anchor_id():
+    """init_followup_state must use ON CONFLICT (user_id, date, task_id).
+
+    The followup_state table has UNIQUE (user_id, date, task_id).
+    Including anchor_id in the ON CONFLICT clause raises a Postgres error
+    because no such constraint exists — this is the root cause of task pings
+    never firing (get_active_followup_states always returned empty).
+    """
+    from db.pg_queries.followup import init_followup_state
+
+    mock_conn = AsyncMock()
+    now = datetime(2026, 5, 5, 10, 0, 0, tzinfo=timezone.utc)
+
+    await init_followup_state(
+        conn=mock_conn,
+        date="2026-05-05",
+        anchor_id="anchor-abc",
+        task_id="task-xyz",
+        now=now,
+    )
+
+    assert mock_conn.execute.called, "execute should be called"
+    sql_arg = mock_conn.execute.call_args[0][0]
+
+    # Must NOT reference anchor_id in the ON CONFLICT clause
+    import re
+    # Extract the ON CONFLICT portion
+    on_conflict_match = re.search(
+        r"ON CONFLICT\s*\(([^)]+)\)", sql_arg, re.IGNORECASE
+    )
+    assert on_conflict_match, "ON CONFLICT clause not found in SQL"
+    conflict_cols = [c.strip() for c in on_conflict_match.group(1).split(",")]
+
+    assert "anchor_id" not in conflict_cols, (
+        f"anchor_id must NOT appear in ON CONFLICT columns — "
+        f"table unique constraint is (user_id, date, task_id). "
+        f"Got: {conflict_cols}"
+    )
+    assert "user_id" in conflict_cols, "user_id must be in ON CONFLICT"
+    assert "date" in conflict_cols, "date must be in ON CONFLICT"
+    assert "task_id" in conflict_cols, "task_id must be in ON CONFLICT"


### PR DESCRIPTION
## Summary

Two bugs that together caused anchor task pings to never fire after the Postgres migration.

### Bug A — `init_followup_state` ON CONFLICT used wrong columns

`followup_state` has a `UNIQUE (user_id, date, task_id)` constraint, but the INSERT used `ON CONFLICT (user_id, date, anchor_id, task_id)` — a column set that matches no constraint. Postgres raised an error on every call, so `get_active_followup_states` always returned empty and `check_followups` exited immediately without sending any pings.

**Fix:** `db/pg_queries/followup.py` — remove `anchor_id` from the `ON CONFLICT` clause.

### Bug B — Cron entries didn't source env vars

`anchor_trigger.py` requires `DATABASE_URL` and `TETHER_USER_ID` after the Postgres migration. Cron does not inherit systemd `EnvironmentFile=` vars, so the generated cron entries now explicitly source the env file:

```
set -a; . ~/.tether-config/env; set +a; python -m bot.anchor_trigger <id>
```

`set -a` auto-exports all bare `KEY=VALUE` vars so they reach child processes. The env file path defaults to `~/.tether-config/env` and can be overridden via `TETHER_CRON_ENV_FILE`.

**Fix:** `bot/crontab.py` — prepend env file sourcing to each generated cron entry.

## Tests

- `tests/db/test_followup_state.py` — regression test asserting `anchor_id` absent from ON CONFLICT
- `tests/bot/test_crontab_env.py` — regression tests asserting env file sourcing in generated cron entries