### PR TITLE
fix(infra): copy alembic.ini into Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN mkdir -p /run/tether/creds \
 WORKDIR /app
 
 # External dependencies (cached layer — only reruns when requirements.txt changes)
-COPY requirements.txt pyproject.toml ./
+COPY requirements.txt pyproject.toml alembic.ini ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Process manager for multi-service Fly.io deployments.


### PR DESCRIPTION
alembic.ini was missing from the COPY layer so `alembic upgrade head` in the Fly release_command failed with 'No script_location key found in configuration'. Added it alongside requirements.txt and pyproject.toml.