### PR TITLE
fix: use group/milestone for hover scope on milestone motif picker

### DIFF
--- a/frontend/src/components/AnchorBlock.vue
+++ b/frontend/src/components/AnchorBlock.vue
@@ -294,12 +294,12 @@ const { isOver: isContainerOver, dropHandlers: containerDropHandlers } = useDrop
               :label="mg.milestone.name"
               :color="mg.milestone.color ?? undefined"
               :level="1"
-              class="mb-1"
+              class="mb-1 group/milestone"
               @header-click="pushPanel({ kind: 'milestone', entityId: mg.milestone.id })">
               <template #header-right>
                 <div
                   data-testid="milestone-motif-picker"
-                  class="opacity-0 group-hover/ctx:opacity-100 transition-opacity ml-1"
+                  class="opacity-0 group-hover/milestone:opacity-100 transition-opacity ml-1"
                   @click.stop>
                   <MotifPicker
                     :model-value="(mg.milestone.motif as MotifSlot | null | undefined) ?? null"


### PR DESCRIPTION
The milestone motif picker incorrectly used group-hover/ctx:opacity-100, which tied its visibility to the outer context group hover rather than the milestone group itself. Added group/milestone class to the milestone GroupContainer and updated the picker to use group-hover/milestone.