### PR TITLE
fix: start postgres in dev force-deploy workflow

### DIFF
--- a/.github/workflows/pi-force-deploy-all.yml
+++ b/.github/workflows/pi-force-deploy-all.yml
@@ -220,7 +220,7 @@ jobs:
               -f docker-compose.yml \
               -f docker-compose.dev.yml \
               -p tether-dev \
-              up -d --no-deps api bot mcp
+              up -d --no-deps postgres api bot mcp
 
   prune:
     name: Prune old images


### PR DESCRIPTION
## Problem

PR #315 fixed the port conflict that stopped the dev postgres container from starting. But even after that fix, the API container still fails — postgres is never actually *started* by any CI workflow.

Every CI workflow uses `--no-deps` when restarting services, which bypasses `depends_on`. The force-deploy-all dev step was:

```yaml
up -d --no-deps api bot mcp
```

Postgres is not in the list, so it is never started. Without a running postgres container in the `tether-dev_default` network, the hostname `postgres` is unresolvable and the API fails with `gaierror: [Errno -5]`.

## Fix

Add `postgres` to the dev restart step in `pi-force-deploy-all.yml`:

```yaml
up -d --no-deps postgres api bot mcp
```

The per-service redeploys (`pi-deploy-dev-api`, etc.) remain unchanged — once postgres is up with `restart: unless-stopped`, routine single-service redeploys leave it alone.