### PR TITLE
ci: sync workflow changes from dev to main

### DIFF
--- a/.github/workflows/cloud-deploy.yml
+++ b/.github/workflows/cloud-deploy.yml
@@ -1,0 +1,80 @@
+name: "Deploy to Fly.io (cloud release)"
+
+# Triggered only when cloud-version.txt changes on main or dev.
+# This is the normal deploy path — fly-deploy.yml is emergency manual override only.
+#
+# Version streams:
+#   cloud-version.txt  -- Fly.io cloud deploys (this workflow)
+#   pyproject.toml     -- public community image (publish-community.yml, tag-triggered)
+#   tether-premium     -- premium package index (tether-premium release workflow)
+#
+# Branch → env binding (enforced per job):
+#   main → tether-prod (fly.toml)
+#   dev  → tether-dev  (fly.dev.toml)
+#
+# Required secrets:
+#   FLY_API_TOKEN        -- Fly.io personal access token
+#   TETHER_PREMIUM_TOKEN -- GitHub PAT for installing tether-premium in remote build
+
+on:
+  push:
+    branches: [main, dev]
+    paths: ['cloud-version.txt']
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-prod:
+    name: Deploy prod (tether-prod)
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Read cloud version
+        run: echo "VERSION=$(cat cloud-version.txt)" >> $GITHUB_ENV
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to tether-prod
+        # --ha=false: single machine (no auto-HA pair). Bot long-polls, not stateless.
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          PREMIUM_GIT_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
+          TETHER_VERSION: ${{ env.VERSION }}
+        run: |
+          flyctl deploy --config fly.toml --remote-only --ha=false \
+            --build-arg PREMIUM_GIT_TOKEN="$PREMIUM_GIT_TOKEN" \
+            --build-arg TETHER_VERSION="$TETHER_VERSION"
+          # PREMIUM_REQUIREMENTS defaults to requirements-premium.txt in Dockerfile
+
+  deploy-dev:
+    name: Deploy dev (tether-dev)
+    if: github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+
+      - name: Read cloud version
+        run: |
+          BASE=$(cat cloud-version.txt)
+          SHA7=$(echo "$GITHUB_SHA" | cut -c1-7)
+          echo "VERSION=${BASE}-dev.${SHA7}" >> $GITHUB_ENV
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to tether-dev
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          PREMIUM_GIT_TOKEN: ${{ secrets.TETHER_PREMIUM_TOKEN }}
+          TETHER_VERSION: ${{ env.VERSION }}
+        run: |
+          flyctl deploy --config fly.dev.toml --remote-only --ha=false \
+            --build-arg PREMIUM_GIT_TOKEN="$PREMIUM_GIT_TOKEN" \
+            --build-arg TETHER_VERSION="$TETHER_VERSION" \
+            --build-arg PREMIUM_REQUIREMENTS=requirements-premium-dev.txt

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,7 +1,9 @@
 name: "Deploy to Fly.io"
 
-# Deploys to Fly.io on pushes to main (prod) or dev (dev).
-# Fly handles the remote image build -- no self-hosted runner needed.
+# Emergency manual override only — normal deploys via cloud-deploy.yml.
+#
+# cloud-deploy.yml fires automatically when cloud-version.txt changes on main or dev.
+# Use this workflow only when you need to force a deploy without bumping the cloud version.
 #
 # Versioning:
 #   TETHER_VERSION is read from pyproject.toml at deploy time.
@@ -15,23 +17,7 @@ name: "Deploy to Fly.io"
 #   TETHER_PREMIUM_TOKEN -- GitHub PAT for cloning tether-premium
 
 on:
-  push:
-    branches: [main, dev]
-    paths:
-      - 'api/**'
-      - 'bot/**'
-      - 'tether_mcp/**'
-      - 'db/**'
-      - 'shared/**'
-      - 'prompts/**'
-      - 'requirements.txt'
-      - 'requirements-premium.txt'
-      - 'requirements-premium-dev.txt'
-      - 'Dockerfile'
-      - 'supervisord.conf'
-      - 'fly.toml'
-      - 'fly.dev.toml'
-      - 'docker-entrypoint.sh'
+  # Emergency manual override only — normal deploys via cloud-deploy.yml
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/publish-community.yml
+++ b/.github/workflows/publish-community.yml
@@ -17,6 +17,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # needed for branch-reachability check
+
+      - name: Assert tag is on the correct branch
+        env:
+          GH_REF: ${{ github.ref }}
+        run: |
+          TAG="${GH_REF#refs/tags/}"
+          # Alpha tags (vX.Y.ZaN) must be reachable from dev; stable (vX.Y.Z) from main.
+          if echo "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+a[0-9]+$'; then
+            REQUIRED_BRANCH="dev"
+          elif echo "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            REQUIRED_BRANCH="main"
+          else
+            echo "ERROR: Unrecognised tag format '${TAG}'. Expected vX.Y.Z or vX.Y.ZaN." >&2
+            exit 1
+          fi
+          git fetch origin "${REQUIRED_BRANCH}" --depth=100 2>/dev/null || git fetch origin "${REQUIRED_BRANCH}"
+          if ! git merge-base --is-ancestor "refs/tags/${TAG}" "origin/${REQUIRED_BRANCH}" 2>/dev/null; then
+            echo "ERROR: Tag '${TAG}' must be reachable from branch '${REQUIRED_BRANCH}' but is not." >&2
+            echo "Stable tags (vX.Y.Z) must be tagged on main; alpha tags (vX.Y.ZaN) must be tagged on dev." >&2
+            exit 1
+          fi
+          echo "Branch guard passed: tag '${TAG}' is reachable from '${REQUIRED_BRANCH}'."
 
       - name: Resolve version tag
         id: version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,9 @@ name: Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
