### PR TITLE
feat: meeting coordination UI — Schedule meeting from connections list

### DIFF
--- a/db/pg_queries/scheduling.py
+++ b/db/pg_queries/scheduling.py
@@ -87,11 +87,14 @@ async def list_connections_for_user(
 ) -> list[dict]:
     rows = await conn.fetch(
         """
-        SELECT *,
-               CASE WHEN user_a = $1::uuid THEN user_b ELSE user_a END AS other_user_id
-        FROM connections
-        WHERE user_a = $1::uuid OR user_b = $1::uuid
-        ORDER BY created_at DESC
+        SELECT c.*,
+               CASE WHEN c.user_a = $1::uuid THEN c.user_b ELSE c.user_a END AS other_user_id,
+               CASE WHEN c.user_a = $1::uuid THEN u_b.username ELSE u_a.username END AS other_username
+        FROM connections c
+        LEFT JOIN users u_a ON u_a.id = c.user_a
+        LEFT JOIN users u_b ON u_b.id = c.user_b
+        WHERE c.user_a = $1::uuid OR c.user_b = $1::uuid
+        ORDER BY c.created_at DESC
         """,
         user_id,
     )

--- a/frontend/src/components/ConnectionsSection.vue
+++ b/frontend/src/components/ConnectionsSection.vue
@@ -15,7 +15,7 @@ const scheduleModalConnectionId = ref<number | null>(null)
 const scheduleModalTarget = computed(() => {
   if (scheduleModalConnectionId.value === null) return ''
   const conn = store.accepted.find(c => c.id === scheduleModalConnectionId.value)
-  return conn?.other_user_id ?? ''
+  return conn?.other_username ?? ''
 })
 
 /** Set of other_user_ids that have an open meeting request */
