### PR TITLE
fix(infra): replace multiline python3 -c with awk in fly-deploy.yml

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -62,15 +62,7 @@ jobs:
       - name: Read version from pyproject.toml
         id: version
         run: |
-          VERSION=$(python3 -c "
-import re, sys
-with open('pyproject.toml') as f:
-    for line in f:
-        m = re.match(r'^version\s*=\s*\"(.+)\"', line)
-        if m:
-            print(m.group(1)); sys.exit(0)
-sys.exit(1)
-")
+          VERSION=$(awk -F'"' '/^version[[:space:]]*=/{print $2; exit}' pyproject.toml)
           echo "value=${VERSION}" >> $GITHUB_OUTPUT
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
@@ -101,15 +93,7 @@ sys.exit(1)
       - name: Read version from pyproject.toml
         id: version
         run: |
-          BASE=$(python3 -c "
-import re, sys
-with open('pyproject.toml') as f:
-    for line in f:
-        m = re.match(r'^version\s*=\s*\"(.+)\"', line)
-        if m:
-            print(m.group(1)); sys.exit(0)
-sys.exit(1)
-")
+          BASE=$(awk -F'"' '/^version[[:space:]]*=/{print $2; exit}' pyproject.toml)
           SHA7=$(echo "$GITHUB_SHA" | cut -c1-7)
           echo "value=${BASE}-dev.${SHA7}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Two bugs that together broke all Fly.io deploys after #340 merged.

1. YAML syntax error in fly-deploy.yml — multiline Python inside $() has lines at column 0, outside the YAML literal block indentation level. Fixed with awk one-liner.

2. Wrong --extra-index-url — the astariul/github-hosted-pypi template serves from the repo root, not /simple/. pip was getting 404 on every version lookup (from versions: none). Fixed by dropping /simple/ from both requirements files.