### PR TITLE
refactor: raw SQL extraction, MoveTaskBody, Optional modernization, _validate_motif dedup

### DIFF
--- a/api/routes/_common.py
+++ b/api/routes/_common.py
@@ -1,0 +1,12 @@
+"""Shared helpers for API route modules."""
+from fastapi import HTTPException
+from db.pg_queries._motif import VALID_MOTIFS
+
+
+def _validate_motif(body: dict) -> None:
+    """Raise 422 if body contains an invalid motif value."""
+    if "motif" in body and body["motif"] not in VALID_MOTIFS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid motif: {body['motif']!r}. Must be one of {sorted(VALID_MOTIFS)}",
+        )

--- a/api/routes/meetings.py
+++ b/api/routes/meetings.py
@@ -5,7 +5,6 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 import asyncpg
-from typing import Optional
 
 log = logging.getLogger(__name__)
 
@@ -44,12 +43,12 @@ class MeetingRequestBody(BaseModel):
     target_usernames: list[str]
     duration_minutes: int = 30
     slots: list[str]
-    context: Optional[str] = None
+    context: str | None = None
 
 
 class ProposeBody(BaseModel):
     slots: list[str]
-    message: Optional[str] = None
+    message: str | None = None
 
 
 class AcceptSlotBody(BaseModel):
