### PR TITLE
feat(ci): dev deployment pipeline (port 8001, tether-dev stack)

### DIFF
--- a/.github/workflows/pi-build-dev.yml
+++ b/.github/workflows/pi-build-dev.yml
@@ -1,0 +1,257 @@
+name: "[Pi] Build dev image"
+
+# Builds the tether-premium-dev image on push to dev, then dispatches
+# per-service restart workflows for each affected service.
+#
+# Separate from pi-build.yml (pi-build-dev concurrency group) so dev
+# and production builds never compete for the pending slot.
+
+on:
+  push:
+    branches: [dev]
+    paths-ignore:
+      - 'docs/**'
+      - 'tests/**'
+      - '**/*.md'
+  workflow_dispatch:
+    inputs:
+      services:
+        description: "Comma-separated services to restart (api,bot,mcp)"
+        required: false
+        default: "bot"
+      no_cache:
+        description: "Force --no-cache build"
+        required: false
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: pi-build-dev
+  cancel-in-progress: false
+
+jobs:
+  detect:
+    name: Detect changed services
+    runs-on: ubuntu-latest
+    outputs:
+      api: ${{ steps.resolve.outputs.api }}
+      bot: ${{ steps.resolve.outputs.bot }}
+      mcp: ${{ steps.resolve.outputs.mcp }}
+      any: ${{ steps.resolve.outputs.any }}
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'push'
+        with:
+          fetch-depth: 2
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'push'
+        with:
+          filters: |
+            api:
+              - 'api/**'
+              - 'db/**'
+              - 'frontend/**'
+              - 'config/**'
+              - 'Dockerfile'
+              - 'requirements.txt'
+              - 'pyproject.toml'
+            bot:
+              - 'bot/**'
+              - 'config/**'
+              - 'prompts/**'
+              - 'Dockerfile'
+              - 'requirements.txt'
+              - 'pyproject.toml'
+            mcp:
+              - 'tether_mcp/**'
+              - 'config/**'
+              - 'Dockerfile'
+              - 'requirements.txt'
+              - 'pyproject.toml'
+
+      - name: Resolve services
+        id: resolve
+        env:
+          EVENT: ${{ github.event_name }}
+          SERVICES_INPUT: ${{ inputs.services }}
+          FILTER_API: ${{ steps.filter.outputs.api }}
+          FILTER_BOT: ${{ steps.filter.outputs.bot }}
+          FILTER_MCP: ${{ steps.filter.outputs.mcp }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            contains() { echo ",$SERVICES_INPUT," | grep -q ",$1,"; }
+            API=$(contains api && echo true || echo false)
+            BOT=$(contains bot && echo true || echo false)
+            MCP=$(contains mcp && echo true || echo false)
+          else
+            API="${FILTER_API:-false}"
+            BOT="${FILTER_BOT:-false}"
+            MCP="${FILTER_MCP:-false}"
+          fi
+          echo "api=$API" >> $GITHUB_OUTPUT
+          echo "bot=$BOT" >> $GITHUB_OUTPUT
+          echo "mcp=$MCP" >> $GITHUB_OUTPUT
+          if [ "$API" = "true" ] || [ "$BOT" = "true" ] || [ "$MCP" = "true" ]; then
+            echo "any=true" >> $GITHUB_OUTPUT
+          else
+            echo "any=false" >> $GITHUB_OUTPUT
+          fi
+
+  build:
+    name: Build tether-premium-dev image
+    needs: detect
+    if: needs.detect.outputs.any == 'true'
+    runs-on: self-hosted
+    env:
+      DEV_DIR: /home/toast/tether-dev
+      TETHER_CONFIG_DIR: /home/toast/.tether-config-dev
+      TETHER_DATA_DIR: /home/toast/.tether-config-dev
+    steps:
+      - name: Ensure dev repo is present
+        run: |
+          if [ ! -d "$DEV_DIR" ]; then
+            git clone git@github.com:jlunder00/tether.git \
+              "$DEV_DIR" --branch dev --single-branch
+          else
+            cd "$DEV_DIR"
+            git fetch origin dev
+            git checkout dev
+            git pull origin dev
+          fi
+
+      - name: Resolve version tag
+        id: version
+        env:
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          echo "tag=sha-$(echo "$GIT_SHA" | cut -c1-7)-dev" >> $GITHUB_OUTPUT
+
+      - name: Resolve premium ref
+        id: premium
+        env:
+          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
+        run: |
+          # Try dev branch first, fall back to HEAD
+          REF=$(git ls-remote \
+            "https://${TETHER_PREMIUM_TOKEN}@github.com/jlunder00/tether-premium.git" \
+            refs/heads/dev 2>/dev/null | cut -f1 | cut -c1-7)
+          if [ -z "$REF" ]; then
+            REF=$(git ls-remote \
+              "https://${TETHER_PREMIUM_TOKEN}@github.com/jlunder00/tether-premium.git" \
+              HEAD | cut -f1 | cut -c1-7)
+          fi
+          if [ -z "$REF" ]; then
+            echo "ERROR: Failed to resolve tether-premium ref" >&2
+            exit 1
+          fi
+          echo "ref=${REF}" >> $GITHUB_OUTPUT
+
+      - name: Build dev image
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          PREMIUM_REF: ${{ steps.premium.outputs.ref }}
+          NO_CACHE: ${{ inputs.no_cache || 'false' }}
+          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
+        run: |
+          cd "$DEV_DIR"
+          BUILD_TARGET=$( [ "$NO_CACHE" = "true" ] && echo build-premium-no-cache || echo build-premium )
+          make ${BUILD_TARGET} \
+            IMAGE=tether-premium-dev \
+            TAG=${TAG} \
+            PREMIUM_GIT_TOKEN=${TETHER_PREMIUM_TOKEN} \
+            PREMIUM_REF=${PREMIUM_REF}
+          docker tag tether-premium-dev:${TAG} tether-premium-dev:latest
+          grep -q "^IMAGE_TAG=" "$DEV_DIR/.env" 2>/dev/null \
+            && sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${TAG}/" "$DEV_DIR/.env" \
+            || echo "IMAGE_TAG=${TAG}" >> "$DEV_DIR/.env"
+
+      - name: Write dev config
+        env:
+          TETHER_JWT_SECRET: ${{ secrets.TETHER_JWT_SECRET }}
+          TETHER_COOKIE_SECURE: ${{ secrets.TETHER_COOKIE_SECURE }}
+          TETHER_ALLOWED_ORIGINS: ${{ secrets.TETHER_ALLOWED_ORIGINS_DEV }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          GOOGLE_CALLBACK_URL: ${{ secrets.GOOGLE_CALLBACK_URL_DEV }}
+          GOOGLE_INTEGRATION_CALLBACK_URL: ${{ secrets.GOOGLE_INTEGRATION_CALLBACK_URL_DEV }}
+          GH_CLIENT_ID: ${{ secrets.GH_CLIENT_ID }}
+          GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
+          GH_CALLBACK_URL: ${{ secrets.GH_CALLBACK_URL_DEV }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN_DEV }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID_DEV }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          TETHER_APP_PASSWORD: ${{ secrets.TETHER_APP_PASSWORD }}
+          TETHER_VAULT_KEY: ${{ secrets.TETHER_VAULT_KEY_DEV }}
+        run: |
+          cd "$DEV_DIR"
+          make configure-auth \
+            TETHER_JWT_SECRET="$TETHER_JWT_SECRET" \
+            TETHER_COOKIE_SECURE="$TETHER_COOKIE_SECURE" \
+            TETHER_ALLOWED_ORIGINS="$TETHER_ALLOWED_ORIGINS"
+          make configure-google \
+            GOOGLE_CLIENT_ID="$GOOGLE_CLIENT_ID" \
+            GOOGLE_CLIENT_SECRET="$GOOGLE_CLIENT_SECRET" \
+            GOOGLE_CALLBACK_URL="$GOOGLE_CALLBACK_URL" \
+            GOOGLE_INTEGRATION_CALLBACK_URL="$GOOGLE_INTEGRATION_CALLBACK_URL"
+          make configure-github \
+            GITHUB_CLIENT_ID="$GH_CLIENT_ID" \
+            GITHUB_CLIENT_SECRET="$GH_CLIENT_SECRET" \
+            GITHUB_CALLBACK_URL="$GH_CALLBACK_URL"
+          make configure-telegram \
+            TELEGRAM_BOT_TOKEN="$TELEGRAM_BOT_TOKEN" \
+            TELEGRAM_CHAT_ID="$TELEGRAM_CHAT_ID"
+          make configure-db \
+            POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+            TETHER_APP_PASSWORD="$TETHER_APP_PASSWORD"
+          make configure-vault \
+            TETHER_VAULT_KEY="$TETHER_VAULT_KEY"
+
+  dispatch-api:
+    name: Dispatch dev API restart
+    needs: [detect, build]
+    if: needs.detect.outputs.api == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh workflow run pi-deploy-dev-api.yml --repo ${{ github.repository }} --ref dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  dispatch-bot:
+    name: Dispatch dev bot restart
+    needs: [detect, build]
+    if: needs.detect.outputs.bot == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh workflow run pi-deploy-dev-bot.yml --repo ${{ github.repository }} --ref dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  dispatch-mcp:
+    name: Dispatch dev MCP restart
+    needs: [detect, build]
+    if: needs.detect.outputs.mcp == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh workflow run pi-deploy-dev-mcp.yml --repo ${{ github.repository }} --ref dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  prune:
+    name: Prune old dev images
+    needs: build
+    runs-on: self-hosted
+    steps:
+      - name: Remove old tether-premium-dev images
+        run: |
+          docker images tether-premium-dev --format "{{.ID}}" \
+            | awk '!seen[$0]++' \
+            | tail -n +4 \
+            | xargs -r docker rmi --force 2>/dev/null || true
+          docker image prune -f

--- a/.github/workflows/pi-build.yml
+++ b/.github/workflows/pi-build.yml
@@ -1,0 +1,271 @@
+name: "[Pi] Build image"
+
+# Builds the tether-premium image on push to main, then dispatches
+# per-service restart workflows for each affected service.
+#
+# Concurrency semantics (cancel-in-progress: false):
+#   - The running build is never cancelled mid-flight.
+#   - Only ONE pending slot exists per group. If a third push arrives
+#     while A is running and B is pending, B is discarded and C takes
+#     the pending slot. Result: A completes, then C runs — intermediates
+#     are automatically skipped.
+#
+# Dev builds use pi-build-dev.yml with the separate pi-build-dev group.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'tests/**'
+      - '**/*.md'
+      - 'config/envs/prod/**'
+  workflow_dispatch:
+    inputs:
+      services:
+        description: "Comma-separated services to restart (api,bot,mcp,sync)"
+        required: false
+        default: "bot"
+      no_cache:
+        description: "Force --no-cache build"
+        required: false
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: pi-build
+  cancel-in-progress: false
+
+jobs:
+  detect:
+    name: Detect changed services
+    runs-on: ubuntu-latest
+    outputs:
+      api: ${{ steps.resolve.outputs.api }}
+      bot: ${{ steps.resolve.outputs.bot }}
+      mcp: ${{ steps.resolve.outputs.mcp }}
+      sync: ${{ steps.resolve.outputs.sync }}
+      any: ${{ steps.resolve.outputs.any }}
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'push'
+        with:
+          fetch-depth: 2
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'push'
+        with:
+          filters: |
+            api:
+              - 'api/**'
+              - 'db/**'
+              - 'frontend/**'
+              - 'config/**'
+              - 'Dockerfile'
+              - 'requirements.txt'
+              - 'pyproject.toml'
+            bot:
+              - 'bot/**'
+              - 'config/**'
+              - 'prompts/**'
+              - 'Dockerfile'
+              - 'requirements.txt'
+              - 'pyproject.toml'
+            mcp:
+              - 'tether_mcp/**'
+              - 'config/**'
+              - 'Dockerfile'
+              - 'requirements.txt'
+              - 'pyproject.toml'
+            sync:
+              - 'sync/**'
+              - 'integrations/**'
+              - 'db/**'
+              - 'config/**'
+              - 'Dockerfile'
+              - 'requirements.txt'
+              - 'pyproject.toml'
+
+      - name: Resolve services
+        id: resolve
+        env:
+          EVENT: ${{ github.event_name }}
+          SERVICES_INPUT: ${{ inputs.services }}
+          FILTER_API: ${{ steps.filter.outputs.api }}
+          FILTER_BOT: ${{ steps.filter.outputs.bot }}
+          FILTER_MCP: ${{ steps.filter.outputs.mcp }}
+          FILTER_SYNC: ${{ steps.filter.outputs.sync }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            contains() { echo ",$SERVICES_INPUT," | grep -q ",$1,"; }
+            API=$(contains api && echo true || echo false)
+            BOT=$(contains bot && echo true || echo false)
+            MCP=$(contains mcp && echo true || echo false)
+            SYNC=$(contains sync && echo true || echo false)
+          else
+            API="${FILTER_API:-false}"
+            BOT="${FILTER_BOT:-false}"
+            MCP="${FILTER_MCP:-false}"
+            SYNC="${FILTER_SYNC:-false}"
+          fi
+          echo "api=$API" >> $GITHUB_OUTPUT
+          echo "bot=$BOT" >> $GITHUB_OUTPUT
+          echo "mcp=$MCP" >> $GITHUB_OUTPUT
+          echo "sync=$SYNC" >> $GITHUB_OUTPUT
+          if [ "$API" = "true" ] || [ "$BOT" = "true" ] || [ "$MCP" = "true" ] || [ "$SYNC" = "true" ]; then
+            echo "any=true" >> $GITHUB_OUTPUT
+          else
+            echo "any=false" >> $GITHUB_OUTPUT
+          fi
+
+  build:
+    name: Build tether-premium image
+    needs: detect
+    if: needs.detect.outputs.any == 'true'
+    runs-on: self-hosted
+    steps:
+      - name: Pull latest code
+        run: |
+          cd /home/toast/tether
+          git pull origin main
+
+      - name: Resolve version tag
+        id: version
+        env:
+          GIT_SHA: ${{ github.sha }}
+          GIT_REF: ${{ github.ref }}
+        run: |
+          SHA_TAG="sha-$(echo "$GIT_SHA" | cut -c1-7)"
+          if [[ "$GIT_REF" == refs/tags/v* ]]; then
+            SEMVER="${GIT_REF#refs/tags/}"
+            echo "tag=${SEMVER}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Resolve premium ref
+        id: premium
+        env:
+          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
+        run: |
+          REF=$(git ls-remote \
+            "https://${TETHER_PREMIUM_TOKEN}@github.com/jlunder00/tether-premium.git" \
+            HEAD | cut -f1 | cut -c1-7)
+          if [ -z "$REF" ]; then
+            echo "ERROR: Failed to resolve tether-premium ref" >&2
+            exit 1
+          fi
+          echo "ref=${REF}" >> $GITHUB_OUTPUT
+
+      - name: Build image
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          PREMIUM_REF: ${{ steps.premium.outputs.ref }}
+          NO_CACHE: ${{ inputs.no_cache || 'false' }}
+          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
+        run: |
+          cd /home/toast/tether
+          BUILD_TARGET=$( [ "$NO_CACHE" = "true" ] && echo build-premium-no-cache || echo build-premium )
+          make ${BUILD_TARGET} \
+            IMAGE=tether-premium \
+            TAG=${TAG} \
+            PREMIUM_GIT_TOKEN=${TETHER_PREMIUM_TOKEN} \
+            PREMIUM_REF=${PREMIUM_REF}
+          docker tag tether-premium:${TAG} tether-premium:latest
+          grep -q "^IMAGE_TAG=" /home/toast/tether/.env \
+            && sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${TAG}/" /home/toast/tether/.env \
+            || echo "IMAGE_TAG=${TAG}" >> /home/toast/tether/.env
+
+      - name: Write production config
+        env:
+          TETHER_JWT_SECRET: ${{ secrets.TETHER_JWT_SECRET }}
+          TETHER_COOKIE_SECURE: ${{ secrets.TETHER_COOKIE_SECURE }}
+          TETHER_ALLOWED_ORIGINS: ${{ secrets.TETHER_ALLOWED_ORIGINS }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          GOOGLE_CALLBACK_URL: ${{ secrets.GOOGLE_CALLBACK_URL }}
+          GOOGLE_INTEGRATION_CALLBACK_URL: ${{ secrets.GOOGLE_INTEGRATION_CALLBACK_URL }}
+          GH_CLIENT_ID: ${{ secrets.GH_CLIENT_ID }}
+          GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
+          GH_CALLBACK_URL: ${{ secrets.GH_CALLBACK_URL }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          TETHER_APP_PASSWORD: ${{ secrets.TETHER_APP_PASSWORD }}
+          TETHER_VAULT_KEY: ${{ secrets.TETHER_VAULT_KEY }}
+        run: |
+          cd /home/toast/tether
+          make configure-auth \
+            TETHER_JWT_SECRET="$TETHER_JWT_SECRET" \
+            TETHER_COOKIE_SECURE="$TETHER_COOKIE_SECURE" \
+            TETHER_ALLOWED_ORIGINS="$TETHER_ALLOWED_ORIGINS"
+          make configure-google \
+            GOOGLE_CLIENT_ID="$GOOGLE_CLIENT_ID" \
+            GOOGLE_CLIENT_SECRET="$GOOGLE_CLIENT_SECRET" \
+            GOOGLE_CALLBACK_URL="$GOOGLE_CALLBACK_URL" \
+            GOOGLE_INTEGRATION_CALLBACK_URL="$GOOGLE_INTEGRATION_CALLBACK_URL"
+          make configure-github \
+            GITHUB_CLIENT_ID="$GH_CLIENT_ID" \
+            GITHUB_CLIENT_SECRET="$GH_CLIENT_SECRET" \
+            GITHUB_CALLBACK_URL="$GH_CALLBACK_URL"
+          make configure-telegram \
+            TELEGRAM_BOT_TOKEN="$TELEGRAM_BOT_TOKEN" \
+            TELEGRAM_CHAT_ID="$TELEGRAM_CHAT_ID"
+          make configure-db \
+            POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+            TETHER_APP_PASSWORD="$TETHER_APP_PASSWORD"
+          make configure-vault \
+            TETHER_VAULT_KEY="$TETHER_VAULT_KEY"
+
+  dispatch-api:
+    name: Dispatch API restart
+    needs: [detect, build]
+    if: needs.detect.outputs.api == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh workflow run pi-deploy-api.yml --repo ${{ github.repository }} --ref main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  dispatch-bot:
+    name: Dispatch bot restart
+    needs: [detect, build]
+    if: needs.detect.outputs.bot == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh workflow run pi-deploy-bot.yml --repo ${{ github.repository }} --ref main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  dispatch-mcp:
+    name: Dispatch MCP restart
+    needs: [detect, build]
+    if: needs.detect.outputs.mcp == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh workflow run pi-deploy-mcp.yml --repo ${{ github.repository }} --ref main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  dispatch-sync:
+    name: Dispatch sync restart
+    needs: [detect, build]
+    if: needs.detect.outputs.sync == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh workflow run pi-deploy-sync.yml --repo ${{ github.repository }} --ref main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  prune:
+    name: Prune old images
+    needs: build
+    uses: ./.github/workflows/pi-prune-images.yml
+    with:
+      keep: 3

--- a/.github/workflows/pi-deploy-api.yml
+++ b/.github/workflows/pi-deploy-api.yml
@@ -23,7 +23,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy-api
+  group: pi-deploy
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pi-deploy-api.yml
+++ b/.github/workflows/pi-deploy-api.yml
@@ -1,127 +1,28 @@
-name: "[Pi] Deploy API"
+name: "[Pi] Restart API service"
+
+# Triggered by pi-build.yml after a successful image build.
+# Just restarts the API container with the image tag written to .env.
+# Frontend static files are baked into the same image, so this also
+# serves any frontend changes.
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'api/**'
-      - 'db/**'
-      - 'config/**'
-      - 'Dockerfile'
-      - 'requirements.txt'
-      - 'pyproject.toml'
   workflow_dispatch:
-    inputs:
-      no_cache:
-        description: "Force --no-cache build"
-        required: false
-        default: "false"
-        type: choice
-        options: ["false", "true"]
 
 permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy
-  cancel-in-progress: false
+  group: pi-deploy-api
+  cancel-in-progress: true
 
 jobs:
-  deploy-api:
-    name: Build and deploy API service
+  restart-api:
+    name: Restart API service
     runs-on: self-hosted
     steps:
-      - name: Pull latest code
+      - name: Restart API with current image
         run: |
           cd /home/toast/tether
-          git pull origin main
-
-      - name: Resolve version tag
-        id: version
-        run: |
-          SHA_TAG="sha-$(echo ${GITHUB_SHA} | cut -c1-7)"
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            SEMVER="${GITHUB_REF#refs/tags/}"
-            echo "tag=${SEMVER}" >> $GITHUB_OUTPUT
-          else
-            echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Resolve premium ref
-        id: premium
-        env:
-          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
-        run: |
-          REF=$(git ls-remote \
-            "https://${TETHER_PREMIUM_TOKEN}@github.com/jlunder00/tether-premium.git" \
-            HEAD | cut -f1 | cut -c1-7)
-          if [ -z "$REF" ]; then
-            echo "ERROR: Failed to resolve tether-premium HEAD ref" >&2
-            exit 1
-          fi
-          echo "ref=${REF}" >> $GITHUB_OUTPUT
-
-      - name: Build API image
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-          PREMIUM_REF: ${{ steps.premium.outputs.ref }}
-          NO_CACHE: ${{ github.event.inputs.no_cache }}
-          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
-        run: |
-          cd /home/toast/tether
-          BUILD_TARGET=$( [ "$NO_CACHE" = "true" ] && echo build-premium-no-cache || echo build-premium )
-          make ${BUILD_TARGET} \
-            IMAGE=tether-premium \
-            TAG=${TAG} \
-            PREMIUM_GIT_TOKEN=${TETHER_PREMIUM_TOKEN} \
-            PREMIUM_REF=${PREMIUM_REF}
-          docker tag tether-premium:${TAG} tether-premium:latest
-          grep -q "^IMAGE_TAG=" /home/toast/tether/.env \
-            && sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${TAG}/" /home/toast/tether/.env \
-            || echo "IMAGE_TAG=${TAG}" >> /home/toast/tether/.env
-
-      - name: Write production config
-        env:
-          TETHER_JWT_SECRET: ${{ secrets.TETHER_JWT_SECRET }}
-          TETHER_COOKIE_SECURE: ${{ secrets.TETHER_COOKIE_SECURE }}
-          TETHER_ALLOWED_ORIGINS: ${{ secrets.TETHER_ALLOWED_ORIGINS }}
-          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-          GOOGLE_CALLBACK_URL: ${{ secrets.GOOGLE_CALLBACK_URL }}
-          GOOGLE_INTEGRATION_CALLBACK_URL: ${{ secrets.GOOGLE_INTEGRATION_CALLBACK_URL }}
-          GH_CLIENT_ID: ${{ secrets.GH_CLIENT_ID }}
-          GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
-          GH_CALLBACK_URL: ${{ secrets.GH_CALLBACK_URL }}
-          TETHER_VAULT_KEY: ${{ secrets.TETHER_VAULT_KEY }}
-        run: |
-          cd /home/toast/tether
-          make configure-auth \
-            TETHER_JWT_SECRET="$TETHER_JWT_SECRET" \
-            TETHER_COOKIE_SECURE="$TETHER_COOKIE_SECURE" \
-            TETHER_ALLOWED_ORIGINS="$TETHER_ALLOWED_ORIGINS"
-          make configure-google \
-            GOOGLE_CLIENT_ID="$GOOGLE_CLIENT_ID" \
-            GOOGLE_CLIENT_SECRET="$GOOGLE_CLIENT_SECRET" \
-            GOOGLE_CALLBACK_URL="$GOOGLE_CALLBACK_URL" \
-            GOOGLE_INTEGRATION_CALLBACK_URL="$GOOGLE_INTEGRATION_CALLBACK_URL"
-          make configure-github \
-            GITHUB_CLIENT_ID="$GH_CLIENT_ID" \
-            GITHUB_CLIENT_SECRET="$GH_CLIENT_SECRET" \
-            GITHUB_CALLBACK_URL="$GH_CALLBACK_URL"
-          make configure-vault \
-            TETHER_VAULT_KEY="$TETHER_VAULT_KEY"
-
-      - name: Restart API service
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          cd /home/toast/tether
-          TETHER_IMAGE=tether-premium IMAGE_TAG=${TAG} \
+          TAG=$(grep "^IMAGE_TAG=" .env 2>/dev/null | cut -d= -f2)
+          TETHER_IMAGE=tether-premium IMAGE_TAG="${TAG:-latest}" \
             docker compose up -d --no-deps api
-
-  prune:
-    name: Prune old images
-    needs: deploy-api
-    uses: ./.github/workflows/pi-prune-images.yml
-    with:
-      keep: 3

--- a/.github/workflows/pi-deploy-bot.yml
+++ b/.github/workflows/pi-deploy-bot.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy-bot
+  group: pi-deploy
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pi-deploy-bot.yml
+++ b/.github/workflows/pi-deploy-bot.yml
@@ -1,115 +1,26 @@
-name: "[Pi] Deploy Bot"
+name: "[Pi] Restart bot service"
+
+# Triggered by pi-build.yml after a successful image build.
+# Just restarts the bot container with the image tag written to .env.
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'bot/**'
-      - 'config/**'
-      - 'prompts/**'
-      - 'Dockerfile'
-      - 'requirements.txt'
-      - 'pyproject.toml'
-  # Triggered by tether-premium when it merges to main.
-  repository_dispatch:
-    types: [premium-updated]
   workflow_dispatch:
-    inputs:
-      no_cache:
-        description: "Force --no-cache build"
-        required: false
-        default: "false"
-        type: choice
-        options: ["false", "true"]
 
 permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy
-  cancel-in-progress: false
+  group: pi-deploy-bot
+  cancel-in-progress: true
 
 jobs:
-  deploy-bot:
-    name: Build and deploy bot service
+  restart-bot:
+    name: Restart bot service
     runs-on: self-hosted
     steps:
-      - name: Pull latest code
+      - name: Restart bot with current image
         run: |
           cd /home/toast/tether
-          git pull origin main
-
-      - name: Resolve version tag
-        id: version
-        run: |
-          SHA_TAG="sha-$(echo ${GITHUB_SHA} | cut -c1-7)"
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            SEMVER="${GITHUB_REF#refs/tags/}"
-            echo "tag=${SEMVER}" >> $GITHUB_OUTPUT
-          else
-            echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Resolve premium ref
-        id: premium
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          PREMIUM_REF_PAYLOAD: ${{ github.event.client_payload.premium_ref }}
-          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
-        run: |
-          if [ "$EVENT_NAME" = "repository_dispatch" ]; then
-            REF="$PREMIUM_REF_PAYLOAD"
-          else
-            REF=$(git ls-remote \
-              "https://${TETHER_PREMIUM_TOKEN}@github.com/jlunder00/tether-premium.git" \
-              HEAD | cut -f1 | cut -c1-7)
-          fi
-          if [ -z "$REF" ]; then
-            echo "ERROR: Failed to resolve tether-premium HEAD ref" >&2
-            exit 1
-          fi
-          echo "ref=${REF}" >> $GITHUB_OUTPUT
-
-      - name: Build bot image
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-          PREMIUM_REF: ${{ steps.premium.outputs.ref }}
-          NO_CACHE: ${{ github.event.inputs.no_cache }}
-          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
-        run: |
-          cd /home/toast/tether
-          BUILD_TARGET=$( [ "$NO_CACHE" = "true" ] && echo build-premium-no-cache || echo build-premium )
-          make ${BUILD_TARGET} \
-            IMAGE=tether-premium \
-            TAG=${TAG} \
-            PREMIUM_GIT_TOKEN=${TETHER_PREMIUM_TOKEN} \
-            PREMIUM_REF=${PREMIUM_REF}
-          docker tag tether-premium:${TAG} tether-premium:latest
-          grep -q "^IMAGE_TAG=" /home/toast/tether/.env \
-            && sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${TAG}/" /home/toast/tether/.env \
-            || echo "IMAGE_TAG=${TAG}" >> /home/toast/tether/.env
-
-      - name: Write production config
-        env:
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-        run: |
-          cd /home/toast/tether
-          make configure-telegram \
-            TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN} \
-            TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}
-
-      - name: Restart bot service
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          cd /home/toast/tether
-          TETHER_IMAGE=tether-premium IMAGE_TAG=${TAG} \
+          TAG=$(grep "^IMAGE_TAG=" .env 2>/dev/null | cut -d= -f2)
+          TETHER_IMAGE=tether-premium IMAGE_TAG="${TAG:-latest}" \
             docker compose up -d --no-deps bot
-
-  prune:
-    name: Prune old images
-    needs: deploy-bot
-    uses: ./.github/workflows/pi-prune-images.yml
-    with:
-      keep: 3

--- a/.github/workflows/pi-deploy-db.yml
+++ b/.github/workflows/pi-deploy-db.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy-db
+  group: pi-deploy
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pi-deploy-db.yml
+++ b/.github/workflows/pi-deploy-db.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy
+  group: pi-deploy-db
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pi-deploy-dev-api.yml
+++ b/.github/workflows/pi-deploy-dev-api.yml
@@ -1,0 +1,155 @@
+name: "[Pi] Deploy Dev API"
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - 'api/**'
+      - 'db/**'
+      - 'config/**'
+      - 'Dockerfile'
+      - 'requirements.txt'
+      - 'pyproject.toml'
+  workflow_dispatch:
+    inputs:
+      no_cache:
+        description: "Force --no-cache build"
+        required: false
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+
+permissions:
+  contents: read
+
+# Dev and production deploys share the single self-hosted Pi runner.
+# Using the same concurrency group (pi-deploy) ensures only one deploy
+# runs at a time across all services and environments.
+concurrency:
+  group: pi-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy-dev-api:
+    name: Build and deploy dev API service
+    runs-on: self-hosted
+    env:
+      DEV_DIR: /home/toast/tether-dev
+      # TETHER_CONFIG_DIR is read by scripts/configure.py to know the host-side config path.
+      # TETHER_DATA_DIR is the bind-mount source in docker-compose.dev.yml.
+      # Both point to the same directory.
+      TETHER_CONFIG_DIR: /home/toast/.tether-config-dev
+      TETHER_DATA_DIR: /home/toast/.tether-config-dev
+    steps:
+      - name: Ensure dev repo is present
+        run: |
+          if [ ! -d "$DEV_DIR" ]; then
+            git clone git@github.com:jlunder00/tether.git \
+              "$DEV_DIR" --branch dev --single-branch
+          else
+            cd "$DEV_DIR"
+            git fetch origin dev
+            git checkout dev
+            git pull origin dev
+          fi
+
+      - name: Resolve version tag
+        id: version
+        run: |
+          SHA_TAG="sha-$(echo ${GITHUB_SHA} | cut -c1-7)-dev"
+          echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Resolve premium ref
+        id: premium
+        env:
+          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
+        run: |
+          # Try dev branch first, fall back to HEAD
+          REF=$(git ls-remote \
+            "https://${TETHER_PREMIUM_TOKEN}@github.com/jlunder00/tether-premium.git" \
+            refs/heads/dev 2>/dev/null | cut -f1 | cut -c1-7)
+          if [ -z "$REF" ]; then
+            REF=$(git ls-remote \
+              "https://${TETHER_PREMIUM_TOKEN}@github.com/jlunder00/tether-premium.git" \
+              HEAD | cut -f1 | cut -c1-7)
+          fi
+          if [ -z "$REF" ]; then
+            echo "ERROR: Failed to resolve tether-premium ref" >&2
+            exit 1
+          fi
+          echo "ref=${REF}" >> $GITHUB_OUTPUT
+
+      - name: Build dev API image
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          PREMIUM_REF: ${{ steps.premium.outputs.ref }}
+          NO_CACHE: ${{ github.event.inputs.no_cache }}
+          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
+        run: |
+          cd "$DEV_DIR"
+          BUILD_TARGET=$( [ "$NO_CACHE" = "true" ] && echo build-premium-no-cache || echo build-premium )
+          make ${BUILD_TARGET} \
+            IMAGE=tether-premium-dev \
+            TAG=${TAG} \
+            PREMIUM_GIT_TOKEN=${TETHER_PREMIUM_TOKEN} \
+            PREMIUM_REF=${PREMIUM_REF}
+          docker tag tether-premium-dev:${TAG} tether-premium-dev:latest
+          grep -q "^IMAGE_TAG=" "$DEV_DIR/.env" 2>/dev/null \
+            && sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${TAG}/" "$DEV_DIR/.env" \
+            || echo "IMAGE_TAG=${TAG}" >> "$DEV_DIR/.env"
+
+      - name: Write dev config
+        env:
+          TETHER_JWT_SECRET: ${{ secrets.TETHER_JWT_SECRET }}
+          TETHER_COOKIE_SECURE: ${{ secrets.TETHER_COOKIE_SECURE }}
+          TETHER_ALLOWED_ORIGINS: ${{ secrets.TETHER_ALLOWED_ORIGINS_DEV }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          GOOGLE_CALLBACK_URL: ${{ secrets.GOOGLE_CALLBACK_URL_DEV }}
+          GOOGLE_INTEGRATION_CALLBACK_URL: ${{ secrets.GOOGLE_INTEGRATION_CALLBACK_URL_DEV }}
+          GH_CLIENT_ID: ${{ secrets.GH_CLIENT_ID }}
+          GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
+          GH_CALLBACK_URL: ${{ secrets.GH_CALLBACK_URL_DEV }}
+          TETHER_VAULT_KEY: ${{ secrets.TETHER_VAULT_KEY_DEV }}
+        run: |
+          cd "$DEV_DIR"
+          make configure-auth \
+            TETHER_JWT_SECRET="$TETHER_JWT_SECRET" \
+            TETHER_COOKIE_SECURE="$TETHER_COOKIE_SECURE" \
+            TETHER_ALLOWED_ORIGINS="$TETHER_ALLOWED_ORIGINS"
+          make configure-google \
+            GOOGLE_CLIENT_ID="$GOOGLE_CLIENT_ID" \
+            GOOGLE_CLIENT_SECRET="$GOOGLE_CLIENT_SECRET" \
+            GOOGLE_CALLBACK_URL="$GOOGLE_CALLBACK_URL" \
+            GOOGLE_INTEGRATION_CALLBACK_URL="$GOOGLE_INTEGRATION_CALLBACK_URL"
+          make configure-github \
+            GITHUB_CLIENT_ID="$GH_CLIENT_ID" \
+            GITHUB_CLIENT_SECRET="$GH_CLIENT_SECRET" \
+            GITHUB_CALLBACK_URL="$GH_CALLBACK_URL"
+          make configure-vault \
+            TETHER_VAULT_KEY="$TETHER_VAULT_KEY"
+
+      - name: Restart dev API service
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          cd "$DEV_DIR"
+          TETHER_IMAGE=tether-premium-dev IMAGE_TAG=${TAG} \
+            docker compose \
+              -f docker-compose.yml \
+              -f docker-compose.dev.yml \
+              -p tether-dev \
+              up -d --no-deps api
+
+  prune:
+    name: Prune old dev images
+    needs: deploy-dev-api
+    runs-on: self-hosted
+    steps:
+      - name: Remove old dev images
+        run: |
+          docker images tether-premium-dev --format "{{.ID}}" \
+            | awk '!seen[$0]++' \
+            | tail -n +4 \
+            | xargs -r docker rmi --force 2>/dev/null || true
+          docker image prune -f

--- a/.github/workflows/pi-deploy-dev-api.yml
+++ b/.github/workflows/pi-deploy-dev-api.yml
@@ -1,155 +1,30 @@
-name: "[Pi] Deploy Dev API"
+name: "[Pi] Restart dev API service"
+
+# Triggered by pi-build-dev.yml after a successful image build.
+# Just restarts the dev API container with the image tag written to .env.
 
 on:
-  push:
-    branches: [dev]
-    paths:
-      - 'api/**'
-      - 'db/**'
-      - 'config/**'
-      - 'Dockerfile'
-      - 'requirements.txt'
-      - 'pyproject.toml'
   workflow_dispatch:
-    inputs:
-      no_cache:
-        description: "Force --no-cache build"
-        required: false
-        default: "false"
-        type: choice
-        options: ["false", "true"]
 
 permissions:
   contents: read
 
-# Dev and production deploys share the single self-hosted Pi runner.
-# Using the same concurrency group (pi-deploy) ensures only one deploy
-# runs at a time across all services and environments.
 concurrency:
-  group: pi-deploy
-  cancel-in-progress: false
+  group: pi-deploy-dev-api
+  cancel-in-progress: true
 
 jobs:
-  deploy-dev-api:
-    name: Build and deploy dev API service
+  restart-dev-api:
+    name: Restart dev API service
     runs-on: self-hosted
-    env:
-      DEV_DIR: /home/toast/tether-dev
-      # TETHER_CONFIG_DIR is read by scripts/configure.py to know the host-side config path.
-      # TETHER_DATA_DIR is the bind-mount source in docker-compose.dev.yml.
-      # Both point to the same directory.
-      TETHER_CONFIG_DIR: /home/toast/.tether-config-dev
-      TETHER_DATA_DIR: /home/toast/.tether-config-dev
     steps:
-      - name: Ensure dev repo is present
+      - name: Restart dev API with current image
         run: |
-          if [ ! -d "$DEV_DIR" ]; then
-            git clone git@github.com:jlunder00/tether.git \
-              "$DEV_DIR" --branch dev --single-branch
-          else
-            cd "$DEV_DIR"
-            git fetch origin dev
-            git checkout dev
-            git pull origin dev
-          fi
-
-      - name: Resolve version tag
-        id: version
-        run: |
-          SHA_TAG="sha-$(echo ${GITHUB_SHA} | cut -c1-7)-dev"
-          echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
-
-      - name: Resolve premium ref
-        id: premium
-        env:
-          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
-        run: |
-          # Try dev branch first, fall back to HEAD
-          REF=$(git ls-remote \
-            "https://${TETHER_PREMIUM_TOKEN}@github.com/jlunder00/tether-premium.git" \
-            refs/heads/dev 2>/dev/null | cut -f1 | cut -c1-7)
-          if [ -z "$REF" ]; then
-            REF=$(git ls-remote \
-              "https://${TETHER_PREMIUM_TOKEN}@github.com/jlunder00/tether-premium.git" \
-              HEAD | cut -f1 | cut -c1-7)
-          fi
-          if [ -z "$REF" ]; then
-            echo "ERROR: Failed to resolve tether-premium ref" >&2
-            exit 1
-          fi
-          echo "ref=${REF}" >> $GITHUB_OUTPUT
-
-      - name: Build dev API image
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-          PREMIUM_REF: ${{ steps.premium.outputs.ref }}
-          NO_CACHE: ${{ github.event.inputs.no_cache }}
-          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
-        run: |
-          cd "$DEV_DIR"
-          BUILD_TARGET=$( [ "$NO_CACHE" = "true" ] && echo build-premium-no-cache || echo build-premium )
-          make ${BUILD_TARGET} \
-            IMAGE=tether-premium-dev \
-            TAG=${TAG} \
-            PREMIUM_GIT_TOKEN=${TETHER_PREMIUM_TOKEN} \
-            PREMIUM_REF=${PREMIUM_REF}
-          docker tag tether-premium-dev:${TAG} tether-premium-dev:latest
-          grep -q "^IMAGE_TAG=" "$DEV_DIR/.env" 2>/dev/null \
-            && sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${TAG}/" "$DEV_DIR/.env" \
-            || echo "IMAGE_TAG=${TAG}" >> "$DEV_DIR/.env"
-
-      - name: Write dev config
-        env:
-          TETHER_JWT_SECRET: ${{ secrets.TETHER_JWT_SECRET }}
-          TETHER_COOKIE_SECURE: ${{ secrets.TETHER_COOKIE_SECURE }}
-          TETHER_ALLOWED_ORIGINS: ${{ secrets.TETHER_ALLOWED_ORIGINS_DEV }}
-          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-          GOOGLE_CALLBACK_URL: ${{ secrets.GOOGLE_CALLBACK_URL_DEV }}
-          GOOGLE_INTEGRATION_CALLBACK_URL: ${{ secrets.GOOGLE_INTEGRATION_CALLBACK_URL_DEV }}
-          GH_CLIENT_ID: ${{ secrets.GH_CLIENT_ID }}
-          GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
-          GH_CALLBACK_URL: ${{ secrets.GH_CALLBACK_URL_DEV }}
-          TETHER_VAULT_KEY: ${{ secrets.TETHER_VAULT_KEY_DEV }}
-        run: |
-          cd "$DEV_DIR"
-          make configure-auth \
-            TETHER_JWT_SECRET="$TETHER_JWT_SECRET" \
-            TETHER_COOKIE_SECURE="$TETHER_COOKIE_SECURE" \
-            TETHER_ALLOWED_ORIGINS="$TETHER_ALLOWED_ORIGINS"
-          make configure-google \
-            GOOGLE_CLIENT_ID="$GOOGLE_CLIENT_ID" \
-            GOOGLE_CLIENT_SECRET="$GOOGLE_CLIENT_SECRET" \
-            GOOGLE_CALLBACK_URL="$GOOGLE_CALLBACK_URL" \
-            GOOGLE_INTEGRATION_CALLBACK_URL="$GOOGLE_INTEGRATION_CALLBACK_URL"
-          make configure-github \
-            GITHUB_CLIENT_ID="$GH_CLIENT_ID" \
-            GITHUB_CLIENT_SECRET="$GH_CLIENT_SECRET" \
-            GITHUB_CALLBACK_URL="$GH_CALLBACK_URL"
-          make configure-vault \
-            TETHER_VAULT_KEY="$TETHER_VAULT_KEY"
-
-      - name: Restart dev API service
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          cd "$DEV_DIR"
-          TETHER_IMAGE=tether-premium-dev IMAGE_TAG=${TAG} \
+          cd /home/toast/tether-dev
+          TAG=$(grep "^IMAGE_TAG=" .env 2>/dev/null | cut -d= -f2)
+          TETHER_IMAGE=tether-premium-dev IMAGE_TAG="${TAG:-latest}" \
             docker compose \
               -f docker-compose.yml \
               -f docker-compose.dev.yml \
               -p tether-dev \
               up -d --no-deps api
-
-  prune:
-    name: Prune old dev images
-    needs: deploy-dev-api
-    runs-on: self-hosted
-    steps:
-      - name: Remove old dev images
-        run: |
-          docker images tether-premium-dev --format "{{.ID}}" \
-            | awk '!seen[$0]++' \
-            | tail -n +4 \
-            | xargs -r docker rmi --force 2>/dev/null || true
-          docker image prune -f

--- a/.github/workflows/pi-deploy-dev-bot.yml
+++ b/.github/workflows/pi-deploy-dev-bot.yml
@@ -1,0 +1,131 @@
+name: "[Pi] Deploy Dev Bot"
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - 'bot/**'
+      - 'config/**'
+      - 'prompts/**'
+      - 'Dockerfile'
+      - 'requirements.txt'
+      - 'pyproject.toml'
+  workflow_dispatch:
+    inputs:
+      no_cache:
+        description: "Force --no-cache build"
+        required: false
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+
+permissions:
+  contents: read
+
+# Dev and production deploys share the single self-hosted Pi runner.
+# Using the same concurrency group (pi-deploy) ensures only one deploy
+# runs at a time across all services and environments.
+concurrency:
+  group: pi-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy-dev-bot:
+    name: Build and deploy dev bot service
+    runs-on: self-hosted
+    env:
+      DEV_DIR: /home/toast/tether-dev
+      TETHER_CONFIG_DIR: /home/toast/.tether-config-dev
+      TETHER_DATA_DIR: /home/toast/.tether-config-dev
+    steps:
+      - name: Ensure dev repo is present
+        run: |
+          if [ ! -d "$DEV_DIR" ]; then
+            git clone git@github.com:jlunder00/tether.git \
+              "$DEV_DIR" --branch dev --single-branch
+          else
+            cd "$DEV_DIR"
+            git fetch origin dev
+            git checkout dev
+            git pull origin dev
+          fi
+
+      - name: Resolve version tag
+        id: version
+        run: |
+          SHA_TAG="sha-$(echo ${GITHUB_SHA} | cut -c1-7)-dev"
+          echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Resolve premium ref
+        id: premium
+        env:
+          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
+        run: |
+          # Try dev branch first, fall back to HEAD
+          REF=$(git ls-remote \
+            "https://${TETHER_PREMIUM_TOKEN}@github.com/jlunder00/tether-premium.git" \
+            refs/heads/dev 2>/dev/null | cut -f1 | cut -c1-7)
+          if [ -z "$REF" ]; then
+            REF=$(git ls-remote \
+              "https://${TETHER_PREMIUM_TOKEN}@github.com/jlunder00/tether-premium.git" \
+              HEAD | cut -f1 | cut -c1-7)
+          fi
+          if [ -z "$REF" ]; then
+            echo "ERROR: Failed to resolve tether-premium ref" >&2
+            exit 1
+          fi
+          echo "ref=${REF}" >> $GITHUB_OUTPUT
+
+      - name: Build dev bot image
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          PREMIUM_REF: ${{ steps.premium.outputs.ref }}
+          NO_CACHE: ${{ github.event.inputs.no_cache }}
+          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
+        run: |
+          cd "$DEV_DIR"
+          BUILD_TARGET=$( [ "$NO_CACHE" = "true" ] && echo build-premium-no-cache || echo build-premium )
+          make ${BUILD_TARGET} \
+            IMAGE=tether-premium-dev \
+            TAG=${TAG} \
+            PREMIUM_GIT_TOKEN=${TETHER_PREMIUM_TOKEN} \
+            PREMIUM_REF=${PREMIUM_REF}
+          docker tag tether-premium-dev:${TAG} tether-premium-dev:latest
+          grep -q "^IMAGE_TAG=" "$DEV_DIR/.env" 2>/dev/null \
+            && sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${TAG}/" "$DEV_DIR/.env" \
+            || echo "IMAGE_TAG=${TAG}" >> "$DEV_DIR/.env"
+
+      - name: Write dev config
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN_DEV }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID_DEV }}
+        run: |
+          cd "$DEV_DIR"
+          make configure-telegram \
+            TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN} \
+            TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}
+
+      - name: Restart dev bot service
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          cd "$DEV_DIR"
+          TETHER_IMAGE=tether-premium-dev IMAGE_TAG=${TAG} \
+            docker compose \
+              -f docker-compose.yml \
+              -f docker-compose.dev.yml \
+              -p tether-dev \
+              up -d --no-deps bot
+
+  prune:
+    name: Prune old dev images
+    needs: deploy-dev-bot
+    runs-on: self-hosted
+    steps:
+      - name: Remove old dev images
+        run: |
+          docker images tether-premium-dev --format "{{.ID}}" \
+            | awk '!seen[$0]++' \
+            | tail -n +4 \
+            | xargs -r docker rmi --force 2>/dev/null || true
+          docker image prune -f

