### PR TITLE
fix: type fixes — plan_date on Task, remove any casts (Phase B)

### DIFF
--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -111,7 +111,7 @@ const STATUS_ROW_STYLE: Record<TaskStatus, Record<string, string>> = {
 }
 
 const isOverdue = computed(() => {
-  const pd = (props.task as any).plan_date as string | null | undefined
+  const pd = props.task.plan_date
   if (!pd) return false
   if (props.task.status === 'done' || props.task.status === 'skipped') return false
   const d = new Date()
@@ -277,13 +277,13 @@ const calendarEventStyle = computed(() => {
 
         <!-- Tags — right-justified, shrink-safe, no overlap with text -->
         <div
-          v-if="(task as any).plan_date || isOverdue || (!hideTags && (milestoneStore.taskMilestones[task.id]?.length || task.context_subject))"
+          v-if="task.plan_date || isOverdue || (!hideTags && (milestoneStore.taskMilestones[task.id]?.length || task.context_subject))"
           class="flex-shrink-0 flex flex-wrap gap-1 justify-end max-w-[40%]">
           <span
-            v-if="(task as any).plan_date"
+            v-if="task.plan_date"
             @click.stop
             class="text-[10px] px-1 py-0.5 rounded bg-purple-500/20 text-purple-300">
-            {{ (task as any).plan_date }}
+            {{ task.plan_date }}
           </span>
           <span v-if="isOverdue" @click.stop
                 class="text-[10px] px-1 py-0.5 rounded bg-[--status-block-bg] text-[--status-block-fg] font-medium">
@@ -359,12 +359,12 @@ const calendarEventStyle = computed(() => {
     </div>
 
     <!-- Tags row — date/anchor always visible; context/milestone hidden when hideTags -->
-    <div v-if="(task as any).plan_date || (!hideTags && (milestoneStore.taskMilestones[task.id]?.length || task.context_subject))" class="flex flex-wrap gap-1">
+    <div v-if="task.plan_date || (!hideTags && (milestoneStore.taskMilestones[task.id]?.length || task.context_subject))" class="flex flex-wrap gap-1">
       <span
-        v-if="(task as any).plan_date"
+        v-if="task.plan_date"
         @click.stop
         class="text-[10px] px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-300">
-        {{ (task as any).plan_date }}{{ (task as any).anchor_id ? ' · ' + (task as any).anchor_id : '' }}
+        {{ task.plan_date }}{{ task.anchor_id ? ' · ' + task.anchor_id : '' }}
       </span>
       <span v-if="isOverdue" @click.stop
             class="text-[10px] px-1.5 py-0.5 rounded bg-[--status-block-bg] text-[--status-block-fg] font-medium">

--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -18,7 +18,7 @@ import { useLinks } from '../composables/useLinks'
 import { useDependencies } from '../composables/useDependencies'
 import { useTaskContexts } from '../composables/useTaskContexts'
 import { useSlideOver } from '../composables/useSlideOver'
-import type { TaskStatus } from '../stores/plan'
+import type { Task, TaskStatus } from '../stores/plan'
 import type { FollowupConfig } from '../stores/anchors'
 import type { RecurrenceEditScope } from '../types/recurrence'
 
@@ -61,7 +61,7 @@ const anchorId = computed(() => taskAndAnchor.value?.anchorId ?? '')
 const isBacklog = computed(() => taskAndAnchor.value?.isBacklog ?? false)
 
 // Standalone task fetch for when task isn't in plan or backlog store yet
-const standaloneTask = ref<any>(null)
+const standaloneTask = ref<Task | null>(null)
 
 // Schedule controls (backlog → plan)
 const scheduleDate = ref(planStore.today)
@@ -507,7 +507,7 @@ onMounted(async () => {
 
 <template>
   <!-- dp-shell: motif data-attr drives the left-rail colour via --m token -->
-  <div class="dp-shell" :data-motif="task?.motif ?? (taskEvent ? 'anchor' : 'anchor')">
+  <div class="dp-shell" :data-motif="task?.motif ?? 'anchor'">
 
     <!-- ── Header ─────────────────────────────────────────────────────────── -->
     <header class="dp-header">
@@ -584,7 +584,7 @@ onMounted(async () => {
       </template>
 
       <!-- ── Full task ─────────────────────────────────────────────────────── -->
-      <template v-else>
+      <template v-else-if="task">
 
         <!-- Motif -->
         <section class="dp-section">

--- a/frontend/src/stores/plan.ts
+++ b/frontend/src/stores/plan.ts
@@ -5,8 +5,6 @@ import { api } from '../lib/api'
 
 export type TaskStatus = 'pending' | 'in_progress' | 'done' | 'skipped' | 'blocked'
 
-export type { FollowupConfig }
-
 export interface Task {
   id: string
   text: string
@@ -23,6 +21,8 @@ export interface Task {
   end_time?: string | null
   // Anchor association — set for plan tasks; null for backlog
   anchor_id?: string | null
+  // Plan date — present on backlog/kanban tasks (null when unscheduled)
+  plan_date?: string | null
   // Recurrence fields — anchor-recurring tasks only
   rrule?: string | null
   is_recurring_master?: boolean


### PR DESCRIPTION
## Summary

- Add `plan_date?: string | null` to base `Task` interface (mirrors backend schema, removes `(task as any).plan_date` casts)
- Remove `FollowupConfig` re-export from plan.ts (no callers import it from here)
- Replace all `(task as any).plan_date` and `(task as any).anchor_id` casts in TaskCard.vue with direct property access
- Type `standaloneTask` as `Task | null` instead of `any` in TaskDetailPanel
- Narrow `<template v-else>` to `<template v-else-if="task">` so TypeScript can infer task is non-null in that branch
- Fix tautological ternary: `(taskEvent ? 'anchor' : 'anchor')` → `'anchor'`

## Test plan

- [x] `vue-tsc -b` — zero type errors
- [x] `npm test` — 532/532 tests pass