### PR TITLE
refactor: extract dateUtils, VOICE export, fetch→load rename (Phase C)

### DIFF
--- a/frontend/src/components/plan/MiniCalendar.vue
+++ b/frontend/src/components/plan/MiniCalendar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
+import { localDateString } from '../../lib/dateUtils'
 import { usePlanStore } from '../../stores/plan'
 import MiniCalendarDay from './MiniCalendarDay.vue'
 
@@ -8,10 +9,6 @@ const planStore = usePlanStore()
 const emit = defineEmits<{
   (e: 'day-click', date: string): void
 }>()
-
-function localDateStr(d: Date): string {
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-}
 
 const viewDate = ref(new Date(planStore.activeDate + 'T12:00:00'))
 
@@ -39,11 +36,11 @@ const calendarDates = computed<string[]>(() => {
   const startOffset = first.getDay() === 0 ? 6 : first.getDay() - 1
   return Array.from({ length: 42 }, (_, i) => {
     const d = new Date(y, m, 1 - startOffset + i)
-    return localDateStr(d)
+    return localDateString(d)
   })
 })
 
-const today = computed(() => localDateStr(new Date()))
+const today = computed(() => localDateString(new Date()))
 
 function taskCount(date: string): number {
   const day = planStore.plans[date]

--- a/frontend/src/components/plan/PlanWeekView.vue
+++ b/frontend/src/components/plan/PlanWeekView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
+import { localDateString } from '../../lib/dateUtils'
 import { usePlanStore } from '../../stores/plan'
 import { useAnchorStore } from '../../stores/anchors'
 import { useDragEdgeScroll } from '../../composables/useDragEdgeScroll'
@@ -19,17 +20,13 @@ function getMonday(dateStr: string): Date {
   return d
 }
 
-function localDateStr(d: Date): string {
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-}
-
 const weekStart = ref(getMonday(planStore.activeDate))
 
 const weekDates = computed<string[]>(() =>
   Array.from({ length: 7 }, (_, i) => {
     const d = new Date(weekStart.value)
     d.setDate(d.getDate() + i)
-    return localDateStr(d)
+    return localDateString(d)
   }),
 )
 

--- a/frontend/src/composables/useDependencies.ts
+++ b/frontend/src/composables/useDependencies.ts
@@ -16,7 +16,7 @@ export interface Dependencies {
 export function useDependencies(entityType: () => string, entityId: () => string) {
   const deps = ref<Dependencies>({ blocks: [], blocked_by: [] })
 
-  async function fetch() {
+  async function load() {
     const resp = await api(`/api/${entityType()}/${entityId()}/dependencies`)
     deps.value = resp.ok ? await resp.json() : { blocks: [], blocked_by: [] }
   }
@@ -27,15 +27,15 @@ export function useDependencies(entityType: () => string, entityId: () => string
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ blocker_type: blockerType, blocker_id: blockerId, blocked_type: blockedType, blocked_id: blockedId }),
     })
-    await fetch()
+    await load()
   }
 
   async function remove(depId: number) {
     await api(`/api/dependencies/${depId}`, { method: 'DELETE' })
-    await fetch()
+    await load()
   }
 
-  watch([entityType, entityId], () => fetch(), { immediate: true })
+  watch([entityType, entityId], () => load(), { immediate: true })
 
-  return { deps, fetch, add, remove }
+  return { deps, load, add, remove }
 }

--- a/frontend/src/composables/useLinks.ts
+++ b/frontend/src/composables/useLinks.ts
@@ -14,7 +14,7 @@ export interface Link {
 export function useLinks(parentType: () => string, parentId: () => string) {
   const links = ref<Link[]>([])
 
-  async function fetch() {
+  async function load() {
     const resp = await api(`/api/${parentType()}/${parentId()}/links`)
     links.value = resp.ok ? await resp.json() : []
   }
@@ -25,15 +25,15 @@ export function useLinks(parentType: () => string, parentId: () => string) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ url, label, category }),
     })
-    await fetch()
+    await load()
   }
 
   async function remove(id: number) {
     await api(`/api/links/${id}`, { method: 'DELETE' })
-    await fetch()
+    await load()
   }
 
-  watch([parentType, parentId], () => fetch(), { immediate: true })
+  watch([parentType, parentId], () => load(), { immediate: true })
 
-  return { links, fetch, create, remove }
+  return { links, load, create, remove }
 }

--- a/frontend/src/composables/useSlideOver.ts
+++ b/frontend/src/composables/useSlideOver.ts
@@ -20,6 +20,10 @@ function encodeStack(panels: Panel[]): string | undefined {
   return panels.map(p => `${p.kind}:${p.entityId}`).join(',')
 }
 