--- a/.github/workflows/pi-deploy-dev-mcp.yml
+++ b/.github/workflows/pi-deploy-dev-mcp.yml
@@ -1,7 +1,7 @@
-name: "[Pi] Restart dev bot service"
+name: "[Pi] Restart dev MCP service"
 
 # Triggered by pi-build-dev.yml after a successful image build.
-# Just restarts the dev bot container with the image tag written to .env.
+# Just restarts the dev MCP container with the image tag written to .env.
 
 on:
   workflow_dispatch:
@@ -10,15 +10,15 @@ permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy-dev-bot
+  group: pi-deploy-dev-mcp
   cancel-in-progress: true
 
 jobs:
-  restart-dev-bot:
-    name: Restart dev bot service
+  restart-dev-mcp:
+    name: Restart dev MCP service
     runs-on: self-hosted
     steps:
-      - name: Restart dev bot with current image
+      - name: Restart dev MCP with current image
         run: |
           cd /home/toast/tether-dev
           TAG=$(grep "^IMAGE_TAG=" .env 2>/dev/null | cut -d= -f2)
@@ -27,4 +27,4 @@ jobs:
               -f docker-compose.yml \
               -f docker-compose.dev.yml \
               -p tether-dev \
-              up -d --no-deps bot
+              up -d --no-deps mcp