@@ -226,7 +225,7 @@ async def cancel_meeting_route(
 
 @router.get("/meetings")
 async def list_meetings(
-    status: Optional[str] = None,
+    status: str | None = None,
     auth=Depends(auth_dependency),
     conn: asyncpg.Connection = Depends(get_db_conn),
 ):

--- a/api/routes/milestones.py
+++ b/api/routes/milestones.py
@@ -5,18 +5,10 @@ from db.pg_queries import (
     link_milestone_task, unlink_milestone_task,
 )
 from db.pool_middleware import get_db_conn
-from db.pg_queries._motif import VALID_MOTIFS
+from api.routes._common import _validate_motif
 from api.auth import auth_dependency
 
 router = APIRouter()
-
-
-def _validate_motif(body: dict) -> None:
-    if "motif" in body and body["motif"] not in VALID_MOTIFS:
-        raise HTTPException(
-            status_code=422,
-            detail=f"Invalid motif: {body['motif']!r}. Must be one of {sorted(VALID_MOTIFS)}",
-        )
 
 
 @router.get("/milestones")

--- a/api/routes/sessions.py
+++ b/api/routes/sessions.py
@@ -3,15 +3,12 @@ from fastapi import APIRouter, Depends
 import asyncpg
 from api.auth import auth_dependency
 from db.pool_middleware import get_db_conn
+from db.pg_queries.sessions import get_active_sessions
 
 router = APIRouter(prefix="/sessions", tags=["sessions"])
 
 
 @router.get("")
-async def get_active_sessions(_auth=Depends(auth_dependency),
-                              conn: asyncpg.Connection = Depends(get_db_conn)):
-    rows = await conn.fetch(
-        "SELECT * FROM sessions WHERE state IN ('active', 'waiting_user') "
-        "ORDER BY last_activity DESC"
-    )
-    return {"sessions": [dict(r) for r in rows]}
+async def get_active_sessions_route(_auth=Depends(auth_dependency),
+                                    conn: asyncpg.Connection = Depends(get_db_conn)):
+    return {"sessions": await get_active_sessions(conn)}

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -1,12 +1,6 @@
 from typing import Literal
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
-
-
-class MoveTaskBody(BaseModel):
-    date: str
-    anchor_id: str
-    position: int | None = None
 import asyncpg
 from db.pg_queries import (
     patch_task_fields, move_task_atomic,
@@ -18,18 +12,16 @@ from db.pg_queries import (
 )
 from db.pg_queries.tasks import set_task_rrule, delete_anchor_occurrence, truncate_anchor_series
 from db.pool_middleware import get_db_conn
-from db.pg_queries._motif import VALID_MOTIFS
+from api.routes._common import _validate_motif
 from api.auth import auth_dependency
 
 router = APIRouter()
 
 
-def _validate_motif(body: dict) -> None:
-    if "motif" in body and body["motif"] not in VALID_MOTIFS:
-        raise HTTPException(
-            status_code=422,
-            detail=f"Invalid motif: {body['motif']!r}. Must be one of {sorted(VALID_MOTIFS)}",
-        )
+class MoveTaskBody(BaseModel):
+    date: str
+    anchor_id: str
+    position: int | None = None
 
 
 class TaskRruleBody(BaseModel):

--- a/api/routes/tasks.py
+++ b/api/routes/tasks.py
@@ -1,6 +1,12 @@
 from typing import Literal
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
+
+
+class MoveTaskBody(BaseModel):
+    date: str
+    anchor_id: str
+    position: int | None = None
 import asyncpg
 from db.pg_queries import (
     patch_task_fields, move_task_atomic,
@@ -153,12 +159,11 @@ async def delete_task(
 
 
 @router.put("/tasks/{task_uuid}/move")
-async def move_task(task_uuid: str, body: dict,
+async def move_task(task_uuid: str, body: MoveTaskBody,
                     _auth=Depends(auth_dependency),
                     conn: asyncpg.Connection = Depends(get_db_conn)):
     try:
-        await move_task_atomic(conn, task_uuid,
-                               body.get("date"), body.get("anchor_id"), body.get("position"))
+        await move_task_atomic(conn, task_uuid, body.date, body.anchor_id, body.position)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     return {"ok": True}

--- a/db/pg_queries/__init__.py
+++ b/db/pg_queries/__init__.py
@@ -48,6 +48,7 @@ from db.pg_queries.followup import (
 from db.pg_queries.sessions import (
     create_session, get_active_session, update_session_state,
     update_session_activity, close_session, get_stale_sessions,
+    get_active_sessions,
 )
 from db.pg_queries.conversation import (
     insert_conversation_turn, get_recent_history, clear_session_state,

--- a/db/pg_queries/sessions.py
+++ b/db/pg_queries/sessions.py
@@ -139,3 +139,12 @@ async def get_stale_sessions(
             d["user_id"] = str(d["user_id"])
         result.append(d)
     return result
+
+
+async def get_active_sessions(conn: asyncpg.Connection) -> list[dict]:
+    """Return all sessions in active or waiting_user state, ordered by last_activity desc."""
+    rows = await conn.fetch(
+        "SELECT * FROM sessions WHERE state IN ('active', 'waiting_user') "
+        "ORDER BY last_activity DESC"
+    )
+    return [dict(r) for r in rows]

--- a/tests/api/test_session_routes.py
+++ b/tests/api/test_session_routes.py
@@ -31,3 +31,22 @@ async def test_closed_sessions_not_returned(api_client, conn):
     data = resp.json()
     ids = [s["id"] for s in data["sessions"]]
     assert active_sid in ids
+
+
+@pytest.mark.asyncio
+async def test_get_active_sessions_uses_query_function(api_client, conn):
+    """GET /sessions must call get_active_sessions() from queries, not raw SQL in handler."""
+    from unittest.mock import patch, AsyncMock
+    # If the handler still uses raw conn.fetch, this patch has no effect and the
+    # real raw SQL runs. If the handler uses get_active_sessions(), the patch controls
+    # the result. We assert the patched function is called.
+    mock_result = [{"id": "test-session-id", "state": "active", "chat_id": "c1",
+                    "turn_count": 0, "max_turns": 10, "last_activity": None, "user_id": None}]
+    with patch(
+        "api.routes.sessions.get_active_sessions",
+        new_callable=AsyncMock,
+        return_value=mock_result,
+    ) as mock_fn:
+        resp = await api_client.get("/api/sessions")
+    assert resp.status_code == 200
+    mock_fn.assert_called_once()


### PR DESCRIPTION
## Summary

- **Extract raw SQL from sessions route**: Added `get_active_sessions(conn)` to `db/pg_queries/sessions.py` and `__init__.py`; `api/routes/sessions.py` now calls it instead of raw `conn.fetch()` inline
- **`MoveTaskBody` Pydantic schema**: `PUT /tasks/{uuid}/move` handler now accepts a typed `MoveTaskBody` instead of untyped `dict`
- **`Optional` → `str | None`**: Removed `from typing import Optional` in `meetings.py`; replaced 3 occurrences with PEP 604 union syntax
- **Extract `_validate_motif`**: Duplicate implementations in `tasks.py` and `milestones.py` consolidated into `api/routes/_common.py`

## Test plan
- [ ] `test_get_active_sessions_uses_query_function` — patches `get_active_sessions` to confirm route calls it (requires `DATABASE_URL` on Pi)
- [ ] All existing session + task + milestone route tests pass
- [ ] Import smoke test: `from api.routes.tasks import router; from api.routes.milestones import router`