### PR TITLE
ci: test gate on dev PRs + branch guard on publish-community (Phases 1 & 7)

### DIFF
--- a/.github/workflows/publish-community.yml
+++ b/.github/workflows/publish-community.yml
@@ -17,6 +17,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # needed for branch-reachability check
+
+      - name: Assert tag is on the correct branch
+        env:
+          GH_REF: ${{ github.ref }}
+        run: |
+          TAG="${GH_REF#refs/tags/}"
+          # Alpha tags (vX.Y.ZaN) must be reachable from dev; stable (vX.Y.Z) from main.
+          if echo "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+a[0-9]+$'; then
+            REQUIRED_BRANCH="dev"
+          elif echo "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            REQUIRED_BRANCH="main"
+          else
+            echo "ERROR: Unrecognised tag format '${TAG}'. Expected vX.Y.Z or vX.Y.ZaN." >&2
+            exit 1
+          fi
+          git fetch origin "${REQUIRED_BRANCH}" --depth=100 2>/dev/null || git fetch origin "${REQUIRED_BRANCH}"
+          if ! git merge-base --is-ancestor "refs/tags/${TAG}" "origin/${REQUIRED_BRANCH}" 2>/dev/null; then
+            echo "ERROR: Tag '${TAG}' must be reachable from branch '${REQUIRED_BRANCH}' but is not." >&2
+            echo "Stable tags (vX.Y.Z) must be tagged on main; alpha tags (vX.Y.ZaN) must be tagged on dev." >&2
+            exit 1
+          fi
+          echo "Branch guard passed: tag '${TAG}' is reachable from '${REQUIRED_BRANCH}'."
 
       - name: Resolve version tag
         id: version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,9 @@ name: Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
+  push:
+    branches: [main, dev]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- **Phase 1** (`test.yml`): Extend CI triggers from `main`-only to both `main` and `dev` for `pull_request` and direct `push`. Every PR into either branch and every merge commit now runs `test`, `postgres-tests`, and `docker-build`. Closes Risk #1 (untested dev PRs) and Risk #9 (untested merge commits on dev).

- **Phase 7** (`publish-community.yml`): Add a branch guard step before the image build. Stable tags (`vX.Y.Z`) must be reachable from `main`; alpha tags (`vX.Y.ZaN`) must be reachable from `dev`. Fails loudly with a descriptive error if the tag was pushed from the wrong branch. Also sets `fetch-depth: 0` on the checkout so `git merge-base` has full history.

## Files changed

- `.github/workflows/test.yml` — `on:` block extended to include dev branch triggers
- `.github/workflows/publish-community.yml` — new "Assert tag is on the correct branch" step added before "Resolve version tag"

## Test plan

- [ ] Open a test PR targeting `dev` — confirm `test`, `postgres-tests`, `docker-build` all appear in checks
- [ ] Merge a commit to `dev` — confirm the same three checks fire on the push event
- [ ] (Phase 7) Push a `v0.0.3a1` tag on `dev` — guard step should pass
- [ ] (Phase 7) Push a `v0.0.3a1` tag NOT on `dev` — guard step should fail with "must be reachable from dev"
- [ ] (Phase 7) Push a `v0.0.3` tag on `main` — guard step should pass