--- a/.github/workflows/pi-deploy-frontend.yml
+++ b/.github/workflows/pi-deploy-frontend.yml
@@ -1,94 +1,28 @@
-name: "[Pi] Deploy Frontend"
+name: "[Pi] Restart frontend (via API service)"
+
+# Triggered by pi-build.yml after a successful image build.
+# Frontend static files are baked into tether-premium; restarting the
+# API service is all that's needed to pick up frontend changes.
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'frontend/**'
-      - 'Dockerfile'
   workflow_dispatch:
-    inputs:
-      no_cache:
-        description: "Force --no-cache build"
-        required: false
-        default: "false"
-        type: choice
-        options: ["false", "true"]
 
 permissions:
   contents: read
 
+# Same concurrency group as pi-deploy-api — both restart the api service.
 concurrency:
-  group: pi-deploy
-  cancel-in-progress: false
+  group: pi-deploy-api
+  cancel-in-progress: true
 
 jobs:
-  deploy-frontend:
-    name: Build and deploy frontend
+  restart-api:
+    name: Restart API service (serves frontend)
     runs-on: self-hosted
     steps:
-      - name: Pull latest code
+      - name: Restart API with current image
         run: |
           cd /home/toast/tether
-          git pull origin main
-
-      - name: Resolve version tag
-        id: version
-        run: |
-          SHA_TAG="sha-$(echo ${GITHUB_SHA} | cut -c1-7)"
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            SEMVER="${GITHUB_REF#refs/tags/}"
-            echo "tag=${SEMVER}" >> $GITHUB_OUTPUT
-            echo "extra_tag=${SEMVER}" >> $GITHUB_OUTPUT
-          else
-            echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
-            echo "extra_tag=" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Resolve premium ref
-        id: premium
-        env:
-          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
-        run: |
-          REF=$(git ls-remote \
-            "https://${TETHER_PREMIUM_TOKEN}@github.com/jlunder00/tether-premium.git" \
-            HEAD | cut -f1 | cut -c1-7)
-          if [ -z "$REF" ]; then
-            echo "ERROR: Failed to resolve tether-premium HEAD ref" >&2
-            exit 1
-          fi
-          echo "ref=${REF}" >> $GITHUB_OUTPUT
-
-      - name: Build image (includes frontend)
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-          PREMIUM_REF: ${{ steps.premium.outputs.ref }}
-          NO_CACHE: ${{ github.event.inputs.no_cache }}
-          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
-        run: |
-          cd /home/toast/tether
-          BUILD_TARGET=$( [ "$NO_CACHE" = "true" ] && echo build-premium-no-cache || echo build-premium )
-          make ${BUILD_TARGET} \
-            IMAGE=tether-premium \
-            TAG=${TAG} \
-            PREMIUM_GIT_TOKEN=${TETHER_PREMIUM_TOKEN} \
-            PREMIUM_REF=${PREMIUM_REF}
-          docker tag tether-premium:${TAG} tether-premium:latest
-          grep -q "^IMAGE_TAG=" /home/toast/tether/.env \
-            && sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${TAG}/" /home/toast/tether/.env \
-            || echo "IMAGE_TAG=${TAG}" >> /home/toast/tether/.env
-
-      - name: Restart API service (serves frontend static files)
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          cd /home/toast/tether
-          TETHER_IMAGE=tether-premium IMAGE_TAG=${TAG} \
+          TAG=$(grep "^IMAGE_TAG=" .env 2>/dev/null | cut -d= -f2)
+          TETHER_IMAGE=tether-premium IMAGE_TAG="${TAG:-latest}" \
             docker compose up -d --no-deps api