+  push:
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/.github/workflows/tether-pin-bump.yml
+++ b/.github/workflows/tether-pin-bump.yml
@@ -1,10 +1,14 @@
-name: "Update premium version pin"
+name: "Bump tether-premium pin"
 
-# Dispatched by tether-premium's release workflow after a tag is pushed.
-# Updates the appropriate requirements file and opens a PR.
+# Dispatched by tether-premium's release workflow after the tether-pypi index
+# update has completed successfully.  Updates the appropriate requirements file,
+# opens a PR, and enables auto-merge so the pin lands without manual intervention.
 #
 #   Alpha release -> requirements-premium-dev.txt, PR targeting dev
 #   Stable release -> requirements-premium.txt,     PR targeting main
+#
+# Branch guard: a prerelease dispatch must target dev; stable must target main.
+# The workflow fails loudly if the inputs are inconsistent.
 
 on:
   workflow_dispatch:
@@ -40,6 +44,21 @@ jobs:
             echo "base=main" >> $GITHUB_OUTPUT
           fi
 
+      - name: Verify branch/prerelease consistency
+        env:
+          PRERELEASE: ${{ inputs.prerelease }}
+          BASE: ${{ steps.target.outputs.base }}
+        run: |
+          if [ "$PRERELEASE" = "true" ] && [ "$BASE" != "dev" ]; then
+            echo "ERROR: prerelease pin bump must target dev (got: ${BASE})"
+            exit 1
+          fi
+          if [ "$PRERELEASE" = "false" ] && [ "$BASE" != "main" ]; then
+            echo "ERROR: stable pin bump must target main (got: ${BASE})"
+            exit 1
+          fi
+          echo "Branch guard passed: prerelease=${PRERELEASE}, base=${BASE}"
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ steps.target.outputs.base }}
@@ -51,7 +70,7 @@ jobs:
         run: |
           sed -i "s/tether-premium==.*/tether-premium==${VERSION}/" "$FILE"
 
-      - name: Open PR
+      - name: Open PR and enable auto-merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
@@ -61,6 +80,8 @@ jobs:
           BRANCH="chore/premium-pin-${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Clean up any stale remote branch from a previous failed run
+          git push origin --delete "$BRANCH" 2>/dev/null || true
           git checkout -b "$BRANCH"
           git add "$FILE"
           git commit -m "chore: bump tether-premium pin to ${VERSION}"
@@ -70,3 +91,4 @@ jobs:
             --body "Automated pin bump triggered by tether-premium release ${VERSION}." \
             --base "$BASE" \
             --head "$BRANCH"
+          gh pr merge --auto --squash "$BRANCH"


### PR DESCRIPTION
Cherry-picks all \`.github/workflows/\` changes that landed on dev to main. **No code changes** — workflow files only.

## Changes

| File | Change |
|------|--------|
| \`tether-pin-bump.yml\` | Renamed from \`update-premium-pin.yml\`; adds auto-merge, branch guard, stale-branch cleanup |
| \`cloud-deploy.yml\` | New — triggers Fly deploy on \`cloud-version.txt\` change (Phase 6) |
| \`fly-deploy.yml\` | Remove push trigger; manual emergency override only |
| \`publish-community.yml\` | Add branch-reachability guard for tags |
| \`test.yml\` | Add \`dev\` branch to \`pull_request\` and \`push\` triggers |

## Why

- \`tether-pin-bump.yml\` must be on \`main\` so \`gh workflow run tether-pin-bump.yml --repo jlunder00/tether\` resolves (GHA looks up workflows on the default branch)
- \`cloud-deploy.yml\` on \`main\` enables \`tether-cli release cloud\` to trigger prod deploys