### PR TITLE
Fix bot startup race and add /api/health endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -176,6 +176,11 @@ def create_app(lifespan_override=None) -> FastAPI:
     except ImportError:
         pass
 
+    @app.get("/api/health")
+    async def health():
+        """Unauthenticated liveness check. Used by supervisord wait loop."""
+        return {"status": "ok"}
+
     @app.post("/api/notify")
     async def notify(request: Request, _auth=Depends(auth_dependency)):
         if not request.state.is_admin:

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -19,7 +19,7 @@ stderr_logfile_maxbytes=0
 autorestart=true
 
 [program:bot]
-command=python -m bot.message_handler
+command=bash -c "until curl -sf http://localhost:8000/api/health > /dev/null; do sleep 2; done && python -m bot.message_handler"
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/fd/2


### PR DESCRIPTION
## Summary
- Adds unauthenticated `GET /api/health` endpoint used by the supervisord wait loop
- Bot process now waits for the API to be ready before starting, preventing WebSocket connection failures on container boot

## Root cause
On Fly.io, supervisord starts all three processes simultaneously. The bot's scheduling event listener tried to connect to `/ws` before uvicorn was accepting connections, causing immediate failure and autorestart churn.

## Test plan
- [ ] Deploy to tether-dev, verify bot starts cleanly without WS connection errors in logs
- [ ] Confirm `GET /api/health` returns `{"status": "ok"}` without auth