-
-  prune:
-    name: Prune old images
-    needs: deploy-frontend
-    uses: ./.github/workflows/pi-prune-images.yml
-    with:
-      keep: 3

--- a/.github/workflows/pi-deploy-frontend.yml
+++ b/.github/workflows/pi-deploy-frontend.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy-frontend
+  group: pi-deploy
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pi-deploy-mcp.yml
+++ b/.github/workflows/pi-deploy-mcp.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy-mcp
+  group: pi-deploy
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pi-deploy-mcp.yml
+++ b/.github/workflows/pi-deploy-mcp.yml
@@ -1,106 +1,26 @@
-name: "[Pi] Deploy MCP"
+name: "[Pi] Restart MCP service"
+
+# Triggered by pi-build.yml after a successful image build.
+# Just restarts the MCP container with the image tag written to .env.
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'tether_mcp/**'
-      - 'config/**'
-      - 'Dockerfile'
-      - 'requirements.txt'
-      - 'pyproject.toml'
   workflow_dispatch:
-    inputs:
-      no_cache:
-        description: "Force --no-cache build"
-        required: false
-        default: "false"
-        type: choice
-        options: ["false", "true"]
 
 permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy
-  cancel-in-progress: false
+  group: pi-deploy-mcp
+  cancel-in-progress: true
 
 jobs:
