### PR TITLE
fix: DnD drop time (already fixed), anchor task moves (regression test), milestone motif picker

### DIFF
--- a/frontend/src/components/AnchorBlock.vue
+++ b/frontend/src/components/AnchorBlock.vue
@@ -296,6 +296,17 @@ const { isOver: isContainerOver, dropHandlers: containerDropHandlers } = useDrop
               :level="1"
               class="mb-1"
               @header-click="pushPanel({ kind: 'milestone', entityId: mg.milestone.id })">
+              <template #header-right>
+                <div
+                  data-testid="milestone-motif-picker"
+                  class="opacity-0 group-hover/ctx:opacity-100 transition-opacity ml-1"
+                  @click.stop>
+                  <MotifPicker
+                    :model-value="(mg.milestone.motif as MotifSlot | null | undefined) ?? null"
+                    @update:model-value="(slot) => milestoneStore.patchMilestone(mg.milestone.id, { motif: slot })"
+                  />
+                </div>
+              </template>
               <div v-for="{ task, index: i } in mg.tasks" :key="task.id || i"
                    :data-task-id="task.id"
                    draggable="true"

--- a/frontend/src/components/__tests__/AnchorBlock.milestone-motif.test.ts
+++ b/frontend/src/components/__tests__/AnchorBlock.milestone-motif.test.ts
@@ -1,0 +1,134 @@
+/**
+ * AnchorBlock — milestone GroupContainer motif picker (Bug 3)
+ *
+ * When a milestone has >1 tasks in an anchor, it renders inside a
+ * GroupContainer. That container should expose a MotifPicker in the
+ * #header-right slot so users can set the milestone's motif colour —
+ * exactly like the context GroupContainer already does.
+ *
+ * Previously the milestone GroupContainer had no #header-right slot,
+ * so there was no way to set its motif from the anchor view.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ path: '/' }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) })),
+}))
+
+vi.mock('../../composables/useDropZone', () => ({
+  useDropZone: vi.fn(() => ({
+    isOver: { value: false },
+    dropHandlers: {
+      onDragEnter: vi.fn(),
+      onDragOver: vi.fn(),
+      onDragLeave: vi.fn(),
+      onDrop: vi.fn(),
+    },
+  })),
+}))
+
+vi.mock('../../composables/useSlideOver', () => ({
+  useSlideOver: () => ({
+    push: vi.fn(),
+    pop: vi.fn(),
+    stack: { value: [] },
+    close: vi.fn(),
+    restoreFromUrl: vi.fn(),
+  }),
+}))
+
+/** Minimal Milestone fixture with two tasks so the GroupContainer renders */
+const MILESTONE_ID = 'ms-1'
+
+// Full Milestone object — task_ids is required by the computed taskMilestones
+const MILESTONE = {
+  id: MILESTONE_ID,
+  name: 'Sprint Goal',
+  color: '#3b82f6',
+  motif: null,
+  status: 'active' as const,
+  description: null,
+  target_date: null,
+  status_override: false,
+  context_subject: 'Work',
+  created_at: '2026-01-01',
+  updated_at: '2026-01-01',
+  task_count: 2,
+  done_count: 0,
+  task_ids: ['t-1', 't-2'],
+  tasks: [],
+}
+
+const TASKS = [
+  { id: 't-1', text: 'Task A', status: 'pending', position: 0, context_subject: null, context_node_id: null, blocks: [], blocked_by: [], followup_config: null, description: null },
+  { id: 't-2', text: 'Task B', status: 'pending', position: 1, context_subject: null, context_node_id: null, blocks: [], blocked_by: [], followup_config: null, description: null },
+]
+
+async function mountBlock() {
+  const { default: AnchorBlock } = await import('../AnchorBlock.vue')
+  const { usePlanStore } = await import('../../stores/plan')
+  const { useMilestoneStore } = await import('../../stores/milestones')
+
+  const planStore = usePlanStore()
+  planStore.plan = {
+    date: '2026-05-05',
+    anchors: {
+      'a1': { tasks: TASKS as any[], notes: '' },
+    },
+    acknowledgements: {},
+    check_in_log: [],
+  } as any
+
+  // Populate all — taskMilestones computed derives from this
+  const msStore = useMilestoneStore()
+  msStore.all = [MILESTONE] as any[]
+
+  return { wrapper: mount(AnchorBlock, {
+    props: {
+      anchorId: 'a1',
+      anchorName: 'Morning',
+      time: '08:00',
+      color: '#fff',
+    },
+  }), msStore }
+}
+
+describe('AnchorBlock — milestone GroupContainer motif picker', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('renders a milestone-motif-picker when milestone group has >1 tasks', async () => {
+    const { wrapper } = await mountBlock()
+    await flushPromises()
+    const picker = wrapper.find('[data-testid="milestone-motif-picker"]')
+    expect(picker.exists()).toBe(true)
+  })
+
+  it('calls milestoneStore.patchMilestone with motif when MotifPicker emits update', async () => {
+    const { wrapper, msStore } = await mountBlock()
+    await flushPromises()
+
+    const patchSpy = vi.spyOn(msStore, 'patchMilestone').mockResolvedValue(undefined as any)
+
+    // Find and click a swatch inside the milestone-motif-picker
+    const pickerContainer = wrapper.find('[data-testid="milestone-motif-picker"]')
+    expect(pickerContainer.exists()).toBe(true)
+
+    // Trigger update:modelValue on the MotifPicker component inside that container
+    const motifPicker = pickerContainer.findComponent({ name: 'MotifPicker' })
+    expect(motifPicker.exists()).toBe(true)
+    await motifPicker.vm.$emit('update:modelValue', 'focus')
+    await flushPromises()
+
+    expect(patchSpy).toHaveBeenCalledWith(MILESTONE_ID, { motif: 'focus' })
+  })
+})

