### PR TITLE
feat(frontend): iCal/ICS import UI — Settings page

### DIFF
--- a/frontend/src/components/ICalSection.vue
+++ b/frontend/src/components/ICalSection.vue
@@ -1,0 +1,245 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useICalStore } from '../stores/ical'
+
+const store = useICalStore()
+
+// ── Mode tabs ────────────────────────────────────────────────────────────────
+type Mode = 'file' | 'url'
+const mode = ref<Mode>('file')
+
+function setMode(m: Mode) {
+  mode.value = m
+  selectedFile.value = null
+  feedUrl.value = ''
+  dropError.value = null
+  store.clearResult()
+}
+
+// ── Options ──────────────────────────────────────────────────────────────────
+const skipAllDay = ref(false)
+
+// ── File mode ────────────────────────────────────────────────────────────────
+const selectedFile = ref<File | null>(null)
+const isDragOver = ref(false)
+const dropError = ref<string | null>(null)
+
+const fileInput = ref<HTMLInputElement | null>(null)
+
+function onFileChange(event: Event) {
+  dropError.value = null
+  const files = (event.target as HTMLInputElement).files
+  if (files && files.length > 0) {
+    const file = files[0]
+    if (!file.name.toLowerCase().endsWith('.ics')) {
+      dropError.value = 'Please select a .ics calendar file.'
+      selectedFile.value = null
+      return
+    }
+    selectedFile.value = file
+    store.clearResult()
+  }
+}
+
+function onDragOver(event: DragEvent) {
+  event.preventDefault()
+  isDragOver.value = true
+}
+
+function onDragLeave() {
+  isDragOver.value = false
+}
+
+function onDrop(event: DragEvent) {
+  event.preventDefault()
+  isDragOver.value = false
+  dropError.value = null
+  const files = event.dataTransfer?.files
+  if (!files || files.length === 0) return
+  const file = files[0]
+  if (!file.name.toLowerCase().endsWith('.ics')) {
+    dropError.value = 'Only .ics calendar files are accepted.'
+    selectedFile.value = null
+    return
+  }
+  selectedFile.value = file
+  store.clearResult()
+}
+
+// ── URL mode ─────────────────────────────────────────────────────────────────
+const feedUrl = ref('')
+
+// ── Import action ─────────────────────────────────────────────────────────────
+const canImport = computed(() => {
+  if (store.importing) return false
+  if (mode.value === 'file') return selectedFile.value !== null
+  return feedUrl.value.trim().length > 0
+})
+
+async function runImport() {
+  if (!canImport.value) return
+  if (mode.value === 'file' && selectedFile.value) {
+    await store.importFile(selectedFile.value, skipAllDay.value)
+  } else if (mode.value === 'url') {
+    await store.importUrl(feedUrl.value.trim(), skipAllDay.value)
+  }
+}
+
+// ── Result summary ─────────────────────────────────────────────────────────
+// Auto-expand errors so they are immediately visible; user can collapse.
+const showErrors = ref(true)
+</script>
+
+<template>
+  <section class="mb-8">
+    <h2 class="text-sm font-semibold text-[--fg-3] uppercase tracking-wider mb-3">iCal / ICS Import</h2>
+    <div class="bg-[--bg-elev-1] rounded-xl p-4 space-y-4">
+
+      <!-- Mode tabs -->
+      <div class="flex gap-1 bg-[--bg-elev-2] rounded-lg p-0.5 w-fit">
+        <button
+          data-testid="ical-tab-file"
+          @click="setMode('file')"
+          :class="mode === 'file'
+            ? 'bg-[--bg-elev-1] text-[--fg-1] shadow-sm'
+            : 'text-[--fg-4] hover:text-[--fg-2]'"
+          class="text-sm font-medium rounded-md px-3 py-1 transition-colors"
+        >
+          File
+        </button>
+        <button
+          data-testid="ical-tab-url"
+          @click="setMode('url')"
+          :class="mode === 'url'
+            ? 'bg-[--bg-elev-1] text-[--fg-1] shadow-sm'
+            : 'text-[--fg-4] hover:text-[--fg-2]'"
+          class="text-sm font-medium rounded-md px-3 py-1 transition-colors"
+        >
+          URL
+        </button>
+      </div>
+
+      <!-- File mode: drag-drop zone -->
+      <template v-if="mode === 'file'">
+        <div
+          data-testid="ical-drop-zone"
+          @dragover="onDragOver"
+          @dragleave="onDragLeave"
+          @drop="onDrop"
+          @click="fileInput?.click()"
+          :class="isDragOver
+            ? 'border-[--accent] bg-[--accent-veil]'
+            : 'border-[--border-1] hover:border-[--border-2]'"
+          class="border-2 border-dashed rounded-xl p-6 flex flex-col items-center gap-2 cursor-pointer transition-colors text-center"
+        >
+          <!-- Calendar icon -->
+          <svg class="w-8 h-8 text-[--fg-4]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
+          </svg>
+          <div>
+            <p class="text-sm text-[--fg-2] font-medium">
+              {{ selectedFile ? selectedFile.name : 'Drop a .ics file here' }}
+            </p>
+            <p class="text-xs text-[--fg-4] mt-0.5">or click to browse</p>
+          </div>
+        </div>
+
+        <!-- Hidden file input -->
+        <input
+          ref="fileInput"
+          data-testid="ical-file-input"
+          type="file"
+          accept=".ics"
+          class="hidden"
+          @change="onFileChange"
+        />
+
+        <!-- Drop validation error -->
+        <p v-if="dropError" class="text-xs text-[--status-block-fg]">{{ dropError }}</p>
+      </template>
+
+      <!-- URL mode: feed input -->
+      <template v-else>
+        <div class="space-y-1">
+          <label class="text-xs text-[--fg-4]">Subscription feed URL</label>
+          <input
+            v-model="feedUrl"
+            data-testid="ical-url-input"
+            type="url"
+            placeholder="webcal://… or https://…"
+            class="w-full bg-[--bg-elev-2] text-[--fg-1] rounded-lg px-3 py-2 text-sm border border-[--border-1] focus:outline-none focus:border-[--accent] placeholder:text-[--fg-5]"
+          />
+          <p class="text-xs text-[--fg-5]">
+            One-shot import. Auto-sync will be available in a future update.
+          </p>
+        </div>
+      </template>
+
+      <!-- Skip all-day checkbox -->
+      <label class="flex items-center gap-2 cursor-pointer select-none">
+        <input
+          v-model="skipAllDay"
+          data-testid="ical-skip-all-day"
+          type="checkbox"
+          class="w-4 h-4 rounded border-[--border-1] text-[--accent] accent-[--accent]"
+        />
+        <span class="text-sm text-[--fg-2]">Skip all-day events</span>
+      </label>
+
+      <!-- Import button -->
+      <button
+        data-testid="ical-import-btn"
+        :disabled="!canImport"
+        @click="runImport"
+        class="w-full bg-[--accent] hover:opacity-90 disabled:opacity-40 text-[--accent-fg] text-sm font-medium rounded-lg px-4 py-2 transition-colors"
+      >
+        {{ store.importing ? 'Importing…' : 'Import' }}
+      </button>
+
+      <!-- Result summary -->
+      <div v-if="store.lastResult" class="rounded-lg bg-[--status-done-bg] border border-[--status-done-fg]/20 px-3 py-2.5 space-y-1.5">
+        <p class="text-sm text-[--status-done-fg] font-medium">
+          ✓ {{ store.lastResult.imported }} imported
+          · {{ store.lastResult.updated }} updated
+          · {{ store.lastResult.skipped }} skipped
+        </p>
+        <p v-if="store.lastResult.warning" class="text-xs text-[--fg-3]">
+          ⚠ {{ store.lastResult.warning }}
+        </p>
+
+        <!-- Per-event errors -->
+        <template v-if="store.lastResult.errors.length > 0">
+          <button
+            @click="showErrors = !showErrors"
+            class="text-xs text-[--fg-3] hover:text-[--fg-1] underline"
+          >
+            {{ showErrors ? 'Hide' : 'Show' }} {{ store.lastResult.errors.length }} error(s)
+          </button>
+          <ul v-if="showErrors" class="space-y-0.5 mt-1">
+            <li
+              v-for="err in store.lastResult.errors"
+              :key="err.uid"
+              class="text-xs text-[--status-block-fg]"
+            >
+              {{ err.uid }}: {{ err.error }}
+            </li>
+          </ul>
+        </template>
+      </div>
+
+      <!-- Error message -->
+      <p
+        v-if="store.lastError"
+        data-testid="ical-error"
+        class="text-sm text-[--status-block-fg]"
+      >
+        {{ store.lastError }}
+      </p>
+
+      <!-- Info text -->
+      <p v-if="!store.lastResult && !store.lastError" class="text-xs text-[--fg-4]">
+        Import calendar events from an ICS file or a subscription feed URL.
+      </p>
+    </div>
+  </section>
+</template>

