### PR TITLE
feat(infra): docker entrypoint downloads tether config from gist/S3 at startup

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -23,6 +23,7 @@ on:
       - 'supervisord.conf'
       - 'fly.toml'
       - 'fly.dev.toml'
+      - 'docker-entrypoint.sh'
 
 permissions:
   contents: read
@@ -36,7 +37,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Deploy to tether-prod
-        run: flyctl deploy --config fly.toml --remote-only --build-arg PREMIUM_GIT_TOKEN=$PREMIUM_GIT_TOKEN
+        # --ha=false: single machine (no auto-HA pair). Bot long-polls, not stateless.
+        run: flyctl deploy --config fly.toml --remote-only --ha=false --build-arg PREMIUM_GIT_TOKEN=$PREMIUM_GIT_TOKEN
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           PREMIUM_GIT_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
@@ -49,7 +51,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Deploy to tether-dev
-        run: flyctl deploy --config fly.dev.toml --remote-only --build-arg PREMIUM_GIT_TOKEN=$PREMIUM_GIT_TOKEN
+        run: flyctl deploy --config fly.dev.toml --remote-only --ha=false --build-arg PREMIUM_GIT_TOKEN=$PREMIUM_GIT_TOKEN
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           PREMIUM_GIT_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM python:3.11-slim
 # cron is needed for anchor trigger scheduling in the bot container.
 # curl is needed for the NodeSource setup script.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc libffi-dev cron git gosu curl \
+    gcc libffi-dev cron git gosu curl gettext-base \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js 20 via NodeSource so npm has a properly self-contained

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,14 @@ RUN if [ -n "$PREMIUM_GIT_TOKEN" ]; then \
 # Default port for API
 EXPOSE 8000
 
