### PR TITLE
fix(infra): Fly.io region sea → sjc

### DIFF
--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -1,5 +1,5 @@
 app = "tether-dev"
-primary_region = "sea"
+primary_region = "sjc"
 
 [build]
   dockerfile = "Dockerfile"

--- a/fly.toml
+++ b/fly.toml
@@ -1,5 +1,5 @@
 app = "tether-prod"
-primary_region = "sea"
+primary_region = "sjc"
 
 [build]
   dockerfile = "Dockerfile"


### PR DESCRIPTION
Fly.io deprecated the `sea` region — new machines cannot be provisioned there. Changing `primary_region` to `sjc` (San Jose) in both `fly.toml` and `fly.dev.toml`.

The image is already built and in Fly's registry from the previous deploy attempt — this just unblocks machine provisioning.