+function genId(): string {
+  return crypto.randomUUID?.() ?? (Math.random().toString(36).slice(2) + Date.now().toString(36))
+}
+
 function decodeStack(param: string): Panel[] {
   const result: Panel[] = []
   for (const segment of param.split(',').filter(Boolean)) {
@@ -27,7 +31,7 @@ function decodeStack(param: string): Panel[] {
     if (colon === -1) continue
     const kind = segment.slice(0, colon) as Panel['kind']
     const entityId = segment.slice(colon + 1)
-    result.push({ id: crypto.randomUUID?.() ?? (Math.random().toString(36).slice(2) + Date.now().toString(36)), kind, entityId })
+    result.push({ id: genId(), kind, entityId })
   }
   return result
 }
@@ -47,7 +51,7 @@ export function useSlideOver() {
   }
 
   function push(panel: Omit<Panel, 'id'>) {
-    stack.value.push({ ...panel, id: crypto.randomUUID?.() ?? (Math.random().toString(36).slice(2) + Date.now().toString(36)) })
+    stack.value.push({ ...panel, id: genId() })
     syncToUrl()
   }
 

--- a/frontend/src/composables/useSubtasks.ts
+++ b/frontend/src/composables/useSubtasks.ts
@@ -13,7 +13,7 @@ export function useSubtasks(taskId: () => string) {
   const subtasks = ref<Subtask[]>([])
   const loading = ref(false)
 
-  async function fetch() {
+  async function load() {
     loading.value = true
     const resp = await api(`/api/tasks/${taskId()}/subtasks`)
     subtasks.value = resp.ok ? await resp.json() : []
@@ -27,7 +27,7 @@ export function useSubtasks(taskId: () => string) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text, position }),
     })
-    if (resp.ok) await fetch()
+    if (resp.ok) await load()
   }
 
   async function update(id: number, fields: Partial<Subtask>) {
@@ -36,14 +36,14 @@ export function useSubtasks(taskId: () => string) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(fields),
     })
-    await fetch()
+    await load()
   }
 
   async function remove(id: number) {
     await api(`/api/tasks/${taskId()}/subtasks/${id}`, {
       method: 'DELETE',
     })
-    await fetch()
+    await load()
   }
 
   async function reorder(idOrder: number[]) {
@@ -52,10 +52,10 @@ export function useSubtasks(taskId: () => string) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id_order: idOrder }),
     })
-    await fetch()
+    await load()
   }
 
-  watch(taskId, () => fetch(), { immediate: true })
+  watch(taskId, () => load(), { immediate: true })
 
-  return { subtasks, loading, fetch, create, update, remove, reorder }
+  return { subtasks, loading, load, create, update, remove, reorder }
 }

--- a/frontend/src/composables/useTaskContexts.ts
+++ b/frontend/src/composables/useTaskContexts.ts
@@ -4,7 +4,7 @@ import { api } from '../lib/api'
 export function useTaskContexts(taskId: () => string) {
   const contexts = ref<string[]>([])
 
-  async function fetch() {
+  async function load() {
     const resp = await api(`/api/tasks/${taskId()}/contexts`)
     // API returns [] or [subject] (single-context model)
     contexts.value = resp.ok ? await resp.json() : []
@@ -17,7 +17,7 @@ export function useTaskContexts(taskId: () => string) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ subject }),
     })
-    await fetch()
+    await load()
   }
 
   async function unlink(subject: string) {
@@ -25,10 +25,10 @@ export function useTaskContexts(taskId: () => string) {
     await api(`/api/tasks/${taskId()}/contexts/${encodeURIComponent(subject)}`, {
       method: 'DELETE',
     })
-    await fetch()
+    await load()
   }
 
-  watch(taskId, () => fetch(), { immediate: true })
+  watch(taskId, () => load(), { immediate: true })
 
-  return { contexts, fetch, link, unlink }
+  return { contexts, load, link, unlink }
 }

--- a/frontend/src/composables/useTheme.ts
+++ b/frontend/src/composables/useTheme.ts
@@ -24,7 +24,7 @@ export const THEMES: ThemeDef[] = [
   { id: 'paper',    name: 'Paper',         tier: 'paid-oss', canvas: '#FAFAF7', accent: '#1C1C1A' },
 ]
 
