### PR TITLE
feat(integrations): handle gcal webhook inline as BackgroundTask (Phase F)

### DIFF
--- a/api/routes/integrations.py
+++ b/api/routes/integrations.py
@@ -26,7 +26,7 @@ import urllib.parse
 import asyncpg
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Request
-from fastapi.responses import RedirectResponse
+from fastapi.responses import RedirectResponse, Response
 from pydantic import BaseModel
 
 import api.config as cfg
@@ -43,6 +43,7 @@ from integrations.google_calendar.auth import (
     verify_oauth_state,
 )
 from integrations.google_calendar.sync import GoogleCalendarSync
+from integrations.models import WebhookPayload
 from sync.dispatch import dispatch_sync  # re-exported so tests can monkeypatch at this name
 
 logger = logging.getLogger(__name__)
@@ -476,33 +477,82 @@ async def google_sync(
 # 5. POST /integrations/google/webhook — Google push notifications
 # ---------------------------------------------------------------------------
 
+async def _process_gcal_event(
+    channel_id: str | None,
+    resource_state: str | None,
+    pool,
+) -> None:
+    """BackgroundTask: process an inbound Google Calendar push notification inline.
+
+    Replaces the former PG NOTIFY → tether-sync worker hop. The HTTP request
+    itself wakes the Fly.io machine; syncing inline means no persistent LISTEN
+    connection is needed.
+
+    resource_state="sync" is Google's registration ping — safe to ignore.
+    An unknown channel_id (no matching integration_sync_state row) is logged
+    and discarded; it could mean a channel that expired and was re-registered
+    under a new ID, or a stale notification after disconnect.
+    """
+    if not channel_id or resource_state == "sync":
+        return
+
+    import db.postgres as pg
+
+    # Resolve channel_id → integration_id via an unscoped connection.
+    # integration_sync_state is a background-system table; no user context needed.
+    async with pg.get_conn(pool) as conn:
+        row = await conn.fetchrow(
+            "SELECT integration_id FROM integration_sync_state WHERE watch_channel_id = $1",
+            channel_id,
+        )
+
+    if not row:
+        logger.warning(
+            "_process_gcal_event: no sync state for channel_id=%s; ignoring",
+            channel_id,
+        )
+        return
+
+    integration_id = str(row["integration_id"])
+    payload = WebhookPayload(
+        channel_id=channel_id,
+        resource_id="",
+        resource_state=resource_state or "",
+        raw_headers={},
+    )
+
+    provider = GoogleCalendarSync(pool)
+    try:
+        await provider.handle_webhook(integration_id, payload)
+    except Exception:
+        logger.exception(
+            "_process_gcal_event: error handling channel_id=%s integration_id=%s",
+            channel_id,
+            integration_id,
+        )
+
+
 @router.post("/integrations/google/webhook")
 async def google_webhook(
     request: Request,
+    background_tasks: BackgroundTasks,
     x_goog_channel_id: str | None = Header(default=None, alias="X-Goog-Channel-Id"),
-    x_goog_resource_id: str | None = Header(default=None, alias="X-Goog-Resource-Id"),
     x_goog_resource_state: str | None = Header(default=None, alias="X-Goog-Resource-State"),
 ):
     """Receive Google Calendar push notifications.
 
-    Must return 200 within Google's timeout. No DB lookup here — the endpoint
-    has no user context so RLS would block any integration_sync_state query.
-    Instead, channel_id is forwarded in the NOTIFY payload; the tether-sync
-    worker resolves it to an integration via its own unscoped DB access.
+    Returns 200 immediately; sync is dispatched as a BackgroundTask so the
+    response is never delayed by DB or Google API latency. The Fly.io machine
+    wakes on this HTTP request, making a persistent PG LISTEN connection
+    unnecessary.
     """
-    if x_goog_channel_id and x_goog_resource_state != "sync":
-        await dispatch_sync(
-            request.app.state.pool,
-            integration_id="",   # unknown — worker resolves via channel_id
-            calendar_id="",      # unknown — worker resolves via channel_id
-            provider=_PROVIDER,
-            notify_type="webhook",
-            channel_id=x_goog_channel_id,
-            resource_id=x_goog_resource_id or "",
-            resource_state=x_goog_resource_state or "",
-        )
-
-    return {"ok": True}
+    background_tasks.add_task(
+        _process_gcal_event,
+        x_goog_channel_id,
+        x_goog_resource_state,
+        request.app.state.pool,
+    )
+    return Response(status_code=200)
 
 
 # ---------------------------------------------------------------------------

--- a/sync/worker.py
+++ b/sync/worker.py
@@ -1,6 +1,17 @@
-"""Tether sync worker.
+"""Tether sync worker — optional local-dev convenience.
 
-Owns:
+**Fly.io / production deployments no longer require this process.**
+Since Phase F (notification-system-overhaul §11), Google Calendar push
+notifications are handled inline as FastAPI BackgroundTasks in
+`api/routes/integrations.py`. The Fly.io machine wakes on the inbound
+HTTP request, so no persistent PG LISTEN connection is needed.
+
+This worker remains useful for local development: it lets you trigger
+syncs via `pg_notify('integration_sync', ...)` without running the API.
+The `[program:sync]` supervisord section is intentionally absent from
+production config (cleanup deferred to Phase K).
+
+Historical ownership (still applies in local-dev mode):
   - PG LISTEN on the `integration_sync` channel
   - APScheduler cron for watch channel renewal (daily, <24h to expiry)
   - APScheduler cron for proactive token refresh (hourly, <1h to expiry)

--- a/tests/api/test_integrations.py
+++ b/tests/api/test_integrations.py
@@ -282,15 +282,18 @@ async def test_sync_no_integration_returns_404(api_client):
 
 
 # ---------------------------------------------------------------------------
-# 5. POST /api/integrations/google/webhook — must return 200 fast
+# 5. POST /api/integrations/google/webhook — inline BackgroundTask (Phase F)
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
 async def test_webhook_returns_200_immediately(api_client, monkeypatch):
-    """Webhook endpoint returns 200 immediately regardless of payload."""
-    async def mock_dispatch(pool, integration_id, calendar_id, *, provider, notify_type="poll", **extra):
-        pass
-    monkeypatch.setattr("api.routes.integrations.dispatch_sync", mock_dispatch)
+    """Webhook endpoint returns 200 immediately; dispatches BackgroundTask."""
+    called: list[tuple] = []
+
+    async def mock_process(channel_id, resource_state, pool):
+        called.append((channel_id, resource_state))
+
+    monkeypatch.setattr("api.routes.integrations._process_gcal_event", mock_process)
 
     resp = await api_client.post(
         "/api/integrations/google/webhook",
@@ -301,11 +304,63 @@ async def test_webhook_returns_200_immediately(api_client, monkeypatch):
         },
     )
     assert resp.status_code == 200
