### PR TITLE
feat(infra): pin tether-premium via pypi index requirements files

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -5,16 +5,14 @@ name: "Deploy to Fly.io"
 #
 # Versioning:
 #   TETHER_VERSION is read from pyproject.toml at deploy time.
-#   Release version bumps are done via scripts/release.sh (which tags + pushes),
-#   not by this workflow. This workflow just bakes whatever version is in
-#   pyproject.toml into the Docker image as an env var.
-#
-#   Prod deploys: TETHER_VERSION = pyproject version (e.g. 0.1.0)
-#   Dev deploys:  TETHER_VERSION = pyproject version + -dev.{sha7} (e.g. 0.1.0-dev.abc1234)
+#   PREMIUM_REQUIREMENTS selects which pinned tether-premium version to install:
+#     requirements-premium.txt     -- prod (stable pin, default)
+#     requirements-premium-dev.txt -- dev  (alpha pin)
+#   To upgrade premium: bump the version in the relevant requirements file.
 #
 # Required secrets:
 #   FLY_API_TOKEN        -- Fly.io personal access token
-#   TETHER_PREMIUM_TOKEN -- GitHub PAT for installing tether-premium from tether-pypi
+#   TETHER_PREMIUM_TOKEN -- GitHub PAT for cloning tether-premium
 
 on:
   push:
@@ -27,6 +25,8 @@ on:
       - 'shared/**'
       - 'prompts/**'
       - 'requirements.txt'
+      - 'requirements-premium.txt'
+      - 'requirements-premium-dev.txt'
       - 'Dockerfile'
       - 'supervisord.conf'
       - 'fly.toml'
@@ -85,6 +85,7 @@ sys.exit(1)
           flyctl deploy --config fly.toml --remote-only --ha=false \
             --build-arg PREMIUM_GIT_TOKEN="$PREMIUM_GIT_TOKEN" \
             --build-arg TETHER_VERSION="$TETHER_VERSION"
+          # PREMIUM_REQUIREMENTS defaults to requirements-premium.txt in Dockerfile
 
   deploy-dev:
     name: Deploy dev (tether-dev)
@@ -122,4 +123,5 @@ sys.exit(1)
         run: |
           flyctl deploy --config fly.dev.toml --remote-only --ha=false \
             --build-arg PREMIUM_GIT_TOKEN="$PREMIUM_GIT_TOKEN" \
-            --build-arg TETHER_VERSION="$TETHER_VERSION"
+            --build-arg TETHER_VERSION="$TETHER_VERSION" \
+            --build-arg PREMIUM_REQUIREMENTS=requirements-premium-dev.txt

--- a/.github/workflows/update-premium-pin.yml
+++ b/.github/workflows/update-premium-pin.yml
@@ -1,0 +1,72 @@
+name: "Update premium version pin"
+
+# Dispatched by tether-premium's release workflow after a tag is pushed.
+# Updates the appropriate requirements file and opens a PR.
+#
+#   Alpha release -> requirements-premium-dev.txt, PR targeting dev
+#   Stable release -> requirements-premium.txt,     PR targeting main
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'PEP 440 version (e.g. 0.0.1 or 0.0.1a1)'
+        required: true
+        type: string
+      prerelease:
+        description: 'Is this a pre-release?'
+        required: true
+        default: 'false'
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-pin:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine target file and base branch
+        id: target
+        env:
+          PRERELEASE: ${{ inputs.prerelease }}
+        run: |
+          if [ "$PRERELEASE" = "true" ]; then
+            echo "file=requirements-premium-dev.txt" >> $GITHUB_OUTPUT
+            echo "base=dev" >> $GITHUB_OUTPUT
+          else
+            echo "file=requirements-premium.txt" >> $GITHUB_OUTPUT
+            echo "base=main" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.target.outputs.base }}
+
+      - name: Bump version pin
+        env:
+          VERSION: ${{ inputs.version }}
+          FILE: ${{ steps.target.outputs.file }}
+        run: |
+          sed -i "s/tether-premium==.*/tether-premium==${VERSION}/" "$FILE"
+
+      - name: Open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          FILE: ${{ steps.target.outputs.file }}
+          BASE: ${{ steps.target.outputs.base }}
+        run: |
+          BRANCH="chore/premium-pin-${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add "$FILE"
+          git commit -m "chore: bump tether-premium pin to ${VERSION}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: bump tether-premium pin to ${VERSION}" \
+            --body "Automated pin bump triggered by tether-premium release ${VERSION}." \
+            --base "$BASE" \
+            --head "$BRANCH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,24 +79,29 @@ COPY supervisord.conf .
 # Frontend build artifacts
 COPY --from=frontend-build /build/dist/ frontend/dist/
 
