### PR TITLE
feat(infra): Fly.io deployment scaffolding (Phase 3a)

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -36,9 +36,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Deploy to tether-prod
-        run: flyctl deploy --config fly.toml --remote-only
+        run: flyctl deploy --config fly.toml --remote-only --build-arg PREMIUM_GIT_TOKEN=$PREMIUM_GIT_TOKEN
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          PREMIUM_GIT_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
 
   deploy-dev:
     name: Deploy dev (tether-dev)
@@ -48,6 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Deploy to tether-dev
-        run: flyctl deploy --config fly.dev.toml --remote-only
+        run: flyctl deploy --config fly.dev.toml --remote-only --build-arg PREMIUM_GIT_TOKEN=$PREMIUM_GIT_TOKEN
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          PREMIUM_GIT_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,53 @@
+name: "Deploy to Fly.io"
+
+# Deploys to Fly.io on pushes to main (prod) or dev (dev).
+# Fly handles the remote image build — no self-hosted runner needed.
+#
+# Separate from Pi deploy workflows (pi-build.yml, pi-build-dev.yml)
+# which manage the local Docker image build and service restarts on the Pi.
+#
+# Required secret: FLY_API_TOKEN (personal access token — works for both apps)
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'api/**'
+      - 'bot/**'
+      - 'tether_mcp/**'
+      - 'db/**'
+      - 'shared/**'
+      - 'prompts/**'
+      - 'requirements.txt'
+      - 'Dockerfile'
+      - 'supervisord.conf'
+      - 'fly.toml'
+      - 'fly.dev.toml'
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-prod:
+    name: Deploy prod (tether-prod)
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy to tether-prod
+        run: flyctl deploy --config fly.toml --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  deploy-dev:
+    name: Deploy dev (tether-dev)
+    if: github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy to tether-dev
+        run: flyctl deploy --config fly.dev.toml --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,11 @@ WORKDIR /app
 COPY requirements.txt pyproject.toml ./
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Process manager for multi-service Fly.io deployments.
+# supervisor is intentionally not in requirements.txt — it's infrastructure,
+# not an application dependency, and shouldn't affect the dev/test environment.
+RUN pip install --no-cache-dir supervisor
+
 # Application code
 COPY api/ api/
 COPY bot/ bot/
@@ -66,6 +71,9 @@ COPY scripts/ scripts/
 
 # Install local package (deps already satisfied — no external downloads)
 RUN pip install --no-cache-dir --no-deps .
+
+# supervisord config — copied late so it doesn't bust the dependency cache
+COPY supervisord.conf .
 
 # Frontend build artifacts
 COPY --from=frontend-build /build/dist/ frontend/dist/
@@ -90,5 +98,6 @@ RUN if [ -n "$PREMIUM_GIT_TOKEN" ]; then \
 # Default port for API
 EXPOSE 8000
 
-# Default CMD — overridden per service in docker-compose.yml
-CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Default CMD — runs all services via supervisord on Fly.io.
+# Overridden per service in docker-compose.yml for Pi deployments.
+CMD ["supervisord", "-c", "/app/supervisord.conf"]

--- a/config/app_config.yaml
+++ b/config/app_config.yaml
@@ -17,3 +17,9 @@ pipeline:
 server:
   api_port: 8000
   mcp_port: 5001
+
+telegram:
+  # Resolved from env vars — allows cloud deployments (Fly.io) without a
+  # local config override dir. Pi deployments override via TETHER_CONFIG_DIR.
+  bot_token: "${TELEGRAM_BOT_TOKEN:-}"
+  chat_id: "${TELEGRAM_CHAT_ID:-}"

--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -1,0 +1,20 @@
+app = "tether-dev"
+primary_region = "sea"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = "suspend"
+  auto_start_machines = true
+  # dev machine can fully sleep — no persistent bot polling needed
+  min_machines_running = 0
+
+[env]
+  PYTHON_ENV = "development"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,21 @@
+app = "tether-prod"
+primary_region = "sea"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = "suspend"
+  auto_start_machines = true
+  # bot long-polling requires a persistent connection — set to 0 once
+  # Telegram webhook mode ships (Phase 3b)
+  min_machines_running = 1
+
+[env]
+  PYTHON_ENV = "production"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,27 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/null
+
+[program:api]
+command=uvicorn api.main:app --host 0.0.0.0 --port 8000
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0
+autorestart=true
+
+[program:mcp]
+command=python -m tether_mcp.server --sse
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0
+autorestart=true
+
+[program:bot]
+command=python -m bot.message_handler
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0
+autorestart=true


### PR DESCRIPTION
## Summary

Phase 3a infra scaffolding — everything needed to deploy to Fly.io. No application code changes.

### Files added/changed

| File | Change |
|------|--------|
| `supervisord.conf` | Runs api, mcp, bot as supervised processes in one container |
| `Dockerfile` | Installs supervisor; copies supervisord.conf; CMD → supervisord |
| `fly.toml` | Prod app config (tether-prod, sea, 512mb, min_machines=1) |
| `fly.dev.toml` | Dev app config (tether-dev, sea, 256mb, min_machines=0) |
| `.github/workflows/fly-deploy.yml` | Single workflow: prod on push to main, dev on push to dev |

### Design decisions

**supervisord over Fly `[processes]`:** One machine = ~$2/month vs ~$6/month for three. Easy to switch later — remove supervisord.conf + pip install, add `[processes]` to fly.toml. No application code changes required either way.

**One workflow file for prod + dev:** Fly deploys are identical (`flyctl deploy --remote-only`) differing only by config file. Two jobs in one file is cleaner than two separate files that would drift.

**Pi deploys unaffected:** docker-compose.yml still overrides CMD per service. The new supervisord CMD only fires when the image runs without compose (i.e. on Fly.io).

**`min_machines_running = 1` for prod:** Bot long-polling requires a persistent connection. Drops to 0 after Telegram webhook mode ships (Phase 3b).

**`min_machines_running = 0` for dev:** Dev machine can fully sleep — no persistent bot needed for testing.

### Phase 3 Step 2 (manual steps after merge)

1. `fly apps create tether-prod` and `fly apps create tether-dev`
2. Create Neon Postgres project, run `alembic upgrade head`
3. Set Fly secrets (DATABASE_URL, TETHER_JWT_SECRET, etc.) for both apps
4. Add `FLY_API_TOKEN` to GitHub repo secrets
5. Push to main — first deploy triggers automatically

## Test plan
- [ ] `flyctl deploy --config fly.toml --remote-only` succeeds (requires secrets set)
- [ ] `flyctl deploy --config fly.dev.toml --remote-only` succeeds
- [ ] Pi deploys still work (docker-compose CMD override still applies)