### PR TITLE
feat: bot_actions audit table + budget enforcement queries

### DIFF
--- a/db/migrations/versions/b2c3d4e5f6a7_bot_actions_table.py
+++ b/db/migrations/versions/b2c3d4e5f6a7_bot_actions_table.py
@@ -1,0 +1,72 @@
+"""bot_actions audit table for bot action tracking and budget enforcement
+
+Revision ID: b2c3d4e5f6a7
+Revises: a6b7c8d9e0f1
+Create Date: 2026-05-07
+
+Records every write action performed by the bot on behalf of a user.
+Provides:
+  - Full audit trail with before/after JSONB diffs
+  - RLS isolation (users see only their own rows)
+  - Foundation for per-session budget enforcement
+
+Budget enforcement: count rows per (user_id, coordination_session_id, action_type)
+and compare against limits defined in db/pg_queries/bot_actions.py.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = 'b2c3d4e5f6a7'
+down_revision: Union[str, Sequence[str], None] = 'a6b7c8d9e0f1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE bot_actions (
+            id                      BIGSERIAL PRIMARY KEY,
+            user_id                 UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            action_type             TEXT NOT NULL,
+            target_resource         TEXT NOT NULL,
+            before_state            JSONB,
+            after_state             JSONB,
+            coordination_session_id BIGINT REFERENCES meeting_requests(id) ON DELETE SET NULL,
+            ts                      TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+    """)
+
+    # RLS — users see only their own bot_actions rows
+    op.execute("ALTER TABLE bot_actions ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE bot_actions FORCE ROW LEVEL SECURITY")
+    op.execute("""
+        CREATE POLICY bot_actions_user_select ON bot_actions
+            FOR SELECT
+            USING (user_id = current_setting('app.current_user_id', true)::uuid)
+    """)
+    op.execute("""
+        CREATE POLICY bot_actions_user_insert ON bot_actions
+            FOR INSERT
+            WITH CHECK (user_id = current_setting('app.current_user_id', true)::uuid)
+    """)
+
+    # Indexes
+    op.execute("""
+        CREATE INDEX bot_actions_user_ts_idx
+            ON bot_actions (user_id, ts DESC)
+    """)
+    op.execute("""
+        CREATE INDEX bot_actions_session_idx
+            ON bot_actions (coordination_session_id)
+            WHERE coordination_session_id IS NOT NULL
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS bot_actions_session_idx")
+    op.execute("DROP INDEX IF EXISTS bot_actions_user_ts_idx")
+    op.execute("DROP POLICY IF EXISTS bot_actions_user_insert ON bot_actions")
+    op.execute("DROP POLICY IF EXISTS bot_actions_user_select ON bot_actions")
+    op.execute("DROP TABLE IF EXISTS bot_actions")

--- a/db/pg_queries/bot_actions.py
+++ b/db/pg_queries/bot_actions.py
@@ -1,0 +1,200 @@
+"""Bot action audit log queries — log, count, and budget enforcement.
+
+All functions take conn: asyncpg.Connection as first arg and operate
+under the caller's RLS context (user_id must be set via set_config).
+
+Budget defaults:
+  coordination  — strict: task_created=1, task_updated=0, task_deleted=0
+  general       — high:   task_created=10, task_updated=20, task_deleted=5
+
+Budget is checked against persisted bot_actions rows so restarts and retries
+are safe (no in-memory state required).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import asyncpg
+
+
+# ─── Budget configuration ─────────────────────────────────────────────────────
+
+_BUDGETS: dict[str, dict[str, int]] = {
+    "coordination": {
+        "task_created": 1,
+        "task_updated": 0,
+        "task_deleted": 0,
+    },
+    "general": {
+        "task_created": 10,
+        "task_updated": 20,
+        "task_deleted": 5,
+    },
+}
+
+_DEFAULT_GENERAL_LIMIT = 20
+
+
+def _budget_limit(action_type: str, session_type: str) -> int:
+    """Return the budget limit for (action_type, session_type).
+
+    Falls back to the general default for unknown action types.
+    """
+    budget = _BUDGETS.get(session_type, _BUDGETS["general"])
+    return budget.get(action_type, _DEFAULT_GENERAL_LIMIT)
+
+
+# ─── Queries ─────────────────────────────────────────────────────────────────
+
+async def log_bot_action(
+    conn: asyncpg.Connection,
+    user_id: str,
+    action_type: str,
+    target_resource: str,
+    before_state: dict[str, Any] | None,
+    after_state: dict[str, Any] | None,
+    coordination_session_id: int | None,
+) -> int:
+    """Insert a bot_actions row and return its id.
+
+    Args:
+        conn: RLS-scoped asyncpg connection (app.current_user_id must be set).
+        user_id: UUID string of the user on whose behalf the action is taken.
+        action_type: Verb describing the mutation (e.g. 'task_created').
+        target_resource: Resource path (e.g. 'tasks/123').
+        before_state: JSONB snapshot before the mutation; None for INSERT ops.
+        after_state: JSONB snapshot after the mutation; None for DELETE ops.
+        coordination_session_id: meeting_requests.id if this action is part of
+            a coordination session; None for general bot operations.
+
+    Returns:
+        The BIGSERIAL id of the newly inserted row.
+    """
+    row = await conn.fetchrow(
+        """
+        INSERT INTO bot_actions
+            (user_id, action_type, target_resource,
+             before_state, after_state, coordination_session_id)
+        VALUES ($1::uuid, $2, $3, $4, $5, $6)
+        RETURNING id
+        """,
+        user_id,
+        action_type,
+        target_resource,
+        before_state,
+        after_state,
+        coordination_session_id,
+    )
+    return int(row["id"])
+
+
+async def count_bot_actions(
+    conn: asyncpg.Connection,
+    user_id: str,
+    action_type: str,
+    since: datetime,
+    coordination_session_id: int | None = None,
+) -> int:
+    """Count bot_actions rows matching the given criteria.
+
+    Args:
+        conn: RLS-scoped asyncpg connection.
+        user_id: Filter to this user's actions.
+        action_type: Filter to this action type (e.g. 'task_created').
+        since: Only count rows where ts >= this timestamp.
+        coordination_session_id: When provided, restrict to rows for this
+            coordination session. When None, counts across all sessions.
+
+    Returns:
+        Integer count of matching rows.
+    """
+    if coordination_session_id is not None:
+        row = await conn.fetchrow(
+            """
+            SELECT COUNT(*) AS n
+            FROM bot_actions
+            WHERE user_id = $1::uuid
+              AND action_type = $2
+              AND ts >= $3
+              AND coordination_session_id = $4
+            """,
+            user_id,
+            action_type,
+            since,
+            coordination_session_id,
+        )
+    else:
+        row = await conn.fetchrow(
+            """
+            SELECT COUNT(*) AS n
+            FROM bot_actions
+            WHERE user_id = $1::uuid
+              AND action_type = $2
+              AND ts >= $3
+            """,
+            user_id,
+            action_type,
+            since,
+        )
+    return int(row["n"])
+
+
+async def check_bot_budget(
+    conn: asyncpg.Connection,
+    user_id: str,
+    coordination_session_id: int | None,
+    action_type: str,
+) -> bool:
+    """Return True if the user is under budget for this action type.
+
+    For coordination sessions (coordination_session_id is not None), applies
+    strict limits. For general operations, applies high-but-bounded limits.
+    Both modes count only rows matching (user_id, coordination_session_id,
+    action_type) so that budget enforcement is scoped to the relevant context.
+
+    Budget is zero-based: a limit of 0 means the action is never permitted
+    (returns False immediately without a DB query).
+
+    Args:
+        conn: RLS-scoped asyncpg connection.
+        user_id: UUID string of the acting user.
+        coordination_session_id: Scopes to a coordination session when set.
+        action_type: The action about to be performed.
+
+    Returns:
+        True if the action is within budget; False if the limit is reached.
+    """
+    session_type = "coordination" if coordination_session_id is not None else "general"
+    limit = _budget_limit(action_type, session_type)
+
+    # Zero-limit actions are never allowed — skip DB round-trip.
+    if limit == 0:
+        return False
+
+    if coordination_session_id is not None:
+        row = await conn.fetchrow(
+            """
+            SELECT COUNT(*) AS n
+            FROM bot_actions
+            WHERE user_id = $1::uuid
+              AND coordination_session_id = $2
+              AND action_type = $3
+            """,
+            user_id,
+            coordination_session_id,
+            action_type,
+        )
+    else:
+        row = await conn.fetchrow(
+            """
+            SELECT COUNT(*) AS n
+            FROM bot_actions
+            WHERE user_id = $1::uuid
+              AND coordination_session_id IS NULL
+              AND action_type = $2
+            """,
+            user_id,
+            action_type,
+        )
+    return int(row["n"]) < limit

--- a/tests/db/test_bot_actions.py
+++ b/tests/db/test_bot_actions.py
@@ -1,0 +1,507 @@
+"""Tests for bot_actions DB queries — log, count, budget enforcement.
+
+Tests require DATABASE_URL env var pointing to a live Postgres instance
+with the bot_actions migration applied.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone, timedelta
+
+import asyncpg
+import pytest
+
+from db.postgres import register_jsonb_codec
+from tests.db.pg_conftest import conn, auth_conn  # noqa: F401
+from db.pg_queries.bot_actions import (
+    log_bot_action,
+    count_bot_actions,
+    check_bot_budget,
+)
+
+TEST_USER_ID = "00000000-0000-0000-0000-000000000001"
+OTHER_USER_ID = "00000000-0000-0000-0000-000000000002"
+
+pytestmark = pytest.mark.asyncio
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _db_url() -> str:
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        pytest.skip("DATABASE_URL not set — Postgres tests skipped")
+    return url
+
+
+async def _ensure_other_user(url: str) -> None:
+    """Seed a second test user outside the rolled-back transaction."""
+    c = await asyncpg.connect(dsn=url)
+    try:
+        await c.execute(
+            """
+            INSERT INTO users (id, username, email, password_hash, is_admin)
+            VALUES ($1::uuid, 'otheruser', 'other@example.com', 'x', false)
+            ON CONFLICT (id) DO NOTHING
+            """,
+            OTHER_USER_ID,
+        )
+    finally:
+        await c.close()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Schema / migration sanity
+# ──────────────────────────────────────────────────────────────────────────────
+
+async def test_bot_actions_table_exists(conn):
+    """Migration must have created the bot_actions table with expected columns."""
+    row = await conn.fetchrow(
+        """
+        SELECT column_name, data_type, is_nullable
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'bot_actions'
+        ORDER BY ordinal_position
+        """
+    )
+    # If no row, the table doesn't exist at all.
+    assert row is not None, "bot_actions table does not exist"
+
+
+async def test_bot_actions_has_required_columns(conn):
+    """All required columns must be present with correct types."""
+    rows = await conn.fetch(
+        """
+        SELECT column_name, data_type, is_nullable
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'bot_actions'
+        """
+    )
+    cols = {r["column_name"]: r for r in rows}
+    assert "id" in cols
+    assert "user_id" in cols
+    assert "action_type" in cols
+    assert "target_resource" in cols
+    assert "before_state" in cols
+    assert "after_state" in cols
+    assert "coordination_session_id" in cols
+    assert "ts" in cols
+
+    assert cols["user_id"]["is_nullable"] == "NO"
+    assert cols["action_type"]["is_nullable"] == "NO"
+    assert cols["target_resource"]["is_nullable"] == "NO"
+    # Nullable columns
+    assert cols["before_state"]["is_nullable"] == "YES"
+    assert cols["after_state"]["is_nullable"] == "YES"
+    assert cols["coordination_session_id"]["is_nullable"] == "YES"
+
+
+async def test_bot_actions_rls_enabled(auth_conn):
+    """RLS must be enabled on bot_actions."""
+    row = await auth_conn.fetchrow(
+        "SELECT relrowsecurity FROM pg_class WHERE relname = 'bot_actions'"
+    )
+    assert row is not None, "bot_actions table not found in pg_class"
+    assert row["relrowsecurity"] is True, "RLS not enabled on bot_actions"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# log_bot_action
+# ──────────────────────────────────────────────────────────────────────────────
+
+async def test_log_bot_action_returns_id(conn):
+    """log_bot_action must insert a row and return an integer id."""
+    action_id = await log_bot_action(
+        conn,
+        user_id=TEST_USER_ID,
+        action_type="task_created",
+        target_resource="tasks/123",
+        before_state=None,
+        after_state={"text": "meeting", "status": "pending"},
+        coordination_session_id=None,
+    )
+    assert isinstance(action_id, int)
+    assert action_id > 0
+
+
+async def test_log_bot_action_row_visible_to_owner(conn):
+    """The owner must be able to see the inserted row via RLS."""
+    action_id = await log_bot_action(
+        conn,
+        user_id=TEST_USER_ID,
+        action_type="task_created",
+        target_resource="tasks/42",
+        before_state=None,
+        after_state={"status": "pending"},
+        coordination_session_id=None,
+    )
+    row = await conn.fetchrow(
+        "SELECT id, action_type, target_resource FROM bot_actions WHERE id = $1",
+        action_id,
+    )
+    assert row is not None
+    assert row["action_type"] == "task_created"
+    assert row["target_resource"] == "tasks/42"
+
+
+async def test_log_bot_action_with_before_and_after_state(conn):
+    """before_state and after_state JSONB fields must round-trip correctly."""
+    before = {"status": "pending", "text": "old text"}
+    after = {"status": "completed", "text": "new text"}
+    action_id = await log_bot_action(
+        conn,
+        user_id=TEST_USER_ID,
+        action_type="task_updated",
+        target_resource="tasks/99",
+        before_state=before,
+        after_state=after,
+        coordination_session_id=None,
+    )
+    row = await conn.fetchrow(
+        "SELECT before_state, after_state FROM bot_actions WHERE id = $1",
+        action_id,
+    )
+    assert row["before_state"] == before
+    assert row["after_state"] == after
+
+
+async def test_log_bot_action_with_coordination_session_id(conn):
+    """coordination_session_id must be stored and queryable."""
+    session_id = 7  # bigint (meeting_requests.id)
+    action_id = await log_bot_action(
+        conn,
+        user_id=TEST_USER_ID,
+        action_type="task_created",
+        target_resource="tasks/77",
+        before_state=None,
+        after_state={"status": "pending"},
+        coordination_session_id=session_id,
+    )
+    row = await conn.fetchrow(
+        "SELECT coordination_session_id FROM bot_actions WHERE id = $1",
+        action_id,
+    )
+    assert row["coordination_session_id"] == session_id
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# RLS isolation
+# ──────────────────────────────────────────────────────────────────────────────
+
+async def test_rls_blocks_cross_user_read():
+    """User B must not see User A's bot_actions rows."""
+    url = _db_url()
+    await _ensure_other_user(url)
+
+    action_id = None
+    conn_a = await asyncpg.connect(dsn=url)
+    await register_jsonb_codec(conn_a)
+    tr_a = conn_a.transaction()
+    await tr_a.start()
+    try:
+        await conn_a.execute(
+            "SELECT set_config('app.current_user_id', $1, true)", TEST_USER_ID
+        )
+        action_id = await log_bot_action(
+            conn_a,
+            user_id=TEST_USER_ID,
+            action_type="task_created",
+            target_resource="tasks/rls-test",
+            before_state=None,
+            after_state=None,
+            coordination_session_id=None,
+        )
+        await tr_a.commit()
+    except Exception:
+        await tr_a.rollback()
+        raise
+    finally:
+        await conn_a.close()
+
+    # User B should not see the row
+    conn_b = await asyncpg.connect(dsn=url)
+    await register_jsonb_codec(conn_b)
+    tr_b = conn_b.transaction()
+    await tr_b.start()
+    try:
+        await conn_b.execute(
+            "SELECT set_config('app.current_user_id', $1, true)", OTHER_USER_ID
+        )
+        row = await conn_b.fetchrow(
+            "SELECT id FROM bot_actions WHERE id = $1", action_id
+        )
+        assert row is None, "User B can see User A's bot_actions row — RLS not enforced"
+    finally:
+        await tr_b.rollback()
+        await conn_b.close()
+
+    # Cleanup
+    cleanup = await asyncpg.connect(dsn=url)
+    try:
+        await cleanup.execute("DELETE FROM bot_actions WHERE id = $1", action_id)
+    finally:
+        await cleanup.close()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# count_bot_actions
+# ──────────────────────────────────────────────────────────────────────────────
+
+async def test_count_bot_actions_basic(conn):
+    """count_bot_actions must return the correct count for a user + type."""
+    since = datetime.now(timezone.utc) - timedelta(minutes=1)
+    # Insert 2 task_created, 1 task_updated
+    for _ in range(2):
+        await log_bot_action(
+            conn,
+            user_id=TEST_USER_ID,
+            action_type="task_created",
+            target_resource="tasks/x",
+            before_state=None,
+            after_state=None,
+            coordination_session_id=None,
+        )
+    await log_bot_action(
+        conn,
+        user_id=TEST_USER_ID,
+        action_type="task_updated",
+        target_resource="tasks/x",
+        before_state=None,
+        after_state=None,
+        coordination_session_id=None,
+    )
+
+    count = await count_bot_actions(
+        conn, user_id=TEST_USER_ID, action_type="task_created", since=since
+    )
+    assert count == 2
+
+    count_updated = await count_bot_actions(
+        conn, user_id=TEST_USER_ID, action_type="task_updated", since=since
+    )
+    assert count_updated == 1
+
+
+async def test_count_bot_actions_filters_by_time_window(conn):
+    """count_bot_actions must exclude rows older than `since`."""
+    future_since = datetime.now(timezone.utc) + timedelta(hours=1)
+    await log_bot_action(
+        conn,
+        user_id=TEST_USER_ID,
+        action_type="task_created",
+        target_resource="tasks/old",
+        before_state=None,
+        after_state=None,
+        coordination_session_id=None,
+    )
+    count = await count_bot_actions(
+        conn,
+        user_id=TEST_USER_ID,
+        action_type="task_created",
+        since=future_since,
+    )
+    assert count == 0
+
+
+async def test_count_bot_actions_filters_by_session(conn):
+    """When coordination_session_id is provided, only count rows for that session."""
+    since = datetime.now(timezone.utc) - timedelta(minutes=1)
+    session_id = 42
+
+    # One in-session, one not
+    await log_bot_action(
+        conn,
+        user_id=TEST_USER_ID,
+        action_type="task_created",
+        target_resource="tasks/s",
+        before_state=None,
+        after_state=None,
+        coordination_session_id=session_id,
+    )
+    await log_bot_action(
+        conn,
+        user_id=TEST_USER_ID,
+        action_type="task_created",
+        target_resource="tasks/ns",
+        before_state=None,
+        after_state=None,
+        coordination_session_id=None,
+    )
+
+    count_session = await count_bot_actions(
+        conn,
+        user_id=TEST_USER_ID,
+        action_type="task_created",
+        since=since,
+        coordination_session_id=session_id,
+    )
+    assert count_session == 1
+
+
+async def test_count_bot_actions_no_session_counts_all(conn):
+    """When coordination_session_id is None, count all actions regardless of session."""
+    since = datetime.now(timezone.utc) - timedelta(minutes=1)
+    await log_bot_action(
+        conn,
+        user_id=TEST_USER_ID,
+        action_type="task_created",
+        target_resource="tasks/a",
+        before_state=None,
+        after_state=None,
+        coordination_session_id=99,
+    )
+    await log_bot_action(
+        conn,
+        user_id=TEST_USER_ID,
+        action_type="task_created",
+        target_resource="tasks/b",
+        before_state=None,
+        after_state=None,
+        coordination_session_id=None,
+    )
+    count = await count_bot_actions(
+        conn, user_id=TEST_USER_ID, action_type="task_created", since=since
+    )
+    assert count == 2
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# check_bot_budget
+# ──────────────────────────────────────────────────────────────────────────────
+
+async def test_check_bot_budget_returns_true_when_under_limit(conn):
+    """check_bot_budget must return True when no actions have been logged yet."""
+    result = await check_bot_budget(
+        conn,
+        user_id=TEST_USER_ID,
+        coordination_session_id=None,
+        action_type="task_created",
+    )
+    assert result is True
+
+
+async def test_check_bot_budget_non_coordination_allows_multiple_creates(conn):
+    """General (non-coordination) budget allows up to 10 task_created actions."""
+    since_start = datetime.now(timezone.utc) - timedelta(minutes=1)
+    for i in range(10):
+        # Log 10 task_created; budget should still allow the 11th to fail
+        await log_bot_action(
+            conn,
+            user_id=TEST_USER_ID,
+            action_type="task_created",
+            target_resource=f"tasks/{i}",
+            before_state=None,
+            after_state=None,
+            coordination_session_id=None,
+        )
+
+    # After 10, budget is exhausted
+    result = await check_bot_budget(
+        conn,
+        user_id=TEST_USER_ID,
+        coordination_session_id=None,
+        action_type="task_created",
+    )
+    assert result is False
+
+
+async def test_check_bot_budget_returns_false_when_over_limit(conn):
+    """check_bot_budget returns False once the action count reaches the limit."""
+    session_id = 55
+    # Coordination budget: task_created = 1
+    await log_bot_action(
+        conn,
+        user_id=TEST_USER_ID,
+        action_type="task_created",
+        target_resource="tasks/m",
+        before_state=None,
+        after_state=None,
+        coordination_session_id=session_id,
+    )
+    result = await check_bot_budget(
+        conn,
+        user_id=TEST_USER_ID,
+        coordination_session_id=session_id,
+        action_type="task_created",
+    )
+    assert result is False
+
+
+async def test_check_bot_budget_coordination_stricter_than_non_coordination(conn):
+    """Coordination sessions have strictly tighter limits than general sessions."""
+    session_id = 66
+    # Log 2 task_created for general (no session) — should still be under limit
+    for i in range(2):
+        await log_bot_action(
+            conn,
+            user_id=TEST_USER_ID,
+            action_type="task_created",
+            target_resource=f"tasks/gen{i}",
+            before_state=None,
+            after_state=None,
+            coordination_session_id=None,
+        )
+    general_ok = await check_bot_budget(
+        conn,
+        user_id=TEST_USER_ID,
+        coordination_session_id=None,
+        action_type="task_created",
+    )
+    assert general_ok is True, "General budget should allow 2 task_created"
+
+    # Log 1 task_created for this coordination session — should hit limit
+    await log_bot_action(
+        conn,
+        user_id=TEST_USER_ID,
+        action_type="task_created",
+        target_resource="tasks/coord",
+        before_state=None,
+        after_state=None,
+        coordination_session_id=session_id,
+    )
+    coord_ok = await check_bot_budget(
+        conn,
+        user_id=TEST_USER_ID,
+        coordination_session_id=session_id,
+        action_type="task_created",
+    )
+    assert coord_ok is False, "Coordination budget limit (1) should be exhausted"
+
+
+async def test_check_bot_budget_task_update_zero_in_coordination(conn):
+    """Coordination budget for task_updated is 0 — always False after first log."""
+    session_id = 77
+    # Even without any logged task_updated, budget should be exhausted (limit=0 means never allowed)
+    result = await check_bot_budget(
+        conn,
+        user_id=TEST_USER_ID,
+        coordination_session_id=session_id,
+        action_type="task_updated",
+    )
+    assert result is False, "task_updated limit in coordination is 0 — should be False"
+
+
+async def test_check_bot_budget_task_delete_zero_in_coordination(conn):
+    """Coordination budget for task_deleted is 0 — always False."""
+    session_id = 88
+    result = await check_bot_budget(
+        conn,
+        user_id=TEST_USER_ID,
+        coordination_session_id=session_id,
+        action_type="task_deleted",
+    )
+    assert result is False, "task_deleted limit in coordination is 0 — should be False"
+
+
+async def test_check_bot_budget_task_delete_allowed_in_general(conn):
+    """Non-coordination budget allows up to 5 task_deleted."""
+    # Zero deletions so far — should be True
+    result = await check_bot_budget(
+        conn,
+        user_id=TEST_USER_ID,
+        coordination_session_id=None,
+        action_type="task_deleted",
+    )
+    assert result is True


### PR DESCRIPTION
## Summary

- Alembic migration (`b2c3d4e5f6a7`) creates `bot_actions` table with RLS, two indexes, and a BIGINT FK to `meeting_requests(id)`
- `db/pg_queries/bot_actions.py` adds three query functions: `log_bot_action`, `count_bot_actions`, `check_bot_budget`
- 19 tests in `tests/db/test_bot_actions.py` covering schema, RLS isolation, log/count/budget behavior

## Schema

```sql
CREATE TABLE bot_actions (
    id                      BIGSERIAL PRIMARY KEY,
    user_id                 UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
    action_type             TEXT NOT NULL,
    target_resource         TEXT NOT NULL,
    before_state            JSONB,
    after_state             JSONB,
    coordination_session_id BIGINT REFERENCES meeting_requests(id) ON DELETE SET NULL,
    ts                      TIMESTAMPTZ NOT NULL DEFAULT now()
);
```

RLS policies: SELECT and INSERT both enforce `user_id = current_setting('app.current_user_id')::uuid`. Two indexes: `(user_id, ts DESC)` for time-range queries, partial `(coordination_session_id) WHERE coordination_session_id IS NOT NULL` for session lookups.

## Budget defaults

| Session type | task_created | task_updated | task_deleted |
|---|---|---|---|
| coordination | 1 | 0 | 0 |
| general | 10 | 20 | 5 |

Zero-limit actions short-circuit without a DB query.

## Test plan

- [ ] `DATABASE_URL` set to a Postgres instance with migration applied
- [ ] `python -m pytest tether/tests/db/test_bot_actions.py -v` — all 19 pass
- [ ] Verify cross-user RLS: `test_rls_blocks_cross_user_read` passes with `tether_app` role (non-superuser)
- [ ] Confirm `check_bot_budget` returns False for `task_updated`/`task_deleted` in coordination scope without any prior inserts