### PR TITLE
fix: use dynamic db name in tether_app role migration (Neon compat)

### DIFF
--- a/db/migrations/versions/845cab7a8515_add_tether_app_role.py
+++ b/db/migrations/versions/845cab7a8515_add_tether_app_role.py
@@ -34,7 +34,8 @@ def upgrade() -> None:
         $$
     """)
 
-    op.execute("GRANT CONNECT ON DATABASE tether TO tether_app")
+    db_name = op.get_bind().engine.url.database
+    op.execute(f'GRANT CONNECT ON DATABASE {db_name} TO tether_app')
     op.execute("GRANT USAGE ON SCHEMA public TO tether_app")
     op.execute("GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO tether_app")
     op.execute("GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO tether_app")
@@ -52,5 +53,6 @@ def downgrade() -> None:
     op.execute("REVOKE ALL ON ALL TABLES IN SCHEMA public FROM tether_app")
     op.execute("REVOKE ALL ON ALL SEQUENCES IN SCHEMA public FROM tether_app")
     op.execute("REVOKE USAGE ON SCHEMA public FROM tether_app")
-    op.execute("REVOKE CONNECT ON DATABASE tether FROM tether_app")
+    db_name = op.get_bind().engine.url.database
+    op.execute(f'REVOKE CONNECT ON DATABASE {db_name} FROM tether_app')
     op.execute("DROP ROLE IF EXISTS tether_app")


### PR DESCRIPTION
## Summary
- Replace hardcoded `'tether'` database name in `GRANT CONNECT ON DATABASE` and `REVOKE CONNECT ON DATABASE` statements with the actual DB name from the connection URL
- Fixes `InvalidCatalogName: database 'tether' does not exist` errors on fresh installs against managed Postgres (Neon), where the database is named `neondb`
- Also fixed the matching hardcoded name in the `downgrade()` function for consistency

## Change
In `db/migrations/versions/845cab7a8515_add_tether_app_role.py`:
```python
# Before
op.execute("GRANT CONNECT ON DATABASE tether TO tether_app")

# After
db_name = op.get_bind().engine.url.database
op.execute(f'GRANT CONNECT ON DATABASE {db_name} TO tether_app')
```

## Test plan
- [ ] Verify migration applies successfully against a Neon database (named `neondb`)
- [ ] Verify migration still applies successfully against a local Postgres database named `tether`