### PR TITLE
fix: capture send_fn responses in WebSocket handler

### DIFF
--- a/api/routes/bot.py
+++ b/api/routes/bot.py
@@ -110,17 +110,21 @@ async def bot_chat(websocket: WebSocket,
                     )
                     raise  # Let the session task propagate disconnect to the outer handler
 
+            # Capture responses delivered via send_fn. handle_message always
+            # calls send_fn(final) and returns None — the return value is not
+            # used for response delivery. This list is local to each message
+            # so it resets automatically on the next loop iteration.
+            response_parts: list[str] = []
+
+            def capture_send_fn(msg: str) -> None:
+                response_parts.append(msg)
+
             # Run the session as a task so we can race it against an incoming
             # stop message without blocking the event loop.
             session_task = asyncio.create_task(
                 handle_message(
                     content,
-                    # send_fn is unused on WebSocket; log at debug so any unexpected
-                    # calls from handle_message are visible rather than silently dropped.
-                    send_fn=lambda msg: logger.debug(
-                        "bot_chat: send_fn called (no-op on WebSocket), user_id=%s, msg=%r",
-                        user_id, msg,
-                    ),
+                    send_fn=capture_send_fn,
                     pool=pool,
                     user_id=user_id,
                     vault=getattr(websocket.app.state, "vault", None),
@@ -190,10 +194,10 @@ async def bot_chat(websocket: WebSocket,
             if session_task is None or session_task.cancelled():
                 continue
 
-            # Deliver the session result. Errors from handle_message keep the
-            # connection alive so the user can try another message.
+            # Re-raise any exception from handle_message so error handlers below
+            # can send a user-facing error frame and keep the connection alive.
             try:
-                response = session_task.result()
+                session_task.result()  # returns None; raises if handle_message raised
             except TimeoutError:
                 # Session exceeded its per-intent timeout. The session manager has
                 # already closed the session on its end; state is preserved and the
@@ -223,6 +227,7 @@ async def bot_chat(websocket: WebSocket,
                 continue
 
             session_task = None
+            response = "\n\n".join(response_parts) if response_parts else None
             if response:
                 await websocket.send_json({"type": "chunk", "content": response})
             await websocket.send_json({"type": "done"})

--- a/tests/api/test_bot_ws.py
+++ b/tests/api/test_bot_ws.py
@@ -82,14 +82,15 @@ def test_bot_ws_invalid_token_rejected_1008():
 def test_bot_ws_valid_cookie_accepted():
     """A valid JWT allows connection; a user message produces chunk + done.
 
-    The redesigned handler uses handle_message's *return value* as the chunk
-    content — send_fn is a no-op on WebSocket.  The mock must return a string.
+    handle_message delivers the response via send_fn (not its return value).
+    The mock mirrors real behaviour: call send_fn, return None.
     """
     app = _make_app()
     token = _valid_token()
 
     async def fake_handle_message(content, send_fn, pool, user_id, vault=None, status_fn=None):
-        return "pong"
+        send_fn("pong")
+        return None
 
     with patch("api.routes.bot.handle_message", new=fake_handle_message):
         with TestClient(app, raise_server_exceptions=False) as client:
@@ -106,12 +107,12 @@ def test_bot_ws_valid_cookie_accepted():
 
 
 def test_bot_ws_none_response_skips_chunk():
-    """When handle_message returns None, no chunk frame is sent — just done."""
+    """When handle_message never calls send_fn, no chunk frame is sent — just done."""
     app = _make_app()
     token = _valid_token()
 
     async def fake_handle_message(content, send_fn, pool, user_id, vault=None, status_fn=None):
-        return None
+        return None  # send_fn not called — empty response
 
     with patch("api.routes.bot.handle_message", new=fake_handle_message):
         with TestClient(app, raise_server_exceptions=False) as client:
@@ -143,7 +144,8 @@ def test_status_messages_pushed_immediately():
     async def fake_handle_with_status(content, send_fn, pool, user_id, vault=None, status_fn=None):
         if status_fn is not None:
             await status_fn("Working on it...")
-        return "final answer"
+        send_fn("final answer")
+        return None
 
     with patch("api.routes.bot.handle_message", new=fake_handle_with_status):
         with TestClient(app, raise_server_exceptions=False) as client:
@@ -174,7 +176,8 @@ def test_multiple_status_messages_in_order():
         if status_fn is not None:
             await status_fn("Step 1: Reading tasks")
             await status_fn("Step 2: Rescheduling blocks")
-        return "done planning"
+        send_fn("done planning")
+        return None
 
     with patch("api.routes.bot.handle_message", new=fake_handle_multi_status):
         with TestClient(app, raise_server_exceptions=False) as client:
@@ -249,7 +252,8 @@ def test_idle_stop_ignored():
     token = _valid_token()
 
     async def fake_handle_message(content, send_fn, pool, user_id, vault=None, status_fn=None):
-        return "ok"
+        send_fn("ok")
+        return None
 
     with patch("api.routes.bot.handle_message", new=fake_handle_message):
         with TestClient(app, raise_server_exceptions=False) as client:
@@ -278,7 +282,8 @@ def test_missing_content_sends_error_keeps_connection():
     token = _valid_token()
 
     async def fake_handle_message(content, send_fn, pool, user_id, vault=None, status_fn=None):
-        return "ok"
+        send_fn("ok")
+        return None
 
     with patch("api.routes.bot.handle_message", new=fake_handle_message):
         with TestClient(app, raise_server_exceptions=False) as client:
@@ -319,7 +324,8 @@ def test_bot_ws_timeout_sends_helpful_error_and_continues_loop():
         call_count += 1
         if call_count == 1:
             raise TimeoutError("session timed out")
-        return "recovered response"
+        send_fn("recovered response")
+        return None
 
     with patch("api.routes.bot.handle_message", new=handle_first_timeouts_second_ok):
         with TestClient(app, raise_server_exceptions=False) as client:
@@ -360,7 +366,8 @@ def test_session_error_sends_error_keeps_connection():
         call_count += 1
         if call_count == 1:
             raise RuntimeError("simulated session failure")
-        return "recovered"
+        send_fn("recovered")
+        return None
 
     with patch("api.routes.bot.handle_message", new=fake_handle_that_raises):
         with TestClient(app, raise_server_exceptions=False) as client:
@@ -421,3 +428,54 @@ def test_disconnect_cancels_session_task():
 
     session_cancelled.wait(timeout=3)
     assert session_cancelled.is_set(), "session_task was not cancelled on disconnect"
+
+
+# ---------------------------------------------------------------------------
+# send_fn capture — response delivered via callback, not return value
+# ---------------------------------------------------------------------------
+
+def test_send_fn_response_delivered_as_chunk():
+    """Response delivered via send_fn (not return value) must reach the browser.
+
+    The real handle_message always calls send_fn(final) and returns None.
+    The WebSocket handler must capture send_fn calls and forward them as
+    {"type": "chunk"} frames — not rely on the return value being non-None.
+    """
+    app = _make_app()
+    token = _valid_token()
+
+    async def fake_handle_message(content, send_fn, pool, user_id, vault=None, status_fn=None):
+        send_fn("hello from send_fn")
+        return None  # real handle_message always returns None
+
+    with patch("api.routes.bot.handle_message", new=fake_handle_message):
+        with TestClient(app, raise_server_exceptions=False) as client:
+            with client.websocket_connect(
+                "/api/bot/chat",
+                cookies={"tether_token": token},
+            ) as ws:
+                ws.send_json({"type": "user", "content": "ping"})
+                chunk = ws.receive_json()
+                assert chunk["type"] == "chunk"
+                assert chunk["content"] == "hello from send_fn"
+                done = ws.receive_json()
+                assert done["type"] == "done"
+
+
+def test_no_send_fn_call_skips_chunk():
+    """When send_fn is never called (empty response), only done is sent."""
+    app = _make_app()
+    token = _valid_token()
+
+    async def fake_handle_message(content, send_fn, pool, user_id, vault=None, status_fn=None):
+        return None  # never calls send_fn
+
+    with patch("api.routes.bot.handle_message", new=fake_handle_message):
+        with TestClient(app, raise_server_exceptions=False) as client:
+            with client.websocket_connect(
+                "/api/bot/chat",
+                cookies={"tether_token": token},
+            ) as ws:
+                ws.send_json({"type": "user", "content": "hello"})
+                done = ws.receive_json()
+                assert done["type"] == "done"


### PR DESCRIPTION
## Summary

- `api/routes/bot.py`: The `bot_chat` WebSocket handler was passing a no-op lambda as `send_fn` to `handle_message`, silently dropping all bot responses. The browser only ever received `{"type":"done"}` with no content. Replaced with a list-based capture function; after the session task completes, captured parts are joined and sent as a `{"type":"chunk"}` frame.
- `tests/api/test_bot_ws.py`: Updated existing tests to call `send_fn` in mocks (matching real behaviour), and added two new tests covering the capture path.

## Test plan

- [ ] Run `pytest tests/api/test_bot_ws.py -v` — all tests pass
- [ ] Send a message via web chat and verify a `{"type":"chunk"}` frame arrives before `{"type":"done"}`