### PR TITLE
fix(deps): add psycopg2-binary for alembic Fly release_command

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ httpx>=0.27
 anthropic>=0.40
 openai>=1.0
 asyncpg>=0.29.0
+psycopg2-binary>=2.9,<3
 alembic>=1.13.0
 sqlalchemy>=2.0
 apscheduler>=3.10,<4


### PR DESCRIPTION
psycopg2-binary was in a Pi-specific fix branch but never landed in main's requirements.txt. Alembic uses psycopg2 dialect by default, so `alembic upgrade head` in the Fly release_command machine fails with `ModuleNotFoundError: No module named 'psycopg2'`.