### PR TITLE
refactor: migrate components off direct api() calls (Phase D)

### DIFF
--- a/frontend/src/components/AnchorBlock.vue
+++ b/frontend/src/components/AnchorBlock.vue
@@ -8,6 +8,7 @@ import type { Task } from '../stores/plan'
 import { useMilestoneStore } from '../stores/milestones'
 import type { Milestone } from '../stores/milestones'
 import { api } from '../lib/api'
+import { useTasksStore } from '../stores/tasks'
 import { useDropZone } from '../composables/useDropZone'
 import { useSlideOver } from '../composables/useSlideOver'
 import { useEventStore } from '../stores/events'
@@ -27,6 +28,7 @@ const props = defineProps<{
 }>()
 
 const store = usePlanStore()
+const tasksStore = useTasksStore()
 const eventStore = useEventStore()
 const tasksRef = ref<HTMLElement | null>(null)
 const effectiveDate = computed(() => props.date ?? store.activeDate)
@@ -111,26 +113,16 @@ function onUpdate(task: Task, index: number) {
 async function onRemove(index: number) {
   const task = anchorPlan.value.tasks[index]
   if (task?.id) {
-    await fetch(`/api/tasks/${task.id}`, { method: 'DELETE', credentials: 'include' })
+    await tasksStore.deleteTask(task.id)
   }
   const updated = anchorPlan.value.tasks.filter((_, i) => i !== index)
   store.updateAnchorTasks(props.anchorId, updated, anchorPlan.value.notes ?? '')
 }
 
 async function onAddNewTask(opts: { context_subject?: string; milestone_id?: string } = {}) {
-  const body: Record<string, unknown> = {
-    text: 'New task',
-    date: effectiveDate.value,
-    anchor_id: props.anchorId,
-    ...opts,
-  }
   try {
-    const resp = await api('/api/tasks/unscheduled', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    })
-    if (!resp.ok) throw new Error(`${resp.status}`)
+    const task = await store.createPlanTask(effectiveDate.value, props.anchorId, opts)
+    if (!task) throw new Error('createPlanTask failed')
     await store.fetchPlan(effectiveDate.value)
   } catch (e) {
     console.error('Failed to create task:', e)

--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -173,22 +173,14 @@ function patchFollowup(fields: Partial<FollowupConfig>) {
 // Schedule / Unschedule
 async function scheduleTask() {
   if (!scheduleDate.value || !scheduleAnchor.value) return
-  await api(`/api/tasks/${props.taskId}/move`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ date: scheduleDate.value, anchor_id: scheduleAnchor.value }),
-  })
+  await planStore.scheduleTask(props.taskId, scheduleDate.value, scheduleAnchor.value)
   await planStore.fetchPlan(scheduleDate.value)
   await backlogStore.fetchTasks()
   // Panel stays open — the task has moved, stores refreshed above
 }
 
 async function moveToBacklog() {
-  await api(`/api/tasks/${props.taskId}/move`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ date: null, anchor_id: null }),
-  })
+  await planStore.moveToBacklog(props.taskId)
   await planStore.fetchPlan()
   await backlogStore.fetchTasks()
 }
@@ -210,7 +202,7 @@ async function onRescheduleDate(e: Event) {
 // Delete
 async function deleteTask() {
   if (!confirm('Delete this task?')) return
-  await api(`/api/tasks/${props.taskId}`, { method: 'DELETE' })
+  await tasksStore.deleteTask(props.taskId)
   // Remove any associated calendar event from local state immediately so the
   // grid updates without waiting for a re-fetch.
   eventStore.removeEventsForTask(props.taskId)
@@ -248,11 +240,7 @@ async function addDependencyFromSearch(item: SearchResult) {
 }
 
 async function linkMilestoneFromSearch(item: SearchResult) {
-  await api(`/api/milestones/${item.id}/tasks`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ task_id: props.taskId }),
-  })
+  await milestoneStore.linkTask(item.id, props.taskId)
   await milestoneStore.fetchAll()
 }
 