+# Entrypoint: downloads ~/.tether-config/{config,anchors}.yaml from a remote
+# source (gist or S3) before handing off to the CMD.  See docker-entrypoint.sh
+# for the URL scheme detection logic and S3 migration notes.
+# Pi deployments override ENTRYPOINT via docker-compose so this has no effect there.
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
 # Default CMD — runs all services via supervisord on Fly.io.
 # Overridden per service in docker-compose.yml for Pi deployments.
 CMD ["supervisord", "-c", "/app/supervisord.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM python:3.11-slim
 # cron is needed for anchor trigger scheduling in the bot container.
 # curl is needed for the NodeSource setup script.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc libffi-dev cron git gosu curl gettext-base \
+    gcc libffi-dev cron git gosu curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js 20 via NodeSource so npm has a properly self-contained

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,57 +1,67 @@
 #!/bin/bash
 # docker-entrypoint.sh
-# Downloads tether config files from a remote source and substitutes secret
-# placeholders from environment variables before starting the app.
+# Downloads tether config files from a remote source before starting the app.
 #
-# This mirrors the ~/.tether-config/ directory that the Pi setup creates:
-#   config.yaml    — Telegram token, chat ID, model assignments, etc.
-#   anchors.yaml   — Time block definitions for the scheduler
+# HOW IT FITS THE CONFIG SYSTEM
+# ─────────────────────────────
+# config/loader.py resolves in this order (later wins):
+#   1. Baked-in defaults   — config/*.yaml baked into the image
+#   2. Local override      — ~/.tether-config/*.yaml  ← this script writes these
+#   3. Placeholder resolve — ${VAR} / ${VAR:-default} expanded from env vars
 #
-# Template substitution:
-#   Config files in the gist use ${PLACEHOLDER} markers for secret values.
-#   envsubst fills them in from environment variables (Fly secrets) at startup.
-#   Non-secret config lives as literal values in the gist — no Fly secret needed.
-#   This mirrors the Pi's configure.py / make configure pattern.
+# The gist holds two files that become the local override layer:
 #
-#   Example gist config.yaml:
-#     telegram:
-#       bot_token: "${TELEGRAM_BOT_TOKEN}"
-#       chat_id: "${TELEGRAM_CHAT_ID}"
-#     models:
-#       orchestrator: claude-sonnet-4-6   ← literal, not a placeholder
+#   auth_config.yaml  — secrets layer: use ${VAR} for truly secret values
+#                       (JWT secret, vault key, OAuth client secrets, Telegram token)
+#                       use literal values for non-secret auth config
+#                       (CORS origins, callback URLs, OAuth client IDs, enabled flags)
 #
-# tether.db is not downloaded — Fly.io uses Postgres via DATABASE_URL.
-# telegram_offset is ephemeral — the bot creates it on first poll.
+#   app_config.yaml   — per-env overrides: all literal values, no secrets
+#                       (model assignments, feature flags, pipeline settings)
+#                       omit a key to inherit the baked-in default
 #
-# Source is detected from the URL scheme:
-#   https://   →  curl with optional auth token header
-#   s3://      →  aws s3 cp  (requires awscli in image; add to Dockerfile if migrating)
+# The TetherConfig loader handles ${VAR} resolution itself — do NOT run
+# envsubst on auth_config.yaml or app_config.yaml.
 #
-# Required env vars:
-#   CONFIG_SOURCE_URL    Base URL / S3 prefix.  File names are appended with a slash.
-#                        Gist example:  https://gist.githubusercontent.com/USER/ID/raw
-#                        S3 example:    s3://my-bucket/tether/prod
+# TEMPORARY: config.yaml
+# ─────────────────────
+# bot/message_handler.py has its own load_config() that reads config.yaml
+# raw (no placeholder resolution). Until that is updated to use TetherConfig,
+# config.yaml must also be in the gist and envsubst is run on it here.
+# See: https://github.com/jlunder00/tether/issues/TODO (bot-backend task)
 #
-# Optional env vars:
-#   CONFIG_SOURCE_TOKEN  Auth token for private sources (GitHub PAT with gist scope).
-#                        Not needed for public gists or S3 with IAM roles.
-#   TETHER_CONFIG_DIR    Override config directory (default: /root/.tether-config).
+# SOURCE DETECTION (URL scheme)
+# ─────────────────────────────
+#   https://   →  curl with optional Authorization header
+#   s3://      →  aws s3 cp  (add awscli to Dockerfile apt-get if migrating)
 #
-# To migrate from gist → S3:
-#   1. Copy config files (with placeholders intact) to s3://bucket/prefix/
-#   2. Change CONFIG_SOURCE_URL to s3://bucket/prefix  (remove CONFIG_SOURCE_TOKEN)
-#   3. Add AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY as Fly secrets (or use IAM)
+# TO MIGRATE FROM GIST → S3
+# ──────────────────────────
+#   1. Copy *.yaml files (with ${VAR} placeholders intact) to s3://bucket/prefix/
+#   2. Change CONFIG_SOURCE_URL to s3://bucket/prefix
+#   3. Remove CONFIG_SOURCE_TOKEN; add AWS credentials as Fly secrets if needed
 #   4. Add awscli to the Dockerfile RUN apt-get line
+#   No changes to this script required.
+#
+# REQUIRED ENV VARS
+# ─────────────────
+#   CONFIG_SOURCE_URL    Base URL / S3 prefix (file names appended with /)
+#                        Gist: https://gist.githubusercontent.com/USER/GIST_ID/raw
+#                        S3:   s3://bucket/tether/prod
+#
+# OPTIONAL ENV VARS
+#   CONFIG_SOURCE_TOKEN  Auth token for private sources (GitHub PAT, gist scope).
+#   TETHER_CONFIG_DIR    Config directory override (default: /root/.tether-config).
 
 set -euo pipefail
 
 CONFIG_DIR="${TETHER_CONFIG_DIR:-/root/.tether-config}"
 mkdir -p "$CONFIG_DIR"
 
-_download_file() {
-    local name="$1"
-    local url="${CONFIG_SOURCE_URL%/}/$name"
+# ── Download helpers ──────────────────────────────────────────────────────────
 
+_fetch_to_stdout() {
+    local url="$1"
     case "$url" in
         s3://*)
             aws s3 cp "$url" -
@@ -64,25 +74,55 @@ _download_file() {
             fi
             ;;
         *)
-            echo "[entrypoint] ERROR: unrecognised URL scheme in CONFIG_SOURCE_URL: $url" >&2
+            echo "[entrypoint] ERROR: unrecognised URL scheme: $url" >&2
             return 1
             ;;
     esac
 }
 
-if [ -n "${CONFIG_SOURCE_URL:-}" ]; then
-    for config_file in config.yaml anchors.yaml; do
-        dest="$CONFIG_DIR/$config_file"
-        # Download to stdout, pipe through envsubst to fill in ${PLACEHOLDER} markers,
-        # write resolved file.  Mirrors the Pi's configure.py / make configure step.
-        if _download_file "$config_file" | envsubst > "$dest"; then
-            echo "[entrypoint] downloaded and resolved $config_file → $dest"
+_download() {
+    local name="$1"
+    local run_envsubst="${2:-false}"
+    local url="${CONFIG_SOURCE_URL%/}/$name"
+    local dest="$CONFIG_DIR/$name"
+
+    if [ "$run_envsubst" = "true" ]; then
+        # Resolve ${VAR} placeholders for callers that do raw yaml.safe_load
+        # (no ${VAR:-default} support — those are left for TetherConfig).
+        if _fetch_to_stdout "$url" | envsubst > "$dest"; then
+            echo "[entrypoint] downloaded + resolved $name → $dest"
         else
-            echo "[entrypoint] WARN: could not fetch $config_file — app may fail to start" >&2
+            echo "[entrypoint] WARN: could not fetch $name" >&2
+            return 1
         fi
-    done
+    else
+        # Leave ${VAR} / ${VAR:-default} intact — TetherConfig resolves them.
+        if _fetch_to_stdout "$url" > "$dest"; then
+            echo "[entrypoint] downloaded $name → $dest"
+        else
+            echo "[entrypoint] WARN: could not fetch $name" >&2
+            return 1
+        fi
+    fi
+}
+
+# ── Config download ───────────────────────────────────────────────────────────
+
+if [ -n "${CONFIG_SOURCE_URL:-}" ]; then
+
+    # TetherConfig layer — leave placeholders for the loader to resolve.
+    _download auth_config.yaml  || true
+    _download app_config.yaml   || true
+
+    # Bot backward-compat layer — bot/message_handler.py:load_config() reads
+    # this file raw (no placeholder resolution), so envsubst is applied here.
+    # Remove once the bot is updated to use TetherConfig.
+    _download config.yaml true  || true
+
 else
     echo "[entrypoint] WARN: CONFIG_SOURCE_URL not set — skipping remote config download" >&2
+    echo "[entrypoint]       API/MCP will use baked-in defaults only." >&2
+    echo "[entrypoint]       Bot will fail to start (requires telegram.bot_token)." >&2
 fi
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,34 +1,33 @@
 #!/bin/bash
 # docker-entrypoint.sh
-# Downloads tether config files from a remote source before starting the app.
+# Optionally downloads tether config override files from a remote source
+# before starting the app.
 #
-# HOW IT FITS THE CONFIG SYSTEM
-# ─────────────────────────────
-# config/loader.py resolves in this order (later wins):
+# HOW THIS FITS THE CONFIG SYSTEM
+# ────────────────────────────────
+# config/loader.py (TetherConfig) resolves in order (later wins):
 #   1. Baked-in defaults   — config/*.yaml baked into the image
-#   2. Local override      — ~/.tether-config/*.yaml  ← this script writes these
+#   2. Local override      — TETHER_CONFIG_DIR/*.yaml  ← this script writes these
 #   3. Placeholder resolve — ${VAR} / ${VAR:-default} expanded from env vars
 #
-# The gist holds two files that become the local override layer:
+# The baked-in defaults + Fly secrets are sufficient to boot. The gist provides
+# the LOCAL OVERRIDE layer — use it to change non-secret values (CORS origins,
+# OAuth callback URLs, model assignments, feature flags) without a redeploy.
 #
-#   auth_config.yaml  — secrets layer: use ${VAR} for truly secret values
-#                       (JWT secret, vault key, OAuth client secrets, Telegram token)
-#                       use literal values for non-secret auth config
-#                       (CORS origins, callback URLs, OAuth client IDs, enabled flags)
+# WHAT TO PUT IN THE GIST
+# ────────────────────────
+# auth_config.yaml — literal values for non-secret auth config:
+#   cors.allowed_origins, oauth.*.callback_url, oauth.*.client_id,
+#   oauth.*.enabled, cookie.secure
+#   (Leave jwt.secret, vault.key, client_secrets as ${VAR} — resolved from
+#   Fly secrets by TetherConfig; no need to put them in the gist at all)
 #
-#   app_config.yaml   — per-env overrides: all literal values, no secrets
-#                       (model assignments, feature flags, pipeline settings)
-#                       omit a key to inherit the baked-in default
+# app_config.yaml  — literal values for per-env app config:
+#   model assignments, feature flags, llm settings, pipeline tuning
+#   (Omit a key to inherit the baked-in default)
 #
-# The TetherConfig loader handles ${VAR} resolution itself — do NOT run
-# envsubst on auth_config.yaml or app_config.yaml.
-#
-# TEMPORARY: config.yaml
-# ─────────────────────
-# bot/message_handler.py has its own load_config() that reads config.yaml
-# raw (no placeholder resolution). Until that is updated to use TetherConfig,
-# config.yaml must also be in the gist and envsubst is run on it here.
-# See: https://github.com/jlunder00/tether/issues/TODO (bot-backend task)
+# No secrets should appear literally in either file. TetherConfig resolves
+# ${VAR} placeholders from environment variables (Fly secrets) itself.
 #
 # SOURCE DETECTION (URL scheme)
 # ─────────────────────────────
@@ -37,30 +36,27 @@
 #
 # TO MIGRATE FROM GIST → S3
 # ──────────────────────────
-#   1. Copy *.yaml files (with ${VAR} placeholders intact) to s3://bucket/prefix/
+#   1. Copy *.yaml files to s3://bucket/prefix/
 #   2. Change CONFIG_SOURCE_URL to s3://bucket/prefix
-#   3. Remove CONFIG_SOURCE_TOKEN; add AWS credentials as Fly secrets if needed
+#   3. Remove CONFIG_SOURCE_TOKEN; add AWS creds as Fly secrets if needed
 #   4. Add awscli to the Dockerfile RUN apt-get line
 #   No changes to this script required.
 #
-# REQUIRED ENV VARS
-# ─────────────────
+# ENV VARS
+# ────────
 #   CONFIG_SOURCE_URL    Base URL / S3 prefix (file names appended with /)
 #                        Gist: https://gist.githubusercontent.com/USER/GIST_ID/raw
 #                        S3:   s3://bucket/tether/prod
-#
-# OPTIONAL ENV VARS
-#   CONFIG_SOURCE_TOKEN  Auth token for private sources (GitHub PAT, gist scope).
-#   TETHER_CONFIG_DIR    Config directory override (default: /root/.tether-config).
+#                        Unset: skip download, boot from baked-in defaults + Fly secrets
+#   CONFIG_SOURCE_TOKEN  Auth token for private gists (GitHub PAT, gist scope).
+#   TETHER_CONFIG_DIR    Config directory (default: /root/.tether-config).
 
 set -euo pipefail
 
 CONFIG_DIR="${TETHER_CONFIG_DIR:-/root/.tether-config}"
 mkdir -p "$CONFIG_DIR"
 
-# ── Download helpers ──────────────────────────────────────────────────────────
-
-_fetch_to_stdout() {
+_fetch() {
     local url="$1"
     case "$url" in
         s3://*)
@@ -82,47 +78,23 @@ _fetch_to_stdout() {
 
 _download() {
     local name="$1"
-    local run_envsubst="${2:-false}"
-    local url="${CONFIG_SOURCE_URL%/}/$name"
     local dest="$CONFIG_DIR/$name"
+    local url="${CONFIG_SOURCE_URL%/}/$name"
 
-    if [ "$run_envsubst" = "true" ]; then
-        # Resolve ${VAR} placeholders for callers that do raw yaml.safe_load
-        # (no ${VAR:-default} support — those are left for TetherConfig).
-        if _fetch_to_stdout "$url" | envsubst > "$dest"; then
-            echo "[entrypoint] downloaded + resolved $name → $dest"
-        else
-            echo "[entrypoint] WARN: could not fetch $name" >&2
-            return 1
-        fi
+    # TetherConfig resolves ${VAR} placeholders itself — write files as-is.
+    if _fetch "$url" > "$dest"; then
+        echo "[entrypoint] downloaded $name → $dest"
     else
-        # Leave ${VAR} / ${VAR:-default} intact — TetherConfig resolves them.
-        if _fetch_to_stdout "$url" > "$dest"; then
-            echo "[entrypoint] downloaded $name → $dest"
-        else
-            echo "[entrypoint] WARN: could not fetch $name" >&2
-            return 1
-        fi
+        echo "[entrypoint] WARN: could not fetch $name — using baked-in default" >&2
+        rm -f "$dest"
     fi
 }
 
-# ── Config download ───────────────────────────────────────────────────────────
-
 if [ -n "${CONFIG_SOURCE_URL:-}" ]; then
-
-    # TetherConfig layer — leave placeholders for the loader to resolve.
-    _download auth_config.yaml  || true
-    _download app_config.yaml   || true
-
-    # Bot backward-compat layer — bot/message_handler.py:load_config() reads
-    # this file raw (no placeholder resolution), so envsubst is applied here.
-    # Remove once the bot is updated to use TetherConfig.
-    _download config.yaml true  || true
-
+    _download auth_config.yaml
+    _download app_config.yaml
 else
-    echo "[entrypoint] WARN: CONFIG_SOURCE_URL not set — skipping remote config download" >&2
-    echo "[entrypoint]       API/MCP will use baked-in defaults only." >&2
-    echo "[entrypoint]       Bot will fail to start (requires telegram.bot_token)." >&2
+    echo "[entrypoint] CONFIG_SOURCE_URL not set — booting from baked-in defaults + env vars"
 fi
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# docker-entrypoint.sh
+# Downloads tether config files from a remote source before starting the app.
+#
+# This mirrors the ~/.tether-config/ directory that the Pi setup creates:
+#   config.yaml    — Telegram token, chat ID, model assignments, etc.
+#   anchors.yaml   — Time block definitions for the scheduler
+#
+# tether.db is not downloaded — Fly.io uses Postgres via DATABASE_URL.
+# telegram_offset is ephemeral — the bot creates it on first poll.
+#
+# Source is detected from the URL scheme:
+#   https://   →  curl with optional Bearer/token auth header
+#   s3://      →  aws s3 cp  (requires awscli in image; add to Dockerfile if migrating)
+#
+# Required env vars:
+#   CONFIG_SOURCE_URL    Base URL / S3 prefix.  File names are appended with a slash.
+#                        Gist example:  https://gist.githubusercontent.com/USER/ID/raw
+#                        S3 example:    s3://my-bucket/tether/prod
+#
+# Optional env vars:
+#   CONFIG_SOURCE_TOKEN  Auth token.  For GitHub gists: a classic PAT with gist scope.
+#                        Not needed for S3 (use IAM role or AWS_ACCESS_KEY_ID instead).
+#   TETHER_CONFIG_DIR    Override config directory (default: /root/.tether-config).
+#
+# To migrate from gist → S3:
+#   1. Copy config files to s3://bucket/prefix/
+#   2. Change CONFIG_SOURCE_URL to s3://bucket/prefix  (remove CONFIG_SOURCE_TOKEN)
+#   3. Add AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY as Fly secrets (or use IAM)
+#   4. Add awscli to the Dockerfile RUN apt-get line
+
+set -euo pipefail
+
+CONFIG_DIR="${TETHER_CONFIG_DIR:-/root/.tether-config}"
+mkdir -p "$CONFIG_DIR"
+
+_download_file() {
+    local name="$1"
+    local dest="$CONFIG_DIR/$name"
+    local url="${CONFIG_SOURCE_URL%/}/$name"
+
+    case "$url" in
+        s3://*)
+            aws s3 cp "$url" "$dest"
+            ;;
+        https://*)
+            if [ -n "${CONFIG_SOURCE_TOKEN:-}" ]; then
+                curl -sfL -H "Authorization: token ${CONFIG_SOURCE_TOKEN}" \
+                    "$url" -o "$dest"
+            else
+                curl -sfL "$url" -o "$dest"
+            fi
+            ;;
+        *)
+            echo "[entrypoint] ERROR: unrecognised URL scheme in CONFIG_SOURCE_URL: $url" >&2
+            return 1
+            ;;
+    esac
+}
+
+if [ -n "${CONFIG_SOURCE_URL:-}" ]; then
+    for config_file in config.yaml anchors.yaml; do
+        if _download_file "$config_file"; then
+            echo "[entrypoint] downloaded $config_file → $CONFIG_DIR/$config_file"
+        else
+            echo "[entrypoint] WARN: could not download $config_file — app may fail to start" >&2
+        fi
+    done
+else
+    echo "[entrypoint] WARN: CONFIG_SOURCE_URL not set — skipping remote config download" >&2
+fi
+
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,16 +1,30 @@
 #!/bin/bash
 # docker-entrypoint.sh
-# Downloads tether config files from a remote source before starting the app.
+# Downloads tether config files from a remote source and substitutes secret
+# placeholders from environment variables before starting the app.
 #
 # This mirrors the ~/.tether-config/ directory that the Pi setup creates:
 #   config.yaml    — Telegram token, chat ID, model assignments, etc.
 #   anchors.yaml   — Time block definitions for the scheduler
 #
+# Template substitution:
+#   Config files in the gist use ${PLACEHOLDER} markers for secret values.
+#   envsubst fills them in from environment variables (Fly secrets) at startup.
+#   Non-secret config lives as literal values in the gist — no Fly secret needed.
+#   This mirrors the Pi's configure.py / make configure pattern.
+#
+#   Example gist config.yaml:
+#     telegram:
+#       bot_token: "${TELEGRAM_BOT_TOKEN}"
+#       chat_id: "${TELEGRAM_CHAT_ID}"
+#     models:
+#       orchestrator: claude-sonnet-4-6   ← literal, not a placeholder
+#
 # tether.db is not downloaded — Fly.io uses Postgres via DATABASE_URL.
 # telegram_offset is ephemeral — the bot creates it on first poll.
 #
 # Source is detected from the URL scheme:
-#   https://   →  curl with optional Bearer/token auth header
+#   https://   →  curl with optional auth token header
 #   s3://      →  aws s3 cp  (requires awscli in image; add to Dockerfile if migrating)
 #
 # Required env vars:
@@ -19,12 +33,12 @@
 #                        S3 example:    s3://my-bucket/tether/prod
 #
 # Optional env vars:
-#   CONFIG_SOURCE_TOKEN  Auth token.  For GitHub gists: a classic PAT with gist scope.
-#                        Not needed for S3 (use IAM role or AWS_ACCESS_KEY_ID instead).
+#   CONFIG_SOURCE_TOKEN  Auth token for private sources (GitHub PAT with gist scope).
+#                        Not needed for public gists or S3 with IAM roles.
 #   TETHER_CONFIG_DIR    Override config directory (default: /root/.tether-config).
 #
 # To migrate from gist → S3:
-#   1. Copy config files to s3://bucket/prefix/
+#   1. Copy config files (with placeholders intact) to s3://bucket/prefix/
 #   2. Change CONFIG_SOURCE_URL to s3://bucket/prefix  (remove CONFIG_SOURCE_TOKEN)
 #   3. Add AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY as Fly secrets (or use IAM)
 #   4. Add awscli to the Dockerfile RUN apt-get line
@@ -36,19 +50,17 @@ mkdir -p "$CONFIG_DIR"
 
 _download_file() {
     local name="$1"
-    local dest="$CONFIG_DIR/$name"
     local url="${CONFIG_SOURCE_URL%/}/$name"
 
     case "$url" in
         s3://*)
-            aws s3 cp "$url" "$dest"
+            aws s3 cp "$url" -
             ;;
         https://*)
             if [ -n "${CONFIG_SOURCE_TOKEN:-}" ]; then
-                curl -sfL -H "Authorization: token ${CONFIG_SOURCE_TOKEN}" \
-                    "$url" -o "$dest"
+                curl -sfL -H "Authorization: token ${CONFIG_SOURCE_TOKEN}" "$url"
             else
-                curl -sfL "$url" -o "$dest"
+                curl -sfL "$url"
             fi
             ;;
         *)
@@ -60,10 +72,13 @@ _download_file() {
 
 if [ -n "${CONFIG_SOURCE_URL:-}" ]; then
     for config_file in config.yaml anchors.yaml; do
-        if _download_file "$config_file"; then
-            echo "[entrypoint] downloaded $config_file → $CONFIG_DIR/$config_file"
+        dest="$CONFIG_DIR/$config_file"
+        # Download to stdout, pipe through envsubst to fill in ${PLACEHOLDER} markers,
+        # write resolved file.  Mirrors the Pi's configure.py / make configure step.
+        if _download_file "$config_file" | envsubst > "$dest"; then
+            echo "[entrypoint] downloaded and resolved $config_file → $dest"
         else
-            echo "[entrypoint] WARN: could not download $config_file — app may fail to start" >&2
+            echo "[entrypoint] WARN: could not fetch $config_file — app may fail to start" >&2
         fi
     done
 else


### PR DESCRIPTION
## Problem

Bot crashes on Fly.io immediately at startup:
```
FileNotFoundError: /root/.tether-config/config.yaml
```
`bot/message_handler.py:load_config()` reads directly from `~/.tether-config/config.yaml`.
On the Pi this file is created by setup scripts. On Fly.io the container starts
with no home directory files.

## Solution

`docker-entrypoint.sh` runs before supervisord and downloads `config.yaml`
and `anchors.yaml` from a remote source into `~/.tether-config/`.

### Config source detection (URL scheme)

| `CONFIG_SOURCE_URL` prefix | Backend | Auth |
|---|---|---|
| `https://gist.githubusercontent.com/…` | curl | `CONFIG_SOURCE_TOKEN` (GitHub PAT, gist scope) |
| `s3://bucket/prefix` | `aws s3 cp` | IAM role or `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` |

### Env scoping

`tether-prod` and `tether-dev` are separate Fly apps with separate secrets,
so `CONFIG_SOURCE_URL` is set independently per app — no conditional logic needed.

### S3 migration path

Change `CONFIG_SOURCE_URL` from a gist URL to `s3://bucket/prefix`.
Add AWS credentials as Fly secrets (or attach an IAM role). No script changes required.

## Also in this PR

- `--ha=false` added to both `fly-deploy.yml` deploy jobs — prevents Fly from
  creating a second HA machine on every deploy (bot uses long-polling, not stateless)
- `docker-entrypoint.sh` added to the workflow `paths:` trigger

## Fly secrets to add

Run these for each app before deploying:
```
fly secrets set CONFIG_SOURCE_URL="https://gist.githubusercontent.com/jlunder00/GIST_ID/raw" --app tether-prod
fly secrets set CONFIG_SOURCE_TOKEN="ghp_..." --app tether-prod

fly secrets set CONFIG_SOURCE_URL="https://gist.githubusercontent.com/jlunder00/DEV_GIST_ID/raw" --app tether-dev
fly secrets set CONFIG_SOURCE_TOKEN="ghp_..." --app tether-dev
```