-  deploy-mcp:
-    name: Build and deploy MCP service
+  restart-mcp:
+    name: Restart MCP service
     runs-on: self-hosted
     steps:
-      - name: Pull latest code
+      - name: Restart MCP with current image
         run: |
           cd /home/toast/tether
-          git pull origin main
-
-      - name: Resolve version tag
-        id: version
-        run: |
-          SHA_TAG="sha-$(echo ${GITHUB_SHA} | cut -c1-7)"
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            SEMVER="${GITHUB_REF#refs/tags/}"
-            echo "tag=${SEMVER}" >> $GITHUB_OUTPUT
-          else
-            echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Resolve premium ref
-        id: premium
-        env:
-          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
-        run: |
-          REF=$(git ls-remote \
-            "https://${TETHER_PREMIUM_TOKEN}@github.com/jlunder00/tether-premium.git" \
-            HEAD | cut -f1 | cut -c1-7)
-          if [ -z "$REF" ]; then
-            echo "ERROR: Failed to resolve tether-premium HEAD ref" >&2
-            exit 1
-          fi
-          echo "ref=${REF}" >> $GITHUB_OUTPUT
-
-      - name: Build MCP image
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-          PREMIUM_REF: ${{ steps.premium.outputs.ref }}
-          NO_CACHE: ${{ github.event.inputs.no_cache }}
-          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
-        run: |
-          cd /home/toast/tether
-          BUILD_TARGET=$( [ "$NO_CACHE" = "true" ] && echo build-premium-no-cache || echo build-premium )
-          make ${BUILD_TARGET} \
-            IMAGE=tether-premium \
-            TAG=${TAG} \
-            PREMIUM_GIT_TOKEN=${TETHER_PREMIUM_TOKEN} \
-            PREMIUM_REF=${PREMIUM_REF}
-          docker tag tether-premium:${TAG} tether-premium:latest
-          grep -q "^IMAGE_TAG=" /home/toast/tether/.env \
-            && sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${TAG}/" /home/toast/tether/.env \
-            || echo "IMAGE_TAG=${TAG}" >> /home/toast/tether/.env
-
-      - name: Write production config
-        env:
-          TETHER_JWT_SECRET: ${{ secrets.TETHER_JWT_SECRET }}
-          TETHER_ALLOWED_ORIGINS: ${{ secrets.TETHER_ALLOWED_ORIGINS }}
-        run: |
-          cd /home/toast/tether
-          make configure-auth \
-            TETHER_JWT_SECRET=${TETHER_JWT_SECRET} \
-            TETHER_COOKIE_SECURE=true \
-            TETHER_ALLOWED_ORIGINS=${TETHER_ALLOWED_ORIGINS}
-
-      - name: Restart MCP service
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          cd /home/toast/tether
-          TETHER_IMAGE=tether-premium IMAGE_TAG=${TAG} \
+          TAG=$(grep "^IMAGE_TAG=" .env 2>/dev/null | cut -d= -f2)
+          TETHER_IMAGE=tether-premium IMAGE_TAG="${TAG:-latest}" \
             docker compose up -d --no-deps mcp
