### PR TITLE
fix: use overSlotIndex in onTimedAreaDrop to fix wrong-slot drops

### DIFF
--- a/frontend/src/components/DayTimeline.vue
+++ b/frontend/src/components/DayTimeline.vue
@@ -276,12 +276,15 @@ function onTimedAreaDragLeave(e: DragEvent) {
 async function onTimedAreaDrop(e: DragEvent) {
   e.preventDefault()
   dragActive.value = false
+  // Prefer the slot tracked by onSlotDragOver (closure-captured i — exact, no math).
+  // Fall back to clientY computation only for drops in the hour-label gutter column,
+  // where no slot div exists and overSlotIndex was never set by a slot's dragover.
+  const i = overSlotIndex.value ?? slotIndexFromClientY(e.clientY)
   overSlotIndex.value = null
   const rawJson = e.dataTransfer?.getData('application/json')
   const rawText = e.dataTransfer?.getData('text/plain')
   const raw = rawJson || rawText
   if (!raw) return
-  const i = slotIndexFromClientY(e.clientY)
   try {
     await handleSlotDrop(JSON.parse(raw), slotTime(i))
   } catch { /* ignore malformed payload */ }

--- a/frontend/src/components/__tests__/DayTimelineDropZone.test.ts
+++ b/frontend/src/components/__tests__/DayTimelineDropZone.test.ts
@@ -288,6 +288,46 @@ describe('DayTimeline – 15-min slot drop targets', () => {
     wrapper.unmount()
   })
 
+  // ── overSlotIndex path: slot div dragover sets exact index, container drop uses it ──
+  it('drop on timed-area container uses overSlotIndex set by slot dragover (no clientY math)', async () => {
+    // When pointer-events-none makes TaskCards transparent, drops land on the underlying
+    // slot div — but the drop event bubbles up to the container. The container must use
+    // overSlotIndex (set by that slot's @dragover handler) rather than slotIndexFromClientY
+    // which depends on getBoundingClientRect/scrollTop and can give wrong results when scrolled.
+    //
+    // Flow: dragenter → dragover on [data-time="09:00"] → drop on timed-area (no clientY)
+    // Expected: promoteTask called with 09:00/09:30 (slot 12), not 06:00 (slot 0 fallback).
+    const { default: DayTimeline } = await import('../DayTimeline.vue')
+    const wrapper = mount(DayTimeline, { props: { date: '2024-06-10' }, attachTo: document.body })
+    const timedArea = wrapper.find('[data-testid="timed-area"]')
+
+    // Step 1: drag enters the timed area (sets dragActive=true)
+    await timedArea.trigger('dragenter', { dataTransfer: { types: ['text/plain'] } })
+    await wrapper.vm.$nextTick()
+
+    // Step 2: drag moves over the 09:00 slot div (sets overSlotIndex via onSlotDragOver)
+    const slot = wrapper.find('[data-time="09:00"]')
+    expect(slot.exists()).toBe(true)
+    await slot.trigger('dragover')
+    await wrapper.vm.$nextTick()
+
+    // Step 3: drop on the container (no clientY — would give slot 0 via slotIndexFromClientY)
+    const payload = { type: 'task', taskId: 'task-99', title: 'overSlotIndex test' }
+    await timedArea.trigger('drop', {
+      clientY: 0,  // would map to slot 0 (06:00) via slotIndexFromClientY — wrong answer
+      dataTransfer: { getData: (t: string) => t === 'text/plain' ? JSON.stringify(payload) : '' },
+    })
+
+    // Should have used overSlotIndex=12 (09:00), not slotIndexFromClientY(0)=0 (06:00)
+    expect(mockPromoteTask).toHaveBeenCalledWith(
+      'task-99',
+      expect.stringContaining('T09:00'),
+      expect.stringContaining('T09:30'),
+      'overSlotIndex test',
+    )
+    wrapper.unmount()
+  })
+
   // ── Structural fix: TaskCards must be transparent to pointer events during drag ──
   it('TaskCard event blocks receive pointer-events-none class while a drag is active', async () => {
     // The structural fix: when dragActive=true, TaskCards have pointer-events-none so


### PR DESCRIPTION
## Problem

After PR #299 landed, drops on the DayTimeline timed area were still placed at the wrong slot. The `pointer-events-none` fix on TaskCards meant drops pass through to slot divs correctly, but the container's `onTimedAreaDrop` was still calling `slotIndexFromClientY(e.clientY)` — which depends on `getBoundingClientRect()` + `scrollTop` and gives wrong results when the timed area is scrolled.

## Fix

`onTimedAreaDrop` now uses `overSlotIndex.value ?? slotIndexFromClientY(e.clientY)`:

- `overSlotIndex` is set by the slot div's `@dragover` handler via closure-captured `i` — exact, no coordinate math
- The `slotIndexFromClientY` fallback only fires when `overSlotIndex` is null (drops in the hour-label gutter column, which has no slot divs)

## Test Added

New flow test in `DayTimelineDropZone.test.ts`:
1. `dragenter` on timed area
2. `dragover` on `[data-time="09:00"]` slot div (sets `overSlotIndex = 12`)
3. `drop` on container with `clientY: 0` (would give slot 0 via math — wrong)
4. Asserts `promoteTask` called with `T09:00`/`T09:30`, not `T06:00`

## Anchor-to-Anchor

The anchor→anchor drop regression (task snaps back to source) is a separate pre-existing issue — this diff does not touch `AnchorBlock.vue`, `useDropZone.ts`, or `PlanView.vue`. Flagged for a separate task.

## Test Results

553/553 tests pass. Build: zero type errors.