--- a/frontend/src/components/__tests__/ICalSection.test.ts
+++ b/frontend/src/components/__tests__/ICalSection.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ path: '/settings' }),
+}))
+
+vi.mock('../../stores/ical', () => ({
+  useICalStore: vi.fn(),
+}))
+
+import { useICalStore } from '../../stores/ical'
+import type { ImportResult } from '../../stores/ical'
+
+function makeStore(overrides: Partial<{
+  importing: boolean
+  lastResult: ImportResult | null
+  lastError: string | null
+  importFile: () => Promise<ImportResult | null>
+  importUrl: () => Promise<ImportResult | null>
+  clearResult: () => void
+}> = {}) {
+  return {
+    importing: false,
+    lastResult: null,
+    lastError: null,
+    importFile: vi.fn().mockResolvedValue(null),
+    importUrl: vi.fn().mockResolvedValue(null),
+    clearResult: vi.fn(),
+    ...overrides,
+  }
+}
+
+async function mountSection(storeOverrides = {}) {
+  vi.mocked(useICalStore).mockReturnValue(makeStore(storeOverrides) as any)
+  const { default: ICalSection } = await import('../ICalSection.vue')
+  return mount(ICalSection, { attachTo: document.body })
+}
+
+describe('ICalSection', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  // ── rendering ──────────────────────────────────────────────────────────────
+
+  it('mounts without error and shows section heading', async () => {
+    const wrapper = await mountSection()
+    expect(wrapper.exists()).toBe(true)
+    expect(wrapper.text()).toMatch(/iCal|ICS|Calendar/i)
+  })
+
+  it('renders two mode tabs: File and URL', async () => {
+    const wrapper = await mountSection()
+    expect(wrapper.text()).toContain('File')
+    expect(wrapper.text()).toContain('URL')
+  })
+
+  it('shows the file drop zone in File mode by default', async () => {
+    const wrapper = await mountSection()
+    const dropZone = wrapper.find('[data-testid="ical-drop-zone"]')
+    expect(dropZone.exists()).toBe(true)
+  })
+
+  it('shows the URL input when URL tab is selected', async () => {
+    const wrapper = await mountSection()
+    const urlTab = wrapper.find('[data-testid="ical-tab-url"]')
+    await urlTab.trigger('click')
+
+    const urlInput = wrapper.find('[data-testid="ical-url-input"]')
+    expect(urlInput.exists()).toBe(true)
+  })
+
+  it('hides the drop zone when URL tab is selected', async () => {
+    const wrapper = await mountSection()
+    await wrapper.find('[data-testid="ical-tab-url"]').trigger('click')
+
+    const dropZone = wrapper.find('[data-testid="ical-drop-zone"]')
+    expect(dropZone.exists()).toBe(false)
+  })
+
+  // ── skip_all_day checkbox ─────────────────────────────────────────────────
+
+  it('renders the skip-all-day checkbox', async () => {
+    const wrapper = await mountSection()
+    const cb = wrapper.find('[data-testid="ical-skip-all-day"]')
+    expect(cb.exists()).toBe(true)
+  })
+
+  // ── file import ────────────────────────────────────────────────────────────
+
+  it('calls store.importFile when Import button is clicked with a file selected', async () => {
+    const importFileMock = vi.fn().mockResolvedValue(null)
+    const wrapper = await mountSection({ importFile: importFileMock })
+
+    // Simulate file selection via the hidden input
+    const fileInput = wrapper.find('[data-testid="ical-file-input"]')
+    expect(fileInput.exists()).toBe(true)
+
+    const file = new File(['BEGIN:VCALENDAR\nEND:VCALENDAR'], 'test.ics', { type: 'text/calendar' })
+    Object.defineProperty(fileInput.element, 'files', { value: [file], configurable: true })
+    await fileInput.trigger('change')
+
+    const importBtn = wrapper.find('[data-testid="ical-import-btn"]')
+    await importBtn.trigger('click')
+    await flushPromises()
+
+    expect(importFileMock).toHaveBeenCalledOnce()
+    expect(importFileMock).toHaveBeenCalledWith(file, expect.any(Boolean))
+  })
+
+  it('disables the import button when no file is selected', async () => {
+    const wrapper = await mountSection()
+    const importBtn = wrapper.find('[data-testid="ical-import-btn"]')
+    expect((importBtn.element as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('disables the import button while importing', async () => {
+    const wrapper = await mountSection({ importing: true })
+    const importBtn = wrapper.find('[data-testid="ical-import-btn"]')
+    expect((importBtn.element as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  // ── URL import ─────────────────────────────────────────────────────────────
+
+  it('calls store.importUrl when Import clicked with a URL entered', async () => {
+    const importUrlMock = vi.fn().mockResolvedValue(null)
+    const wrapper = await mountSection({ importUrl: importUrlMock })
+
+    await wrapper.find('[data-testid="ical-tab-url"]').trigger('click')
+
+    const urlInput = wrapper.find('[data-testid="ical-url-input"]')
+    await urlInput.setValue('webcal://example.com/feed.ics')
+
+    const importBtn = wrapper.find('[data-testid="ical-import-btn"]')
+    await importBtn.trigger('click')
+    await flushPromises()
+
+    expect(importUrlMock).toHaveBeenCalledOnce()
+    expect(importUrlMock).toHaveBeenCalledWith('webcal://example.com/feed.ics', expect.any(Boolean))
+  })
+
+  it('disables the import button when URL input is empty', async () => {
+    const wrapper = await mountSection()
+    await wrapper.find('[data-testid="ical-tab-url"]').trigger('click')
+
+    const importBtn = wrapper.find('[data-testid="ical-import-btn"]')
+    expect((importBtn.element as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  // ── result display ─────────────────────────────────────────────────────────
+
+  it('shows import counts when lastResult is set', async () => {
+    const result: ImportResult = { imported: 3, updated: 1, skipped: 0, errors: [], total_events: 4 }
+    const wrapper = await mountSection({ lastResult: result })
+
+    expect(wrapper.text()).toContain('3')
+    expect(wrapper.text()).toContain('imported')
+    expect(wrapper.text()).toContain('1')
+    expect(wrapper.text()).toContain('updated')
+  })
+
+  it('shows a warning message when result.warning is present', async () => {
+    const result: ImportResult = {
+      imported: 1000, updated: 0, skipped: 0, errors: [], total_events: 1500,
+      warning: 'Only first 1000 events were imported',
+    }
+    const wrapper = await mountSection({ lastResult: result })
+    expect(wrapper.text()).toContain('1000')
+  })
+
+  it('shows per-event errors when result.errors is non-empty', async () => {
+    const result: ImportResult = {
+      imported: 2, updated: 0, skipped: 0,
+      errors: [{ uid: 'abc', error: 'Parse failed' }],
+      total_events: 3,
+    }
+    const wrapper = await mountSection({ lastResult: result })
+    expect(wrapper.text()).toContain('Parse failed')
+  })
+
+  // ── error display ──────────────────────────────────────────────────────────
+
+  it('shows lastError when set', async () => {
+    const wrapper = await mountSection({ lastError: 'File is too large (max 5 MB).' })
+    expect(wrapper.text()).toContain('File is too large')
+  })
+
+  it('does not show an error section when lastError is null', async () => {
+    const wrapper = await mountSection({ lastError: null })
+    const errEl = wrapper.find('[data-testid="ical-error"]')
+    expect(errEl.exists()).toBe(false)
+  })
+
+  // ── drag and drop ──────────────────────────────────────────────────────────
+
+  it('accepts .ics files dropped on the drop zone', async () => {
+    const importFileMock = vi.fn().mockResolvedValue(null)
+    const wrapper = await mountSection({ importFile: importFileMock })
+
+    const dropZone = wrapper.find('[data-testid="ical-drop-zone"]')
+    const file = new File(['BEGIN:VCALENDAR\nEND:VCALENDAR'], 'events.ics', { type: 'text/calendar' })
+
+    // dragover should not be prevented from default but drop should select file
+    await dropZone.trigger('dragover', { dataTransfer: { files: [] } })
+    await dropZone.trigger('drop', {
+      dataTransfer: { files: [file] },
+    })
+
+    // After drop, clicking import should call importFile
+    const importBtn = wrapper.find('[data-testid="ical-import-btn"]')
+    expect((importBtn.element as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('rejects non-.ics files dropped on the drop zone', async () => {
+    const wrapper = await mountSection()
+
+    const dropZone = wrapper.find('[data-testid="ical-drop-zone"]')
+    const file = new File(['not ics'], 'document.pdf', { type: 'application/pdf' })
+
+    await dropZone.trigger('drop', {
+      dataTransfer: { files: [file] },
+    })
+
+    // Button should remain disabled (no valid file selected)
+    const importBtn = wrapper.find('[data-testid="ical-import-btn"]')
+    expect((importBtn.element as HTMLButtonElement).disabled).toBe(true)
+    // Error or warning shown
+    expect(wrapper.text()).toMatch(/\.ics|ICS|calendar/i)
+  })
+})

--- a/frontend/src/stores/__tests__/ical.test.ts
+++ b/frontend/src/stores/__tests__/ical.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: false, json: async () => ({}) })),
+}))
+
+describe('useICalStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  // ── initial state ──────────────────────────────────────────────────────────
+
+  describe('initial state', () => {
+    it('starts with importing=false, lastResult=null, lastError=null', async () => {
+      const { useICalStore } = await import('../ical')
+      const store = useICalStore()
+      expect(store.importing).toBe(false)
+      expect(store.lastResult).toBeNull()
+      expect(store.lastError).toBeNull()
+    })
+  })
+
+  // ── importFile ─────────────────────────────────────────────────────────────
+
+  describe('importFile', () => {
+    it('sends a multipart POST to /api/ical/import', async () => {
+      const { api } = await import('../../lib/api')
+      const mockApi = vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ imported: 3, updated: 1, skipped: 0, errors: [], total_events: 4 }),
+      } as any)
+
+      const { useICalStore } = await import('../ical')
+      const store = useICalStore()
+      const file = new File(['BEGIN:VCALENDAR\nEND:VCALENDAR'], 'test.ics', { type: 'text/calendar' })
+      await store.importFile(file, false)
+
+      expect(mockApi).toHaveBeenCalledOnce()
+      const [url, init] = mockApi.mock.calls[0]
+      expect(url).toBe('/api/ical/import')
+      expect((init as RequestInit).method).toBe('POST')
+      expect((init as RequestInit).body).toBeInstanceOf(FormData)
+    })
+
+    it('appends skip_all_day=true to query string when requested', async () => {
+      const { api } = await import('../../lib/api')
+      const mockApi = vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ imported: 0, updated: 0, skipped: 0, errors: [], total_events: 0 }),
+      } as any)
+
+      const { useICalStore } = await import('../ical')
+      const store = useICalStore()
+      const file = new File(['BEGIN:VCALENDAR'], 'test.ics', { type: 'text/calendar' })
+      await store.importFile(file, true)
+
+      const [url] = mockApi.mock.calls[0]
+      expect(String(url)).toContain('skip_all_day=true')
+    })
+
+    it('sets lastResult on success', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ imported: 3, updated: 1, skipped: 0, errors: [], total_events: 4 }),
+      } as any)
+
+      const { useICalStore } = await import('../ical')
+      const store = useICalStore()
+      const file = new File(['BEGIN:VCALENDAR'], 'test.ics', { type: 'text/calendar' })
+      const result = await store.importFile(file, false)
+
+      expect(result?.imported).toBe(3)
+      expect(result?.updated).toBe(1)
+      expect(store.lastResult?.imported).toBe(3)
+      expect(store.lastError).toBeNull()
+    })
+
+    it('sets lastError for 413 (file too large)', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: false,
+        status: 413,
+        json: async () => ({ detail: 'File too large' }),
+      } as any)
+
+      const { useICalStore } = await import('../ical')
+      const store = useICalStore()
+      const file = new File(['x'], 'big.ics', { type: 'text/calendar' })
+      const result = await store.importFile(file, false)
+
+      expect(result).toBeNull()
+      expect(store.lastError).toContain('too large')
+    })
+
+    it('sets lastError for 422 (invalid ICS)', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        json: async () => ({ detail: 'Not a valid ICS file' }),
+      } as any)
+
+      const { useICalStore } = await import('../ical')
+      const store = useICalStore()
+      const file = new File(['not ics'], 'bad.ics', { type: 'text/calendar' })
+      const result = await store.importFile(file, false)
+
+      expect(result).toBeNull()
+      expect(store.lastError).toMatch(/invalid|not a valid/i)
+    })
+
+    it('sets lastError for 502 (remote fetch failed)', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        json: async () => ({ detail: 'Failed to fetch remote URL' }),
+      } as any)
+
+      const { useICalStore } = await import('../ical')
+      const store = useICalStore()
+      const file = new File(['x'], 'x.ics', { type: 'text/calendar' })
+      const result = await store.importFile(file, false)
+
+      expect(result).toBeNull()
+      expect(store.lastError).toMatch(/fetch|server/i)
+    })
+
+    it('sets lastError on network error', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockRejectedValueOnce(new Error('Network error'))
+
+      const { useICalStore } = await import('../ical')
+      const store = useICalStore()
+      const file = new File(['x'], 'x.ics', { type: 'text/calendar' })
+      const result = await store.importFile(file, false)
+
+      expect(result).toBeNull()
+      expect(store.lastError).toBeTruthy()
+    })
+
+    it('clears lastError when starting a new import', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ imported: 0, updated: 0, skipped: 0, errors: [], total_events: 0 }),
+      } as any)
+
+      const { useICalStore } = await import('../ical')
+      const store = useICalStore()
+      store.lastError = 'old error'
+      const file = new File(['x'], 'x.ics', { type: 'text/calendar' })
+      await store.importFile(file, false)
+
+      expect(store.lastError).toBeNull()
+    })
+
+    it('sets importing=false after completion', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ imported: 0, updated: 0, skipped: 0, errors: [], total_events: 0 }),
+      } as any)
+
+      const { useICalStore } = await import('../ical')
+      const store = useICalStore()
+      const file = new File(['x'], 'x.ics', { type: 'text/calendar' })
+      await store.importFile(file, false)
+
+      expect(store.importing).toBe(false)
+    })
+  })
+
+  // ── importUrl ──────────────────────────────────────────────────────────────
+
+  describe('importUrl', () => {
+    it('sends a JSON POST to /api/ical/import with the url', async () => {
+      const { api } = await import('../../lib/api')
+      const mockApi = vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ imported: 2, updated: 0, skipped: 0, errors: [], total_events: 2 }),
+      } as any)
+
+      const { useICalStore } = await import('../ical')
+      const store = useICalStore()
+      await store.importUrl('webcal://example.com/feed.ics', false)
+
+      expect(mockApi).toHaveBeenCalledOnce()
+      const [url, init] = mockApi.mock.calls[0]
+      expect(String(url)).toBe('/api/ical/import')
+      expect((init as RequestInit).method).toBe('POST')
+      const body = JSON.parse((init as RequestInit).body as string)
+      expect(body.url).toBe('webcal://example.com/feed.ics')
+    })
+
+    it('appends skip_all_day=true to query string when requested', async () => {
+      const { api } = await import('../../lib/api')
+      const mockApi = vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ imported: 0, updated: 0, skipped: 0, errors: [], total_events: 0 }),
+      } as any)
+
+      const { useICalStore } = await import('../ical')
+      const store = useICalStore()
+      await store.importUrl('https://example.com/feed.ics', true)
+
+      const [url] = mockApi.mock.calls[0]
+      expect(String(url)).toContain('skip_all_day=true')
+    })
+
+    it('sets lastResult on success', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ imported: 2, updated: 0, skipped: 1, errors: [], total_events: 3 }),
+      } as any)
+
+      const { useICalStore } = await import('../ical')
+      const store = useICalStore()
+      const result = await store.importUrl('https://example.com/feed.ics', false)
+
+      expect(result?.imported).toBe(2)
+      expect(result?.skipped).toBe(1)
+      expect(store.lastResult?.imported).toBe(2)
+      expect(store.lastError).toBeNull()
+    })
+
+    it('sets lastError for 422 (private address blocked)', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        json: async () => ({ detail: 'URL targets a private address' }),
+      } as any)
+
+      const { useICalStore } = await import('../ical')
+      const store = useICalStore()
+      const result = await store.importUrl('http://192.168.1.1/feed.ics', false)
+
+      expect(result).toBeNull()
+      expect(store.lastError).toBeTruthy()
+    })
+
+    it('sets lastError for 502 (remote fetch failed)', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        json: async () => ({ detail: 'Upstream timeout' }),
+      } as any)
+
+      const { useICalStore } = await import('../ical')
+      const store = useICalStore()
+      const result = await store.importUrl('https://example.com/feed.ics', false)
+
+      expect(result).toBeNull()
+      expect(store.lastError).toMatch(/fetch|server|remote/i)
+    })
+
+    it('sets importing=false after completion', async () => {
+      const { api } = await import('../../lib/api')
+      vi.mocked(api).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ imported: 0, updated: 0, skipped: 0, errors: [], total_events: 0 }),
+      } as any)
+
+      const { useICalStore } = await import('../ical')
+      const store = useICalStore()
+      await store.importUrl('https://example.com/feed.ics', false)
+
+      expect(store.importing).toBe(false)
+    })
+  })
+
+  // ── clearResult ────────────────────────────────────────────────────────────
+
+  describe('clearResult', () => {
+    it('resets lastResult and lastError to null', async () => {
+      const { useICalStore } = await import('../ical')
+      const store = useICalStore()
+      store.lastError = 'some error'
+      store.lastResult = { imported: 1, updated: 0, skipped: 0, errors: [], total_events: 1 }
+      store.clearResult()
+      expect(store.lastResult).toBeNull()
+      expect(store.lastError).toBeNull()
+    })
+  })
+})