@@ -35,6 +35,11 @@ onMounted(() => {
 
 function dismissError() {
   store.error = null
+}
+
+async function handleMeetingSent() {
+  // Refresh open meetings so the pending indicator reflects the new request immediately
+  await meetingsStore.fetchMeetings('open')
 }
 
 async function handleSendRequest() {
@@ -136,8 +141,8 @@ function closeScheduleModal() {
           :data-testid="`accepted-${conn.id}`"
         >
           <div class="flex items-center gap-2">
-            <span class="text-sm text-[--fg-1] font-mono" :title="conn.other_user_id">
-              {{ truncateUuid(conn.other_user_id) }}
+            <span class="text-sm text-[--fg-1]" :title="conn.other_user_id">
+              {{ conn.other_username || truncateUuid(conn.other_user_id) }}
             </span>
             <span class="text-[10px] bg-[--status-done-bg] text-[--status-done-fg] rounded px-1.5 py-0.5 font-medium tracking-wide">
               connected
@@ -233,7 +238,7 @@ function closeScheduleModal() {
       :visible="scheduleModalConnectionId !== null"
       :target-username="scheduleModalTarget"
       @close="closeScheduleModal"
-      @sent="closeScheduleModal"
+      @sent="handleMeetingSent"
     />
   </section>
 </template>

--- a/frontend/src/components/ConnectionsSection.vue
+++ b/frontend/src/components/ConnectionsSection.vue
@@ -1,12 +1,36 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useConnectionsStore } from '../stores/connections'
+import { useMeetingsStore } from '../stores/meetings'
+import ScheduleMeetingModal from './ScheduleMeetingModal.vue'
 
 const store = useConnectionsStore()
+const meetingsStore = useMeetingsStore()
 const requestUsername = ref('')
+
+/** Which connection's "Schedule meeting" modal is open (by connection id) */
+const scheduleModalConnectionId = ref<number | null>(null)
+
+/** The username of the connection whose modal is open */
+const scheduleModalTarget = computed(() => {
+  if (scheduleModalConnectionId.value === null) return ''
+  const conn = store.accepted.find(c => c.id === scheduleModalConnectionId.value)
+  return conn?.other_user_id ?? ''
+})
+
+/** Set of other_user_ids that have an open meeting request */
+const openMeetingUserIds = computed(() => {
+  const ids = new Set<string>()
+  for (const m of meetingsStore.openMeetings) {
+    for (const tid of m.target_ids) ids.add(tid)
+    if (m.initiator_id) ids.add(m.initiator_id)
+  }
+  return ids
+})
 
 onMounted(() => {
   store.fetchConnections()
+  meetingsStore.fetchMeetings('open')
 })
 
 function dismissError() {
@@ -22,6 +46,14 @@ async function handleSendRequest() {
 
 function truncateUuid(uuid: string): string {
   return uuid.length > 8 ? `${uuid.slice(0, 8)}…` : uuid
+}
+
+function openScheduleModal(connectionId: number) {
+  scheduleModalConnectionId.value = connectionId
+}
+
+function closeScheduleModal() {
+  scheduleModalConnectionId.value = null
 }
 </script>
 
@@ -110,24 +142,47 @@ function truncateUuid(uuid: string): string {
             <span class="text-[10px] bg-[--status-done-bg] text-[--status-done-fg] rounded px-1.5 py-0.5 font-medium tracking-wide">
               connected
             </span>
-          </div>
-          <!-- Auto-schedule toggle -->
-          <div class="flex items-center gap-2">
-            <span class="text-xs text-[--fg-4]">Auto-schedule</span>
-            <button
-              :disabled="store.loading"
-              @click="store.toggleAutoSchedule(conn.id, !conn.auto_schedule)"
-              :class="conn.auto_schedule ? 'bg-[--accent]' : 'bg-[--bg-elev-3]'"
-              class="relative w-9 h-5 rounded-full transition-colors disabled:opacity-50"
-              :data-testid="`auto-schedule-${conn.id}`"
-              :aria-pressed="conn.auto_schedule"
-              :aria-label="`Auto-schedule for ${conn.other_user_id}`"
+            <!-- Pending meeting indicator -->
+            <span
+              v-if="openMeetingUserIds.has(conn.other_user_id)"
+              class="text-[10px] bg-[--status-pending-bg] text-[--status-pending-fg] rounded px-1.5 py-0.5 font-medium tracking-wide"
+              style="background-color: var(--status-pending-bg, #fef9c3); color: var(--status-pending-fg, #713f12)"
+              :data-testid="`meeting-pending-${conn.id}`"
+              title="A meeting request is open with this person"
             >
-              <span
-                :class="conn.auto_schedule ? 'translate-x-4' : 'translate-x-0.5'"
-                class="inline-block w-4 h-4 bg-white rounded-full transition-transform transform mt-0.5"
-              />
+              meeting pending
+            </span>
+          </div>
+          <!-- Right side: schedule button + auto-schedule toggle -->
+          <div class="flex items-center gap-3">
+            <!-- Schedule meeting button -->
+            <button
+              :disabled="store.loading || meetingsStore.loading"
+              @click="openScheduleModal(conn.id)"
+              class="text-xs text-[--accent] hover:opacity-80 disabled:opacity-40 transition-opacity"
+              :data-testid="`schedule-meeting-${conn.id}`"
+              :aria-label="`Schedule meeting with ${conn.other_user_id}`"
+            >
+              {{ openMeetingUserIds.has(conn.other_user_id) ? 'Schedule again' : 'Schedule meeting' }}
             </button>
+            <!-- Auto-schedule toggle -->
+            <div class="flex items-center gap-2">
+              <span class="text-xs text-[--fg-4]">Auto-schedule</span>
+              <button
+                :disabled="store.loading"
+                @click="store.toggleAutoSchedule(conn.id, !conn.auto_schedule)"
+                :class="conn.auto_schedule ? 'bg-[--accent]' : 'bg-[--bg-elev-3]'"
+                class="relative w-9 h-5 rounded-full transition-colors disabled:opacity-50"
+                :data-testid="`auto-schedule-${conn.id}`"
+                :aria-pressed="conn.auto_schedule"
+                :aria-label="`Auto-schedule for ${conn.other_user_id}`"
+              >
+                <span
+                  :class="conn.auto_schedule ? 'translate-x-4' : 'translate-x-0.5'"
+                  class="inline-block w-4 h-4 bg-white rounded-full transition-transform transform mt-0.5"
+                />
+              </button>
+            </div>
           </div>
         </li>
       </ul>
@@ -173,5 +228,12 @@ function truncateUuid(uuid: string): string {
         </ul>
       </div>
     </div>
+    <!-- Schedule meeting modal -->
+    <ScheduleMeetingModal
+      :visible="scheduleModalConnectionId !== null"
+      :target-username="scheduleModalTarget"
+      @close="closeScheduleModal"
+      @sent="closeScheduleModal"
+    />
   </section>
 </template>

--- a/frontend/src/components/ScheduleMeetingModal.vue
+++ b/frontend/src/components/ScheduleMeetingModal.vue
@@ -1,0 +1,226 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { useMeetingsStore } from '../stores/meetings'
+
+const props = defineProps<{
+  visible: boolean
+  /** Username (display handle) of the connection we're scheduling with */
+  targetUsername: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'sent'): void
+}>()
+
+const store = useMeetingsStore()
+
+const durationMinutes = ref(30)
+const context = ref('')
+/** Set of ISO strings the user has toggled on */
+const selectedSlots = ref<Set<string>>(new Set())
+
+const DURATIONS = [
+  { label: '15 min', value: 15 },
+  { label: '30 min', value: 30 },
+  { label: '60 min', value: 60 },
+  { label: '90 min', value: 90 },
+]
+
+/** Pre-populate next 5 weekdays × 3 times (9am, 1pm, 4pm) in local time */
+function buildDefaultSlots(): Array<{ iso: string; label: string }> {
+  const slots: Array<{ iso: string; label: string }> = []
+  const hours = [9, 13, 16]
+  const date = new Date()
+  date.setHours(0, 0, 0, 0)
+  let weekdaysFound = 0
+  while (weekdaysFound < 5) {
+    date.setDate(date.getDate() + 1)
+    const dow = date.getDay()
+    if (dow === 0 || dow === 6) continue // skip weekends
+    weekdaysFound++
+    for (const h of hours) {
+      const d = new Date(date)
+      d.setHours(h, 0, 0, 0)
+      const label = d.toLocaleString(undefined, {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      })
+      // Use UTC ISO string so the backend gets unambiguous times
+      slots.push({ iso: d.toISOString(), label })
+    }
+  }
+  return slots
+}
+
+const defaultSlots = ref(buildDefaultSlots())
+
+// Re-generate and pre-select all slots whenever the modal opens
+watch(() => props.visible, (open) => {
+  if (open) {
+    durationMinutes.value = 30
+    context.value = ''
+    store.error = null
+    defaultSlots.value = buildDefaultSlots()
+    selectedSlots.value = new Set(defaultSlots.value.map(s => s.iso))
+  }
+})
+
+function toggleSlot(iso: string) {
+  const next = new Set(selectedSlots.value)
+  if (next.has(iso)) {
+    next.delete(iso)
+  } else {
+    next.add(iso)
+  }
+  selectedSlots.value = next
+}
+
+const canSubmit = computed(() => selectedSlots.value.size > 0 && !store.loading)
+
+async function handleSubmit() {
+  if (!canSubmit.value) return
+  await store.requestMeeting({
+    target_usernames: [props.targetUsername],
+    duration_minutes: durationMinutes.value,
+    slots: Array.from(selectedSlots.value),
+    context: context.value.trim() || undefined,
+  })
+  if (!store.error) {
+    emit('sent')
+    emit('close')
+  }
+}
+
+function onCancel() {
+  store.error = null
+  emit('close')
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') onCancel()
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="visible"
+      class="fixed inset-0 z-[200] flex items-center justify-center bg-black/60"
+      data-testid="schedule-meeting-modal"
+      @click.self="onCancel"
+      @keydown="onKeydown"
+      tabindex="0"
+    >
+      <div class="w-96 bg-[--bg-elev-1] border border-[--border-1] rounded-xl shadow-xl p-5 space-y-4 max-h-[90vh] overflow-y-auto">
+        <h3 class="text-sm font-semibold text-[--fg-1]">
+          Schedule meeting with
+          <span class="text-[--accent]">{{ targetUsername }}</span>
+        </h3>
+
+        <!-- Error -->
+        <div
+          v-if="store.error"
+          class="bg-[--status-block-bg] border border-[--border-1] rounded-lg p-3 text-sm text-[--status-block-fg]"
+          data-testid="schedule-modal-error"
+        >
+          {{ store.error }}
+        </div>
+
+        <!-- Duration -->
+        <div>
+          <p class="text-xs font-medium text-[--fg-4] uppercase tracking-wide mb-2">Duration</p>
+          <div class="flex gap-2">
+            <button
+              v-for="d in DURATIONS"
+              :key="d.value"
+              :class="durationMinutes === d.value
+                ? 'bg-[--accent] text-[--accent-fg]'
+                : 'bg-[--bg-elev-2] text-[--fg-2] hover:bg-[--bg-elev-3]'"
+              class="text-xs px-3 py-1.5 rounded-lg transition-colors"
+              :data-testid="`duration-${d.value}`"
+              @click="durationMinutes = d.value"
+            >
+              {{ d.label }}
+            </button>
+          </div>
+        </div>
+
+        <!-- Proposed times -->
+        <div>
+          <p class="text-xs font-medium text-[--fg-4] uppercase tracking-wide mb-2">
+            Proposed times
+            <span class="normal-case tracking-normal font-normal text-[--fg-5] ml-1">({{ selectedSlots.size }} selected)</span>
+          </p>
+          <p class="text-xs text-[--fg-5] mb-2">Uncheck any slots you can't make. The other person will see your available times.</p>
+          <ul class="space-y-1 max-h-52 overflow-y-auto pr-1">
+            <li
+              v-for="slot in defaultSlots"
+              :key="slot.iso"
+              class="flex items-center gap-2 py-0.5"
+            >
+              <input
+                type="checkbox"
+                :checked="selectedSlots.has(slot.iso)"
+                :id="`slot-${slot.iso}`"
+                @change="toggleSlot(slot.iso)"
+                class="rounded accent-[--accent] cursor-pointer"
+                :data-testid="`slot-checkbox-${slot.iso}`"
+              />
+              <label
+                :for="`slot-${slot.iso}`"
+                class="text-sm text-[--fg-2] cursor-pointer select-none"
+              >
+                {{ slot.label }}
+              </label>
+            </li>
+          </ul>
+          <p
+            v-if="selectedSlots.size === 0"
+            class="text-xs text-[--status-block-fg] mt-1"
+            data-testid="no-slots-warning"
+          >
+            Select at least one time slot.
+          </p>
+        </div>
+
+        <!-- Context / note -->
+        <div>
+          <label class="text-xs font-medium text-[--fg-4] uppercase tracking-wide mb-1 block" for="meeting-context">
+            Note <span class="normal-case font-normal tracking-normal text-[--fg-5]">(optional)</span>
+          </label>
+          <textarea
+            id="meeting-context"
+            v-model="context"
+            rows="2"
+            placeholder="e.g. Weekly sync, project review…"
+            class="w-full bg-[--bg-elev-2] text-[--fg-1] border border-[--border-1] rounded-lg px-3 py-2 text-sm resize-none focus:outline-none focus:border-[--accent] placeholder:text-[--fg-5]"
+            data-testid="meeting-context-input"
+          />
+        </div>
+
+        <!-- Actions -->
+        <div class="flex justify-end gap-2 pt-1">
+          <button
+            class="px-3 py-1.5 text-xs rounded-lg text-[--fg-3] hover:text-[--fg-1] hover:bg-[--bg-elev-2] transition-colors"
+            data-testid="schedule-modal-cancel"
+            @click="onCancel"
+          >
+            Cancel
+          </button>
+          <button
+            :disabled="!canSubmit"
+            class="px-4 py-1.5 text-xs rounded-lg bg-[--accent] text-[--accent-fg] hover:opacity-90 disabled:opacity-50 transition-opacity"
+            data-testid="schedule-modal-submit"
+            @click="handleSubmit"
+          >
+            {{ store.loading ? 'Sending…' : 'Send request' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/frontend/src/components/ScheduleMeetingModal.vue
+++ b/frontend/src/components/ScheduleMeetingModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, nextTick } from 'vue'
 import { useMeetingsStore } from '../stores/meetings'
 
 const props = defineProps<{
@@ -15,6 +15,7 @@ const emit = defineEmits<{
 
 const store = useMeetingsStore()
 
+const wrapperRef = ref<HTMLDivElement | null>(null)
 const durationMinutes = ref(30)
 const context = ref('')
 /** Set of ISO strings the user has toggled on */
@@ -58,14 +59,16 @@ function buildDefaultSlots(): Array<{ iso: string; label: string }> {
 
 const defaultSlots = ref(buildDefaultSlots())
 
-// Re-generate and pre-select all slots whenever the modal opens
-watch(() => props.visible, (open) => {
+// Re-generate and pre-select all slots whenever the modal opens; also auto-focus for keyboard use
+watch(() => props.visible, async (open) => {
   if (open) {
     durationMinutes.value = 30
     context.value = ''
     store.error = null
     defaultSlots.value = buildDefaultSlots()
     selectedSlots.value = new Set(defaultSlots.value.map(s => s.iso))
+    await nextTick()
+    wrapperRef.value?.focus()
   }
 })
 
@@ -109,6 +112,7 @@ function onKeydown(e: KeyboardEvent) {
   <Teleport to="body">
     <div
       v-if="visible"
+      ref="wrapperRef"
       class="fixed inset-0 z-[200] flex items-center justify-center bg-black/60"
       data-testid="schedule-meeting-modal"
       @click.self="onCancel"

--- a/frontend/src/stores/__tests__/connections.test.ts
+++ b/frontend/src/stores/__tests__/connections.test.ts
@@ -21,6 +21,7 @@ function makeConnection(overrides: Partial<Connection> = {}): Connection {
     created_at: '2024-01-01T00:00:00Z',
     updated_at: '2024-01-01T00:00:00Z',
     other_user_id: 'user-other-uuid',
+    other_username: 'alice',
     ...overrides,
   }
 }

--- a/frontend/src/stores/__tests__/meetings.test.ts
+++ b/frontend/src/stores/__tests__/meetings.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import type { MeetingRequest } from '../../types/meetings'
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: false, json: async () => ({}) })),
+}))
+
+function makeMeeting(overrides: Partial<MeetingRequest> = {}): MeetingRequest {
+  return {
+    id: 1,
+    initiator_id: 'user-me-uuid',
+    target_ids: ['user-other-uuid'],
+    duration_minutes: 30,
+    context: null,
+    status: 'open',
+    round: 1,
+    agreed_slot: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('useMeetingsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.restoreAllMocks()
+  })
+
+  describe('requestMeeting', () => {
+    it('posts to /api/meetings/request with correct body', async () => {
+      const { api } = await import('../../lib/api')
+      const mockApi = vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ id: 42, status: 'open', round: 1 }),
+      } as any)
+
+      const { useMeetingsStore } = await import('../meetings')
+      const store = useMeetingsStore()
+      await store.requestMeeting({
+        target_usernames: ['alice'],
+        duration_minutes: 30,
+        slots: ['2026-05-10T09:00:00Z', '2026-05-10T13:00:00Z'],
+        context: 'Sync up',
+      })
+
+      expect(mockApi).toHaveBeenCalledWith(
+        '/api/meetings/request',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            target_usernames: ['alice'],
+            duration_minutes: 30,
+            slots: ['2026-05-10T09:00:00Z', '2026-05-10T13:00:00Z'],
+            context: 'Sync up',
+          }),
+        }),
+      )
+    })
+
+    it('adds the new meeting to state on success', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ id: 42, status: 'open', round: 1 }),
+      } as any)
+
+      const { useMeetingsStore } = await import('../meetings')
+      const store = useMeetingsStore()
+      await store.requestMeeting({
+        target_usernames: ['alice'],
+        duration_minutes: 30,
+        slots: ['2026-05-10T09:00:00Z'],
+      })
+
+      // After requestMeeting succeeds, pendingByUsername should show alice as having a request
+      expect(store.pendingRequestIds).toContain(42)
+    })
+
+    it('sets error on API failure', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ detail: 'slots cannot be empty' }),
+      } as any)
+
+      const { useMeetingsStore } = await import('../meetings')
+      const store = useMeetingsStore()
+      await store.requestMeeting({
+        target_usernames: ['alice'],
+        duration_minutes: 30,
+        slots: [],
+      })
+
+      expect(store.error).toBeTruthy()
+    })
+
+    it('sets loading false after completion', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ id: 1, status: 'open', round: 1 }),
+      } as any)
+
+      const { useMeetingsStore } = await import('../meetings')
+      const store = useMeetingsStore()
+      await store.requestMeeting({
+        target_usernames: ['bob'],
+        duration_minutes: 60,
+        slots: ['2026-05-10T09:00:00Z'],
+      })
+
+      expect(store.loading).toBe(false)
+    })
+  })
+
+  describe('fetchMeetings', () => {
+    it('populates meetings from API response', async () => {
+      const { api } = await import('../../lib/api')
+      const data: MeetingRequest[] = [makeMeeting({ id: 1 }), makeMeeting({ id: 2 })]
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        json: async () => data,
+      } as any)
+
+      const { useMeetingsStore } = await import('../meetings')
+      const store = useMeetingsStore()
+      await store.fetchMeetings()
+
+      expect(store.meetings).toHaveLength(2)
+      expect(store.loading).toBe(false)
+    })
+
+    it('calls GET /api/meetings', async () => {
+      const { api } = await import('../../lib/api')
+      const mockApi = vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      } as any)
+
+      const { useMeetingsStore } = await import('../meetings')
+      const store = useMeetingsStore()
+      await store.fetchMeetings()
+
+      expect(mockApi).toHaveBeenCalledWith('/api/meetings', expect.anything())
+    })
+
+    it('calls GET /api/meetings?status=open when status filter provided', async () => {
+      const { api } = await import('../../lib/api')
+      const mockApi = vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      } as any)
+
+      const { useMeetingsStore } = await import('../meetings')
+      const store = useMeetingsStore()
+      await store.fetchMeetings('open')
+
+      expect(mockApi).toHaveBeenCalledWith('/api/meetings?status=open', expect.anything())
+    })
+
+    it('sets error on API failure', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({ ok: false, json: async () => ({}) } as any)
+
+      const { useMeetingsStore } = await import('../meetings')
+      const store = useMeetingsStore()
+      await store.fetchMeetings()
+
+      expect(store.error).toBeTruthy()
+    })
+  })
+
+  describe('cancelMeeting', () => {
+    it('updates the meeting status to cancelled in state', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 1, status: 'cancelled' }),
+      } as any)
+
+      const { useMeetingsStore } = await import('../meetings')
+      const store = useMeetingsStore()
+      store.meetings = [makeMeeting({ id: 1, status: 'open' })]
+      await store.cancelMeeting(1)
+
+      expect(store.meetings[0].status).toBe('cancelled')
+    })
+
+    it('calls POST /api/meetings/{id}/cancel', async () => {
+      const { api } = await import('../../lib/api')
+      const mockApi = vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 5, status: 'cancelled' }),
+      } as any)
+
+      const { useMeetingsStore } = await import('../meetings')
+      const store = useMeetingsStore()
+      store.meetings = [makeMeeting({ id: 5 })]
+      await store.cancelMeeting(5)
+
+      expect(mockApi).toHaveBeenCalledWith(
+        '/api/meetings/5/cancel',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+
+    it('sets error on failure', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({ ok: false, json: async () => ({}) } as any)
+
+      const { useMeetingsStore } = await import('../meetings')
+      const store = useMeetingsStore()
+      store.meetings = [makeMeeting({ id: 1 })]
+      await store.cancelMeeting(1)
+
+      expect(store.error).toBeTruthy()
+    })
+  })
+
+  describe('computed: pendingRequestIds, openMeetings', () => {
+    it('pendingRequestIds returns ids of open meetings', async () => {
+      const { useMeetingsStore } = await import('../meetings')
+      const store = useMeetingsStore()
+      store.meetings = [
+        makeMeeting({ id: 1, status: 'open' }),
+        makeMeeting({ id: 2, status: 'agreed' }),
+        makeMeeting({ id: 3, status: 'cancelled' }),
+      ]
+      expect(store.pendingRequestIds).toEqual([1])
+    })
+
+    it('openMeetings returns only open meetings', async () => {
+      const { useMeetingsStore } = await import('../meetings')
+      const store = useMeetingsStore()
+      store.meetings = [
+        makeMeeting({ id: 1, status: 'open' }),
+        makeMeeting({ id: 2, status: 'agreed' }),
+      ]
+      expect(store.openMeetings).toHaveLength(1)
+      expect(store.openMeetings[0].id).toBe(1)
+    })
+  })
+})