-
-  prune:
-    name: Prune old images
-    needs: deploy-mcp
-    uses: ./.github/workflows/pi-prune-images.yml
-    with:
-      keep: 3

--- a/.github/workflows/pi-deploy-sync.yml
+++ b/.github/workflows/pi-deploy-sync.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy-sync
+  group: pi-deploy
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pi-deploy-sync.yml
+++ b/.github/workflows/pi-deploy-sync.yml
@@ -1,97 +1,26 @@
-name: "[Pi] Deploy Sync"
+name: "[Pi] Restart sync service"
+
+# Triggered by pi-build.yml after a successful image build.
+# Just restarts the sync container with the image tag written to .env.
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'sync/**'
-      - 'integrations/**'
-      - 'db/**'
-      - 'config/**'
-      - 'Dockerfile'
-      - 'requirements.txt'
-      - 'pyproject.toml'
   workflow_dispatch:
-    inputs:
-      no_cache:
-        description: "Force --no-cache build"
-        required: false
-        default: "false"
-        type: choice
-        options: ["false", "true"]
 
 permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy
-  cancel-in-progress: false
+  group: pi-deploy-sync
+  cancel-in-progress: true
 
 jobs:
-  deploy-sync:
-    name: Build and deploy sync service
+  restart-sync:
+    name: Restart sync service
     runs-on: self-hosted
     steps:
-      - name: Pull latest code
+      - name: Restart sync with current image
         run: |
           cd /home/toast/tether
-          git pull origin main
-
-      - name: Resolve version tag
-        id: version
-        run: |
-          SHA_TAG="sha-$(echo ${GITHUB_SHA} | cut -c1-7)"
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            SEMVER="${GITHUB_REF#refs/tags/}"
-            echo "tag=${SEMVER}" >> $GITHUB_OUTPUT
-          else
-            echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Resolve premium ref
-        id: premium
-        env:
-          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
-        run: |
-          REF=$(git ls-remote \
-            "https://${TETHER_PREMIUM_TOKEN}@github.com/jlunder00/tether-premium.git" \
-            HEAD | cut -f1 | cut -c1-7)
-          if [ -z "$REF" ]; then
-            echo "ERROR: Failed to resolve tether-premium HEAD ref" >&2
-            exit 1
-          fi
-          echo "ref=${REF}" >> $GITHUB_OUTPUT
-
-      - name: Build image
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-          PREMIUM_REF: ${{ steps.premium.outputs.ref }}
-          NO_CACHE: ${{ github.event.inputs.no_cache }}
-          TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
-        run: |
-          cd /home/toast/tether
-          BUILD_TARGET=$( [ "$NO_CACHE" = "true" ] && echo build-premium-no-cache || echo build-premium )
-          make ${BUILD_TARGET} \
-            IMAGE=tether-premium \
-            TAG=${TAG} \
-            PREMIUM_GIT_TOKEN=${TETHER_PREMIUM_TOKEN} \
-            PREMIUM_REF=${PREMIUM_REF}
-          docker tag tether-premium:${TAG} tether-premium:latest
-          grep -q "^IMAGE_TAG=" /home/toast/tether/.env \
-            && sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${TAG}/" /home/toast/tether/.env \
-            || echo "IMAGE_TAG=${TAG}" >> /home/toast/tether/.env
-
-      - name: Restart sync service
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          cd /home/toast/tether
-          TETHER_IMAGE=tether-premium IMAGE_TAG=${TAG} \
+          TAG=$(grep "^IMAGE_TAG=" .env 2>/dev/null | cut -d= -f2)
+          TETHER_IMAGE=tether-premium IMAGE_TAG="${TAG:-latest}" \
             docker compose up -d --no-deps sync
-
-  prune:
-    name: Prune old images
-    needs: deploy-sync
-    uses: ./.github/workflows/pi-prune-images.yml
-    with:
-      keep: 3

--- a/.github/workflows/pi-force-deploy-all.yml
+++ b/.github/workflows/pi-force-deploy-all.yml
@@ -3,6 +3,12 @@ name: "[Pi] Force deploy all services"
 on:
   workflow_dispatch:
     inputs:
+      target:
+        description: "Target environment to redeploy"
+        required: false
+        default: "main"
+        type: choice
+        options: ["main", "dev"]
       no_cache:
         description: "Force --no-cache build"
         required: false
@@ -21,36 +27,66 @@ jobs:
   deploy-all:
     name: Rebuild and redeploy all services
     runs-on: self-hosted
+    env:
+      TARGET: ${{ github.event.inputs.target }}
+      NO_CACHE: ${{ github.event.inputs.no_cache }}
     steps:
-      - name: Pull latest code
+      - name: Resolve target paths and image name
+        id: target
         run: |