-const VOICE: Record<string, TypeVoice> = {
+export const VOICE: Record<string, TypeVoice> = {
   tether: 'sharp', horizon: 'editorial', contrast: 'sharp',
   terminal: 'terminal', solstice: 'sharp', dracula: 'terminal', paper: 'editorial',
 }

--- a/frontend/src/lib/dateUtils.ts
+++ b/frontend/src/lib/dateUtils.ts
@@ -1,0 +1,23 @@
+/**
+ * Format a Date as YYYY-MM-DD in local time.
+ * Equivalent to the many inline localDateString / localDateStr / localToday helpers.
+ */
+export function localDateString(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+/**
+ * Return today's date as YYYY-MM-DD in local time.
+ */
+export function localToday(): string {
+  return localDateString(new Date())
+}
+
+/**
+ * Offset a YYYY-MM-DD string by N calendar days (positive = future, negative = past).
+ */
+export function offsetDate(base: string, days: number): string {
+  const d = new Date(base + 'T12:00:00')
+  d.setDate(d.getDate() + days)
+  return localDateString(d)
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,6 +2,7 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
+import { VOICE } from './composables/useTheme'
 import './assets/themes.css'
 import './assets/motifs.css'
 import './assets/theme-distinctives.css'
@@ -15,10 +16,6 @@ document.documentElement.dataset.theme = savedTheme
 document.documentElement.dataset.mode = savedMode as 'light' | 'dark'
 
 // Also set type-voice to match theme
-const VOICE: Record<string, string> = {
-  tether: 'sharp', horizon: 'editorial', contrast: 'sharp',
-  terminal: 'terminal', solstice: 'sharp', dracula: 'terminal', paper: 'editorial',
-}
 document.documentElement.dataset.typeVoice = VOICE[savedTheme] ?? 'sharp'
 
 createApp(App).use(createPinia()).use(router).mount('#app')

--- a/frontend/src/stores/plan.ts
+++ b/frontend/src/stores/plan.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import type { FollowupConfig } from './anchors'
 import { api } from '../lib/api'
+import { localDateString } from '../lib/dateUtils'
 
 export type TaskStatus = 'pending' | 'in_progress' | 'done' | 'skipped' | 'blocked'
 
@@ -38,11 +39,6 @@ export interface DayPlan {
   acknowledgements: Record<string, string>
   check_in_log: unknown[]
 }
-
-function localDateString(d: Date): string {
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-}
-
 
 export const usePlanStore = defineStore('plan', () => {
   const plan = ref<DayPlan | null>(null)

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { localDateString } from '../lib/dateUtils'
 import { useDragEdgeScroll } from '../composables/useDragEdgeScroll'
 import { useAnchorStore } from '../stores/anchors'
 import { useEventStore } from '../stores/events'
@@ -198,10 +199,6 @@ onUnmounted(() => {
 })
 
 // ─── Week date range ──────────────────────────────────────────
-function localDateString(d: Date): string {
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-}
-
 function getWeekStart(d: Date): Date {
   const result = new Date(d)
   result.setDate(result.getDate() - result.getDay()) // Sunday start

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -8,17 +8,13 @@ import { useEventStore } from '../stores/events'
 import TaskCard from '../components/TaskCard.vue'
 import AnchorFocusWidget from '../components/AnchorFocusWidget.vue'
 import { textOnColor } from '../composables/useTextOnColor'
+import { localToday } from '../lib/dateUtils'
 
 const planStore = usePlanStore()
 const anchorStore = useAnchorStore()
 const milestoneStore = useMilestoneStore()
 const eventStore = useEventStore()
 const botStatus = ref('unknown')
-
-function localToday(): string {
-  const d = new Date()
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-}
 
 onMounted(async () => {
   planStore.fetchPlan()

--- a/frontend/src/views/PlanView.vue
+++ b/frontend/src/views/PlanView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, watch, onMounted, onUnmounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
+import { offsetDate } from '../lib/dateUtils'
 import { usePlanStore } from '../stores/plan'
 import { useAnchorStore, computeAnchorStates } from '../stores/anchors'
 import { useMilestoneStore } from '../stores/milestones'
@@ -78,15 +79,6 @@ function onDocumentClick(e: MouseEvent) {
   }
 }
 
-
-function offsetDate(base: string, days: number): string {
-  const d = new Date(base + 'T12:00:00')
-  d.setDate(d.getDate() + days)
-  const year = d.getFullYear()
-  const month = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
 
 function goToDate(date: string) {
   router.push(`/plan/${props.view}/${date}`)


### PR DESCRIPTION
## Summary

- Create `src/lib/dateUtils.ts` with `localDateString`, `localToday`, `offsetDate` — removes the same function duplicated across 6 files
- Remove local definitions in `plan.ts`, `DashboardView`, `PlanView`, `CalendarView`, `PlanWeekView`, `MiniCalendar`; all now import from `dateUtils`
- Export `VOICE` from `useTheme.ts`; remove the duplicate inline mapping from `main.ts`
- Extract `genId()` helper in `useSlideOver.ts` (removes duplicated UUID expression)
- Rename internal `fetch()` → `load()` in `useLinks`, `useDependencies`, `useSubtasks`, `useTaskContexts` — stops shadowing the global Web `fetch` API

## Test plan

- [x] `vue-tsc -b` — zero type errors
- [x] `npm test` — 532/532 tests pass