### PR TITLE
fix(ci): use PAT in tether-pin-bump to trigger test workflows on PR

### DIFF
--- a/.github/workflows/tether-pin-bump.yml
+++ b/.github/workflows/tether-pin-bump.yml
@@ -72,7 +72,10 @@ jobs:
 
       - name: Open PR and enable auto-merge
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT here instead of GITHUB_TOKEN so that test workflows
+          # trigger on the opened PR. PRs created by GITHUB_TOKEN are exempt
+          # from workflow triggers (GitHub restriction to prevent loops).
+          GH_TOKEN: ${{ secrets.TETHER_REPO_PAT }}
           VERSION: ${{ inputs.version }}
           FILE: ${{ steps.target.outputs.file }}
           BASE: ${{ steps.target.outputs.base }}


### PR DESCRIPTION
PRs created by `GITHUB_TOKEN` are exempt from workflow triggers (GitHub security restriction to prevent loops). Switching `gh pr create` to use `TETHER_REPO_PAT` allows `test.yml` to fire on the pin bump PR, which unblocks auto-merge.

**Requires:** `TETHER_REPO_PAT` added to `jlunder00/tether` Actions secrets (same PAT already on tether-premium).