### PR TITLE
perf: eliminate N+1 queries in plan range and meetings

### DIFF
--- a/api/routes/meetings.py
+++ b/api/routes/meetings.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 from api.auth import auth_dependency
 from db.pool_middleware import get_db_conn
-from db.pg_auth_queries import get_user_by_username, get_user_by_id
+from db.pg_auth_queries import get_user_by_username, get_user_by_id, get_users_by_usernames, get_users_by_ids
 from db.pg_queries.scheduling import (
     create_meeting_request,
     create_proposal,
@@ -21,6 +21,7 @@ from db.pg_queries.scheduling import (
     list_meetings_for_user,
     list_incoming_for_user,
     get_connection_by_users,
+    get_connections_for_caller,
     get_participants,
 )
 from api.ws import manager
@@ -67,22 +68,20 @@ async def request_meeting(
     if not body.slots:
         raise HTTPException(status_code=400, detail="slots cannot be empty")
 
-    # Resolve target usernames to user IDs
-    target_ids = []
-    for username in body.target_usernames:
-        user = await get_user_by_username(conn, username)
-        if not user:
-            raise HTTPException(status_code=404, detail=f"User '{username}' not found")
-        target_ids.append(user["id"])
+    # Batch-resolve target usernames to user IDs
+    users_by_name = await get_users_by_usernames(conn, body.target_usernames)
+    missing = [u for u in body.target_usernames if u not in users_by_name]
+    if missing:
+        raise HTTPException(status_code=404, detail=f"User(s) not found: {missing}")
+    target_ids = [users_by_name[u]["id"] for u in body.target_usernames]
 
-    # Verify each target has an accepted connection with caller
-    for target_id in target_ids:
-        connection = await get_connection_by_users(conn, caller_id, target_id)
-        if not connection or connection["status"] != "accepted":
-            raise HTTPException(
-                status_code=400,
-                detail=f"No accepted connection with one or more targets",
-            )
+    # Batch-verify all targets have an accepted connection with caller
+    connections = await get_connections_for_caller(conn, caller_id, target_ids)
+    if any(connections.get(tid, {}).get("status") != "accepted" for tid in target_ids):
+        raise HTTPException(
+            status_code=400,
+            detail="No accepted connection with one or more targets",
+        )
 
     request = await create_meeting_request(
         conn, caller_id, target_ids, body.duration_minutes, body.context, body.slots
@@ -176,13 +175,10 @@ async def accept_slot(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    # Gather participant usernames for the WS event
+    # Batch-fetch participant usernames for the WS event
     participant_ids = get_participants(updated)
-    usernames = []
-    for uid in participant_ids:
-        user = await get_user_by_id(conn, uid)
-        if user:
-            usernames.append(user["username"])
+    users = await get_users_by_ids(conn, list(participant_ids))
+    usernames = [users[uid]["username"] for uid in participant_ids if uid in users]
 
     event = {
         "type": "meeting_agreed",

--- a/api/routes/plan.py
+++ b/api/routes/plan.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Request
-from datetime import date as date_type, timedelta
 import asyncpg
 from db.pg_queries import get_plan, upsert_plan, upsert_tasks, list_plan_dates
+from db.pg_queries.plans import get_plans_for_range
 from db.pool_middleware import get_db_conn
 from api.ws import manager
 from api.auth import auth_dependency
@@ -18,14 +18,7 @@ async def list_plans(_auth=Depends(auth_dependency),
 @router.get("/plan/range")
 async def get_plan_range(start: str, end: str, _auth=Depends(auth_dependency),
                          conn: asyncpg.Connection = Depends(get_db_conn)):
-    start_d = date_type.fromisoformat(start)
-    end_d = date_type.fromisoformat(end)
-    result = {}
-    d = start_d
-    while d <= end_d:
-        result[str(d)] = await get_plan(conn, str(d))
-        d += timedelta(days=1)
-    return result
+    return await get_plans_for_range(conn, start, end)
 
 
 @router.get("/plan/{date}")

--- a/db/pg_auth_queries.py
+++ b/db/pg_auth_queries.py
@@ -64,6 +64,27 @@ async def get_user_by_username(conn: asyncpg.Connection, username: str) -> dict 
     return _row(row)
 
 
+async def get_users_by_usernames(
+    conn: asyncpg.Connection, usernames: list[str]
+) -> dict[str, dict]:
+    """Return {username: user_row} for each found username. Missing entries omitted."""
+    if not usernames:
+        return {}
+    rows = await conn.fetch("SELECT * FROM users WHERE username = ANY($1)", usernames)
+    return {r["username"]: _row(r) for r in rows}
+
+
+async def get_users_by_ids(
+    conn: asyncpg.Connection, ids: list[str]
+) -> dict[str, dict]:
+    """Return {id: user_row} for each found id. Missing entries omitted."""
+    if not ids:
+        return {}
+    uuids = [_uuid.UUID(i) for i in ids]
+    rows = await conn.fetch("SELECT * FROM users WHERE id = ANY($1)", uuids)
+    return {str(r["id"]): _row(r) for r in rows}
+
+
 async def get_user_count(conn: asyncpg.Connection) -> int:
     return await conn.fetchval("SELECT COUNT(*) FROM users")
 

--- a/db/pg_queries/plans.py
+++ b/db/pg_queries/plans.py
@@ -150,6 +150,189 @@ async def get_plan(conn: asyncpg.Connection, date: str) -> dict:
     }
 
 
+async def get_plans_for_range(
+    conn: asyncpg.Connection,
+    start_date: str,
+    end_date: str,
+) -> dict[str, dict]:
+    """Return all plans and their tasks for the given inclusive date range.
+
+    Issues ~6 queries total regardless of range length, replacing the previous
+    O(days) loop over get_plan(). Dates with no plan entry are included with an
+    empty-tasks structure matching the get_plan() shape.
+    """
+    # 1. Which dates in range have a plan row?
+    plan_rows = await conn.fetch(
+        "SELECT date FROM plans WHERE date BETWEEN $1 AND $2",
+        start_date, end_date,
+    )
+    plan_dates = {str(r["date"]) for r in plan_rows}
+
+    # 2. All tasks for dates in range.
+    task_rows = await conn.fetch(
+        """
+        SELECT uuid, anchor_id, text, status, notes, position,
+               followup_config, description, context_subject, context_node_id, motif, version,
+               plan_date
+        FROM tasks
+        WHERE plan_date BETWEEN $1 AND $2
+        ORDER BY plan_date, anchor_id, position
+        """,
+        start_date, end_date,
+    )
+
+    # Group tasks into {date: {anchor_id: {tasks, notes}}}.
+    date_anchors: dict[str, dict] = {}
+    for row in task_rows:
+        d = str(row["plan_date"])
+        aid = str(row["anchor_id"]) if row["anchor_id"] else None
+        date_anchors.setdefault(d, {}).setdefault(aid, {"tasks": [], "notes": row["notes"]})
+        date_anchors[d][aid]["tasks"].append(_row_to_task(row))
+
+    # 3. Anchor-recurring masters — fetch once, expand per date in Python.
+    master_rows = await conn.fetch(
+        """
+        SELECT uuid, anchor_id, text, status, notes, position,
+               rrule, color, context_subject, context_node_id,
+               followup_config, description, motif, version, exdates
+        FROM tasks
+        WHERE anchor_id IS NOT NULL
+          AND rrule IS NOT NULL
+          AND plan_date IS NULL
+          AND recurrence_id IS NULL
+          AND start_time IS NULL
+          AND (source_status IS NULL OR source_status != 'cancelled')
+        ORDER BY anchor_id, position
+        """,
+    )
+
+    # Fetch exception rows for all masters × all dates in range in one shot.
+    master_uuids = [str(r["uuid"]) for r in master_rows]
+    exception_set: set[tuple[str, str]] = set()
+    if master_uuids:
+        exc_rows = await conn.fetch(
+            """
+            SELECT recurrence_id, plan_date FROM tasks
+            WHERE recurrence_id = ANY($1) AND plan_date BETWEEN $2 AND $3
+            """,
+            master_uuids, start_date, end_date,
+        )
+        exception_set = {(str(r["recurrence_id"]), str(r["plan_date"])) for r in exc_rows}
+
+    # Determine all dates in range.
+    dates_in_range: list[str] = []
+    start_d = _dt.date.fromisoformat(start_date)
+    end_d = _dt.date.fromisoformat(end_date)
+    d = start_d
+    while d <= end_d:
+        dates_in_range.append(str(d))
+        d += _dt.timedelta(days=1)
+
+    # Expand masters for each date.
+    for master in master_rows:
+        rrule_str = master["rrule"]
+        exdates = list(master["exdates"] or [])
+        master_uuid = str(master["uuid"])
+        for date_str in dates_in_range:
+            if date_str not in plan_dates:
+                continue
+            if date_str in exdates:
+                continue
+            if (master_uuid, date_str) in exception_set:
+                continue
+            if not _anchor_recurring_occurs_on(rrule_str, date_str):
+                continue
+            aid = str(master["anchor_id"])
+            date_anchors.setdefault(date_str, {}).setdefault(
+                aid, {"tasks": [], "notes": master["notes"]}
+            )
+            date_anchors[date_str][aid]["tasks"].append({
+                "id": master_uuid,
+                "text": master["text"],
+                "status": master["status"] or "pending",
+                "position": master["position"] or 0,
+                "description": master["description"],
+                "context_subject": master["context_subject"],
+                "context_node_id": str(master["context_node_id"]) if master["context_node_id"] else None,
+                "followup_config": master["followup_config"],
+                "motif": master["motif"],
+                "version": master["version"] or 0,
+                "anchor_id": aid,
+                "plan_date": date_str,
+                "rrule": rrule_str,
+                "color": master["color"],
+                "is_recurring_master": True,
+                "blocks": [],
+                "blocked_by": [],
+            })
+
+    # 4. Dependencies — one batch query for all task UUIDs in range.
+    all_uuids = [
+        t["id"]
+        for anchors in date_anchors.values()
+        for a in anchors.values()
+        for t in a["tasks"]
+        if t.get("id")
+    ]
+    if all_uuids:
+        dep_rows = await conn.fetch(
+            """
+            SELECT blocker_id, blocked_id FROM dependencies
+            WHERE blocker_type = 'task' AND blocked_type = 'task'
+              AND (blocker_id = ANY($1) OR blocked_id = ANY($1))
+            """,
+            all_uuids,
+        )
+        blocked_by_map: dict[str, list] = {}
+        blocks_map: dict[str, list] = {}
+        for dep in dep_rows:
+            blocked_by_map.setdefault(dep["blocked_id"], []).append(dep["blocker_id"])
+            blocks_map.setdefault(dep["blocker_id"], []).append(dep["blocked_id"])
+        for anchors in date_anchors.values():
+            for anchor_data in anchors.values():
+                for task in anchor_data["tasks"]:
+                    task["blocked_by"] = blocked_by_map.get(task["id"], [])
+                    task["blocks"] = blocks_map.get(task["id"], [])
+
+    # 5. Acknowledgements and check-ins — two queries for the whole range.
+    ack_rows = await conn.fetch(
+        "SELECT anchor_id, acknowledged_at, plan_date FROM acknowledgements WHERE plan_date BETWEEN $1 AND $2",
+        start_date, end_date,
+    )
+    date_acks: dict[str, dict] = {}
+    for r in ack_rows:
+        d_str = str(r["plan_date"])
+        date_acks.setdefault(d_str, {})[str(r["anchor_id"])] = r["acknowledged_at"]
+
+    checkin_rows = await conn.fetch(
+        "SELECT * FROM check_ins WHERE plan_date BETWEEN $1 AND $2 ORDER BY plan_date, timestamp",
+        start_date, end_date,
+    )
+    date_checkins: dict[str, list] = {}
+    for r in checkin_rows:
+        d_str = str(r["plan_date"])
+        date_checkins.setdefault(d_str, []).append(dict(r))
+
+    # 6. Assemble result for every date in range.
+    result: dict[str, dict] = {}
+    for date_str in dates_in_range:
+        if date_str not in plan_dates:
+            result[date_str] = {
+                "date": date_str,
+                "anchors": {},
+                "acknowledgements": {},
+                "check_in_log": [],
+            }
+        else:
+            result[date_str] = {
+                "date": date_str,
+                "anchors": date_anchors.get(date_str, {}),
+                "acknowledgements": date_acks.get(date_str, {}),
+                "check_in_log": date_checkins.get(date_str, []),
+            }
+    return result
+
+
 async def list_plan_dates(conn: asyncpg.Connection) -> list[str]:
     rows = await conn.fetch("SELECT date FROM plans ORDER BY date DESC")
     return [r["date"] for r in rows]

--- a/db/pg_queries/scheduling.py
+++ b/db/pg_queries/scheduling.py
@@ -82,6 +82,38 @@ async def get_connection_by_users(
     return _row(row)
 
 
+async def get_connections_for_caller(
+    conn: asyncpg.Connection, caller_id: str, target_ids: list[str]
+) -> dict[str, dict]:
+    """Return {target_id: connection_row} for all target_ids. Missing = no connection.
+
+    Uses canonical ordering (user_a < user_b) consistent with get_connection_by_users.
+    """
+    if not target_ids:
+        return {}
+    # Build canonical pairs and fetch all matching rows in one query.
+    # connections table stores user_a < user_b (by UUID sort order).
+    caller_uuid = _uuid.UUID(caller_id)
+    target_uuids = [_uuid.UUID(t) for t in target_ids]
+    rows = await conn.fetch(
+        """
+        SELECT * FROM connections
+        WHERE (user_a = $1::uuid AND user_b = ANY($2))
+           OR (user_b = $1::uuid AND user_a = ANY($2))
+        """,
+        str(caller_uuid), target_uuids,
+    )
+    result: dict[str, dict] = {}
+    for row in rows:
+        row_dict = _row(row)
+        # Determine which side is the target.
+        if row_dict["user_a"] == str(caller_uuid):
+            result[row_dict["user_b"]] = row_dict
+        else:
+            result[row_dict["user_a"]] = row_dict
+    return result
+
+
 async def list_connections_for_user(
     conn: asyncpg.Connection, user_id: str
 ) -> list[dict]:

--- a/tests/api/test_meetings.py
+++ b/tests/api/test_meetings.py
@@ -288,3 +288,43 @@ async def test_expire_old_requests(conn):
     # Verify status
     row2 = await conn.fetchrow("SELECT status FROM meeting_requests WHERE id = $1", req_id)
     assert row2["status"] == "expired"
+
+# ─── N+1 batch-query assertions ───────────────────────────────────────────────
+
+async def test_request_meeting_uses_batch_username_resolution(api_client, conn):
+    """POST /meetings/request must use get_users_by_usernames, not get_user_by_username."""
+    from unittest.mock import patch
+    await _setup_accepted_connection(conn)
+    with patch(
+        "api.routes.meetings.get_user_by_username",
+        side_effect=AssertionError("get_user_by_username called — batch not used"),
+    ):
+        resp = await api_client.post(
+            "/api/meetings/request",
+            json={
+                "target_usernames": [TEST_USER_B_NAME],
+                "duration_minutes": 30,
+                "slots": SAMPLE_SLOTS,
+            },
+        )
+    assert resp.status_code == 201
+
+
+async def test_accept_slot_uses_batch_user_lookup(api_client, api_client_b, conn, pool):
+    """POST /meetings/{id}/accept must use get_users_by_ids, not get_user_by_id."""
+    from unittest.mock import patch
+    meeting = await _create_meeting(api_client, conn)
+    meeting_id = meeting["id"]
+    await api_client_b.post(
+        f"/api/meetings/{meeting_id}/propose",
+        json={"slots": [SAMPLE_SLOTS[0]]},
+    )
+    with patch(
+        "api.routes.meetings.get_user_by_id",
+        side_effect=AssertionError("get_user_by_id called — batch not used"),
+    ):
+        resp = await api_client.post(
+            f"/api/meetings/{meeting_id}/accept",
+            json={"slot": SAMPLE_SLOTS[0]},
+        )
+    assert resp.status_code == 200

--- a/tests/api/test_plan_routes.py
+++ b/tests/api/test_plan_routes.py
@@ -131,3 +131,32 @@ async def test_get_plan_range_returns_dict_of_day_plans(api_client, conn):
     assert today in data
     assert tomorrow in data
     assert "anchors" in data[today]
+
+
+@pytest.mark.asyncio
+async def test_get_plan_range_uses_batch_query(api_client, conn):
+    """GET /plan/range should use get_plans_for_range (batch), not get_plan per day."""
+    from unittest.mock import patch
+    from datetime import date, timedelta
+
+    start = date.today()
+    end = start + timedelta(days=2)
+
+    # Seed 3 days of plans
+    await upsert_anchor(conn, ANCHOR)
+    for i in range(3):
+        d = str(start + timedelta(days=i))
+        await upsert_plan(conn, d)
+        await upsert_tasks(conn, d, ANCHOR_ID, tasks=[f"Task day {i}"], notes="")
+
+    # If the route still calls get_plan() individually, this patch raises and the test fails.
+    # After the fix, get_plans_for_range is called instead, and get_plan is never invoked.
+    with patch("api.routes.plan.get_plan", side_effect=AssertionError("get_plan called — N+1 not fixed")):
+        resp = await api_client.get(f"/api/plan/range?start={start}&end={end}")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    for i in range(3):
+        d = str(start + timedelta(days=i))
+        assert d in data, f"Date {d} missing from range response"
+        assert ANCHOR_ID in data[d]["anchors"]


### PR DESCRIPTION
## Summary

### `GET /plan/range` — O(days) → O(1) queries
- Added `get_plans_for_range(conn, start_date, end_date)` to `db/pg_queries/plans.py`
- Issues 6 queries total regardless of date range (was 5–6 per day): plan dates, tasks, recurring masters, exception rows, dependencies, acknowledgements, check-ins — all batched with `BETWEEN $1 AND $2` or `ANY($1)` clauses
- Updated handler in `api/routes/plan.py` to call `get_plans_for_range` directly

### `POST /meetings/request` + `POST /meetings/{id}/accept` — 3 N+1 loops removed
- Added `get_users_by_usernames(conn, usernames)` and `get_users_by_ids(conn, ids)` to `db/pg_auth_queries.py`
- Added `get_connections_for_caller(conn, caller_id, target_ids)` to `db/pg_queries/scheduling.py`
- Updated `request_meeting` handler: single batch lookup for usernames → ids, single batch connection check
- Updated `accept_slot` handler: single batch lookup for participant usernames

## Test plan
- [ ] `test_get_plan_range_uses_batch_query` — patches `get_plan` to raise, confirms batch path used (requires `DATABASE_URL` on Pi)
- [ ] `test_request_meeting_uses_batch_username_resolution` — patches individual lookup to raise, confirms batch used
- [ ] `test_accept_slot_uses_batch_user_lookup` — patches individual lookup to raise, confirms batch used
- [ ] All existing plan + meetings tests pass (skipped here, require `DATABASE_URL`)