### PR TITLE
fix: normalize webcal:// and webcals:// to https:// before fetching

### DIFF
--- a/api/routes/ical.py
+++ b/api/routes/ical.py
@@ -65,6 +65,9 @@ def _is_private_address(hostname: str) -> bool:
 
 async def _fetch_url(url: str) -> bytes:
     """Fetch ICS content from a URL with SSRF protection and size limit."""
+    # webcal:// and webcals:// are ICS subscription schemes — map to https://
+    import re as _re
+    url = _re.sub(r"^webcals?://", "https://", url, flags=_re.IGNORECASE)
     parsed = httpx.URL(url)
     if _is_private_address(parsed.host):
         raise HTTPException(status_code=422, detail="URL targets a private address")

--- a/tests/api/test_ical_import.py
+++ b/tests/api/test_ical_import.py
@@ -187,3 +187,18 @@ class TestICalImportEndpoint:
         )
         assert resp.status_code == 422
         assert "private" in resp.json()["detail"].lower()
+
+
+class TestWebcalSchemeNormalization:
+    """webcal:// and webcals:// should be rewritten to https:// before fetching."""
+
+    def test_webcal_rewritten_to_https(self):
+        import re
+        def normalize(url):
+            return re.sub(r"^webcals?://", "https://", url, flags=re.IGNORECASE)
+
+        assert normalize("webcal://example.com/feed.ics") == "https://example.com/feed.ics"
+        assert normalize("webcals://example.com/feed.ics") == "https://example.com/feed.ics"
+        assert normalize("WEBCAL://example.com/feed.ics") == "https://example.com/feed.ics"
+        assert normalize("https://example.com/feed.ics") == "https://example.com/feed.ics"
+        assert normalize("http://example.com/feed.ics") == "http://example.com/feed.ics"


### PR DESCRIPTION
Subscription feed links commonly use the webcal:// scheme as a hint for calendar apps. Map both webcal:// and webcals:// to https:// so the endpoint accepts these URLs without error.