+    assert ("ch_test_001", "exists") in called
+
+
+@pytest.mark.asyncio
+async def test_webhook_dispatches_background_task_args(api_client, monkeypatch):
+    """Webhook handler passes channel_id and resource_state to _process_gcal_event."""
+    captured: list[dict] = []
+
+    async def mock_process(channel_id, resource_state, pool):
+        captured.append({"channel_id": channel_id, "resource_state": resource_state})
+
+    monkeypatch.setattr("api.routes.integrations._process_gcal_event", mock_process)
+
+    resp = await api_client.post(
+        "/api/integrations/google/webhook",
+        headers={
+            "X-Goog-Channel-Id": "my-channel-123",
+            "X-Goog-Resource-State": "exists",
+        },
+    )
+    assert resp.status_code == 200
+    assert len(captured) == 1
+    assert captured[0]["channel_id"] == "my-channel-123"
+    assert captured[0]["resource_state"] == "exists"
+
+
+@pytest.mark.asyncio
+async def test_webhook_dispatch_does_not_call_dispatch_sync(api_client, monkeypatch):
+    """Webhook handler no longer calls dispatch_sync (removed PG NOTIFY from path)."""
+    dispatch_called = []
+
+    async def spy_dispatch(*args, **kwargs):
+        dispatch_called.append(1)
+
+    async def mock_process(channel_id, resource_state, pool):
+        pass
+
+    monkeypatch.setattr("api.routes.integrations.dispatch_sync", spy_dispatch)
+    monkeypatch.setattr("api.routes.integrations._process_gcal_event", mock_process)
+
+    resp = await api_client.post(
+        "/api/integrations/google/webhook",
+        headers={
+            "X-Goog-Channel-Id": "ch_001",
+            "X-Goog-Resource-State": "exists",
+        },
+    )
+    assert resp.status_code == 200
+    assert dispatch_called == [], "dispatch_sync must not be called from the webhook handler"
 
 
 @pytest.mark.asyncio
 async def test_webhook_unknown_channel_still_200(api_client):
-    """Webhook with unknown channel-id still returns 200 (Google's requirement)."""
+    """Webhook with unknown channel-id still returns 200 (Google's requirement).
+
+    _process_gcal_event finds no integration_sync_state row and returns silently.
+    """
     resp = await api_client.post(
         "/api/integrations/google/webhook",
         headers={
@@ -315,6 +370,130 @@ async def test_webhook_unknown_channel_still_200(api_client):
         },
     )
     assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# 5b. _process_gcal_event unit tests (Phase F inline handler)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_process_gcal_event_skips_sync_resource_state(monkeypatch):