--- a/frontend/src/views/__tests__/PlanViewDnD.test.ts
+++ b/frontend/src/views/__tests__/PlanViewDnD.test.ts
@@ -103,6 +103,57 @@ vi.mock('../../composables/useSlideOver', () => ({
   }),
 }))
 
+/**
+ * Bug B: PlanView outer anchor wrapper must not swallow task→task drops.
+ *
+ * The outer `data-anchor-drop-zone` div carries @drop="onAnchorDrop". That handler
+ * only acts when the payload has `fromStartTime` (calendar event demotion). When a
+ * plain task is dropped (no fromStartTime), the outer handler must return early so
+ * AnchorBlock's internal useDropZone can process the move. Regression: if
+ * onAnchorDrop were ever changed to call preventDefault/stopPropagation
+ * unconditionally, task→task inter-anchor moves would be silently swallowed.
+ */
+describe('PlanView — Bug B: outer wrapper ignores plain task drops (no fromStartTime)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockDemoteEvent.mockReset()
+    mockFetchPlan.mockReset()
+  })
+
+  it('dropping a plain task (no fromStartTime) onto anchor zone does NOT call demoteEvent', async () => {
+    const { default: PlanView } = await import('../PlanView.vue')
+    const wrapper = mount(PlanView, { props: { view: 'day', date: '2024-06-10' } })
+    await flushPromises()
+    // fetchPlan is called once on mount (watch immediate) — reset before drop so we
+    // only assert on what the drop handler itself triggers.
+    mockFetchPlan.mockReset()
+    mockDemoteEvent.mockReset()
+
+    const dropZones = wrapper.findAll('[data-anchor-drop-zone]')
+    expect(dropZones.length).toBe(2)
+
+    // Plain task payload — NO fromStartTime
+    const payload = {
+      type: 'task',
+      taskId: 'task-99',
+      title: 'Regular task',
+      fromAnchorId: 'anchor-morning',
+      fromDate: '2024-06-10',
+    }
+    await dropZones[1].trigger('drop', {
+      dataTransfer: {
+        getData: (t: string) => t === 'text/plain' ? JSON.stringify(payload) : '',
+      },
+    })
+    await flushPromises()
+
+    // demoteEvent must NOT be called for regular task moves
+    expect(mockDemoteEvent).not.toHaveBeenCalled()
+    // fetchPlan must NOT be triggered by the outer handler for non-demotion drops
+    expect(mockFetchPlan).not.toHaveBeenCalled()
+  })
+})
+
 describe('PlanView — Bug C: per-anchor demotion drop', () => {
   beforeEach(() => {
     setActivePinia(createPinia())


### PR DESCRIPTION
## Summary

Three frontend bugs investigated from the phase-1 DnD/motif list:

### Bug A — DayTimeline container-relative drop coordinate (Bug 1)
**Finding:** Already fixed in prior commit `ed6329c`. The `slotIndexFromClientY` function at `DayTimeline.vue:241` already uses the correct formula:
```
const relY = Math.max(0, clientY - rect.top + timedAreaEl.value.scrollTop)
```
No code change needed. Existing tests in `DayTimelineDropZone.test.ts` cover the code path.

### Bug B — task→task inter-anchor moves swallowed (Bug 2)
**Finding:** No code regression present. The `onAnchorDrop` handler in `PlanView.vue` already guards with `data.fromStartTime` before demoting — plain task drops return early and AnchorBlock's internal `useDropZone` handles them unimpeded.

**Action:** Added regression test (`PlanViewDnD.test.ts`) to document correct behavior and guard against future breakage.

### Bug C — Milestone GroupContainer missing motif picker (Bug 3)
**Fix implemented.** Milestone GroupContainers with >1 tasks (in `AnchorBlock.vue`) were missing the `#header-right` MotifPicker slot that context GroupContainers already had. Added the picker, wired to `milestoneStore.patchMilestone(id, { motif: slot })`.

## Files changed
- `frontend/src/components/AnchorBlock.vue` — add `#header-right` slot with MotifPicker to milestone GroupContainer
- `frontend/src/components/__tests__/AnchorBlock.milestone-motif.test.ts` — new: 2 tests (TDD, red→green)
- `frontend/src/views/__tests__/PlanViewDnD.test.ts` — new test: outer wrapper ignores non-demotion drops

## Test plan
- [x] `npm run test` — 535 tests pass (0 failures)
- [x] `npm run build` — zero TypeScript errors
- [ ] Manual smoke: open AnchorBlock with milestone group (≥2 tasks), hover header, verify motif picker appears