### PR TITLE
fix(frontend): anchor→anchor task drops silently fail on rail/gap area

### DIFF
--- a/frontend/src/composables/__tests__/useDropZone.test.ts
+++ b/frontend/src/composables/__tests__/useDropZone.test.ts
@@ -81,6 +81,15 @@ describe('useDropZone', () => {
     expect(onDrop).toHaveBeenCalledWith(payload, undefined)
   })
 
+  it('onDrop calls stopPropagation to prevent event bubbling to outer wrappers', () => {
+    const onDrop = vi.fn()
+    const { dropHandlers } = useDropZone({ onDrop })
+    const payload = { type: 'task', taskId: 'task-1' }
+    const evt = makeDragEvent(JSON.stringify(payload))
+    dropHandlers.onDrop(evt)
+    expect(evt.stopPropagation).toHaveBeenCalled()
+  })
+
   it('passes targetContext through to onDrop callback', () => {
     const onDrop = vi.fn()
     const targetContext = { anchorId: 'morning', date: '2026-05-02' }

--- a/frontend/src/composables/useDropZone.ts
+++ b/frontend/src/composables/useDropZone.ts
@@ -48,6 +48,9 @@ export function useDropZone<TContext = unknown>(options: UseDropZoneOptions<TCon
 
   function onDrop(evt: DragEvent) {
     evt.preventDefault()
+    // Stop propagation so drops handled here don't bubble to outer wrappers
+    // (e.g. PlanView's per-anchor [data-anchor-drop-zone] div).
+    evt.stopPropagation()
     enterCount = 0
     isOver.value = false
 

--- a/frontend/src/views/PlanView.vue
+++ b/frontend/src/views/PlanView.vue
@@ -131,8 +131,8 @@ async function onAnchorDrop(e: DragEvent, anchorId: string) {
   if (!raw) return
   try {
     const data = JSON.parse(raw)
-    // type:'task' with fromStartTime = calendar event being demoted back to anchor
     if (data.type === 'task' && data.taskId && data.fromStartTime) {
+      // Calendar event demotion — remove from timeline and land in the targeted anchor
       const taskId = data.taskId as string
       // Dual lookup: task_id for task-linked events; id for standalone events
       const ev = eventStore.events.find(e => e.task_id === taskId)
@@ -140,6 +140,14 @@ async function onAnchorDrop(e: DragEvent, anchorId: string) {
       if (!ev) return
       await eventStore.demoteEvent(ev.id, anchorId, activeDate.value)
       await planStore.fetchPlan(activeDate.value)
+    } else if (data.type === 'task' && data.taskId && !data.fromStartTime) {
+      // Plain task backstop — fires when drop lands on the .anchor-rail gutter or
+      // CSS grid gap (areas with no AnchorBlock drop zone). AnchorBlock content-area
+      // drops are handled by useDropZone (which now stopPropagates) and never reach here.
+      const taskId = data.taskId as string
+      const fromDate = (data.fromDate as string) ?? activeDate.value
+      const fromAnchorId = (data.fromAnchorId as string) ?? anchorId
+      await planStore.moveTask(taskId, fromDate, fromAnchorId, activeDate.value, anchorId)
     }
   } catch {
     // ignore malformed drag data

--- a/frontend/src/views/__tests__/PlanViewDnD.test.ts
+++ b/frontend/src/views/__tests__/PlanViewDnD.test.ts
@@ -36,6 +36,7 @@ vi.mock('../../lib/api', () => ({
 
 const mockDemoteEvent = vi.fn()
 const mockFetchPlan = vi.fn()
+const mockMoveTask = vi.fn()
 
 vi.mock('../../stores/events', () => ({
   useEventStore: () => ({
@@ -84,6 +85,7 @@ vi.mock('../../stores/plan', () => ({
     loading: false,
     today: '2024-06-10',
     fetchPlan: mockFetchPlan,
+    moveTask: mockMoveTask,
     plans: {},
     activeDate: '2024-06-10',
   }),
@@ -104,23 +106,27 @@ vi.mock('../../composables/useSlideOver', () => ({
 }))
 
 /**
- * Bug B: PlanView outer anchor wrapper must not swallow task→task drops.
+ * Bug B: PlanView outer anchor wrapper acts as backstop for plain task drops that
+ * land on the .anchor-rail gutter or CSS grid gap (areas with no AnchorBlock
+ * drop zone). The fix has two parts:
+ *   1. useDropZone.onDrop calls stopPropagation — drops on AnchorBlock content
+ *      area stop there and never reach this outer handler.
+ *   2. onAnchorDrop handles plain tasks via moveTask — drops that miss the
+ *      AnchorBlock content area (rail/gap) are caught here as a backstop.
  *
- * The outer `data-anchor-drop-zone` div carries @drop="onAnchorDrop". That handler
- * only acts when the payload has `fromStartTime` (calendar event demotion). When a
- * plain task is dropped (no fromStartTime), the outer handler must return early so
- * AnchorBlock's internal useDropZone can process the move. Regression: if
- * onAnchorDrop were ever changed to call preventDefault/stopPropagation
- * unconditionally, task→task inter-anchor moves would be silently swallowed.
+ * Regression guard: demoteEvent must NOT be called for plain-task moves (no
+ * fromStartTime); fetchPlan must NOT be triggered (moveTask handles its own
+ * optimistic update without needing a full plan refresh).
  */
-describe('PlanView — Bug B: outer wrapper ignores plain task drops (no fromStartTime)', () => {
+describe('PlanView — Bug B: outer wrapper is backstop for plain task drops (rail/gap area)', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     mockDemoteEvent.mockReset()
     mockFetchPlan.mockReset()
+    mockMoveTask.mockReset()
   })
 
-  it('dropping a plain task (no fromStartTime) onto anchor zone does NOT call demoteEvent', async () => {
+  it('dropping a plain task (no fromStartTime) onto the outer anchor zone calls moveTask with correct anchor', async () => {
     const { default: PlanView } = await import('../PlanView.vue')
     const wrapper = mount(PlanView, { props: { view: 'day', date: '2024-06-10' } })
     await flushPromises()
@@ -128,11 +134,12 @@ describe('PlanView — Bug B: outer wrapper ignores plain task drops (no fromSta
     // only assert on what the drop handler itself triggers.
     mockFetchPlan.mockReset()
     mockDemoteEvent.mockReset()
+    mockMoveTask.mockReset()
 
     const dropZones = wrapper.findAll('[data-anchor-drop-zone]')
     expect(dropZones.length).toBe(2)
 
-    // Plain task payload — NO fromStartTime
+    // Plain task payload — NO fromStartTime (rail/gap backstop scenario)
     const payload = {
       type: 'task',
       taskId: 'task-99',
@@ -149,8 +156,12 @@ describe('PlanView — Bug B: outer wrapper ignores plain task drops (no fromSta
 
     // demoteEvent must NOT be called for regular task moves
     expect(mockDemoteEvent).not.toHaveBeenCalled()
-    // fetchPlan must NOT be triggered by the outer handler for non-demotion drops
+    // fetchPlan must NOT be triggered (moveTask has optimistic update)
     expect(mockFetchPlan).not.toHaveBeenCalled()
+    // moveTask MUST be called with the correct anchor id (the targeted anchor, not silently dropped)
+    expect(mockMoveTask).toHaveBeenCalledWith(
+      'task-99', '2024-06-10', 'anchor-morning', '2024-06-10', 'anchor-afternoon',
+    )
   })
 })
 
@@ -159,6 +170,7 @@ describe('PlanView — Bug C: per-anchor demotion drop', () => {
     setActivePinia(createPinia())
     mockDemoteEvent.mockReset()
     mockFetchPlan.mockReset()
+    mockMoveTask.mockReset()
   })
 
   it('renders one drop zone per anchor (not a single column drop zone)', async () => {


### PR DESCRIPTION
## Summary

- **`useDropZone.onDrop`**: adds `evt.stopPropagation()` so drops handled by AnchorBlock's internal drop zone stop there and never bubble to PlanView's outer `[data-anchor-drop-zone]` wrapper
- **`PlanView.onAnchorDrop`**: adds backstop branch for plain-task payloads (`type:'task'`, no `fromStartTime`) that land on the 24px `.anchor-rail` gutter or the 12px CSS grid gap between the rail and card columns — these areas have no AnchorBlock drop zone, so the event previously bubbled all the way up and was silently discarded; the backstop calls `planStore.moveTask` with the exact targeted anchor id
- Tests updated: `PlanViewDnD.test.ts` Bug B describe/test corrected to reflect backstop behavior; `mockMoveTask` added and asserted; `useDropZone.test.ts` gains a test verifying `stopPropagation` is called

**Root cause:** The `.anchor-rail` gutter (24px) and CSS grid gap (12px) between rail and card are dead zones for drop events. `useDropZone` (AnchorBlock's internal handler) was not calling `stopPropagation`, so even card-content drops could bubble out. `onAnchorDrop` was returning early for non-demotion payloads, silently discarding inter-anchor task moves that hit these areas.

**Bug 2 (DayTimeline wrong slot) status:** Coordinate math in `slotIndexFromClientY` is verified correct. Unable to reproduce a wrong-slot placement from code analysis. Requesting team lead for a specific reproducer (which component, drag from/to what, what time appeared vs expected) before proceeding.

## Test plan

- [x] `useDropZone.test.ts` — 11 tests all pass (new: `stopPropagation` assertion)
- [x] `PlanViewDnD.test.ts` — 5 tests all pass (updated Bug B; new: `mockMoveTask` assertion)
- [x] Full suite: 536 tests across 57 files — all pass
- [x] `npm run build` — zero type errors