### PR TITLE
Fix dev overlay ports: !override instead of !reset

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,11 +26,11 @@ services:
       - pgdata-dev:/var/lib/postgresql/data
 
   api:
-    ports: !reset
+    ports: !override
       - "8001:8000"
 
   mcp:
-    ports: !reset
+    ports: !override
       - "5002:5001"
 
 volumes:


### PR DESCRIPTION
## Problem

The dev API and MCP containers have no host port binding — `docker ps` shows `8000/tcp` (exposed but unpublished) instead of `0.0.0.0:8001->8000/tcp`.

Root cause: compose v5 changed `!reset` semantics. `!reset` now resets a field to its zero value (empty list for `ports`) and **ignores** the value that follows. So:

```yaml
ports: !reset
  - "8001:8000"   # silently ignored in compose v5
```

resolves to `ports: []` — no host binding.

## Fix

Use `!override` instead, which replaces the base file value with the tagged value:

```yaml
ports: !override
  - "8001:8000"   # correctly applied
```

`postgres` keeps `ports: !reset []` since the intent there is explicitly an empty list (no host ports), which `!reset` handles correctly.

## Test plan
- [ ] `docker compose -f docker-compose.yml -f docker-compose.dev.yml -p tether-dev config | grep -A3 ports` shows `8001:8000` for api and `5002:5001` for mcp
- [ ] Dev API reachable at http://raspberrypi.tail...:8001 after restart