### PR TITLE
chore: remove stale comments (Phase E)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -17,7 +17,7 @@ function toggleMode() {
 }
 
 // Load premium theme CSS once the user is known to be authenticated.
-// isPaid is always false today; this fires when backend adds the field.
+// Loads premium CSS if the user is a paid subscriber (is_paid field on User).
 watch(
   () => authStore.user,
   (user) => {

--- a/frontend/src/components/AnchorBlock.vue
+++ b/frontend/src/components/AnchorBlock.vue
@@ -80,10 +80,8 @@ function contextTaskCount(ctx: { milestoneGroups: { tasks: TaskWithIndex[] }[]; 
 }
 
 // Local cache of motif selections per context subject.
-// TODO(motif-db-api): backend read path not yet wired. When the parallel
-// `feature/motif-db-api` stream ships a `motif` field on context-entry responses,
-// seed this map from there (e.g. via a context store) so picks survive remount.
-// Until then, selections are lost on reload — acceptable per spec.
+// Motif selections are not yet persisted to the context store — picks are lost on reload.
+// When the context store exposes a motif field, seed this map on mount.
 const contextMotifs = ref<Record<string, MotifSlot>>({})
 
 async function setContextMotif(subject: string | null, slot: MotifSlot) {

--- a/frontend/src/stores/events.ts
+++ b/frontend/src/stores/events.ts
@@ -29,7 +29,7 @@ export const useEventStore = defineStore('events', () => {
 
   /**
    * Promote a task to a calendar event (sets start/end time).
-   * POST /api/events — not yet implemented; returns a local optimistic event.
+   * POST /api/events — creates a calendar event with the given time range.
    */
   async function promoteTask(taskId: string, startTime: string, endTime: string, title: string): Promise<CalendarEvent | null> {
     try {

--- a/frontend/src/types/events.ts
+++ b/frontend/src/types/events.ts
@@ -1,7 +1,5 @@
-// Event entity — mirrors the planned DB schema.
-// Backend endpoints (GET/POST/PATCH /api/events) are not yet implemented;
-// the store uses fixture data until the backend ships.
-// Assumed API contract:
+// Event entity — mirrors the backend CalendarEvent schema.
+// API contract:
 //   GET  /api/events?start=ISO&end=ISO  → CalendarEvent[]
 //   POST /api/events                    → CalendarEvent  (promote task to event)
 //   PATCH /api/events/:id               → CalendarEvent


### PR DESCRIPTION
## Summary
- Remove outdated "not yet implemented" and "fixture data" comments from types/events.ts
- Update stale JSDoc in events store and motif comment in AnchorBlock
- Update stale watch comment in App.vue

## Test plan
- [ ] Zero type errors (`npm run build`)
- [ ] All tests pass (comment-only changes, no logic affected)