--- a/frontend/src/stores/backlog.ts
+++ b/frontend/src/stores/backlog.ts
@@ -21,11 +21,14 @@ export const useBacklogStore = defineStore('backlog', () => {
     }
   }
 
-  async function createTask(text: string, description?: string) {
+  async function createTask(
+    text: string,
+    opts: { description?: string; status?: string; date?: string; context_subject?: string; milestone_id?: string } = {},
+  ): Promise<Task> {
     const resp = await api('/api/tasks/unscheduled', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text, description }),
+      body: JSON.stringify({ text, ...opts }),
     })
     if (!resp.ok) throw new Error(`${resp.status}`)
     const task = await resp.json()

--- a/frontend/src/stores/events.ts
+++ b/frontend/src/stores/events.ts
@@ -243,5 +243,22 @@ export const useEventStore = defineStore('events', () => {
     } catch { /* ignore — optimistic update stays */ }
   }
 
-  return { events, loading, error, fetchEvents, promoteTask, createTaskAndPromote, moveEvent, demoteEvent, deleteEvent, removeEventsForTask, setRecurrence, updateEventColor }
+  /**
+   * PATCH an event with scope support (single / this_and_future / all).
+   * Used by CalendarView.onRecurrenceScopeConfirm (event-edit branch).
+   */
+  async function patchEvent(
+    eventId: string,
+    patch: Record<string, unknown>,
+    scope: RecurrenceEditScope,
+    originalStartTime?: string,
+  ): Promise<void> {
+    await api(`/api/events/${eventId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...patch, scope, original_start_time: originalStartTime }),
+    })
+  }
+
+  return { events, loading, error, fetchEvents, promoteTask, createTaskAndPromote, moveEvent, demoteEvent, deleteEvent, removeEventsForTask, setRecurrence, updateEventColor, patchEvent }
 })

--- a/frontend/src/stores/plan.ts
+++ b/frontend/src/stores/plan.ts
@@ -245,10 +245,54 @@ export const usePlanStore = defineStore('plan', () => {
     return resp.ok
   }
 
+  /**
+   * Move a backlog task onto a specific date+anchor (schedule it).
+   * Calls PUT /api/tasks/:id/move.
+   */
+  async function scheduleTask(taskId: string, date: string, anchorId: string): Promise<void> {
+    await api(`/api/tasks/${taskId}/move`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ date, anchor_id: anchorId }),
+    })
+  }
+
+  /**
+   * Unschedule a plan task — move it back to the backlog (date: null, anchor_id: null).
+   */
+  async function moveToBacklog(taskId: string): Promise<void> {
+    await api(`/api/tasks/${taskId}/move`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ date: null, anchor_id: null }),
+    })
+  }
+
+  /**
+   * Create a new task directly on a specific date+anchor.
+   * Used by AnchorBlock.onAddNewTask and DashboardView.onAddTaskToNow.
+   */
+  async function createPlanTask(
+    date: string,
+    anchorId: string,
+    opts: { text?: string; context_subject?: string; milestone_id?: string } = {},
+  ): Promise<Task | null> {
+    const resp = await api('/api/tasks/unscheduled', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: opts.text ?? 'New task', date, anchor_id: anchorId, ...opts }),
+    })
+    if (!resp.ok) return null
+    return resp.json()
+  }
+
+  // Deprecated: superceeded by auth store manage ws transport in /api/bot/chat
+
   return {
     plan, loading, today, activeDate, plans,
     fetchPlan,
     fetchPlanRange, moveTask, moveTaskToAnchor, reorderTask,
     updateAnchorTasks, updateTaskStatus, patchTaskFields,
+    scheduleTask, moveToBacklog, createPlanTask,
   }
 })

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -76,14 +76,12 @@ async function onRecurrenceScopeConfirm(scope: RecurrenceEditScope) {
   if (pending.kind === 'event-move') {
     await eventStore.moveEvent(pending.eventId, pending.startTime, pending.endTime, scope, pending.originalStartTime)
   } else if (pending.kind === 'event-edit') {
-    // Apply patch with scope — PATCH /api/events/:id
-    try {
-      await fetch(`/api/events/${pending.eventId}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...pending.patch, scope, original_start_time: pending.patch.original_start_time }),
-      })
-    } catch { /* ignore */ }
+    await eventStore.patchEvent(
+      pending.eventId,
+      pending.patch,
+      scope,
+      pending.patch.original_start_time as string | undefined,
+    )
   } else if (pending.kind === 'event-delete') {
     await eventStore.deleteEvent(pending.eventId, scope, pending.originalStartTime)
   } else if (pending.kind === 'task-edit' || pending.kind === 'task-move' || pending.kind === 'task-delete') {

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -60,12 +60,8 @@ async function onAddTaskToNow() {
   if (!currentAnchor.value) return
   const today = localToday()
   try {
-    const resp = await api('/api/tasks/unscheduled', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text: 'New task', date: today, anchor_id: currentAnchor.value.id }),
-    })
-    if (!resp.ok) throw new Error(`${resp.status}`)
+    const task = await planStore.createPlanTask(today, currentAnchor.value.id)
+    if (!task) throw new Error('createPlanTask failed')
     await planStore.fetchPlan(today)
   } catch (e) {
     console.error('Failed to create task:', e)

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -3,12 +3,13 @@ import { onMounted, computed } from 'vue'
 import KanbanColumn from '../components/KanbanColumn.vue'
 import { useKanbanStore, type KanbanTask } from '../stores/kanban'
 import { useMilestoneStore } from '../stores/milestones'
-import { api } from '../lib/api'
+import { useBacklogStore } from '../stores/backlog'
 import { useSlideOver } from '../composables/useSlideOver'
 
 const { push: pushPanel } = useSlideOver()
 const kanbanStore = useKanbanStore()
 const milestoneStore = useMilestoneStore()
+const backlogStore = useBacklogStore()
 
 onMounted(() => {
   kanbanStore.fetchColumns()
@@ -19,20 +20,12 @@ onMounted(() => {
 async function onAddTask(columnId: string, opts: { context_subject?: string; milestone_id?: string }) {
   const col = kanbanStore.columns.find(c => c.id === columnId)
   if (!col) return
-  const body: Record<string, unknown> = { text: 'New task', ...opts }
+  const taskOpts: Record<string, unknown> = { ...opts }
   const rules = col.entry_rules ?? {}
-  if (typeof rules['set_status'] === 'string') body.status = rules['set_status']
-  if (rules['prompt_schedule']) {
-    body.date = new Date().toISOString().slice(0, 10)
-  }
+  if (typeof rules['set_status'] === 'string') taskOpts.status = rules['set_status']
+  if (rules['prompt_schedule']) taskOpts.date = new Date().toISOString().slice(0, 10)
   try {
-    const resp = await api('/api/tasks/unscheduled', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    })
-    if (!resp.ok) throw new Error(`${resp.status}`)
-    const task = await resp.json()
+    const task = await backlogStore.createTask('New task', taskOpts)
     await kanbanStore.fetchAllTasks()
     pushPanel({ kind: 'task', entityId: task.id })
   } catch (e) {


### PR DESCRIPTION
## Summary
- Add `scheduleTask`, `moveToBacklog`, `createPlanTask` actions to plan store
- Add `patchEvent` action to events store; extend backlog `createTask` signature
- Migrate TaskDetailPanel, AnchorBlock, DashboardView, KanbanView, CalendarView to use store actions instead of calling `api()` directly

## Test plan
- [ ] All 552 tests pass
- [ ] Zero type errors (`npm run build`)
- [ ] TaskDetailPanel schedule/delete/move-to-backlog flows still work
- [ ] AnchorBlock add-task and remove-task flows still work