-          cd /home/toast/tether
-          git pull origin main
+          if [ "$TARGET" = "dev" ]; then
+            echo "deploy_dir=/home/toast/tether-dev" >> $GITHUB_OUTPUT
+            echo "image=tether-premium-dev" >> $GITHUB_OUTPUT
+            echo "branch=dev" >> $GITHUB_OUTPUT
+            echo "tag_suffix=-dev" >> $GITHUB_OUTPUT
+          else
+            echo "deploy_dir=/home/toast/tether" >> $GITHUB_OUTPUT
+            echo "image=tether-premium" >> $GITHUB_OUTPUT
+            echo "branch=main" >> $GITHUB_OUTPUT
+            echo "tag_suffix=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Pull latest code
+        env:
+          DEPLOY_DIR: ${{ steps.target.outputs.deploy_dir }}
+          BRANCH: ${{ steps.target.outputs.branch }}
+        run: |
+          if [ ! -d "$DEPLOY_DIR" ]; then
+            git clone git@github.com:jlunder00/tether.git \
+              "$DEPLOY_DIR" --branch "$BRANCH" --single-branch
+          else
+            cd "$DEPLOY_DIR"
+            git fetch origin "$BRANCH"
+            git checkout "$BRANCH"
+            git pull origin "$BRANCH"
+          fi
 
       - name: Resolve version tag
         id: version
         env:
           GIT_SHA: ${{ github.sha }}
-          GIT_REF: ${{ github.ref }}
+          TAG_SUFFIX: ${{ steps.target.outputs.tag_suffix }}
         run: |
-          SHA_TAG="sha-$(echo "$GIT_SHA" | cut -c1-7)"
-          if [[ "$GIT_REF" == refs/tags/v* ]]; then
-            SEMVER="${GIT_REF#refs/tags/}"
-            echo "tag=${SEMVER}" >> $GITHUB_OUTPUT
-          else
-            echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
-          fi
+          SHA_TAG="sha-$(echo "$GIT_SHA" | cut -c1-7)${TAG_SUFFIX}"
+          echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
 
       - name: Resolve premium ref
         id: premium
         env:
           TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
+          BRANCH: ${{ steps.target.outputs.branch }}
         run: |
+          # Try target branch first, fall back to HEAD
           REF=$(git ls-remote \
             "https://${TETHER_PREMIUM_TOKEN}@github.com/jlunder00/tether-premium.git" \
-            HEAD | cut -f1 | cut -c1-7)
+            "refs/heads/${BRANCH}" 2>/dev/null | cut -f1 | cut -c1-7)
           if [ -z "$REF" ]; then
-            echo "ERROR: Failed to resolve tether-premium HEAD ref" >&2
+            REF=$(git ls-remote \
+              "https://${TETHER_PREMIUM_TOKEN}@github.com/jlunder00/tether-premium.git" \
+              HEAD | cut -f1 | cut -c1-7)
+          fi
+          if [ -z "$REF" ]; then
+            echo "ERROR: Failed to resolve tether-premium ref" >&2
             exit 1
           fi
           echo "ref=${REF}" >> $GITHUB_OUTPUT
@@ -58,24 +94,27 @@ jobs:
       - name: Build all images
         env:
           TAG: ${{ steps.version.outputs.tag }}
+          IMAGE: ${{ steps.target.outputs.image }}
+          DEPLOY_DIR: ${{ steps.target.outputs.deploy_dir }}
           PREMIUM_REF: ${{ steps.premium.outputs.ref }}
-          NO_CACHE: ${{ github.event.inputs.no_cache }}
           TETHER_PREMIUM_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
         run: |
-          cd /home/toast/tether
+          cd "$DEPLOY_DIR"
           BUILD_TARGET=$( [ "$NO_CACHE" = "true" ] && echo build-premium-no-cache || echo build-premium )
           make ${BUILD_TARGET} \
-            IMAGE=tether-premium \
+            IMAGE=${IMAGE} \
             TAG=${TAG} \
             PREMIUM_GIT_TOKEN=${TETHER_PREMIUM_TOKEN} \
             PREMIUM_REF=${PREMIUM_REF}
-          docker tag tether-premium:${TAG} tether-premium:latest
-          grep -q "^IMAGE_TAG=" /home/toast/tether/.env \
-            && sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${TAG}/" /home/toast/tether/.env \
-            || echo "IMAGE_TAG=${TAG}" >> /home/toast/tether/.env
+          docker tag ${IMAGE}:${TAG} ${IMAGE}:latest
+          grep -q "^IMAGE_TAG=" "$DEPLOY_DIR/.env" 2>/dev/null \
+            && sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${TAG}/" "$DEPLOY_DIR/.env" \
+            || echo "IMAGE_TAG=${TAG}" >> "$DEPLOY_DIR/.env"
 
-      - name: Write production config
+      - name: Write config (production target)
+        if: env.TARGET == 'main'
         env:
+          DEPLOY_DIR: ${{ steps.target.outputs.deploy_dir }}
           TETHER_JWT_SECRET: ${{ secrets.TETHER_JWT_SECRET }}
           TETHER_COOKIE_SECURE: ${{ secrets.TETHER_COOKIE_SECURE }}
           TETHER_ALLOWED_ORIGINS: ${{ secrets.TETHER_ALLOWED_ORIGINS }}
@@ -91,7 +130,7 @@ jobs:
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           TETHER_APP_PASSWORD: ${{ secrets.TETHER_APP_PASSWORD }}
         run: |
-          cd /home/toast/tether
+          cd "$DEPLOY_DIR"
           make configure-auth \
             TETHER_JWT_SECRET="$TETHER_JWT_SECRET" \
             TETHER_COOKIE_SECURE="$TETHER_COOKIE_SECURE" \
@@ -112,14 +151,70 @@ jobs:
             POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
             TETHER_APP_PASSWORD="$TETHER_APP_PASSWORD"
 
+      - name: Write config (dev target)
+        if: env.TARGET == 'dev'
+        env:
+          DEPLOY_DIR: ${{ steps.target.outputs.deploy_dir }}
+          TETHER_JWT_SECRET: ${{ secrets.TETHER_JWT_SECRET }}
+          TETHER_COOKIE_SECURE: ${{ secrets.TETHER_COOKIE_SECURE }}
+          TETHER_ALLOWED_ORIGINS: ${{ secrets.TETHER_ALLOWED_ORIGINS_DEV }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          GOOGLE_CALLBACK_URL: ${{ secrets.GOOGLE_CALLBACK_URL_DEV }}
+          GOOGLE_INTEGRATION_CALLBACK_URL: ${{ secrets.GOOGLE_INTEGRATION_CALLBACK_URL_DEV }}
+          GH_CLIENT_ID: ${{ secrets.GH_CLIENT_ID }}
+          GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
+          GH_CALLBACK_URL: ${{ secrets.GH_CALLBACK_URL_DEV }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN_DEV }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID_DEV }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          TETHER_APP_PASSWORD: ${{ secrets.TETHER_APP_PASSWORD }}
+          TETHER_VAULT_KEY: ${{ secrets.TETHER_VAULT_KEY_DEV }}
+        run: |
+          cd "$DEPLOY_DIR"
+          make configure-auth \
+            TETHER_JWT_SECRET="$TETHER_JWT_SECRET" \
+            TETHER_COOKIE_SECURE="$TETHER_COOKIE_SECURE" \
+            TETHER_ALLOWED_ORIGINS="$TETHER_ALLOWED_ORIGINS"
+          make configure-google \
+            GOOGLE_CLIENT_ID="$GOOGLE_CLIENT_ID" \
+            GOOGLE_CLIENT_SECRET="$GOOGLE_CLIENT_SECRET" \
+            GOOGLE_CALLBACK_URL="$GOOGLE_CALLBACK_URL" \
+            GOOGLE_INTEGRATION_CALLBACK_URL="$GOOGLE_INTEGRATION_CALLBACK_URL"
+          make configure-github \
+            GITHUB_CLIENT_ID="$GH_CLIENT_ID" \
+            GITHUB_CLIENT_SECRET="$GH_CLIENT_SECRET" \
+            GITHUB_CALLBACK_URL="$GH_CALLBACK_URL"
+          make configure-telegram \
+            TELEGRAM_BOT_TOKEN="$TELEGRAM_BOT_TOKEN" \
+            TELEGRAM_CHAT_ID="$TELEGRAM_CHAT_ID"
+          make configure-db \
+            POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+            TETHER_APP_PASSWORD="$TETHER_APP_PASSWORD"
+          make configure-vault \
+            TETHER_VAULT_KEY="$TETHER_VAULT_KEY"
 
-      - name: Restart all services
+      - name: Restart all services (production)
+        if: env.TARGET == 'main'
         env:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           cd /home/toast/tether
           TETHER_IMAGE=tether-premium IMAGE_TAG=${TAG} \
             docker compose up -d --no-deps api bot mcp
+
+      - name: Restart all services (dev)
+        if: env.TARGET == 'dev'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          cd /home/toast/tether-dev
+          TETHER_IMAGE=tether-premium-dev IMAGE_TAG=${TAG} \
+            docker compose \
+              -f docker-compose.yml \
+              -f docker-compose.dev.yml \
+              -p tether-dev \
+              up -d --no-deps api bot mcp
 
   prune:
     name: Prune old images

--- a/.github/workflows/pi-force-deploy-all.yml
+++ b/.github/workflows/pi-force-deploy-all.yml
@@ -65,10 +65,16 @@ jobs:
         id: version
         env:
           GIT_SHA: ${{ github.sha }}
+          GIT_REF: ${{ github.ref }}
           TAG_SUFFIX: ${{ steps.target.outputs.tag_suffix }}
         run: |
           SHA_TAG="sha-$(echo "$GIT_SHA" | cut -c1-7)${TAG_SUFFIX}"
-          echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
+          if [[ "$GIT_REF" == refs/tags/v* ]] && [ "$TARGET" = "main" ]; then
+            SEMVER="${GIT_REF#refs/tags/}"
+            echo "tag=${SEMVER}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${SHA_TAG}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Resolve premium ref
         id: premium

--- a/.github/workflows/pi-refresh-config.yml
+++ b/.github/workflows/pi-refresh-config.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pi-deploy
+  group: pi-refresh-config
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pi-trigger-all-deploys.yml
+++ b/.github/workflows/pi-trigger-all-deploys.yml
@@ -1,12 +1,9 @@
-name: "[Pi] Trigger all per-service deploys"
+name: "[Pi] Trigger build and all service deploys"
 