+    """_process_gcal_event returns early for resource_state='sync' (channel registration ping)."""
+    from api.routes import integrations as routes
+
+    handle_called = []
+
+    async def mock_handle_webhook(self, integration_id, payload):
+        handle_called.append(1)
+
+    monkeypatch.setattr(
+        "api.routes.integrations.GoogleCalendarSync.handle_webhook",
+        mock_handle_webhook,
+    )
+
+    # Should return without calling handle_webhook
+    await routes._process_gcal_event("ch_001", "sync", pool=None)
+    assert handle_called == []
+
+
+@pytest.mark.asyncio
+async def test_process_gcal_event_skips_none_channel_id(monkeypatch):
+    """_process_gcal_event returns early when channel_id is None."""
+    from api.routes import integrations as routes
+
+    handle_called = []
+
+    async def mock_handle_webhook(self, integration_id, payload):
+        handle_called.append(1)
+
+    monkeypatch.setattr(
+        "api.routes.integrations.GoogleCalendarSync.handle_webhook",
+        mock_handle_webhook,
+    )
+
+    await routes._process_gcal_event(None, "exists", pool=None)
+    assert handle_called == []
+
+
+@pytest.mark.asyncio
+async def test_process_gcal_event_unknown_channel_no_raise(monkeypatch):
+    """_process_gcal_event logs and returns silently when channel has no sync state row."""
+    from api.routes import integrations as routes
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def fake_get_conn(pool, user_id=None):
+        conn = AsyncMock()
+        conn.fetchrow = AsyncMock(return_value=None)
+        yield conn
+
+    monkeypatch.setattr("db.postgres.get_conn", fake_get_conn)
+
+    # Must not raise
+    await routes._process_gcal_event("ch-unknown", "exists", pool=None)
+
+
+@pytest.mark.asyncio
+async def test_process_gcal_event_calls_handle_webhook(monkeypatch):
+    """_process_gcal_event resolves integration_id from channel_id and calls handle_webhook."""
+    import uuid
+    from api.routes import integrations as routes
+    from contextlib import asynccontextmanager
+
+    fake_integration_id = str(uuid.uuid4())
+
+    @asynccontextmanager
+    async def fake_get_conn(pool, user_id=None):
+        conn = AsyncMock()
+        conn.fetchrow = AsyncMock(return_value={"integration_id": uuid.UUID(fake_integration_id)})
+        yield conn
+
+    monkeypatch.setattr("db.postgres.get_conn", fake_get_conn)
+
+    handle_calls: list[dict] = []
+
+    async def mock_handle_webhook(self, integration_id, payload):
+        handle_calls.append({"integration_id": integration_id, "channel_id": payload.channel_id})
+
+    monkeypatch.setattr(
+        "api.routes.integrations.GoogleCalendarSync.handle_webhook",
+        mock_handle_webhook,
+    )
+
+    await routes._process_gcal_event("ch-known", "exists", pool=None)
+
+    assert len(handle_calls) == 1
+    assert handle_calls[0]["integration_id"] == fake_integration_id
+    assert handle_calls[0]["channel_id"] == "ch-known"
+
+
+@pytest.mark.asyncio
+async def test_process_gcal_event_exception_does_not_propagate(monkeypatch):
+    """_process_gcal_event catches and logs exceptions from handle_webhook."""
+    import uuid
+    from api.routes import integrations as routes
+    from contextlib import asynccontextmanager
+
+    fake_id = str(uuid.uuid4())
+
+    @asynccontextmanager
+    async def fake_get_conn(pool, user_id=None):
+        conn = AsyncMock()
+        conn.fetchrow = AsyncMock(return_value={"integration_id": uuid.UUID(fake_id)})
+        yield conn
+
+    monkeypatch.setattr("db.postgres.get_conn", fake_get_conn)
+
+    async def mock_handle_webhook_raises(self, integration_id, payload):
+        raise RuntimeError("Google API flaked")
+
+    monkeypatch.setattr(
+        "api.routes.integrations.GoogleCalendarSync.handle_webhook",
+        mock_handle_webhook_raises,
+    )
+
+    # Must not propagate the exception
+    await routes._process_gcal_event("ch-boom", "exists", pool=None)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Removes PG NOTIFY from the Google Calendar webhook path** — no persistent `tether-sync` worker connection needed on Fly.io
- Adds `_process_gcal_event()` background handler that resolves `watch_channel_id → integration_id` via `integration_sync_state` and calls `GoogleCalendarSync.handle_webhook()` directly
- `google_webhook` now dispatches a `BackgroundTask` and returns 200 immediately (machine wakes on the HTTP request itself)
- Marks `sync/worker.py` as optional local-dev convenience; production does not run it (supervisord `[program:sync]` cleanup deferred to Phase K per plan §17)

## Changes

- `api/routes/integrations.py` — new `_process_gcal_event()` function; updated `google_webhook()` to use BackgroundTasks; added `WebhookPayload` + `Response` imports
- `sync/worker.py` — updated module docstring noting it is no longer required by Fly.io deployment
- `tests/api/test_integrations.py` — 5 new unit tests for `_process_gcal_event`; 3 updated webhook handler tests asserting `dispatch_sync` is no longer called

## Test plan

- [ ] All 9 runnable tests pass locally (`pytest tests/api/test_integrations.py -v`)
- [ ] 20 DB-dependent tests (api_client fixture) pass in CI with DATABASE_URL set
- [ ] Manual: connect GCal, trigger a calendar change, verify `_process_gcal_event` fires and tasks sync without running `sync/worker.py`
- [ ] Verify `resource_state=sync` ping is ignored (no spurious poll)
- [ ] Verify unknown channel_id logs warning and returns 200

## Plan reference

Notification system overhaul §11 + §18 Phase F