### PR TITLE
feat: Bearer auth fallback in auth_dependency

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -4,6 +4,8 @@ import jwt
 from datetime import datetime, timedelta
 from fastapi import Request, HTTPException, WebSocket, WebSocketException, status
 import api.config as cfg
+import db.postgres as pg
+import db.pg_queries.api_keys as key_queries
 
 
 def hash_password(password: str) -> str:
@@ -36,26 +38,65 @@ def create_jwt(
 def decode_jwt(token: str) -> dict:
     return jwt.decode(token, cfg.JWT_SECRET, algorithms=["HS256"])
 
+
 def _decode_token_from_cookies(cookies: dict) -> dict:
     token = cookies.get('tether_token')
     if not token:
         raise ValueError("missing")
     return decode_jwt(token)
 
+
+async def _validate_bearer_key(pool, raw_key: str) -> str | None:
+    """Validate a ttr_ prefixed API key against the database.
+
+    Uses an unscoped connection (no RLS user set) because identity is bootstrapped
+    from the key itself — user_id is unknown until validation completes.
+    Returns the owner's user_id as a string, or None if the key is invalid/revoked.
+    """
+    async with pg.get_conn(pool, user_id=None) as conn:
+        return await key_queries.validate_key(conn, raw_key)
+
+
 async def auth_dependency(request: Request):
-    """FastAPI dependency — extracts JWT from cookie, sets request.state.user_id."""
-    try:
-        payload = _decode_token_from_cookies(request.cookies)
-    except ValueError:
-        raise HTTPException(status_code=401, detail="Not authenticated")
-    except jwt.ExpiredSignatureError:
-        raise HTTPException(status_code=401, detail="Token expired")
-    except jwt.InvalidTokenError:
-        raise HTTPException(status_code=401, detail="Invalid token")
-    request.state.user_id = payload["user_id"]
-    request.state.username = payload["username"]
-    request.state.is_admin = payload.get("is_admin", False)
-    return payload
+    """FastAPI dependency — authenticates via JWT cookie or Bearer API key.
+
+    Resolution order:
+    1. tether_token cookie (JWT) — takes precedence if present and valid.
+    2. Authorization: Bearer ttr_<key> header — validated against api_keys table.
+    3. Neither present → 401.
+
+    On success, sets request.state.user_id, request.state.username, and
+    request.state.is_admin. Bearer-authenticated requests have username=None.
+    """
+    # --- Cookie path (existing behavior) ---
+    cookie_token = request.cookies.get("tether_token")
+    if cookie_token:
+        try:
+            payload = decode_jwt(cookie_token)
+        except jwt.ExpiredSignatureError:
+            raise HTTPException(status_code=401, detail="Token expired")
+        except jwt.InvalidTokenError:
+            raise HTTPException(status_code=401, detail="Invalid token")
+        request.state.user_id = payload["user_id"]
+        request.state.username = payload["username"]
+        request.state.is_admin = payload.get("is_admin", False)
+        return payload
+
+    # --- Bearer API key path ---
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer ttr_"):
+        raw_key = auth_header[len("Bearer "):]
+        pool = request.app.state.pool
+        user_id = await _validate_bearer_key(pool, raw_key)
+        if user_id is None:
+            raise HTTPException(status_code=401, detail="Invalid API key")
+        request.state.user_id = user_id
+        request.state.username = None
+        request.state.is_admin = False
+        return {"user_id": user_id, "is_admin": False}
+
+    raise HTTPException(status_code=401, detail="Not authenticated")
+
 
 async def ws_auth_dependency(websocket: WebSocket):
     try:

--- a/api/auth.py
+++ b/api/auth.py
@@ -80,6 +80,7 @@ async def auth_dependency(request: Request):
         request.state.user_id = payload["user_id"]
         request.state.username = payload["username"]
         request.state.is_admin = payload.get("is_admin", False)
+        request.state.auth_method = "cookie"
         return payload
 
     # --- Bearer API key path ---
@@ -93,6 +94,7 @@ async def auth_dependency(request: Request):
         request.state.user_id = user_id
         request.state.username = None
         request.state.is_admin = False
+        request.state.auth_method = "bearer"
         return {"user_id": user_id, "is_admin": False}
 
     raise HTTPException(status_code=401, detail="Not authenticated")

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -110,10 +110,9 @@ def _make_request(*, cookie_token: str | None = None, auth_header: str | None = 
 
 @pytest.mark.asyncio
 async def test_bearer_valid_key_authenticates(monkeypatch):
-    """Valid ttr_ Bearer key succeeds; user_id and is_admin are set correctly."""
+    """Valid ttr_ Bearer key succeeds; user_id, is_admin, and auth_method are set."""
     from unittest.mock import AsyncMock
     import api.auth as auth_mod
-    from fastapi import HTTPException
 
     monkeypatch.setattr(auth_mod, "_validate_bearer_key", AsyncMock(return_value=TEST_BEARER_USER_ID))
 
@@ -125,6 +124,7 @@ async def test_bearer_valid_key_authenticates(monkeypatch):
     assert request.state.user_id == TEST_BEARER_USER_ID
     assert request.state.is_admin is False
     assert request.state.username is None
+    assert request.state.auth_method == "bearer"
 
 
 @pytest.mark.asyncio
@@ -198,3 +198,29 @@ async def test_cookie_auth_regression_passes():
     assert result["user_id"] == "cookie-user-id"
     assert result["username"] == "cookieuser"
     assert result["is_admin"] is False
+    assert request.state.auth_method == "cookie"
+
+
+@pytest.mark.asyncio
+async def test_invalid_cookie_does_not_fall_through_to_bearer(monkeypatch):
+    """An invalid cookie raises 401 immediately; the Bearer header is NOT consulted.
+
+    This locks in an important invariant: Bearer cannot be used as a bypass when
+    a cookie is present but invalid (e.g. tampered or from a different secret).
+    """
+    from unittest.mock import AsyncMock
+    import api.auth as auth_mod
+    from fastapi import HTTPException
+
+    mock_validate = AsyncMock(return_value=TEST_BEARER_USER_ID)
+    monkeypatch.setattr(auth_mod, "_validate_bearer_key", mock_validate)
+
+    request = _make_request(
+        cookie_token="bad.token.value",
+        auth_header=f"Bearer {TEST_RAW_KEY}",
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_mod.auth_dependency(request)
+
+    assert exc_info.value.status_code == 401
+    mock_validate.assert_not_called()

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -83,3 +83,118 @@ async def test_invalid_token_returns_401(auth_client):
         cookies={"tether_token": "bad.token.here"},
     )
     assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# auth_dependency — Bearer token fallback (unit tests, no DB required)
+#
+# These tests call auth_dependency directly with a mock Request rather than
+# going through an HTTP client. This avoids needing a real Postgres pool while
+# still verifying the exact auth logic.
+# ---------------------------------------------------------------------------
+
+TEST_BEARER_USER_ID = "00000000-0000-0000-0000-000000000001"
+TEST_RAW_KEY = "ttr_testkey1234567890abcdefghijklmnopqrstuv"
+
+
+def _make_request(*, cookie_token: str | None = None, auth_header: str | None = None):
+    """Build a minimal mock Request for auth_dependency testing."""
+    from unittest.mock import MagicMock
+
+    request = MagicMock()
+    request.cookies = {"tether_token": cookie_token} if cookie_token else {}
+    request.headers = {"Authorization": auth_header} if auth_header else {}
+    request.app.state.pool = MagicMock()  # never actually called when _validate_bearer_key is mocked
+    return request
+
+
+@pytest.mark.asyncio
+async def test_bearer_valid_key_authenticates(monkeypatch):
+    """Valid ttr_ Bearer key succeeds; user_id and is_admin are set correctly."""
+    from unittest.mock import AsyncMock
+    import api.auth as auth_mod
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(auth_mod, "_validate_bearer_key", AsyncMock(return_value=TEST_BEARER_USER_ID))
+
+    request = _make_request(auth_header=f"Bearer {TEST_RAW_KEY}")
+    result = await auth_mod.auth_dependency(request)
+
+    assert result["user_id"] == TEST_BEARER_USER_ID
+    assert result["is_admin"] is False
+    assert request.state.user_id == TEST_BEARER_USER_ID
+    assert request.state.is_admin is False
+    assert request.state.username is None
+
+
+@pytest.mark.asyncio
+async def test_bearer_invalid_key_returns_401(monkeypatch):
+    """Invalid ttr_ Bearer key (validate returns None) → 401."""
+    from unittest.mock import AsyncMock
+    import api.auth as auth_mod
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(auth_mod, "_validate_bearer_key", AsyncMock(return_value=None))
+
+    request = _make_request(auth_header=f"Bearer {TEST_RAW_KEY}")
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_mod.auth_dependency(request)
+
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_bearer_non_ttr_prefix_ignored(monkeypatch):
+    """Bearer token without ttr_ prefix falls through to cookie path → 401 (no cookie)."""
+    import api.auth as auth_mod
+    from fastapi import HTTPException
+
+    request = _make_request(auth_header="Bearer some_other_token")
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_mod.auth_dependency(request)
+
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_cookie_wins_when_both_present(monkeypatch):
+    """Valid cookie takes precedence; _validate_bearer_key is never called."""
+    from unittest.mock import AsyncMock
+    import api.auth as auth_mod
+
+    mock_validate = AsyncMock(return_value=TEST_BEARER_USER_ID)
+    monkeypatch.setattr(auth_mod, "_validate_bearer_key", mock_validate)
+
+    token = create_jwt(TEST_BEARER_USER_ID, "testuser", is_admin=False)
+    request = _make_request(cookie_token=token, auth_header=f"Bearer {TEST_RAW_KEY}")
+    result = await auth_mod.auth_dependency(request)
+
+    assert result["user_id"] == TEST_BEARER_USER_ID
+    mock_validate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_neither_cookie_nor_bearer_returns_401():
+    """No cookie, no Bearer → 401."""
+    import api.auth as auth_mod
+    from fastapi import HTTPException
+
+    request = _make_request()
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_mod.auth_dependency(request)
+
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_cookie_auth_regression_passes():
+    """Existing cookie auth still works — no regression."""
+    import api.auth as auth_mod
+
+    token = create_jwt("cookie-user-id", "cookieuser", is_admin=False)
+    request = _make_request(cookie_token=token)
+    result = await auth_mod.auth_dependency(request)
+
+    assert result["user_id"] == "cookie-user-id"
+    assert result["username"] == "cookieuser"
+    assert result["is_admin"] is False


### PR DESCRIPTION
## Summary

- Extends `auth_dependency` to accept `Authorization: Bearer ttr_<key>` headers as a fallback when no `tether_token` cookie is present
- Cookie path is unchanged and takes precedence when both are present
- Invalid cookie → 401 immediately (Bearer header is NOT consulted as a bypass)
- Bearer path validates via `validate_key()` SECURITY DEFINER SQL function; sets `request.state.user_id` from key owner, `username=None`, `is_admin=False`
- Adds `request.state.auth_method` (`"cookie"` or `"bearer"`) for future key-management gating

## Test plan

- [x] All new tests are pure unit tests (no DB required) — call `auth_dependency` directly with mock `Request`
- [x] `test_bearer_valid_key_authenticates` — valid ttr_ key → user_id + auth_method=="bearer"
- [x] `test_bearer_invalid_key_returns_401` — validate returns None → 401
- [x] `test_bearer_non_ttr_prefix_ignored` — non-ttr_ Bearer falls through → 401
- [x] `test_cookie_wins_when_both_present` — cookie takes precedence, bearer never called
- [x] `test_neither_cookie_nor_bearer_returns_401` — no auth → 401
- [x] `test_cookie_auth_regression_passes` — existing cookie path unchanged
- [x] `test_invalid_cookie_does_not_fall_through_to_bearer` — bad cookie + Bearer → 401 (invariant test)