### PR TITLE
feat(infra): alembic migrations via Fly release_command

### DIFF
--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -4,6 +4,9 @@ primary_region = "sjc"
 [build]
   dockerfile = "Dockerfile"
 
+[deploy]
+  release_command = "alembic upgrade head"
+
 [http_service]
   internal_port = 8000
   force_https = true

--- a/fly.toml
+++ b/fly.toml
@@ -4,6 +4,12 @@ primary_region = "sjc"
 [build]
   dockerfile = "Dockerfile"
 
+[deploy]
+  # Runs inside a temporary machine before traffic cuts over.
+  # Fly rolls back the deploy if this exits non-zero.
+  # Requires ADMIN_DATABASE_URL Fly secret (neondb_owner credentials).
+  release_command = "alembic upgrade head"
+
 [http_service]
   internal_port = 8000
   force_https = true


### PR DESCRIPTION
## Summary

Adds `release_command = "alembic upgrade head"` to both `fly.toml` and `fly.dev.toml`.

Fly.io runs this in a temporary machine before cutting traffic over to the new image. If migrations fail, the deploy is automatically rolled back — no bad deploys with mismatched schema.

Replaces the archived `pi-deploy-db.yml` workflow.

## Required Fly secrets

Add `ADMIN_DATABASE_URL` (neondb_owner direct connection URL) to both apps:
- `tether-prod` → prod Neon branch direct URL
- `tether-dev` → dev Neon branch direct URL

Alembic's `env.py` prefers `ADMIN_DATABASE_URL`, falls back to `DATABASE_URL`.