### PR TITLE
Fix dev CI: write DB passwords to dev .env, sync tether_app role

### DIFF
--- a/.github/workflows/pi-build-dev.yml
+++ b/.github/workflows/pi-build-dev.yml
@@ -113,6 +113,10 @@ jobs:
       DEV_DIR: /home/toast/tether-dev
       TETHER_CONFIG_DIR: /home/toast/.tether-config-dev
       TETHER_DATA_DIR: /home/toast/.tether-config-dev
+      # configure.py reads TETHER_COMPOSE_DIR to know where to write .env.
+      # Without this, it defaults to ~/tether (production), so POSTGRES_PASSWORD
+      # and TETHER_APP_PASSWORD would never land in the dev stack's .env.
+      TETHER_COMPOSE_DIR: /home/toast/tether-dev
     steps:
       - name: Ensure dev repo is present
         run: |
@@ -210,6 +214,18 @@ jobs:
           make configure-db \
             POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
             TETHER_APP_PASSWORD="$TETHER_APP_PASSWORD"
+          # Sync tether_app password directly against the dev postgres container
+          # (if it is running). make configure-db also attempts this but uses a
+          # plain `docker compose` call without the dev project flags, so it
+          # targets the wrong container. This explicit call uses the correct
+          # project name and overlay file.
+          docker compose \
+            -f "${DEV_DIR}/docker-compose.yml" \
+            -f "${DEV_DIR}/docker-compose.dev.yml" \
+            -p tether-dev \
+            exec -T postgres psql -U tether \
+            -c "ALTER ROLE tether_app WITH PASSWORD '${TETHER_APP_PASSWORD}';" \
+            2>/dev/null || true
           make configure-vault \
             TETHER_VAULT_KEY="$TETHER_VAULT_KEY"
 


### PR DESCRIPTION
## Problem

The dev API fails with `password authentication failed for user "tether_app"` on startup because of two related bugs in `pi-build-dev.yml`:

### Bug 1 — `configure-db` writes to the wrong `.env`

`scripts/configure.py` reads `TETHER_COMPOSE_DIR` to decide where to write the compose `.env`. The build job never set this variable, so it defaulted to `~/tether` (production). `POSTGRES_PASSWORD` and `TETHER_APP_PASSWORD` were written to `~/tether/.env` instead of `~/tether-dev/.env`.

When the dev API starts, compose reads `~/tether-dev/.env` — which only has `IMAGE_TAG` — and falls back to the `tether_app_dev` hardcoded default for `DATABASE_URL`.

### Bug 2 — `configure-db`'s ALTER ROLE targets the wrong container

`make configure-db` tries to `ALTER ROLE tether_app` in postgres after writing config, but uses a plain `docker compose exec` without `-p tether-dev` or the dev overlay file. If the prod stack isn't running (it usually isn't during CI), the `|| true` eats the error silently.

## Fix

1. **Set `TETHER_COMPOSE_DIR: /home/toast/tether-dev`** on the build job — `configure-db` now writes to the correct file, so compose interpolates the real passwords.
2. **Add an explicit ALTER ROLE step** after `configure-db`, targeting the dev postgres via the correct `-p tether-dev` project flags. Handles the case where `tether_app` already exists with a stale password (e.g. after the role was first created with a different value).

## Immediate workaround (before this merges)

```bash
# Check what password compose is actually using for tether_app
cat ~/tether-dev/.env   # if TETHER_APP_PASSWORD is absent, compose uses tether_app_dev

# Set the postgres role to match the compose default
docker exec -it tether-dev-postgres-1 psql -U tether -d tether \
  -c "ALTER ROLE tether_app WITH PASSWORD 'tether_app_dev';"
```

## Test plan
- [ ] Merge and let CI rebuild the dev image
- [ ] Confirm `~/tether-dev/.env` contains `TETHER_APP_PASSWORD=<secret>` after next CI run
- [ ] Confirm dev API starts without `InvalidPasswordError`