### PR TITLE
chore: backend quick-win dead-code cleanup

### DIFF
--- a/api/routes/bot.py
+++ b/api/routes/bot.py
@@ -66,10 +66,6 @@ async def bot_chat(websocket: WebSocket,
     - WebSocketDisconnect (client gone) cancels the running session_task
       and awaits it before returning (prevents orphaned LLM calls).
 
-    Dependency note: full status_fn threading into the premium session requires
-    bot-backend's PR (session.py + return-type changes). Until merged,
-    status_fn is accepted but silently ignored by handle_message, and chunk
-    content will be empty (handle_message returns None).
     """
     await websocket.accept()
     pool = websocket.app.state.pool

--- a/api/routes/integrations.py
+++ b/api/routes/integrations.py
@@ -72,7 +72,6 @@ _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 # `claude setup-token` prints a long-lived OAuth token to stdout (sk-ant-oat-…)
 # rather than writing a credentials file. The trailing run is URL-safe base64
 # plus dashes/underscores; we capture the longest such run after the prefix.
-_OAUTH_TOKEN_RE = re.compile(r"sk-ant-[A-Za-z0-9_-]+")
 _ANTHROPIC_URL_SCHEME = "https"
 # claude setup-token may emit URLs on either domain depending on version.
 _VALID_ANTHROPIC_NETLOCS = {"console.anthropic.com", "claude.com"}

--- a/bot/message_handler.py
+++ b/bot/message_handler.py
@@ -35,7 +35,6 @@ from db.pg_queries import (
     upsert_tasks,
     clear_session_state,
     insert_orchestrator_turn,
-    get_orchestrator_conversation,
     link_milestone_task,
     patch_milestone,
     init_followup_state,

--- a/db/pg_queries/__init__.py
+++ b/db/pg_queries/__init__.py
@@ -11,7 +11,7 @@ from db.pg_queries.plans import (
 from db.pg_queries.tasks import (
     upsert_tasks, patch_task_fields, get_task_by_uuid, get_all_tasks,
     get_unscheduled_tasks, create_unscheduled_task, delete_task_by_uuid, move_task_atomic,
-    search_tasks, search_entities,
+    search_entities,
     add_dependency, remove_dependency, get_dependencies_for, get_full_task_dependencies,
     add_task_dependency, remove_task_dependency,
     get_subtasks, create_subtask, update_subtask, delete_subtask, reorder_subtasks,
@@ -69,12 +69,6 @@ from db.pg_queries.state_monitor import (
 )
 from db.pg_queries.beacon import (
     record_beacon_invocation, get_last_invocation,
-)
-from db.pg_queries.journal import (
-    append_journal_entry, get_journal, rollback_journal_entry,
-)
-from db.pg_queries.activity import (
-    acquire_lease, release_lease, heartbeat_lease, get_active_writers,
 )
 from db.pg_queries.subscriptions import (
     get_user_is_paid,


### PR DESCRIPTION
## Summary

- Remove dead `get_orchestrator_conversation` import from `bot/message_handler.py` (import-only, no callers)
- Remove first (duplicate) `_OAUTH_TOKEN_RE = re.compile(...)` in `api/routes/integrations.py` — both definitions are identical; the second at line 79 shadows the first at line 75
- Remove `search_tasks`, `journal` (`append_journal_entry`, `get_journal`, `rollback_journal_entry`), and `activity` (`acquire_lease`, `release_lease`, `heartbeat_lease`, `get_active_writers`) re-exports from `db/pg_queries/__init__.py` — built-but-unwired infrastructure; underlying files (`activity.py`, `journal.py`) kept
- Remove stale "Dependency note" comment in `api/routes/bot.py` describing status_fn threading as unmerged — that PR (#32) has been merged

## Test plan
- [ ] Zero production callers for removed re-exports (verified with grep pre-commit)
- [ ] Full test suite passes (pre-existing ical failure unrelated): `python -m pytest tests/ --ignore=tests/ical -x -q`