### PR TITLE
fix: remove dead SQLite migration step from deploy workflows

### DIFF
--- a/.github/workflows/pi-deploy-api.yml
+++ b/.github/workflows/pi-deploy-api.yml
@@ -111,30 +111,6 @@ jobs:
           make configure-vault \
             TETHER_VAULT_KEY="$TETHER_VAULT_KEY"
 
-      - name: Run DB migrations
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          cd /home/toast/tether
-          migration_failed=0
-          for db in /home/toast/.tether-config/users/*.db; do
-            if [ -f "$db" ]; then
-              if TETHER_IMAGE=tether-premium IMAGE_TAG=${TAG} \
-                   TETHER_DATA_DIR=/home/toast/.tether-config \
-                   docker compose run --rm --no-deps api \
-                     python db/migrate_data_model.py /data/users/$(basename "$db"); then
-                echo "Migrated $db"
-              else
-                echo "ERROR: Migration failed for $db" >&2
-                migration_failed=1
-              fi
-            fi
-          done
-          if [ "$migration_failed" -ne 0 ]; then
-            echo "One or more migrations failed — aborting deploy" >&2
-            exit 1
-          fi
-
       - name: Restart API service
         env:
           TAG: ${{ steps.version.outputs.tag }}

--- a/.github/workflows/pi-deploy-db.yml
+++ b/.github/workflows/pi-deploy-db.yml
@@ -51,24 +51,3 @@ jobs:
           DATABASE_URL=postgresql://tether:${POSTGRES_PASSWORD}@localhost:5432/tether \
             alembic upgrade head
 
-      - name: Run DB migrations
-        run: |
-          cd /home/toast/tether
-          migration_failed=0
-          for db in /home/toast/.tether-config/users/*.db; do
-            if [ -f "$db" ]; then
-              if TETHER_IMAGE=tether-premium IMAGE_TAG=latest \
-                   TETHER_DATA_DIR=/home/toast/.tether-config \
-                   docker compose run --rm --no-deps api \
-                     python db/migrate_data_model.py /data/users/$(basename "$db"); then
-                echo "Migrated $db"
-              else
-                echo "ERROR: Migration failed for $db" >&2
-                migration_failed=1
-              fi
-            fi
-          done
-          if [ "$migration_failed" -ne 0 ]; then
-            echo "One or more migrations failed — aborting deploy" >&2
-            exit 1
-          fi

--- a/.github/workflows/pi-force-deploy-all.yml
+++ b/.github/workflows/pi-force-deploy-all.yml
@@ -112,29 +112,6 @@ jobs:
             POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
             TETHER_APP_PASSWORD="$TETHER_APP_PASSWORD"
 
-      - name: Run DB migrations
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          cd /home/toast/tether
-          migration_failed=0
-          for db in /home/toast/.tether-config/users/*.db; do
-            if [ -f "$db" ]; then
-              if TETHER_IMAGE=tether-premium IMAGE_TAG=${TAG} \
-                   TETHER_DATA_DIR=/home/toast/.tether-config \
-                   docker compose run --rm --no-deps api \
-                     python db/migrate_data_model.py /data/users/$(basename "$db"); then
-                echo "Migrated $db"
-              else
-                echo "ERROR: Migration failed for $db" >&2
-                migration_failed=1
-              fi
-            fi
-          done
-          if [ "$migration_failed" -ne 0 ]; then
-            echo "One or more migrations failed — aborting deploy" >&2
-            exit 1
-          fi
 
       - name: Restart all services
         env:


### PR DESCRIPTION
The SQLite migration files were removed in b8c5e1c but three workflow files still referenced them, causing all Pi deployments to fail. Removes the 'Run DB migrations' step from pi-deploy-api.yml, pi-deploy-db.yml, and pi-force-deploy-all.yml.