--- a/frontend/src/stores/meetings.ts
+++ b/frontend/src/stores/meetings.ts
@@ -1,0 +1,103 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { api } from '../lib/api'
+import type { MeetingRequest, MeetingRequestBody, MeetingStatus } from '../types/meetings'
+
+export const useMeetingsStore = defineStore('meetings', () => {
+  const meetings = ref<MeetingRequest[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const openMeetings = computed(() =>
+    meetings.value.filter(m => m.status === 'open'),
+  )
+
+  const pendingRequestIds = computed(() =>
+    meetings.value.filter(m => m.status === 'open').map(m => m.id),
+  )
+
+  async function fetchMeetings(status?: MeetingStatus | string) {
+    loading.value = true
+    error.value = null
+    try {
+      const url = status ? `/api/meetings?status=${status}` : '/api/meetings'
+      const resp = await api(url, { credentials: 'include' })
+      if (resp.ok) {
+        meetings.value = await resp.json()
+      } else {
+        error.value = 'Failed to load meetings.'
+      }
+    } catch {
+      error.value = 'Could not reach server.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function requestMeeting(body: MeetingRequestBody) {
+    loading.value = true
+    error.value = null
+    try {
+      const resp = await api('/api/meetings/request', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (resp.ok) {
+        const result = await resp.json()
+        // Add a minimal stub meeting record so computed properties reflect the new request
+        const stub: MeetingRequest = {
+          id: result.id,
+          initiator_id: '',
+          target_ids: [],
+          duration_minutes: body.duration_minutes,
+          context: body.context ?? null,
+          status: result.status,
+          round: result.round,
+          agreed_slot: null,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }
+        meetings.value = [...meetings.value, stub]
+      } else {
+        const data = await resp.json().catch(() => ({}))
+        error.value = (data as { detail?: string }).detail || 'Failed to send meeting request.'
+      }
+    } catch {
+      error.value = 'Could not reach server.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function cancelMeeting(meetingId: number) {
+    loading.value = true
+    error.value = null
+    try {
+      const resp = await api(`/api/meetings/${meetingId}/cancel`, { method: 'POST' })
+      if (resp.ok) {
+        const result = await resp.json()
+        meetings.value = meetings.value.map(m =>
+          m.id === meetingId ? { ...m, status: result.status } : m,
+        )
+      } else {
+        error.value = 'Failed to cancel meeting.'
+      }
+    } catch {
+      error.value = 'Could not reach server.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    meetings,
+    loading,
+    error,
+    openMeetings,
+    pendingRequestIds,
+    fetchMeetings,
+    requestMeeting,
+    cancelMeeting,
+  }
+})

--- a/frontend/src/types/connections.ts
+++ b/frontend/src/types/connections.ts
@@ -13,6 +13,8 @@ export interface Connection {
   updated_at: string
   /** Backend-computed: always the other party's UUID regardless of user_a/user_b ordering */
   other_user_id: string
+  /** Backend-computed: the other party's username (for display and API calls that require usernames) */
+  other_username: string
 }
 
 /** Partial shape returned by POST /connections/{id}/accept */

--- a/frontend/src/types/meetings.ts
+++ b/frontend/src/types/meetings.ts
@@ -1,0 +1,36 @@
+/** Meeting request as returned by GET /api/meetings and POST /api/meetings/request */
+export interface MeetingRequest {
+  id: number
+  initiator_id: string
+  target_ids: string[]
+  duration_minutes: number
+  context: string | null
+  status: MeetingStatus
+  round: number
+  agreed_slot: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type MeetingStatus = 'open' | 'agreed' | 'cancelled'
+
+/** Body for POST /api/meetings/request */
+export interface MeetingRequestBody {
+  target_usernames: string[]
+  duration_minutes: number
+  slots: string[]
+  context?: string
+}
+
+/** Response from POST /api/meetings/request */
+export interface MeetingRequestResponse {
+  id: number
+  status: MeetingStatus
+  round: number
+}
+
+/** Response from POST /api/meetings/{id}/cancel */
+export interface MeetingCancelResponse {
+  id: number
+  status: MeetingStatus
+}


### PR DESCRIPTION
## Summary

- Adds **`stores/meetings.ts`** — Pinia store with `requestMeeting`, `fetchMeetings`, `cancelMeeting`; computed `openMeetings` and `pendingRequestIds`; full TDD (13 tests)
- Adds **`types/meetings.ts`** — TypeScript mirrors of backend request/response shapes
- Adds **`ScheduleMeetingModal.vue`** — per-connection modal with duration selector (15/30/60/90 min), pre-populated slot checklist (next 5 weekdays × 9am/1pm/4pm, user-toggleable), optional context note; Escape/backdrop-click/auto-focus keyboard support
- Extends **`ConnectionsSection.vue`** — "Schedule meeting" button per accepted connection, "meeting pending" badge when an open request exists, fetches open meetings on mount and refreshes after submission

### Bug discovered and fixed during review

`list_connections_for_user` returned only UUIDs for connected users — but `POST /api/meetings/request` resolves targets via `get_user_by_username`. Without this fix, every "Send request" click would 404. Fix: SQL now JOINs the `users` table to expose `other_username`. `Connection` TypeScript type gains `other_username: string`. Connection rows now show the human username rather than a truncated UUID.

## Test plan

- [ ] Settings → Connections: accepted connections show "Schedule meeting" button
- [ ] Click "Schedule meeting" — modal opens with correct username in title
- [ ] Pre-populated slot checkboxes span next 5 weekdays × 3 daily slots; unchecking reduces count
- [ ] Duration buttons highlight selection; note textarea accepts freeform text
- [ ] Submit with ≥1 slot selected → POST succeeds → modal closes → "meeting pending" badge appears on the connection row
- [ ] Submit with 0 slots → warning message shown, send button remains disabled
- [ ] Escape / backdrop click closes modal without submitting
- [ ] API failure shows inline error inside the modal

## Checklist

- [x] All 545 tests pass
- [x] `tsc --noEmit` exits 0 (zero type errors)
- [x] `vite build` exits 0
- [x] `pr-review-toolkit:code-reviewer` ran — all findings addressed
- [x] ACCOUNTING.md updated