### PR TITLE
fix(frontend): fix 4 DnD bugs + CalendarView sidebar TS errors

### DIFF
--- a/frontend/src/components/DayTimeline.vue
+++ b/frontend/src/components/DayTimeline.vue
@@ -177,8 +177,14 @@ function slotTime(i: number): string {
 }
 
 async function handleSlotDrop(payload: DropPayload, time: string) {
-  const slotStart = `${props.date}T${time}:00`
-  const slotStartMs = new Date(slotStart).getTime()
+  // Build a proper UTC Date from props.date + slot time. Using string interpolation
+  // ("2024-06-10T09:00:00") produces a local-naive ISO that backends treat as UTC,
+  // placing events hours off. Date + setHours + toISOString() is always unambiguous.
+  const [slotHours, slotMinutes] = time.split(':').map(Number)
+  const slotDate = new Date(`${props.date}T00:00:00`)
+  slotDate.setHours(slotHours, slotMinutes, 0, 0)
+  const slotStart = slotDate.toISOString()   // UTC with Z suffix — unambiguous for backend
+  const slotStartMs = slotDate.getTime()
 
   // type === 'task' handles both plan-view promotions AND calendar-event repositions
   // (useDraggableTask always writes type:'task'; fromStartTime present <-> calendar event)
@@ -190,13 +196,15 @@ async function handleSlotDrop(payload: DropPayload, time: string) {
     ?? eventStore.events.find(e => e.id === taskId)
   if (existing) {
     const dur = new Date(existing.end_time).getTime() - new Date(existing.start_time).getTime()
-    const newEnd = toLocalIso(new Date(slotStartMs + (dur || 30 * 60_000)))
+    const newEnd = new Date(slotStartMs + (dur || 30 * 60_000)).toISOString()
     await handleEventMove(existing, slotStart, newEnd)
   } else {
-    const endISO = toLocalIso(new Date(slotStartMs + 30 * 60_000))
+    const endISO = new Date(slotStartMs + 30 * 60_000).toISOString()
     await eventStore.promoteTask(taskId, slotStart, endISO, title)
-    // Refresh plan cache so the promoted task is removed from anchor blocks
-    await planStore.fetchPlan(props.date)
+    // Use fetchPlanRange (not fetchPlan) — fetchPlan flips loading=true which causes
+    // PlanView's v-if="planStore.loading" to destroy and remount the entire grid.
+    // fetchPlanRange updates plans.value directly without touching loading.
+    await planStore.fetchPlanRange(props.date, props.date)
   }
 }
 
@@ -251,7 +259,7 @@ function onTimedAreaDragEnter(e: DragEvent) {
 
 /** Map clientY to the nearest 15-min slot index, accounting for scroll offset. */
 function slotIndexFromClientY(clientY: number): number {
-  if (!timedAreaEl.value) return 0
+  if (!timedAreaEl.value || !Number.isFinite(clientY)) return 0
   const rect = timedAreaEl.value.getBoundingClientRect()
   const relY = Math.max(0, clientY - rect.top + timedAreaEl.value.scrollTop)
   return Math.max(0, Math.min(SLOT_COUNT - 1, Math.floor(relY / (15 * PX_PER_MINUTE))))

--- a/frontend/src/components/__tests__/DayTimelineDropZone.test.ts
+++ b/frontend/src/components/__tests__/DayTimelineDropZone.test.ts
@@ -34,6 +34,7 @@ vi.mock('../../lib/api', () => ({
 const mockPromoteTask = vi.fn()
 const mockMoveEvent = vi.fn()
 const mockFetchPlan = vi.fn()
+const mockFetchPlanRange = vi.fn()
 
 const mockTimedEvent: CalendarEvent = {
   id: 'ev-timed',
@@ -78,6 +79,7 @@ vi.mock('../../stores/plan', () => ({
     plan: null,
     plans: {},
     fetchPlan: mockFetchPlan,
+    fetchPlanRange: mockFetchPlanRange,
     today: '2024-06-10',
     activeDate: { value: '2024-06-10' },
   }),
@@ -117,6 +119,7 @@ describe('DayTimeline – 15-min slot drop targets', () => {
     mockPromoteTask.mockReset()
     mockMoveEvent.mockReset()
     mockFetchPlan.mockReset()
+    mockFetchPlanRange.mockReset()
   })
 
   it('each 15-min slot has data-date and data-time attributes', async () => {
@@ -142,23 +145,52 @@ describe('DayTimeline – 15-min slot drop targets', () => {
     expect(slot.exists()).toBe(true)
     const payload = { type: 'task', taskId: 'task-99', title: 'Do the thing' }
     await slot.trigger('drop', { dataTransfer: { getData: (t: string) => t === 'application/json' ? JSON.stringify(payload) : '' } })
-    expect(mockPromoteTask).toHaveBeenCalledWith(
-      'task-99',
-      expect.stringContaining('09:00'),
-      expect.stringContaining('09:30'),
-      'Do the thing',
-    )
+    // Compute expected UTC ISO for local 09:00 (timezone-safe)
+    const expected09 = (() => { const d = new Date('2024-06-10T00:00:00'); d.setHours(9, 0, 0, 0); return d.toISOString() })()
+    const expected0930 = (() => { const d = new Date('2024-06-10T00:00:00'); d.setHours(9, 30, 0, 0); return d.toISOString() })()
+    expect(mockPromoteTask).toHaveBeenCalledWith('task-99', expected09, expected0930, 'Do the thing')
   })
 
-  it('after promoting a task to calendar, planStore.fetchPlan is called to refresh the plan cache', async () => {
-    // Bug 1: promoteTask runs but plan cache is never refreshed, so the task stays visible in the anchor block
+  it('after promoting a task, fetchPlanRange(date, date) is called — not fetchPlan — to avoid loading flash', async () => {
+    // Bug 1 + 3: fetchPlan flips loading=true which destroys the entire plan grid (v-if in PlanView).
+    // Fix: fetchPlanRange(date, date) updates plans.value without touching loading, so no remount.
     const { default: DayTimeline } = await import('../DayTimeline.vue')
     const wrapper = mount(DayTimeline, { props: { date: '2024-06-10' } })
     const slot = wrapper.find('[data-time="09:00"]')
     const payload = { type: 'task', taskId: 'task-99', title: 'Do the thing' }
     await slot.trigger('drop', { dataTransfer: { getData: (t: string) => t === 'application/json' ? JSON.stringify(payload) : '' } })
     expect(mockPromoteTask).toHaveBeenCalled()
-    expect(mockFetchPlan).toHaveBeenCalledWith('2024-06-10')
+    expect(mockFetchPlanRange).toHaveBeenCalledWith('2024-06-10', '2024-06-10')
+    expect(mockFetchPlan).not.toHaveBeenCalled()
+  })
+
+  it('promoted event start and end times are UTC ISO strings (end in Z, not local-naive)', async () => {
+    // Bug 2: local-naive "2024-06-10T09:00:00" is treated as UTC by backend → event appears
+    // 7h early in PDT. Fix uses new Date(...).toISOString() which always produces UTC with Z suffix.
+    const { default: DayTimeline } = await import('../DayTimeline.vue')
+    const wrapper = mount(DayTimeline, { props: { date: '2024-06-10' } })
+    const slot = wrapper.find('[data-time="09:00"]')
+    const payload = { type: 'task', taskId: 'task-99', title: 'UTC test' }
+    await slot.trigger('drop', { dataTransfer: { getData: (t: string) => t === 'application/json' ? JSON.stringify(payload) : '' } })
+    expect(mockPromoteTask).toHaveBeenCalled()
+    const [, startTime, endTime] = mockPromoteTask.mock.calls[0]
+    expect(startTime).toMatch(/Z$/)  // Must be UTC ISO — unambiguous for backend
+    expect(endTime).toMatch(/Z$/)
+  })
+
+  it('repositioned event (drop of already-promoted task) passes UTC ISO times to moveEvent', async () => {
+    // Bug 2 also affects the existing-event move path: slotStart was built as local-naive.
+    // Fix: both move and promote paths use the same Date + toISOString() construction.
+    const { default: DayTimeline } = await import('../DayTimeline.vue')
+    const wrapper = mount(DayTimeline, { props: { date: '2024-06-10' } })
+    const slot = wrapper.find('[data-time="10:00"]')
+    // task-1 matches mockTimedEvent.task_id — triggers move path, not promote
+    const payload = { type: 'task', taskId: 'task-1', title: 'Team standup' }
+    await slot.trigger('drop', { dataTransfer: { getData: (t: string) => t === 'application/json' ? JSON.stringify(payload) : '' } })
+    expect(mockMoveEvent).toHaveBeenCalled()
+    const [, startTime, endTime] = mockMoveEvent.mock.calls[0]
+    expect(startTime).toMatch(/Z$/)  // UTC ISO required
+    expect(endTime).toMatch(/Z$/)
   })
 
   it('dropping a task payload with fromStartTime moves the event preserving duration (PATCH /api/events/:id)', async () => {
@@ -176,11 +208,10 @@ describe('DayTimeline – 15-min slot drop targets', () => {
       durationMs,
     }
     await slot.trigger('drop', { dataTransfer: { getData: (t: string) => t === 'application/json' ? JSON.stringify(payload) : '' } })
-    expect(mockMoveEvent).toHaveBeenCalledWith(
-      'ev-timed',
-      expect.stringContaining('10:00'),
-      expect.stringContaining('10:30'),
-    )
+    // Compute expected UTC ISO for local 10:00 / 10:30 (timezone-safe)
+    const expected10 = (() => { const d = new Date('2024-06-10T00:00:00'); d.setHours(10, 0, 0, 0); return d.toISOString() })()
+    const expected1030 = (() => { const d = new Date('2024-06-10T00:00:00'); d.setHours(10, 30, 0, 0); return d.toISOString() })()
+    expect(mockMoveEvent).toHaveBeenCalledWith('ev-timed', expected10, expected1030)
   })
 
   it('source event block is hidden (v-show=false) while its drag is active', async () => {
@@ -279,12 +310,10 @@ describe('DayTimeline – 15-min slot drop targets', () => {
       clientY: 190,
       dataTransfer: { getData: (t: string) => t === 'text/plain' ? JSON.stringify(payload) : '' },
     })
-    expect(mockPromoteTask).toHaveBeenCalledWith(
-      'task-99',
-      expect.stringContaining('T07:00'),
-      expect.stringContaining('T07:30'),
-      'X',
-    )
+    // Compute expected UTC ISO for local 07:00 / 07:30 (timezone-safe)
+    const expected07 = (() => { const d = new Date('2024-06-10T00:00:00'); d.setHours(7, 0, 0, 0); return d.toISOString() })()
+    const expected0730 = (() => { const d = new Date('2024-06-10T00:00:00'); d.setHours(7, 30, 0, 0); return d.toISOString() })()
+    expect(mockPromoteTask).toHaveBeenCalledWith('task-99', expected07, expected0730, 'X')
     wrapper.unmount()
   })
 
@@ -319,12 +348,10 @@ describe('DayTimeline – 15-min slot drop targets', () => {
     })
 
     // Should have used overSlotIndex=12 (09:00), not slotIndexFromClientY(0)=0 (06:00)
-    expect(mockPromoteTask).toHaveBeenCalledWith(
-      'task-99',
-      expect.stringContaining('T09:00'),
-      expect.stringContaining('T09:30'),
-      'overSlotIndex test',
-    )
+    // Compute expected UTC ISO for local 09:00 / 09:30 (timezone-safe)
+    const expected09 = (() => { const d = new Date('2024-06-10T00:00:00'); d.setHours(9, 0, 0, 0); return d.toISOString() })()
+    const expected0930 = (() => { const d = new Date('2024-06-10T00:00:00'); d.setHours(9, 30, 0, 0); return d.toISOString() })()
+    expect(mockPromoteTask).toHaveBeenCalledWith('task-99', expected09, expected0930, 'overSlotIndex test')
     wrapper.unmount()
   })
 

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -704,6 +704,26 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 // rAF deferral lets the browser snapshot the ghost image before the source is hidden.
 const draggingTaskId = ref<string | null>(null)
 
+function onSidebarTaskDragStart(
+  e: DragEvent,
+  task: { id: string; text: string },
+  anchorId: string,
+  fromDate: string,
+) {
+  if (e.dataTransfer) {
+    e.dataTransfer.effectAllowed = 'move'
+    e.dataTransfer.setData('text/plain', JSON.stringify({
+      type: 'task',
+      taskId: task.id,
+      title: task.text,
+      fromAnchorId: anchorId,
+      fromDate,
+    }))
+  }
+  // Defer hiding until after the browser snapshots the drag ghost image
+  requestAnimationFrame(() => { draggingTaskId.value = task.id })
+}
+
 // ── Edge-scroll: advance calendar week when dragging to left/right edge ────────
 const calendarGridRef = ref<HTMLElement | null>(null)
 const { onDragOver: calendarEdgeDragOver, onDragLeave: calendarEdgeDragLeave, onDragEnd: calendarEdgeDragEnd } =
@@ -768,19 +788,7 @@ const { onDragOver: calendarEdgeDragOver, onDragLeave: calendarEdgeDragLeave, on
               class="text-xs px-1.5 py-1 rounded cursor-grab hover:bg-[--bg-elev-2] text-[--fg-3] hover:text-[--fg-1] transition-colors truncate"
               :class="task.status === 'done' ? 'line-through opacity-40' : ''"
               @click.stop="pushPanel({ kind: 'task', entityId: task.id })"
-              @dragstart="(e: DragEvent) => {
-                if (e.dataTransfer) {
-                  e.dataTransfer.effectAllowed = 'move'
-                  e.dataTransfer.setData('text/plain', JSON.stringify({
-                    type: 'task',
-                    taskId: task.id,
-                    title: task.text,
-                    fromAnchorId: anchor.id,
-                    fromDate: focusedDay,
-                  }))
-                }
-                requestAnimationFrame(() => { draggingTaskId.value = task.id })
-              }"
+              @dragstart="(e: DragEvent) => onSidebarTaskDragStart(e, task, anchor.id, focusedDay)"
               @dragend="draggingTaskId = null"
             >
               {{ task.text }}

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -700,6 +700,10 @@ function loadEvents() {
 
 const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 
+// ── Sidebar task drag-source hiding (mirrors AnchorBlock.vue:143-165) ────────
+// rAF deferral lets the browser snapshot the ghost image before the source is hidden.
+const draggingTaskId = ref<string | null>(null)
+
 // ── Edge-scroll: advance calendar week when dragging to left/right edge ────────
 const calendarGridRef = ref<HTMLElement | null>(null)
 const { onDragOver: calendarEdgeDragOver, onDragLeave: calendarEdgeDragLeave, onDragEnd: calendarEdgeDragEnd } =
@@ -759,6 +763,7 @@ const { onDragOver: calendarEdgeDragOver, onDragLeave: calendarEdgeDragLeave, on
             <li
               v-for="task in tasks"
               :key="task.id"
+              v-show="draggingTaskId !== task.id"
               draggable="true"
               class="text-xs px-1.5 py-1 rounded cursor-grab hover:bg-[--bg-elev-2] text-[--fg-3] hover:text-[--fg-1] transition-colors truncate"
               :class="task.status === 'done' ? 'line-through opacity-40' : ''"
@@ -774,7 +779,9 @@ const { onDragOver: calendarEdgeDragOver, onDragLeave: calendarEdgeDragLeave, on
                     fromDate: focusedDay,
                   }))
                 }
+                requestAnimationFrame(() => { draggingTaskId.value = task.id })
               }"
+              @dragend="draggingTaskId = null"
             >
               {{ task.text }}
             </li>


### PR DESCRIPTION
## Summary

Re-applies the DnD fixes from #338 (which was reverted due to Docker build failure) with the TypeScript errors corrected.

**Bug fixes (same as #338):**
- **Bug 1+3** — `DayTimeline`: use `fetchPlanRange(date, date)` instead of `fetchPlan()` after promotion. `fetchPlan` toggles `loading=true`, triggering `PlanView`'s `v-if="planStore.loading"` to destroy/remount the entire plan grid on every drop.
- **Bug 2** — `DayTimeline`: replace local-naive ISO construction (`"2026-05-09T14:00:00"`) with `Date + setHours + toISOString()`. Backend treated naive strings as UTC, placing promoted events 7h early in PDT.
- **Bug 5** — `CalendarView` sidebar: add `draggingTaskId` ref + `v-show` + `requestAnimationFrame` deferral on task `<li>` elements. Mirrors `AnchorBlock.vue` pattern to eliminate post-drop source flicker.
- **Hardening** — `slotIndexFromClientY`: guard against non-finite `clientY` to prevent NaN propagation.

**TS fix (the reason #338 was reverted):**
The inline `@dragstart` template handler used `requestAnimationFrame` (not a component instance method in vue-tsc's view) and `draggingTaskId.value` (`.value` doesn't exist on the template-unwrapped `string | null` type). Extracted to `onSidebarTaskDragStart()` in `<script setup>` where `draggingTaskId` is correctly typed as `Ref<string | null>`.

## Test plan

- [x] `npm run build` (vite build + vue-tsc): zero type errors
- [x] `vitest run`: 591/591 passing
- [x] 3 new regression tests: `fetchPlanRange` called after promotion; UTC Z-suffix on both promote and move paths