### PR TITLE
fix: reset postgres ports+volumes in dev compose overlay

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,8 +21,8 @@ services:
   postgres:
     # Don't expose postgres on the host — dev postgres is internal only.
     # Production exposes 5432 for tooling access; dev avoids the port conflict.
-    ports: []
-    volumes:
+    ports: !reset []
+    volumes: !reset
       - pgdata-dev:/var/lib/postgresql/data
 
   api:


### PR DESCRIPTION
## Root cause

`docker-compose.dev.yml` was missing `!reset` tags on the `postgres` service's `ports` and `volumes` fields.

Docker Compose v2 **concatenates** sequences when merging overlay files — it does not replace them. Without `!reset`:

- `ports: []` → merged result still contains `5432:5432` from the base compose → dev postgres tries to bind the same host port as production postgres → **container fails to start** → not in the `tether-dev_default` network → `postgres` hostname unresolvable to the API container → `socket.gaierror: [Errno -5] No address associated with hostname`
- `volumes: []` → merged result contains both `pgdata` and `pgdata-dev` mounting to `/var/lib/postgresql/data` → second mount conflicts → container fails to start

The `api` and `mcp` services already used `ports: !reset [...]` correctly. The `postgres` service was the only one missing the tag.

## Fix

```yaml
postgres:
  ports: !reset []          # was: ports: []
  volumes: !reset           # was: volumes:
    - pgdata-dev:/var/lib/postgresql/data
```

Two characters added per field — that's the entire change.

## Verification

After merging, run the force-deploy-all workflow targeting `dev`. The postgres container should start cleanly (no port conflict), join the `tether-dev_default` network, and the API container should resolve the `postgres` hostname successfully.