### PR TITLE
feat: WS server-side topic filtering for bot connections (PR 6)

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -18,15 +18,18 @@ def create_jwt(
     user_id: str,
     username: str,
     is_admin: bool,
+    is_bot_service: bool = False,
     expires_in: timedelta | None = None,
 ) -> str:
     exp = datetime.utcnow() + (expires_in if expires_in is not None else timedelta(days=7))
-    payload = {
+    payload: dict = {
         "user_id": user_id,
         "username": username,
         "is_admin": is_admin,
         "exp": exp,
     }
+    if is_bot_service:
+        payload["is_bot_service"] = True
     return jwt.encode(payload, cfg.JWT_SECRET, algorithm="HS256")
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -186,15 +186,36 @@ def create_app(lifespan_override=None) -> FastAPI:
 
     @app.websocket("/ws")
     async def websocket_endpoint(websocket: WebSocket):
+        import db.pg_queries.api_keys as _api_keys_queries
+
         token = websocket.cookies.get("tether_token")
         if token:
             try:
                 payload = decode_jwt(token)
                 user_id = payload["user_id"]
                 is_admin = payload.get("is_admin", False)
+                is_bot_service = payload.get("is_bot_service", False)
             except Exception:
                 await websocket.close(code=1008)
                 return
+
+            # Bot service path: register with per-user delegation filtering.
+            # Backward-compat: is_admin path (__bot__ channel) retained until PR 7.
+            if is_bot_service:
+                delegated = await _api_keys_queries.get_delegated_user_ids(
+                    websocket.app.state.pool, user_id
+                )
+                await websocket.accept()
+                manager.register_bot(websocket, user_id, delegated)
+                try:
+                    while True:
+                        await websocket.receive_text()
+                except (WebSocketDisconnect, RuntimeError):
+                    pass
+                finally:
+                    manager.disconnect_bot(user_id)
+                return
+
             await manager.connect(websocket, user_id)
             if is_admin:
                 manager.register_only(websocket, "__bot__")
@@ -222,9 +243,26 @@ def create_app(lifespan_override=None) -> FastAPI:
                 payload = decode_jwt(msg["token"])
                 user_id = payload["user_id"]
                 is_admin = payload.get("is_admin", False)
+                is_bot_service = payload.get("is_bot_service", False)
             except Exception:
                 await websocket.close(code=1008)
                 return
+
+            # Bot service path via message auth.
+            if is_bot_service:
+                delegated = await _api_keys_queries.get_delegated_user_ids(
+                    websocket.app.state.pool, user_id
+                )
+                manager.register_bot(websocket, user_id, delegated)
+                try:
+                    while True:
+                        await websocket.receive_text()
+                except (WebSocketDisconnect, RuntimeError):
+                    pass
+                finally:
+                    manager.disconnect_bot(user_id)
+                return
+
             manager.register_only(websocket, user_id)
             if is_admin:
                 manager.register_only(websocket, "__bot__")

--- a/api/ws.py
+++ b/api/ws.py
@@ -4,6 +4,11 @@ from typing import Any
 class ConnectionManager:
     def __init__(self):
         self._connections: dict[str, list] = {}
+        # bot_id -> (ws, delegated_user_ids)
+        # Keyed by bot identity so update_bot_delegation can find the ws by id.
+        # PR 4 will populate delegation sets via the key-claim flow; until then
+        # each bot registers with whatever set get_delegated_user_ids returns.
+        self._bot_connections: dict[str, tuple[Any, set[str]]] = {}
 
     async def connect(self, ws, user_id: str) -> None:
         await ws.accept()
@@ -17,11 +22,35 @@ class ConnectionManager:
         """
         self._connections.setdefault(user_id, []).append(ws)
 
+    def register_bot(self, ws, bot_id: str, delegated_user_ids: set[str]) -> None:
+        """Register a bot WS connection with an initial delegation set.
+
+        The websocket must already be accepted. Events are delivered to this
+        connection only for user_ids present in delegated_user_ids.
+        """
+        self._bot_connections[bot_id] = (ws, set(delegated_user_ids))
+
     def disconnect(self, ws, user_id: str) -> None:
         conns = self._connections.get(user_id, [])
         self._connections[user_id] = [c for c in conns if c is not ws]
 
+    def disconnect_bot(self, bot_id: str) -> None:
+        """Remove a bot connection registration by bot_id."""
+        self._bot_connections.pop(bot_id, None)
+
+    def update_bot_delegation(self, bot_id: str, delegated_user_ids: set[str]) -> None:
+        """Update the delegation set for an active bot connection.
+
+        Called when a new key is claimed (PR 4) or revoked. The bot connection
+        stays open — only the filter set changes. No-op if bot_id is not
+        currently connected.
+        """
+        if bot_id in self._bot_connections:
+            ws, _ = self._bot_connections[bot_id]
+            self._bot_connections[bot_id] = (ws, set(delegated_user_ids))
+
     async def broadcast(self, data: Any, user_id: str) -> None:
+        # Deliver to regular per-user connections.
         conns = self._connections.get(user_id, [])
         dead = []
         for ws in conns:
@@ -31,6 +60,18 @@ class ConnectionManager:
                 dead.append(ws)
         for ws in dead:
             self.disconnect(ws, user_id)
+
+        # Deliver to bot connections delegated for this user.
+        # Inject for_user_id so the bot can demultiplex events across users.
+        dead_bots = []
+        for bot_id, (bot_ws, delegated_set) in self._bot_connections.items():
+            if user_id in delegated_set:
+                try:
+                    await bot_ws.send_json({**data, "for_user_id": str(user_id)})
+                except Exception:
+                    dead_bots.append(bot_id)
+        for bot_id in dead_bots:
+            self.disconnect_bot(bot_id)
 
 
 manager = ConnectionManager()

--- a/db/pg_queries/api_keys.py
+++ b/db/pg_queries/api_keys.py
@@ -104,6 +104,28 @@ async def revoke_key(
     )
 
 
+async def get_delegated_user_ids(pool, bot_service_id: str) -> set[str]:
+    """Return all user_ids for which an active bot delegation key exists.
+
+    Queries api_keys for rows named 'bot_delegation_*' that have not been
+    revoked. These keys are minted by the claim flow (PR 4). Until PR 4
+    lands, no rows match and the returned set is empty.
+
+    NOTE: bot_service_id is reserved for future multi-bot scoping (PR 4).
+    Currently delegation keys are bot-global — the parameter is accepted so
+    call sites remain forward-compatible when PR 4 adds per-bot scoping.
+    """
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT DISTINCT user_id
+            FROM api_keys
+            WHERE name LIKE 'bot_delegation_%' AND revoked_at IS NULL
+            """,
+        )
+    return {str(row["user_id"]) for row in rows}
+
+
 async def validate_key(
     conn: asyncpg.Connection,
     raw_key: str,

--- a/tests/api/test_ws_filtering.py
+++ b/tests/api/test_ws_filtering.py
@@ -1,0 +1,200 @@
+"""Tests for server-side WebSocket topic filtering for bot connections.
+
+Bot connections register with a delegation set (user_ids they are authorized
+to receive events for). Server-side filtering ensures bots only receive events
+for delegated users.
+
+These tests do NOT require a database — unit tests exercise ConnectionManager
+directly. One integration test uses monkeypatching for the delegation lookup.
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("TETHER_DISABLE_RATE_LIMITS", "1")
+os.environ.setdefault("TETHER_COOKIE_SECURE", "false")
+os.environ.setdefault("TETHER_JWT_SECRET", "test-secret-for-ws-filtering-tests")
+
+from contextlib import asynccontextmanager
+
+import pytest
+from starlette.testclient import TestClient
+
+from api.auth import create_jwt
+from api.ws import ConnectionManager
+
+
+USER_A_ID = "00000000-0000-0000-0000-aaaaaaaaaaaa"
+USER_B_ID = "00000000-0000-0000-0000-bbbbbbbbbbbb"
+BOT_ID = "00000000-0000-0000-0000-000000000b07"
+BOT_USERNAME = "bot_service"
+
+
+class _MockWS:
+    """Minimal mock WebSocket — captures sent messages."""
+
+    def __init__(self):
+        self.sent: list[dict] = []
+
+    async def accept(self) -> None:
+        pass
+
+    async def send_json(self, data: dict) -> None:
+        self.sent.append(data)
+
+
+class _FakePool:
+    """Stub pool — WS auth does not hit the DB."""
+    pass
+
+
+@asynccontextmanager
+async def _noop_lifespan(app):
+    app.state.pool = _FakePool()
+    yield
+
+
+def _make_app():
+    from api.main import create_app
+    return create_app(lifespan_override=_noop_lifespan)
+
+
+# ── ConnectionManager unit tests ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bot_receives_event_for_delegated_user():
+    """Bot with delegation for user A receives events broadcast to user A."""
+    manager = ConnectionManager()
+    bot_ws = _MockWS()
+    manager.register_bot(bot_ws, BOT_ID, {USER_A_ID})
+
+    await manager.broadcast({"type": "task_updated", "id": "t1"}, USER_A_ID)
+
+    assert len(bot_ws.sent) == 1
+    assert bot_ws.sent[0]["type"] == "task_updated"
+    assert bot_ws.sent[0]["for_user_id"] == USER_A_ID
+
+
+@pytest.mark.asyncio
+async def test_bot_does_not_receive_event_for_non_delegated_user():
+    """Bot with delegation for user A does NOT receive events broadcast to user B."""
+    manager = ConnectionManager()
+    bot_ws = _MockWS()
+    manager.register_bot(bot_ws, BOT_ID, {USER_A_ID})
+
+    await manager.broadcast({"type": "task_updated", "id": "t2"}, USER_B_ID)
+
+    assert bot_ws.sent == []
+
+
+@pytest.mark.asyncio
+async def test_bot_receives_events_for_all_delegated_users():
+    """Bot with delegation for both A and B receives events for both."""
+    manager = ConnectionManager()
+    bot_ws = _MockWS()
+    manager.register_bot(bot_ws, BOT_ID, {USER_A_ID, USER_B_ID})
+
+    await manager.broadcast({"type": "anchor_updated"}, USER_A_ID)
+    await manager.broadcast({"type": "anchor_updated"}, USER_B_ID)
+
+    assert len(bot_ws.sent) == 2
+    user_ids_received = {msg["for_user_id"] for msg in bot_ws.sent}
+    assert user_ids_received == {USER_A_ID, USER_B_ID}
+
+
+@pytest.mark.asyncio
+async def test_update_bot_delegation_adds_new_user():
+    """Adding a user to the delegation set causes bot to receive their events (no reconnect)."""
+    manager = ConnectionManager()
+    bot_ws = _MockWS()
+    manager.register_bot(bot_ws, BOT_ID, {USER_A_ID})
+
+    # Before update — user B's events not delivered
+    await manager.broadcast({"type": "task_updated"}, USER_B_ID)
+    assert bot_ws.sent == []
+
+    # Expand delegation to include user B
+    manager.update_bot_delegation(BOT_ID, {USER_A_ID, USER_B_ID})
+
+    # After update — user B's events now delivered
+    await manager.broadcast({"type": "task_updated"}, USER_B_ID)
+    assert len(bot_ws.sent) == 1
+    assert bot_ws.sent[0]["for_user_id"] == USER_B_ID
+
+
+@pytest.mark.asyncio
+async def test_revoke_delegation_stops_events_for_user():
+    """Removing a user from the delegation set stops delivery of their events."""
+    manager = ConnectionManager()
+    bot_ws = _MockWS()
+    manager.register_bot(bot_ws, BOT_ID, {USER_A_ID, USER_B_ID})
+
+    # Confirm user A's events arrive before revocation
+    await manager.broadcast({"type": "task_updated"}, USER_A_ID)
+    assert len(bot_ws.sent) == 1
+
+    # Revoke user A — only user B remains
+    manager.update_bot_delegation(BOT_ID, {USER_B_ID})
+
+    # User A's events no longer delivered
+    await manager.broadcast({"type": "task_updated"}, USER_A_ID)
+    assert len(bot_ws.sent) == 1  # count unchanged
+
+
+@pytest.mark.asyncio
+async def test_regular_user_broadcast_unaffected_by_bot_registration():
+    """Regular user still receives their own events; undelegated bot receives none."""
+    manager = ConnectionManager()
+    user_ws = _MockWS()
+    bot_ws = _MockWS()
+
+    await manager.connect(user_ws, USER_A_ID)
+    # Bot is NOT delegated for user A
+    manager.register_bot(bot_ws, BOT_ID, {USER_B_ID})
+
+    await manager.broadcast({"type": "plan_updated"}, USER_A_ID)
+
+    assert user_ws.sent == [{"type": "plan_updated"}]
+    assert bot_ws.sent == []
+
+
+@pytest.mark.asyncio
+async def test_bot_disconnect_removes_registration():
+    """After disconnect_bot, no events are delivered to that connection."""
+    manager = ConnectionManager()
+    bot_ws = _MockWS()
+    manager.register_bot(bot_ws, BOT_ID, {USER_A_ID})
+
+    manager.disconnect_bot(BOT_ID)
+
+    await manager.broadcast({"type": "task_updated"}, USER_A_ID)
+    assert bot_ws.sent == []
+
+
+# ── Integration test — /ws endpoint with is_bot_service JWT ─────────────────
+
+
+def test_bot_service_ws_registers_with_delegation(monkeypatch):
+    """Bot WS with is_bot_service=True JWT registers in _bot_connections with delegation set."""
+    import db.pg_queries.api_keys as _api_keys
+
+    async def _mock_get_delegated(pool, bot_service_id: str) -> set[str]:
+        return {USER_A_ID}
+
+    monkeypatch.setattr(_api_keys, "get_delegated_user_ids", _mock_get_delegated)
+
+    app = _make_app()
+    token = create_jwt(BOT_ID, BOT_USERNAME, is_admin=False, is_bot_service=True)
+
+    from api.ws import manager as global_manager
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        with client.websocket_connect("/ws", cookies={"tether_token": token}) as ws:
+            ws.send_text("ping")
+            assert BOT_ID in global_manager._bot_connections
+            _, delegated = global_manager._bot_connections[BOT_ID]
+            assert USER_A_ID in delegated
+
+    # After disconnect, bot registration is cleaned up
+    assert BOT_ID not in global_manager._bot_connections


### PR DESCRIPTION
## Summary

- Adds `_bot_connections` dict to `ConnectionManager` tracking bot WS connections with per-connection delegation sets (`{user_id: (ws, set[str])}`)
- `register_bot(ws, bot_id, delegated_user_ids)` / `disconnect_bot(bot_id)` / `update_bot_delegation(bot_id, user_ids)` methods for managing bot connections
- `broadcast()` now also delivers events to bot connections delegated for the target user, injecting `for_user_id` for bot-side demultiplexing
- `is_bot_service` flag added to `create_jwt()` — bot WS connections use this claim to opt into the filtered path
- `get_delegated_user_ids(pool, bot_service_id)` added to `db/pg_queries/api_keys.py` — queries `api_keys` for `bot_delegation_*` rows (seam for PR 4 claim flow)
- Backwards-compat: existing `__bot__` channel + `is_admin=True` path retained until PR 7 removes it

## Test plan

- [x] `test_bot_receives_event_for_delegated_user` — bot gets events for delegated user with `for_user_id` field
- [x] `test_bot_does_not_receive_event_for_non_delegated_user` — bot gets nothing for non-delegated user
- [x] `test_bot_receives_events_for_all_delegated_users` — both users delivered when both delegated
- [x] `test_update_bot_delegation_adds_new_user` — live delegation expansion without reconnect
- [x] `test_revoke_delegation_stops_events_for_user` — live delegation shrink without reconnect
- [x] `test_regular_user_broadcast_unaffected_by_bot_registration` — regular WS path unchanged
- [x] `test_bot_disconnect_removes_registration` — cleanup verified
- [x] `test_bot_service_ws_registers_with_delegation` — integration: WS endpoint registers bot with monkeypatched delegation lookup
- [x] All pre-existing WS tests still pass (`test_ws.py`, `test_ws_admin_bot.py`, `test_bot_ws.py`)