### PR TITLE
fix: remove stale SQLite-era Beacon block in message_handler

### DIFF
--- a/bot/message_handler.py
+++ b/bot/message_handler.py
@@ -1365,48 +1365,6 @@ def run_polling(token: str, chat_id: str) -> None:
                             [t["id"] for t in _plan["anchors"][_current_anchor["id"]]["tasks"] if t.get("id")],
                             _dt.now()
                         ))
-                    # Premium Beacon hook — review accumulated changes on anchor transition.
-                    # Runs in a background thread so the polling loop isn't blocked
-                    # while Beacon makes its LLM calls (can take 5-30s).
-                    # _active_db = last_user_id is passed as the "db path" string for Phase 3b
-                    # compatibility — premium functions will be updated to use user_id in Phase 3b.
-                    _active_db = last_user_id
-                    try:
-                        from tether_premium.bot.beacon import should_trigger_beacon, run_beacon
-                        if should_trigger_beacon(str(_active_db), is_anchor_transition=True):
-                            from tether_premium.bot.state_monitor import peek_changes, consume_changes
-                            from tether_premium.bot.router import LLMRouter
-                            import threading as _threading
-                            _beacon_changes = peek_changes(str(_active_db))
-                            if _beacon_changes:
-                                _cfg = load_config()
-                                _mcp_url = _cfg.get("llm", {}).get("mcp_server_url", "http://localhost:5001/sse")
-                                _beacon_router = LLMRouter(mcp_server_url=_mcp_url)
-                                _beacon_db = str(_active_db)
-
-                                def _run_beacon_bg():
-                                    import asyncio as _aio
-                                    async def _beacon_notify(msg):
-                                        _send(msg)
-                                    try:
-                                        _result = _aio.run(run_beacon(
-                                            router=_beacon_router,
-                                            db_path=_beacon_db,
-                                            changes=_beacon_changes,
-                                            notify=_beacon_notify,
-                                        ))
-                                        if _result.get("triggered"):
-                                            consume_changes(_beacon_db)
-                                    except Exception as _be:
-                                        logger.warning("Beacon background run failed: %s", _be)
-
-                                _threading.Thread(
-                                    target=_run_beacon_bg, daemon=True, name="beacon"
-                                ).start()
-                    except ImportError:
-                        pass  # Premium not installed
-                    except Exception as _be:
-                        logger.warning("Beacon anchor transition check failed: %s", _be)
 
             # Run follow-up pings for the active user
             if last_user_id:

--- a/tests/bot/test_message_handler.py
+++ b/tests/bot/test_message_handler.py
@@ -306,3 +306,22 @@ def test_format_history_renders_turns():
     assert "User: Move my tasks" in result
     assert "Bot: Done." in result
     assert "2026-03-28 14:00" in result
+
+
+# ---------------------------------------------------------------------------
+# Stale SQLite-era Beacon block removal
+# ---------------------------------------------------------------------------
+
+def test_stale_beacon_block_removed():
+    """Confirm the SQLite-era Beacon invocation is no longer present in message_handler source.
+
+    After the Postgres migration, should_trigger_beacon and run_beacon take
+    asyncpg.Connection, not a db_path string. The old block always silently
+    hit the except-handler. This test acts as a regression guard.
+    """
+    import inspect
+    from bot import message_handler
+    src = inspect.getsource(message_handler)
+    assert "Beacon anchor transition check failed" not in src, (
+        "Stale SQLite-era Beacon block still present in message_handler.py — remove it."
+    )


### PR DESCRIPTION
## Summary

- Removes the stale `# Premium Beacon hook — review accumulated changes on anchor transition` try/except block (~42 lines) from `bot/message_handler.py`.
- This block called `should_trigger_beacon(str(_active_db), ...)` and `run_beacon(db_path=...)`, but after the Postgres migration both functions take `asyncpg.Connection`, not a db path string. Every invocation silently hit the `except Exception` handler.
- The live Beacon trigger is `_do_beacon_check` in `tether_premium/bot/register.py` and is unaffected.
- Also removes the now-dead `_active_db = last_user_id` assignment.

## Test plan
- [ ] New test asserts the stale Beacon string is not present in message_handler source
- [ ] Full test suite passes: `python -m pytest tests/ -x -q`