-# ── Optional premium layer ────────────────────────────────
-# Pass PREMIUM_GIT_TOKEN to install premium from the private repo.
-# PREMIUM_REF is a cache-buster: change it to force a fresh install.
-#   Now:    set to the premium repo HEAD SHA (7 chars)
-#   Future: set to the pip version tag when a private PyPI server is ready;
-#           swap the install command to: pip install tether-premium==${PREMIUM_REF}
-# Deployment version tag — set by CI to v{date}-{sha7}, defaults to "dev".
-# Baked into the image as an env var so all services can report it at runtime.
+# Deployment version tag — set by CI from pyproject.toml, defaults to "dev".
+# Baked in as an env var so all services can report it at runtime.
 ARG TETHER_VERSION=dev
 ENV TETHER_VERSION=${TETHER_VERSION}
 
+# ── Optional premium layer ────────────────────────────────
+# PREMIUM_GIT_TOKEN: GitHub PAT with repo access to tether-premium.
+# PREMIUM_REQUIREMENTS: which requirements file to use for premium.
+#   requirements-premium.txt     — prod (pinned stable, default)
+#   requirements-premium-dev.txt — dev  (pinned alpha)
+# To upgrade premium: bump the version pin in the relevant requirements file.
 ARG PREMIUM_GIT_TOKEN=
-ARG PREMIUM_REF=unknown
+ARG PREMIUM_REQUIREMENTS=requirements-premium.txt
+COPY requirements-premium.txt requirements-premium-dev.txt ./
 RUN if [ -n "$PREMIUM_GIT_TOKEN" ]; then \
-      echo "Installing tether-premium @ ${PREMIUM_REF}" && \
-      pip install --no-cache-dir --timeout 120 --retries 3 \
-        "git+https://${PREMIUM_GIT_TOKEN}@github.com/jlunder00/tether-premium.git" && \
-      python -c "from tether_premium.register import get_premium_handler; print('[ok] premium loaded')" ; \
+      git config --global \
+        url."https://${PREMIUM_GIT_TOKEN}@github.com/".insteadOf \
+        "https://github.com/" \
+      && pip install --no-cache-dir --timeout 120 --retries 3 \
+           -r "${PREMIUM_REQUIREMENTS}" \
+      && git config --global --unset \
+           url."https://${PREMIUM_GIT_TOKEN}@github.com/".insteadOf \
+      && python -c "from tether_premium.register import get_premium_handler; print('[ok] premium loaded')" ; \
     else \
       echo "[skip] no token — community edition" ; \
     fi

--- a/requirements-premium-dev.txt
+++ b/requirements-premium-dev.txt
@@ -1,0 +1,2 @@
+--extra-index-url https://jlunder00.github.io/tether-pypi/simple/
+tether-premium==0.0.1a1

--- a/requirements-premium.txt
+++ b/requirements-premium.txt
@@ -1,0 +1,2 @@
+--extra-index-url https://jlunder00.github.io/tether-pypi/simple/
+tether-premium==0.0.1


### PR DESCRIPTION
## Summary

Switches tether-premium installation from unpinned \`git+https://HEAD\` to versioned installs via the tether-pypi index.

- **requirements-premium.txt** — prod pin: \`tether-premium==0.0.1\`
- **requirements-premium-dev.txt** — dev pin: \`tether-premium==0.0.1a1\`
- **Dockerfile**: installs from \`\${PREMIUM_REQUIREMENTS}\` file; git credential config is scoped to the single RUN layer (set before pip, unset after)
- **fly-deploy.yml**: dev deploy passes \`PREMIUM_REQUIREMENTS=requirements-premium-dev.txt\`; prod uses the Dockerfile default

## Upgrade workflow going forward

When a new tether-premium release is cut:
1. Bump the version in \`requirements-premium.txt\` (stable) or \`requirements-premium-dev.txt\` (alpha)
2. Commit + push → Fly deploy triggers automatically