### PR TITLE
fix: add alembic.ini to image and dev migration workflow

### DIFF
--- a/.github/workflows/pi-deploy-db-dev.yml
+++ b/.github/workflows/pi-deploy-db-dev.yml
@@ -1,0 +1,45 @@
+name: "[Pi] Deploy DB dev (migrations)"
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - 'db/**'
+      - 'alembic.ini'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pi-deploy-db-dev
+  cancel-in-progress: false
+
+jobs:
+  deploy-db-dev:
+    name: Run DB migrations (dev)
+    runs-on: self-hosted
+    steps:
+      - name: Pull latest code
+        run: |
+          cd /home/toast/tether-dev
+          git fetch origin dev
+          git checkout dev
+          git pull origin dev
+
+      - name: Run Alembic migrations
+        env:
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          TETHER_APP_PASSWORD: ${{ secrets.TETHER_APP_PASSWORD }}
+        run: |
+          cd /home/toast/tether-dev
+          TAG=$(grep "^IMAGE_TAG=" .env 2>/dev/null | cut -d= -f2)
+          TETHER_IMAGE=tether-premium-dev IMAGE_TAG="${TAG:-latest}" \
+            docker compose \
+              -f docker-compose.yml \
+              -f docker-compose.dev.yml \
+              -p tether-dev \
+              run --rm --no-deps \
+              -e ADMIN_DATABASE_URL="postgresql://tether:${POSTGRES_PASSWORD}@postgres:5432/tether" \
+              -e TETHER_APP_PASSWORD="${TETHER_APP_PASSWORD}" \
+              api alembic upgrade head

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ COPY config/ config/
 COPY prompts/ prompts/
 COPY cron/ cron/
 COPY scripts/ scripts/
+COPY alembic.ini ./
 
 # Install local package (deps already satisfied — no external downloads)
 RUN pip install --no-cache-dir --no-deps .


### PR DESCRIPTION
## Problem

`alembic.ini` was never copied into the Docker image (no `COPY alembic.ini ./` in Dockerfile). This means:

- `docker compose run --rm api alembic upgrade head` silently fails — alembic can't find its config
- Fresh postgres volumes (like `pgdata-dev`) can't be initialized via the documented command
- The docs at `docs/site/self-hosting/installation.md` claim this command works, but it doesn't

This is the root cause of the current dev API failure: after fixing the port conflict (PR #315) and starting dev postgres (#317), the `tether_app` role and schema don't exist because migrations were never run against the fresh `pgdata-dev` volume.

## Fix

1. **Dockerfile**: Add `COPY alembic.ini ./` so the image includes the migration config
2. **`pi-deploy-db-dev.yml`**: New workflow that runs `alembic upgrade head` against dev postgres on push to `dev` (when `db/` or `alembic.ini` changes) or manual dispatch

## Immediate unblock

While waiting for this PR to build and deploy, run migrations manually on the Pi:

```bash
cd ~/tether-dev
IMAGE_TAG=$(grep '^IMAGE_TAG=' .env | cut -d= -f2)
POSTGRES_PASSWORD=$(grep '^POSTGRES_PASSWORD=' .env | cut -d= -f2)
TETHER_APP_PASSWORD=$(grep '^TETHER_APP_PASSWORD=' .env | cut -d= -f2)

docker run --rm \
  --network tether-dev_default \
  -v ~/tether-dev/alembic.ini:/app/alembic.ini:ro \
  -e ADMIN_DATABASE_URL="postgresql://tether:${POSTGRES_PASSWORD}@postgres:5432/tether" \
  -e TETHER_APP_PASSWORD="${TETHER_APP_PASSWORD}" \
  "tether-premium-dev:${IMAGE_TAG}" \
  alembic upgrade head
```

This mounts `alembic.ini` from the Pi into the existing image to run migrations without a rebuild.