### PR TITLE
fix(scripts): add --bot-service flag to generate_bot_token.py

### DIFF
--- a/scripts/generate_bot_token.py
+++ b/scripts/generate_bot_token.py
@@ -1,10 +1,24 @@
 #!/usr/bin/env python3
-"""Generate a long-lived admin JWT for the bot WS listener.
+"""Generate a long-lived JWT for the bot WS listener.
 
-Usage: python scripts/generate_bot_token.py
+The bot WS listener (tether_premium.bot.scheduling.events) connects to /ws
+and authenticates using a token stored in the TETHER_API_BOT_TOKEN Fly secret.
 
-Output: the token + the config.yaml snippet to paste.
+Usage:
+    # Inside a Fly.io machine (JWT secret already in env):
+    python scripts/generate_bot_token.py
+
+    # Locally (must supply the same JWT secret as the target app):
+    TETHER_JWT_SECRET=<secret> python scripts/generate_bot_token.py
+
+Flags:
+    --bot-service   Generate an is_bot_service token (default, recommended).
+                    Registers the WS connection with per-user delegation filtering.
+    --admin         Generate an is_admin token (legacy, uses __bot__ channel).
+
+Output: the token value to set as TETHER_API_BOT_TOKEN Fly secret.
 """
+import argparse
 import sys
 import os
 
@@ -13,8 +27,50 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from datetime import timedelta
 from api.auth import create_jwt
 
-# Reserved bot UUID — must not collide with any real user
+# Reserved bot UUID — must not collide with any real user.
 BOT_USER_ID = "00000000-0000-0000-0000-000000000b07"
 
-token = create_jwt(BOT_USER_ID, "bot", is_admin=True, expires_in=timedelta(days=365))
-print(f"Add to ~/.tether-config/config.yaml:\n\napi:\n  bot_token: {token}\n")
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a long-lived bot JWT.")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--bot-service",
+        action="store_true",
+        default=True,
+        help="Generate is_bot_service=True token (default, recommended for meeting listener)",
+    )
+    group.add_argument(
+        "--admin",
+        action="store_true",
+        default=False,
+        help="Generate is_admin=True token (legacy __bot__ channel path)",
+    )
+    args = parser.parse_args()
+
+    use_bot_service = not args.admin
+
+    token = create_jwt(
+        BOT_USER_ID,
+        "bot",
+        is_admin=args.admin,
+        is_bot_service=use_bot_service,
+        expires_in=timedelta(days=365),
+    )
+
+    token_type = "is_bot_service=True" if use_bot_service else "is_admin=True"
+    print(f"Generated bot token ({token_type}, expires 365 days):\n")
+    print(token)
+    print()
+    print("Set as Fly secret:")
+    print(f"  flyctl secrets set TETHER_API_BOT_TOKEN={token} --app tether-prod")
+    print(f"  flyctl secrets set TETHER_API_BOT_TOKEN={token} --app tether-dev")
+    print()
+    print("Note: tether-prod and tether-dev use different JWT secrets.")
+    print("Run this script inside each app's Fly machine to get the correct token:")
+    print("  flyctl ssh console --app tether-prod -C 'python /app/scripts/generate_bot_token.py'")
+    print("  flyctl ssh console --app tether-dev -C 'python /app/scripts/generate_bot_token.py'")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `--bot-service` (default) and `--admin` flags to `generate_bot_token.py`
- `--bot-service` generates `is_bot_service=True` token — correct type for the meeting event WS listener in tether-premium
- Script output now includes `flyctl secrets set` commands and `flyctl ssh console` instructions for generating per-app tokens

## Why this matters
The meeting event listener (`tether_premium.bot.scheduling.events`) connects to `/ws` and authenticates with the token from `TETHER_API_BOT_TOKEN`. The `/ws` endpoint routes `is_bot_service=True` tokens through `register_bot()` with per-user delegation filtering. The old `is_admin=True` default used the `__bot__` channel path instead — wrong for this use case.

## Deployment step required (manual)
After merging, generate and set the secret on both apps:
```bash
# Generates token using the app's actual JWT secret (already in env on Fly machine)
flyctl ssh console --app tether-prod -C "python /app/scripts/generate_bot_token.py"
flyctl ssh console --app tether-dev  -C "python /app/scripts/generate_bot_token.py"
# Then set each output token:
flyctl secrets set TETHER_API_BOT_TOKEN=<prod-token> --app tether-prod
flyctl secrets set TETHER_API_BOT_TOKEN=<dev-token>  --app tether-dev
```