-# Fan-out dispatcher: kicks off every per-service deploy workflow.
-# Each runs as its own independent run with its own concurrency group
-# (pi-deploy-<service>) and queues at the runner level. Use this when
-# you want each service redeployed via its normal path-aware workflow.
+# Dispatches pi-build.yml with all services, which handles the single
+# shared image build and then restarts each service independently.
 #
-# For a single-log, fully-inline rebuild of all services, use
-# pi-force-deploy-all.yml instead.
+# For a fully-inline single-log rebuild, use pi-force-deploy-all.yml instead.
 
 on:
   workflow_dispatch:
@@ -23,25 +20,22 @@ permissions:
   actions: write
 
 jobs:
-  trigger-all:
-    name: Dispatch every service deploy
+  trigger-build:
+    name: Dispatch build with all services
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger each service deploy
+      - name: Trigger pi-build with all services
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NO_CACHE: ${{ inputs.no_cache }}
           REPO: ${{ github.repository }}
           REF: ${{ github.ref_name }}
         run: |
-          set -euo pipefail
-          for wf in pi-deploy-api pi-deploy-bot pi-deploy-mcp pi-deploy-frontend pi-deploy-sync pi-deploy-db; do
-            echo "Dispatching $wf.yml (no_cache=$NO_CACHE, ref=$REF)"
-            gh workflow run "$wf.yml" \
-              --repo "$REPO" \
-              --ref "$REF" \
-              -f no_cache="$NO_CACHE"
-          done
-          echo
-          echo "Dispatched. Each workflow will queue independently and run"
-          echo "sequentially through the single self-hosted runner."
+          gh workflow run pi-build.yml \
+            --repo "$REPO" \
+            --ref "$REF" \
+            -f services=api,bot,mcp,sync \
+            -f no_cache="$NO_CACHE"
+          echo "Dispatched pi-build.yml with all services."
+          echo "Build will queue on pi-build concurrency group."
+          echo "Each service restarts independently after the build completes."

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,37 @@
+# docker-compose.dev.yml
+# Overlay for the dev stack running on the same Pi as production.
+#
+# Port mapping (dev vs prod):
+#   API:      8001  (prod: 8000)
+#   MCP:      5002  (prod: 5001)
+#   Postgres: not exposed on host (internal only; prod exposes 5432)
+#
+# Data:
+#   ~/.tether-config-dev    (prod: ~/.tether-config)
+#   pgdata-dev volume       (prod: pgdata)
+#
+# Usage via CI (see docs/DEV.md for full setup):
+#   COMPOSE_PROJECT_NAME=tether-dev \
+#   TETHER_IMAGE=tether-premium-dev IMAGE_TAG=<tag> \
+#   TETHER_DATA_DIR=~/.tether-config-dev \
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml \
+#     -p tether-dev up -d
+
+services:
+  postgres:
+    # Don't expose postgres on the host — dev postgres is internal only.
+    # Production exposes 5432 for tooling access; dev avoids the port conflict.
+    ports: []
+    volumes:
+      - pgdata-dev:/var/lib/postgresql/data
+
+  api:
+    ports:
+      - "8001:8000"
+
+  mcp:
+    ports:
+      - "5002:5001"
+
+volumes:
+  pgdata-dev:

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -15,7 +15,7 @@ regression testing and validating PRs before they merge to `main`.
 | API port         | `8000`                  | `8001`                         |
 | MCP port         | `5001`                  | `5002`                         |
 | Postgres port    | `5432` (host-exposed)   | internal only (no host binding)|
-| Bot              | `tether-bot-staging` → | separate docker service        |
+| Bot image        | `tether-premium`        | `tether-premium-dev`           |
 
 ## GitHub Actions Workflows
 
@@ -48,6 +48,22 @@ will work. Most share the same OAuth app as production — only callback URLs di
 | `TETHER_VAULT_KEY_DEV`               | Vault key for dev config encryption            |
 | `TELEGRAM_BOT_TOKEN_DEV`             | Telegram bot token for the dev bot             |
 | `TELEGRAM_CHAT_ID_DEV`               | Telegram chat ID for the dev bot               |
+
+## Prerequisites (one-time branch setup)
+
+Before the first dev deploy can trigger, the `dev` branch must exist in both repos:
+
+```bash
+# In tether repo
+git checkout -b dev main
+git push origin dev
+
+# In tether-premium repo
+git checkout -b dev main
+git push origin dev
+```
+
+This only needs to be done once. After that, PRs can target `dev` and CI will handle deploys automatically.
 
 ## One-time Pi Setup
 

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -1,0 +1,89 @@
+# Dev Deployment (Pi)
+
+The `dev` branch deploys a parallel stack on the same Pi as production, used for
+regression testing and validating PRs before they merge to `main`.
+
+## Architecture
+
+| Component        | Production              | Dev                            |
+|------------------|-------------------------|--------------------------------|
+| Code directory   | `/home/toast/tether`    | `/home/toast/tether-dev`       |
+| Config directory | `~/.tether-config`      | `~/.tether-config-dev`         |
+| Docker project   | `tether` (default)      | `tether-dev`                   |
+| Docker image     | `tether-premium`        | `tether-premium-dev`           |
+| Compose files    | `docker-compose.yml`    | `+docker-compose.dev.yml`      |
+| API port         | `8000`                  | `8001`                         |
+| MCP port         | `5001`                  | `5002`                         |
+| Postgres port    | `5432` (host-exposed)   | internal only (no host binding)|
+| Bot              | `tether-bot-staging` → | separate docker service        |
+
+## GitHub Actions Workflows
+
+| Workflow                        | Trigger               | What it does                          |
+|---------------------------------|-----------------------|---------------------------------------|
+| `pi-deploy-dev-api.yml`         | push to `dev` (api/*) | Build & restart dev API on port 8001  |
+| `pi-deploy-dev-bot.yml`         | push to `dev` (bot/*) | Build & restart dev bot               |
+| `pi-force-deploy-all.yml`       | `workflow_dispatch`   | Add `target=dev` to force full redeploy |
+
+All workflows (production + dev) share the `pi-deploy` concurrency group so only one
+deploy runs at a time on the shared self-hosted runner.
+
+## tether-premium Integration
+
+When `dev` is pushed in `tether-premium`, the `trigger-deploy-dev.yml` workflow
+dispatches `pi-deploy-dev-bot.yml` in this repo via `workflow_dispatch`. This keeps
+the dev bot in sync with premium changes on the `dev` branch.
+
+## Required GitHub Secrets
+
+The following secrets must be added to the **tether** repo settings before dev deploys
+will work. Most share the same OAuth app as production — only callback URLs differ.
+
+| Secret                               | Description                                    |
+|--------------------------------------|------------------------------------------------|
+| `TETHER_ALLOWED_ORIGINS_DEV`         | Allowed CORS origins for dev API               |
+| `GOOGLE_CALLBACK_URL_DEV`            | OAuth callback pointing to dev (port 8001)     |
+| `GOOGLE_INTEGRATION_CALLBACK_URL_DEV`| Google integration callback for dev            |
+| `GH_CALLBACK_URL_DEV`                | GitHub OAuth callback for dev                  |
+| `TETHER_VAULT_KEY_DEV`               | Vault key for dev config encryption            |
+| `TELEGRAM_BOT_TOKEN_DEV`             | Telegram bot token for the dev bot             |
+| `TELEGRAM_CHAT_ID_DEV`               | Telegram chat ID for the dev bot               |
+
+## One-time Pi Setup
+
+On first deploy, the CI workflow auto-clones the dev repo:
+```bash
+git clone git@github.com:jlunder00/tether.git /home/toast/tether-dev --branch dev
+```
+
+After that, every push to `dev` does `git pull origin dev` to update.
+
+The `~/.tether-config-dev` directory is created automatically by `scripts/configure.py`
+on first config write.
+
+## Exposing Dev Externally (Tailscale Funnel)
+
+To make the dev API reachable outside the local network, run once manually on the Pi:
+
+```bash
+tailscale funnel --bg 8001
+```
+
+This is intentionally not automated in CI — it's a one-time Pi setup step.
+
+For the dev frontend (if needed), configure a separate nginx vhost:
+```nginx
+server {
+    listen 443 ssl;
+    server_name dev.your-tailscale-domain.ts.net;
+    location / {
+        proxy_pass http://localhost:8001;
+    }
+}
+```
+
+## Note on systemd Service Files
+
+The `systemd/` directory contains bare-metal service files (`tether-api.service`, etc.)
+that run uvicorn directly from a virtualenv. These are **production-only** and not used
+by the dev pipeline. The CI deploy path (both production and dev) uses `docker compose`.


### PR DESCRIPTION
## Summary

- Add `docker-compose.dev.yml` overlay (API→8001, MCP→5002, separate pgdata-dev volume, no host postgres port)
- Add `pi-deploy-dev-api.yml` workflow — triggers on `dev` branch push to api/db/config paths
- Add `pi-deploy-dev-bot.yml` workflow — triggers on `dev` branch push to bot/config/Dockerfile paths; also accepts `workflow_dispatch` from tether-premium
- Update `pi-force-deploy-all.yml` — add `target=main/dev` input, restore semver tag handling for production releases
- Unify all existing deploy workflows onto shared `pi-deploy` concurrency group (was fragmented per-service)
- Add `docs/DEV.md` — architecture table, required secrets, one-time branch/Pi setup, Tailscale funnel instructions

## Cross-repo dependency

The tether-premium companion PR (`feature/dev-pipeline`) adds `trigger-deploy-dev.yml` which dispatches `pi-deploy-dev-bot.yml` from this repo. Merge this PR first, then the tether-premium PR.

## Prerequisites before first dev deploy

1. Create `dev` branch from `main` in both repos (see `docs/DEV.md` → Prerequisites section)
2. Add the 7 dev secrets listed in `docs/DEV.md` → Required GitHub Secrets
3. Run `tailscale funnel --bg 8001` on the Pi once for external access

## Test plan

- [ ] Verify `pi-deploy-dev-api.yml` triggers on push to `dev` branch touching `api/**`
- [ ] Verify `pi-deploy-dev-bot.yml` triggers on `workflow_dispatch` from tether-premium
- [ ] Verify `pi-force-deploy-all.yml` `target=dev` deploys to `/home/toast/tether-dev` with `-p tether-dev`
- [ ] Verify `pi-force-deploy-all.yml` `target=main` with a `v*` tag still produces a semver image tag
- [ ] Verify all deploy workflows queue correctly via `pi-deploy` concurrency group