### PR TITLE
fix: DayTimeline DnD drop always lands at slot 0 (z-order race)

### DIFF
--- a/frontend/src/components/DayTimeline.vue
+++ b/frontend/src/components/DayTimeline.vue
@@ -203,6 +203,15 @@ async function handleSlotDrop(payload: DropPayload, time: string) {
 /** Index of the currently hovered slot (for drop-zone highlight), or null. */
 const overSlotIndex = ref<number | null>(null)
 
+/**
+ * True while an HTML5 DnD drag is active over the timed area.
+ * Used to apply `pointer-events-none` to TaskCard blocks so drops over
+ * event-block areas pass through to the underlying slot divs directly,
+ * bypassing the clientY→slot computation and the z-order race where the
+ * highlighted slot 0 div would otherwise intercept all drops.
+ */
+const dragActive = ref(false)
+
 function onSlotDragOver(e: DragEvent, i: number) {
   e.preventDefault()
   overSlotIndex.value = i
@@ -217,6 +226,7 @@ function onSlotDragLeave(e: DragEvent, i: number) {
 
 async function onSlotDrop(e: DragEvent, i: number) {
   e.preventDefault()
+  dragActive.value = false
   overSlotIndex.value = null
   const rawJson = e.dataTransfer?.getData('application/json')
   const rawText = e.dataTransfer?.getData('text/plain')
@@ -227,12 +237,17 @@ async function onSlotDrop(e: DragEvent, i: number) {
   } catch { /* ignore malformed payload */ }
 }
 
-// --- Container-level DnD handlers (Bug B fix) ---
-// TaskCards are rendered after slot divs in the DOM and sit above them in z-order.
-// When a drag passes over a TaskCard block, dragover fires on the card but the card
-// doesn't call preventDefault, so the browser marks that position as no-drop.
-// The container-level handlers catch those events (dragover bubbles up from TaskCard)
-// and compute the target slot from clientY, enabling drops anywhere in the timed area.
+// --- Container-level DnD handlers ---
+// dragActive makes TaskCard blocks transparent to pointer events (pointer-events-none)
+// while a drag is in progress over the timed area. This ensures drops over event-block
+// areas pass through to the underlying slot divs, bypassing slotIndexFromClientY and
+// the z-order race where the highlighted slot div could intercept the wrong drop.
+// The container handlers remain as a safety net for the hour-labels gutter column.
+
+function onTimedAreaDragEnter(e: DragEvent) {
+  e.preventDefault()
+  dragActive.value = true
+}
 
 /** Map clientY to the nearest 15-min slot index, accounting for scroll offset. */
 function slotIndexFromClientY(clientY: number): number {
@@ -255,10 +270,12 @@ function onTimedAreaDragLeave(e: DragEvent) {
   const related = e.relatedTarget as Node | null
   if (related && (e.currentTarget as HTMLElement).contains(related)) return
   overSlotIndex.value = null
+  dragActive.value = false
 }
 
 async function onTimedAreaDrop(e: DragEvent) {
   e.preventDefault()
+  dragActive.value = false
   overSlotIndex.value = null
   const rawJson = e.dataTransfer?.getData('application/json')
   const rawText = e.dataTransfer?.getData('text/plain')
@@ -348,6 +365,7 @@ function anchorBandStyle(anchor: { color: string; id: string }) {
       class="relative flex overflow-y-auto"
       :style="{ height: 'calc(100vh - 200px)' }"
       @click="onTimedAreaClick"
+      @dragenter="onTimedAreaDragEnter"
       @dragover="onTimedAreaDragOver"
       @dragleave="onTimedAreaDragLeave"
       @drop="onTimedAreaDrop"
@@ -415,6 +433,7 @@ function anchorBandStyle(anchor: { color: string; id: string }) {
         />
 
         <!-- Timed event blocks -- TaskCard in calendar-event mode -->
+        <!-- pointer-events-none while dragActive so drops pass through to slot divs -->
         <TaskCard
           v-for="ev in timedEvents"
           :key="ev.id"
@@ -426,6 +445,7 @@ function anchorBandStyle(anchor: { color: string; id: string }) {
           :left-percent="overlapLayout[ev.id]?.leftPercent ?? 0"
           :width-percent="overlapLayout[ev.id]?.widthPercent ?? 100"
           :resolved-color="resolveColor(ev)"
+          :class="{ 'pointer-events-none': dragActive }"
           data-event-block
           @click.stop="emit('open-event', ev)"
         />

--- a/frontend/src/components/__tests__/DayTimelineDropZone.test.ts
+++ b/frontend/src/components/__tests__/DayTimelineDropZone.test.ts
@@ -258,4 +258,64 @@ describe('DayTimeline – 15-min slot drop targets', () => {
       'Dropped over event block',
     )
   })
+
+  // ── Slot position accuracy: regression test for slotIndexFromClientY math ──
+  it('onTimedAreaDrop maps clientY to the correct 15-min slot using rect.top + scrollTop', async () => {
+    // Mocks getBoundingClientRect so the formula can be exercised with known values.
+    // clientY=190, rect.top=100, scrollTop=0 → relY=90 → slot4 (90/22.5=4) → 07:00
+    const { default: DayTimeline } = await import('../DayTimeline.vue')
+    const wrapper = mount(DayTimeline, { props: { date: '2024-06-10' }, attachTo: document.body })
+    const timedArea = wrapper.find('[data-testid="timed-area"]')
+    const el = timedArea.element as HTMLElement
+
+    vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+      top: 100, left: 0, right: 320, bottom: 800, width: 320, height: 700,
+      x: 0, y: 100, toJSON: () => ({}),
+    } as DOMRect)
+    Object.defineProperty(el, 'scrollTop', { value: 0, configurable: true, writable: true })
+
+    const payload = { type: 'task', taskId: 'task-99', title: 'X' }
+    await timedArea.trigger('drop', {
+      clientY: 190,
+      dataTransfer: { getData: (t: string) => t === 'text/plain' ? JSON.stringify(payload) : '' },
+    })
+    expect(mockPromoteTask).toHaveBeenCalledWith(
+      'task-99',
+      expect.stringContaining('T07:00'),
+      expect.stringContaining('T07:30'),
+      'X',
+    )
+    wrapper.unmount()
+  })
+
+  // ── Structural fix: TaskCards must be transparent to pointer events during drag ──
+  it('TaskCard event blocks receive pointer-events-none class while a drag is active', async () => {
+    // The structural fix: when dragActive=true, TaskCards have pointer-events-none so
+    // drops over event block areas land on the underlying slot div directly, bypassing
+    // slotIndexFromClientY and the z-order race that caused slot 0 to always win.
+    const { default: DayTimeline } = await import('../DayTimeline.vue')
+    const wrapper = mount(DayTimeline, { props: { date: '2024-06-10' }, attachTo: document.body })
+    const eventBlock = wrapper.find('[data-event-block]')
+    expect(eventBlock.exists()).toBe(true)
+
+    // Before drag: no pointer-events-none
+    expect(eventBlock.classes()).not.toContain('pointer-events-none')
+
+    // Simulate drag entering the timed area
+    const timedArea = wrapper.find('[data-testid="timed-area"]')
+    await timedArea.trigger('dragenter', {
+      dataTransfer: { types: ['text/plain'] },
+    })
+    await wrapper.vm.$nextTick()
+
+    // Should have pointer-events-none during drag
+    expect(eventBlock.classes()).toContain('pointer-events-none')
+
+    // After dragleave (leaving the container — relatedTarget null = outside)
+    await timedArea.trigger('dragleave', { relatedTarget: null })
+    await wrapper.vm.$nextTick()
+    expect(eventBlock.classes()).not.toContain('pointer-events-none')
+
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
## Problem

Dragging a task from the plan's anchor list and dropping it onto the DayTimeline always scheduled it at 6:00 AM (slot 0) instead of the visually targeted time slot.

**Root cause — z-order race:**
1. Slot divs are rendered before `TaskCard` blocks in DOM order; TaskCards have higher z-order by default.
2. When `overSlotIndex` was computed from `clientY` (via `slotIndexFromClientY`), any inaccuracy in `getBoundingClientRect()` at drag-start (e.g., during the first dragover into the component) could produce slot 0.
3. The highlighted slot 0 got `z-30` (above TaskCards). Subsequent drop events hit slot 0 regardless of the cursor position, calling `onSlotDrop(e, 0)` → always 6:00 AM.

## Fix

Set `dragActive = ref(false)` in `DayTimeline`. On `@dragenter` it flips true; on `@dragleave` (container exit), `@drop` (container fallback), and `@drop.stop` (slot-direct) it flips false.

While `dragActive` is true, TaskCard blocks receive `pointer-events-none`. Drops over event-block areas pass through directly to the underlying slot divs, calling `onSlotDrop(e, i)` with the exact slot index — no `slotIndexFromClientY` math involved, no z-order race.

`slotIndexFromClientY` and `onTimedAreaDrop` remain as a safety net for drops landing in the hour-labels gutter column (left strip with no slot divs).

## Tests

- **Regression:** `onTimedAreaDrop maps clientY to the correct 15-min slot using rect.top + scrollTop` — mocks `getBoundingClientRect` and verifies `clientY=190 / top=100` maps to slot 4 (07:00). Passes before and after (math was always correct).
- **Structural (TDD red→green):** `TaskCard event blocks receive pointer-events-none class while a drag is active` — fails before fix, passes after.

All 539 tests pass. Build is clean (zero `vue-tsc` errors).

## Note on approach

Team-lead's post-compact reminder suggested `await nextTick()` in `onTimedAreaDrop`. This is incorrect — `e.clientY` is immutable at event-fire time and `getBoundingClientRect()` is synchronous; there is nothing to settle with a tick. The structural `pointer-events-none` fix eliminates the z-order race entirely rather than patching the coordinate math.