### PR TITLE
fix(frontend): restore calendar event demotion from DayTimeline to an…

### DIFF
--- a/frontend/src/components/AnchorBlock.vue
+++ b/frontend/src/components/AnchorBlock.vue
@@ -10,6 +10,7 @@ import type { Milestone } from '../stores/milestones'
 import { api } from '../lib/api'
 import { useDropZone } from '../composables/useDropZone'
 import { useSlideOver } from '../composables/useSlideOver'
+import { useEventStore } from '../stores/events'
 
 const { push: pushPanel } = useSlideOver()
 
@@ -26,6 +27,7 @@ const props = defineProps<{
 }>()
 
 const store = usePlanStore()
+const eventStore = useEventStore()
 const tasksRef = ref<HTMLElement | null>(null)
 const effectiveDate = computed(() => props.date ?? store.activeDate)
 const dayPlan = computed(() => props.date ? store.plans[props.date] : store.plan)
@@ -179,10 +181,24 @@ function onDrop(evt: DragEvent, toIndex: number) {
 // ── Container-level drop zone (fixes empty-anchor drop bug) ──────────────────
 // When anchor has no tasks, there are no per-task wrapper drop zones. The
 // container drop zone catches those drops and appends the task.
+//
+// Also handles calendar event demotion (fromStartTime present) for drops that
+// land on the card content area. useDropZone.onDrop calls stopPropagation(), so
+// these drops no longer bubble to PlanView.onAnchorDrop; we own the demotion here.
+// Rail/gap drops that miss the card content still bubble to PlanView.onAnchorDrop.
 const { isOver: isContainerOver, dropHandlers: containerDropHandlers } = useDropZone({
   onDrop(payload) {
-    const p = payload as { taskId?: string; fromAnchorId?: string; fromDate?: string }
+    const p = payload as { taskId?: string; fromAnchorId?: string; fromDate?: string; fromStartTime?: string }
     if (!p.taskId) return
+    if (p.fromStartTime) {
+      // Calendar event → anchor demotion (dropped on card content area)
+      const ev = eventStore.events.find(e => e.task_id === p.taskId)
+        ?? eventStore.events.find(e => e.id === p.taskId)
+      if (!ev) return
+      eventStore.demoteEvent(ev.id, props.anchorId, effectiveDate.value)
+        .then(() => store.fetchPlan(effectiveDate.value))
+      return
+    }
     const toIndex = anchorPlan.value.tasks.length
     if (p.fromAnchorId === props.anchorId && p.fromDate === effectiveDate.value) {
       store.reorderTask(p.taskId, effectiveDate.value, props.anchorId, toIndex)

--- a/frontend/src/components/__tests__/AnchorBlock.dnd.test.ts
+++ b/frontend/src/components/__tests__/AnchorBlock.dnd.test.ts
@@ -65,6 +65,32 @@ describe('AnchorBlock — container drop zone (Track 3)', () => {
     expect(capturedContainerOnDrop).not.toBeNull()
   })
 
+  it('drop with fromStartTime calls eventStore.demoteEvent (calendar event → anchor demotion)', async () => {
+    // Regression: stopPropagation() in useDropZone.onDrop blocks bubbling to
+    // PlanView.onAnchorDrop, so AnchorBlock must handle demotion itself.
+    const { useEventStore } = await import('../../stores/events')
+    const { usePlanStore } = await import('../../stores/plan')
+    const eventStore = useEventStore()
+    const planStore = usePlanStore()
+    // Seed one calendar event for task-1
+    ;(eventStore as any).events = [
+      { id: 'ev-1', task_id: 'task-1', start_time: '2026-05-01T09:00:00', end_time: '2026-05-01T09:30:00' },
+    ]
+    const demoteSpy = vi.spyOn(eventStore, 'demoteEvent').mockResolvedValue(undefined)
+    vi.spyOn(planStore, 'fetchPlan').mockResolvedValue(undefined)
+
+    await mountBlock({ anchorId: 'a1' })
+
+    capturedContainerOnDrop!({
+      type: 'task',
+      taskId: 'task-1',
+      fromStartTime: '2026-05-01T09:00:00',
+      durationMs: 1800000,
+    }, undefined)
+
+    expect(demoteSpy).toHaveBeenCalledWith('ev-1', 'a1', expect.any(String))
+  })
+
   it('drop on empty anchor calls store.moveTask when task is from different anchor', async () => {
     const { usePlanStore } = await import('../../stores/plan')
     const store = usePlanStore()


### PR DESCRIPTION
…chors

stopPropagation() in useDropZone.onDrop was blocking calendar event drops from bubbling to PlanView.onAnchorDrop, silently breaking the DayTimeline → anchor demotion flow.

Fix: handle demotion inside AnchorBlock's useDropZone callback for card-content-area drops. Rail/gap drops still reach PlanView.onAnchorDrop as the backstop. Each surface now owns its own demotion logic; no implicit coupling via bubbling required.

AnchorBlock.vue: import useEventStore; check fromStartTime in the containerDropHandlers onDrop callback; call demoteEvent + fetchPlan. AnchorBlock.dnd.test.ts: add regression test for calendar event drop.