--- a/frontend/src/stores/ical.ts
+++ b/frontend/src/stores/ical.ts
@@ -1,0 +1,102 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { api } from '../lib/api'
+
+export interface ImportResult {
+  imported: number
+  updated: number
+  skipped: number
+  errors: { uid: string; error: string }[]
+  total_events: number
+  warning?: string
+}
+
+function errorMessageForStatus(status: number, detail?: string): string {
+  if (status === 413) return 'File is too large (max 5 MB).'
+  if (status === 422) return detail ?? 'Invalid ICS file or URL.'
+  if (status === 502) return 'Could not fetch the remote calendar — server or URL may be unavailable.'
+  return detail ?? 'Import failed. Please try again.'
+}
+
+export const useICalStore = defineStore('ical', () => {
+  const importing = ref(false)
+  const lastResult = ref<ImportResult | null>(null)
+  const lastError = ref<string | null>(null)
+
+  /**
+   * Import events from a local .ics file.
+   * POST /api/ical/import (multipart/form-data)
+   */
+  async function importFile(file: File, skipAllDay: boolean): Promise<ImportResult | null> {
+    importing.value = true
+    lastError.value = null
+
+    try {
+      const body = new FormData()
+      body.append('file', file)
+
+      const url = skipAllDay ? '/api/ical/import?skip_all_day=true' : '/api/ical/import'
+      const resp = await api(url, { method: 'POST', body })
+
+      if (!resp.ok) {
+        const data = await resp.json().catch(() => ({})) as { detail?: string }
+        lastError.value = errorMessageForStatus(resp.status, data.detail)
+        lastResult.value = null
+        return null
+      }
+
+      const result: ImportResult = await resp.json()
+      lastResult.value = result
+      return result
+    } catch {
+      lastError.value = 'Network error. Check your connection and try again.'
+      lastResult.value = null
+      return null
+    } finally {
+      importing.value = false
+    }
+  }
+
+  /**
+   * Import events from a subscription URL (webcal:// or https://).
+   * POST /api/ical/import (application/json)
+   */
+  async function importUrl(feedUrl: string, skipAllDay: boolean): Promise<ImportResult | null> {
+    importing.value = true
+    lastError.value = null
+
+    try {
+      const url = skipAllDay ? '/api/ical/import?skip_all_day=true' : '/api/ical/import'
+      const resp = await api(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: feedUrl }),
+      })
+
+      if (!resp.ok) {
+        const data = await resp.json().catch(() => ({})) as { detail?: string }
+        lastError.value = errorMessageForStatus(resp.status, data.detail)
+        lastResult.value = null
+        return null
+      }
+
+      const result: ImportResult = await resp.json()
+      lastResult.value = result
+      return result
+    } catch {
+      lastError.value = 'Network error. Check your connection and try again.'
+      lastResult.value = null
+      return null
+    } finally {
+      importing.value = false
+    }
+  }
+
+  /** Reset result and error state (e.g. when the user switches modes or dismisses). */
+  function clearResult() {
+    lastResult.value = null
+    lastError.value = null
+  }
+
+  return { importing, lastResult, lastError, importFile, importUrl, clearResult }
+})

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -7,6 +7,7 @@ import GoogleCalendarSection from '../components/GoogleCalendarSection.vue'
 import AnthropicAccountSection from '../components/AnthropicAccountSection.vue'
 import ConnectionsSection from '../components/ConnectionsSection.vue'
 import ApiKeysSection from '../components/ApiKeysSection.vue'
+import ICalSection from '../components/ICalSection.vue'
 
 const auth = useAuthStore()
 
@@ -356,6 +357,9 @@ async function linkTelegram() {
 
       <!-- Google Calendar Integration -->
       <GoogleCalendarSection />
+
+      <!-- iCal / ICS Import -->
+      <ICalSection />
 
       <!-- Anthropic Account Integration -->
       <AnthropicAccountSection />

--- a/frontend/src/views/__tests__/SettingsView.test.ts
+++ b/frontend/src/views/__tests__/SettingsView.test.ts
@@ -40,6 +40,9 @@ vi.mock('../../components/AnthropicAccountSection.vue', () => ({
 vi.mock('../../components/ConnectionsSection.vue', () => ({
   default: { template: '<div />' },
 }))
+vi.mock('../../components/ICalSection.vue', () => ({
+  default: { template: '<div data-testid="ical-section-stub" />' },
+}))
 
 describe('SettingsView - Appearance theme picker', () => {
   beforeEach(() => {
@@ -125,5 +128,22 @@ describe('SettingsView - Appearance theme picker', () => {
 
     await wrapper.find('button[title="Solstice"]').trigger('mouseenter')
     expect(document.documentElement.dataset.theme).toBe('solstice')
+  })
+})
+
+describe('SettingsView - ICalSection integration', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('renders ICalSection in the settings page', async () => {
+    const { default: SettingsView } = await import('../SettingsView.vue')
+    const wrapper = mount(SettingsView, {
+      global: { stubs: { 'router-link': { template: '<a><slot /></a>' } } },
+    })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="ical-section-stub"]').exists()).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- New `ICalSection.vue` component in Settings, alongside Google Calendar section
- Two import modes via tabs: **File** (drag-drop or file picker for `.ics`) and **URL** (webcal:// or https:// subscription feed)
- Skip all-day events checkbox
- Result summary: imported · updated · skipped counts, optional warning, expandable per-event errors
- New `useICalStore` Pinia store — `importFile`, `importUrl`, `clearResult`; per-status error messages (413 file too large, 422 invalid ICS/URL, 502 remote fetch failed)
- `SettingsView.vue` updated to include `<ICalSection />`
- `npm run build` passes with zero type errors

## Backend

Depends on PRs #287 and #292 (`feature/ical-import`) — both merged.

## Tests

- 17 store unit tests (all passing)
- 18 component tests covering file/URL modes, drag-drop accept/reject, result display, error display (all passing)
- 1 SettingsView integration test confirming ICalSection mounts (passing)
- Full suite: 567/568 tests pass; 1 pre-existing flaky CalendarView timeout unrelated to this branch