### PR TITLE
feat: notification system Phase B — schema + dispatcher

### DIFF
--- a/bot/notify.py
+++ b/bot/notify.py
@@ -1,0 +1,362 @@
+"""Unified notification dispatcher for Tether bot.
+
+Single entry point for all bot-initiated messages. Resolves or creates
+the target conversation, files a conversation_history record, then
+delivers the message to each configured channel.
+
+Usage (Phase C and later — not called from existing code yet):
+
+    from bot.notify import dispatch
+
+    result = await dispatch(
+        user_id=user_id,
+        notification_type="anchor_ping",
+        text="Good morning! Here's your morning plan...",
+        pool=pool,
+        priority="important",
+        thread_key=f"anchor:{anchor_id}:{date.today()}",
+        ws_manager=ws_manager,
+    )
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Literal
+
+import asyncpg
+
+import db.postgres as pg
+from db.pg_queries import conversations as conv_queries
+from db.pg_queries import notifications as notif_queries
+
+logger = logging.getLogger(__name__)
+
+NotificationPriority = Literal["normal", "important", "urgent"]
+NotificationChannel = Literal["telegram", "web", "discord", "slack"]
+
+
+@dataclass
+class NotificationResult:
+    """Outcome of a dispatch() call."""
+
+    conversation_id: str
+    channels_sent: list[str] = field(default_factory=list)
+    channels_failed: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def dispatch(
+    user_id: str,
+    notification_type: str,
+    text: str,
+    pool,
+    *,
+    priority: NotificationPriority = "normal",
+    context_node_id: str | None = None,
+    thread_key: str | None = None,
+    conversation_id: str | None = None,
+    channels: list[str] | None = None,
+    ws_manager=None,
+) -> NotificationResult:
+    """Route a notification to all configured channels for this user/type.
+
+    Args:
+        user_id: The recipient's UUID.
+        notification_type: Logical type key used for routing lookup
+            (e.g. "anchor_ping", "task_followup", "beacon", "bot_reply").
+        text: The message text to deliver.
+        pool: Async connection pool (asyncpg.Pool).
+        priority: Urgency level — 'normal' | 'important' | 'urgent'.
+        context_node_id: Optional context node to file the conversation under.
+        thread_key: When set, uses thread_by_key routing to find/create the
+            conversation. Ignored if conversation_id is provided.
+        conversation_id: When provided, bypasses _resolve_conversation()
+            entirely and files directly into this conversation. Used by
+            Phase C call sites that already know the active conversation
+            (e.g. bot replies in an ongoing interactive session).
+        channels: Override the routing prefs. When provided, only these
+            channel types are attempted (e.g. ["telegram"], ["web"]).
+        ws_manager: ConnectionManager instance for web channel delivery.
+            Required for 'web' channel; absent → web channel fails gracefully.
+
+    Returns:
+        NotificationResult with the resolved conversation_id and per-channel
+        send outcomes.
+    """
+    async with pg.get_conn(pool, user_id) as conn:
+        # ------------------------------------------------------------------
+        # 1. Resolve the target conversation
+        # ------------------------------------------------------------------
+        if conversation_id is None:
+            routing = await notif_queries.get_notification_routing_with_defaults(
+                conn, user_id
+            )
+            conversation_id = await _resolve_conversation(
+                conn=conn,
+                user_id=user_id,
+                notification_type=notification_type,
+                routing=routing,
+                context_node_id=context_node_id,
+                thread_key=thread_key,
+            )
+
+        # ------------------------------------------------------------------
+        # 2. File message to conversation_history with new columns
+        # ------------------------------------------------------------------
+        channel_for_history = (channels[0] if channels else "web")
+        await conn.execute(
+            """
+            INSERT INTO conversation_history (user_id, role, body, conversation_id, source, channel)
+            VALUES ($1::uuid, 'assistant', $2, $3::uuid, 'notification', $4)
+            """,
+            user_id,
+            text,
+            conversation_id,
+            channel_for_history,
+        )
+
+        await conv_queries.touch_conversation(conn, conversation_id)
+
+        # ------------------------------------------------------------------
+        # 3. Determine which channel types to send on
+        # ------------------------------------------------------------------
+        if channels is not None:
+            target_channels = channels
+        else:
+            routing = await notif_queries.get_notification_routing_with_defaults(
+                conn, user_id
+            )
+            type_routing = routing.get(notification_type, {})
+            target_channels = type_routing.get("external", [])
+
+        # ------------------------------------------------------------------
+        # 4. Load channel configs and send
+        # ------------------------------------------------------------------
+        result = NotificationResult(conversation_id=conversation_id)
+
+        for channel_type in target_channels:
+            try:
+                channel_rows = await notif_queries.get_channels_by_type(
+                    conn, user_id, channel_type
+                )
+
+                if channel_type == "telegram":
+                    if not channel_rows:
+                        logger.debug(
+                            "dispatch: no telegram channel configured for user %s", user_id
+                        )
+                        continue
+                    for ch in channel_rows:
+                        chat_id = ch["config"].get("chat_id", "")
+                        await _send_telegram_channel(chat_id, text)
+                    result.channels_sent.append("telegram")
+
+                elif channel_type == "web":
+                    if ws_manager is None:
+                        logger.warning(
+                            "dispatch: web channel requested but ws_manager is None"
+                        )
+                        result.channels_failed.append("web")
+                        continue
+                    await _send_web_channel(
+                        user_id=user_id,
+                        conversation_id=conversation_id,
+                        text=text,
+                        priority=priority,
+                        ws_manager=ws_manager,
+                    )
+                    result.channels_sent.append("web")
+
+                elif channel_type == "discord":
+                    if not channel_rows:
+                        continue
+                    for ch in channel_rows:
+                        await _send_discord_channel(
+                            ch["config"].get("webhook_url", ""), text
+                        )
+                    result.channels_sent.append("discord")
+
+                elif channel_type == "slack":
+                    if not channel_rows:
+                        continue
+                    for ch in channel_rows:
+                        await _send_slack_channel(
+                            ch["config"].get("webhook_url", ""), text
+                        )
+                    result.channels_sent.append("slack")
+
+                else:
+                    logger.warning("dispatch: unknown channel type %r — skipping", channel_type)
+
+            except NotImplementedError:
+                raise
+            except Exception:
+                logger.exception(
+                    "dispatch: channel %r failed for user %s", channel_type, user_id
+                )
+                result.channels_failed.append(channel_type)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Private: conversation resolution
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_conversation(
+    *,
+    conn: asyncpg.Connection,
+    user_id: str,
+    notification_type: str,
+    routing: dict,
+    context_node_id: str | None,
+    thread_key: str | None,
+) -> str:
+    """Find or create the target conversation. Returns conversation_id.
+
+    Routing modes:
+      thread_by_key — deduplicate by (user_id, thread_key)
+      fixed         — use a pre-configured conversation_id from routing prefs
+      bot_decides   — pick the most relevant open conversation (fallback: new)
+      new_each      — always create a new conversation
+    """
+    type_routing = routing.get(notification_type, {})
+    mode = type_routing.get("mode", "thread_by_key")
+    conv_priority = type_routing.get("priority", "normal")
+
+    if mode == "thread_by_key":
+        key = thread_key or _build_thread_key(type_routing.get("key_template", ""), notification_type)
+        name = _default_conv_name(notification_type)
+        return await conv_queries.get_or_create_by_thread_key(
+            conn,
+            user_id=user_id,
+            thread_key=key,
+            name=name,
+            notification_type=notification_type,
+            context_node_id=context_node_id,
+            priority=conv_priority,
+        )
+
+    elif mode == "fixed":
+        fixed_id = type_routing.get("conversation_id")
+        if fixed_id:
+            return fixed_id
+        # Fallback: create new
+        logger.warning(
+            "_resolve_conversation: fixed mode but no conversation_id in routing for %s",
+            notification_type,
+        )
+        return await conv_queries.create_conversation(
+            conn,
+            user_id=user_id,
+            name=_default_conv_name(notification_type),
+            notification_type=notification_type,
+            context_node_id=context_node_id,
+            priority=conv_priority,
+        )
+
+    elif mode == "new_each":
+        return await conv_queries.create_conversation(
+            conn,
+            user_id=user_id,
+            name=_default_conv_name(notification_type),
+            notification_type=notification_type,
+            context_node_id=context_node_id,
+            priority=conv_priority,
+        )
+
+    else:
+        # bot_decides or unknown — create a new conversation for now.
+        # Phase G will implement the "most relevant open conversation" logic.
+        return await conv_queries.create_conversation(
+            conn,
+            user_id=user_id,
+            name=_default_conv_name(notification_type),
+            notification_type=notification_type,
+            context_node_id=context_node_id,
+            priority=conv_priority,
+        )
+
+
+def _build_thread_key(template: str, notification_type: str) -> str:
+    """Build a thread key from a template. Falls back to notification_type if template empty."""
+    if not template:
+        return notification_type
+    # Templates like "anchor:{anchor_id}:{date}" are filled by callers;
+    # if they arrive here unfilled, return the template literal as the key.
+    return template
+
+
+def _default_conv_name(notification_type: str) -> str:
+    _NAMES = {
+        "anchor_ping": "Anchor Update",
+        "task_followup": "Task Follow-up",
+        "beacon": "Beacon Insight",
+        "meeting_event": "Meeting",
+        "scheduling_update": "Scheduling Update",
+        "bot_reply": "Chat",
+    }
+    return _NAMES.get(notification_type, notification_type.replace("_", " ").title())
+
+
+# ---------------------------------------------------------------------------
+# Private: channel senders
+# ---------------------------------------------------------------------------
+
+
+async def _send_telegram_channel(chat_id: str, text: str) -> None:
+    """Send a message via the Telegram Bot API.
+
+    Uses the python-telegram-bot library imported lazily to avoid making it a
+    hard dependency when only web channel is in use.
+
+    Phase C wires the actual bot token from config; for now the import and
+    call structure is established here so tests can mock this function.
+    """
+    try:
+        from telegram import Bot
+        from bot.message_handler import _get_bot_token  # set up in Phase C
+    except ImportError:
+        logger.warning("_send_telegram_channel: python-telegram-bot not available")
+        raise
+
+    token = _get_bot_token()
+    bot = Bot(token=token)
+    await bot.send_message(chat_id=chat_id, text=text)
+
+
+async def _send_web_channel(
+    user_id: str,
+    conversation_id: str,
+    text: str,
+    priority: NotificationPriority,
+    ws_manager,
+) -> None:
+    """Push a notification event over WebSocket to the frontend."""
+    await ws_manager.broadcast(
+        {
+            "type": "notification",
+            "conversation_id": conversation_id,
+            "text": text,
+            "priority": priority,
+            "ts": datetime.now(timezone.utc).isoformat(),
+        },
+        user_id,
+    )
+
+
+async def _send_discord_channel(webhook_url: str, text: str) -> None:
+    """Discord channel — not yet implemented."""
+    raise NotImplementedError("Discord channel not yet implemented")
+
+
+async def _send_slack_channel(webhook_url: str, text: str) -> None:
+    """Slack channel — not yet implemented."""
+    raise NotImplementedError("Slack channel not yet implemented")

--- a/db/migrations/versions/9b8a7f6e5d4c_notification_system_phase_b.py
+++ b/db/migrations/versions/9b8a7f6e5d4c_notification_system_phase_b.py
@@ -7,7 +7,7 @@ Adds the schema required for the unified notification dispatcher:
   - context_nodes: summary, summary_updated_at columns
   - Backfills existing users' telegram_chat_id into notification_channels rows
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: 9b8a7f6e5d4c
 Revises: f5a6b7c8d9e0
 Create Date: 2026-05-13
 """
@@ -15,7 +15,7 @@ from typing import Sequence, Union
 
 from alembic import op
 
-revision: str = "a1b2c3d4e5f6"
+revision: str = "9b8a7f6e5d4c"
 down_revision: Union[str, Sequence[str], None] = "f5a6b7c8d9e0"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/db/migrations/versions/9b8a7f6e5d4c_notification_system_phase_b.py
+++ b/db/migrations/versions/9b8a7f6e5d4c_notification_system_phase_b.py
@@ -8,7 +8,7 @@ Adds the schema required for the unified notification dispatcher:
   - Backfills existing users' telegram_chat_id into notification_channels rows
 
 Revision ID: 9b8a7f6e5d4c
-Revises: f5a6b7c8d9e0
+Revises: b2c3d4e5f6a7
 Create Date: 2026-05-13
 """
 from typing import Sequence, Union
@@ -16,7 +16,7 @@ from typing import Sequence, Union
 from alembic import op
 
 revision: str = "9b8a7f6e5d4c"
-down_revision: Union[str, Sequence[str], None] = "f5a6b7c8d9e0"
+down_revision: Union[str, Sequence[str], None] = "b2c3d4e5f6a7"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/db/migrations/versions/9b8a7f6e5d4c_notification_system_phase_b.py
+++ b/db/migrations/versions/9b8a7f6e5d4c_notification_system_phase_b.py
@@ -109,19 +109,18 @@ def upgrade() -> None:
         """
     )
 
-    # §3.3 backfill: existing telegram_chat_id → notification_channels row
+    # §3.3 backfill: existing telegram_connections rows → notification_channels
+    # telegram_chat_id lives in telegram_connections (user_id PK, telegram_chat_id TEXT).
     # Runs in the same transaction as the DDL — exactly once on deploy.
     op.execute(
         """
         INSERT INTO notification_channels (user_id, channel_type, config, label)
         SELECT
-            id,
+            tc.user_id,
             'telegram',
-            jsonb_build_object('chat_id', telegram_chat_id::text),
+            jsonb_build_object('chat_id', tc.telegram_chat_id),
             'Telegram (migrated)'
-        FROM users
-        WHERE telegram_chat_id IS NOT NULL
-          AND telegram_chat_id != ''
+        FROM telegram_connections tc
         ON CONFLICT DO NOTHING
         """
     )

--- a/db/migrations/versions/a1b2c3d4e5f6_notification_system_phase_b.py
+++ b/db/migrations/versions/a1b2c3d4e5f6_notification_system_phase_b.py
@@ -1,0 +1,165 @@
+"""notification system phase B — conversations, channels, context_nodes summary
+
+Adds the schema required for the unified notification dispatcher:
+  - conversations table (with RLS)
+  - conversation_history: conversation_id, source, channel columns
+  - notification_channels table (with RLS)
+  - context_nodes: summary, summary_updated_at columns
+  - Backfills existing users' telegram_chat_id into notification_channels rows
+
+Revision ID: a1b2c3d4e5f6
+Revises: f5a6b7c8d9e0
+Create Date: 2026-05-13
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, Sequence[str], None] = "f5a6b7c8d9e0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # §3.1  conversations table
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE conversations (
+            id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id          UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            name             TEXT NOT NULL,
+            type             TEXT NOT NULL DEFAULT 'interactive',
+            priority         TEXT NOT NULL DEFAULT 'normal',
+            state            TEXT NOT NULL DEFAULT 'open',
+            context_node_id  UUID REFERENCES context_nodes(id) ON DELETE SET NULL,
+            thread_key       TEXT,
+            is_system        BOOLEAN NOT NULL DEFAULT false,
+            created_at       TIMESTAMPTZ DEFAULT now(),
+            last_message_at  TIMESTAMPTZ DEFAULT now()
+        )
+        """
+    )
+
+    # Partial unique index: one open thread per (user, thread_key) when thread_key is set
+    op.execute(
+        """
+        CREATE UNIQUE INDEX conversations_thread_key_user
+            ON conversations (user_id, thread_key)
+            WHERE thread_key IS NOT NULL
+        """
+    )
+
+    op.execute("ALTER TABLE conversations ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE conversations FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY conversations_isolation ON conversations
+            USING (user_id = current_setting('app.current_user_id', true)::uuid)
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # §3.2  conversation_history additions
+    # ------------------------------------------------------------------
+    op.execute(
+        "ALTER TABLE conversation_history "
+        "ADD COLUMN conversation_id UUID REFERENCES conversations(id) ON DELETE SET NULL"
+    )
+    op.execute(
+        "ALTER TABLE conversation_history "
+        "ADD COLUMN source TEXT NOT NULL DEFAULT 'chat'"
+    )
+    op.execute(
+        "ALTER TABLE conversation_history "
+        "ADD COLUMN channel TEXT NOT NULL DEFAULT 'telegram'"
+    )
+    op.execute(
+        """
+        CREATE INDEX conversation_history_conversation_id
+            ON conversation_history (conversation_id, id DESC)
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # §3.3  notification_channels table
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE notification_channels (
+            id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id       UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            channel_type  TEXT NOT NULL CHECK (channel_type IN ('telegram', 'web', 'discord', 'slack')),
+            config        JSONB NOT NULL DEFAULT '{}',
+            label         TEXT,
+            enabled       BOOLEAN NOT NULL DEFAULT true,
+            created_at    TIMESTAMPTZ DEFAULT now()
+        )
+        """
+    )
+
+    op.execute("ALTER TABLE notification_channels ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE notification_channels FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY notification_channels_isolation ON notification_channels
+            USING (user_id = current_setting('app.current_user_id', true)::uuid)
+        """
+    )
+
+    # §3.3 backfill: existing telegram_chat_id → notification_channels row
+    # Runs in the same transaction as the DDL — exactly once on deploy.
+    op.execute(
+        """
+        INSERT INTO notification_channels (user_id, channel_type, config, label)
+        SELECT
+            id,
+            'telegram',
+            jsonb_build_object('chat_id', telegram_chat_id::text),
+            'Telegram (migrated)'
+        FROM users
+        WHERE telegram_chat_id IS NOT NULL
+          AND telegram_chat_id != ''
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # §3.4  context_nodes additions
+    # ------------------------------------------------------------------
+    op.execute(
+        "ALTER TABLE context_nodes "
+        "ADD COLUMN summary TEXT"
+    )
+    op.execute(
+        "ALTER TABLE context_nodes "
+        "ADD COLUMN summary_updated_at TIMESTAMPTZ"
+    )
+
+
+def downgrade() -> None:
+    # context_nodes
+    op.execute("ALTER TABLE context_nodes DROP COLUMN IF EXISTS summary_updated_at")
+    op.execute("ALTER TABLE context_nodes DROP COLUMN IF EXISTS summary")
+
+    # notification_channels
+    op.execute("DROP TABLE IF EXISTS notification_channels")
+
+    # conversation_history additions
+    op.execute(
+        "DROP INDEX IF EXISTS conversation_history_conversation_id"
+    )
+    op.execute(
+        "ALTER TABLE conversation_history DROP COLUMN IF EXISTS channel"
+    )
+    op.execute(
+        "ALTER TABLE conversation_history DROP COLUMN IF EXISTS source"
+    )
+    op.execute(
+        "ALTER TABLE conversation_history DROP COLUMN IF EXISTS conversation_id"
+    )
+
+    # conversations
+    op.execute("DROP TABLE IF EXISTS conversations")

--- a/db/pg_queries/conversations.py
+++ b/db/pg_queries/conversations.py
@@ -1,0 +1,204 @@
+"""Async Postgres queries — conversations table.
+
+Covers CRUD for the conversations model introduced in the notification
+system overhaul (Phase B). RLS on the conversations table enforces
+per-user isolation; callers must have set app.current_user_id before
+invoking these functions.
+"""
+from __future__ import annotations
+
+import asyncpg
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+async def create_conversation(
+    conn: asyncpg.Connection,
+    *,
+    user_id: str,
+    name: str,
+    notification_type: str,
+    conversation_type: str = "interactive",
+    priority: str = "normal",
+    context_node_id: str | None = None,
+    thread_key: str | None = None,
+    is_system: bool = False,
+) -> str:
+    """Insert a new conversation row. Returns the new UUID as a string."""
+    row = await conn.fetchrow(
+        """
+        INSERT INTO conversations
+            (user_id, name, type, priority, context_node_id, thread_key, is_system)
+        VALUES
+            ($1::uuid, $2, $3, $4, $5::uuid, $6, $7)
+        RETURNING id::text
+        """,
+        user_id,
+        name,
+        conversation_type,
+        priority,
+        context_node_id,
+        thread_key,
+        is_system,
+    )
+    return row["id"]
+
+
+async def get_or_create_by_thread_key(
+    conn: asyncpg.Connection,
+    *,
+    user_id: str,
+    thread_key: str,
+    name: str,
+    notification_type: str,
+    context_node_id: str | None = None,
+    priority: str = "normal",
+) -> str:
+    """Return an existing open conversation matching (user_id, thread_key),
+    or create a new one. Returns the conversation UUID as a string.
+
+    Uses INSERT ... ON CONFLICT DO NOTHING + a follow-up SELECT so the
+    operation is safe under concurrent callers (the partial unique index
+    on (user_id, thread_key) WHERE thread_key IS NOT NULL guarantees at-most-one).
+    """
+    # Try to insert; ignore if the (user_id, thread_key) pair already exists.
+    await conn.execute(
+        """
+        INSERT INTO conversations
+            (user_id, name, type, priority, context_node_id, thread_key)
+        VALUES
+            ($1::uuid, $2, 'interactive', $3, $4::uuid, $5)
+        ON CONFLICT DO NOTHING
+        """,
+        user_id,
+        name,
+        priority,
+        context_node_id,
+        thread_key,
+    )
+
+    row = await conn.fetchrow(
+        """
+        SELECT id::text
+        FROM conversations
+        WHERE user_id = $1::uuid
+          AND thread_key = $2
+          AND state = 'open'
+        LIMIT 1
+        """,
+        user_id,
+        thread_key,
+    )
+    return row["id"]
+
+
+# ---------------------------------------------------------------------------
+# Read
+# ---------------------------------------------------------------------------
+
+
+async def get_conversation(
+    conn: asyncpg.Connection,
+    conversation_id: str,
+) -> dict | None:
+    """Fetch a conversation by id. Returns None if not found."""
+    row = await conn.fetchrow(
+        """
+        SELECT
+            id::text AS id,
+            user_id::text AS user_id,
+            name,
+            type,
+            priority,
+            state,
+            context_node_id::text AS context_node_id,
+            thread_key,
+            is_system,
+            created_at,
+            last_message_at
+        FROM conversations
+        WHERE id = $1::uuid
+        """,
+        conversation_id,
+    )
+    return dict(row) if row else None
+
+
+async def get_open_conversation_by_thread_key(
+    conn: asyncpg.Connection,
+    user_id: str,
+    thread_key: str,
+) -> dict | None:
+    """Return the open conversation matching (user_id, thread_key), or None."""
+    row = await conn.fetchrow(
+        """
+        SELECT id::text AS id, name, priority, context_node_id::text AS context_node_id
+        FROM conversations
+        WHERE user_id = $1::uuid
+          AND thread_key = $2
+          AND state = 'open'
+        LIMIT 1
+        """,
+        user_id,
+        thread_key,
+    )
+    return dict(row) if row else None
+
+
+# ---------------------------------------------------------------------------
+# Update
+# ---------------------------------------------------------------------------
+
+
+async def touch_conversation(
+    conn: asyncpg.Connection,
+    conversation_id: str,
+) -> None:
+    """Update last_message_at to now() for the given conversation."""
+    await conn.execute(
+        """
+        UPDATE conversations
+        SET last_message_at = now()
+        WHERE id = $1::uuid
+        """,
+        conversation_id,
+    )
+
+
+async def update_conversation(
+    conn: asyncpg.Connection,
+    conversation_id: str,
+    *,
+    name: str | None = None,
+    priority: str | None = None,
+    context_node_id: str | None = None,
+    state: str | None = None,
+) -> None:
+    """Patch mutable fields on a conversation. Only provided fields are updated."""
+    if name is not None:
+        await conn.execute(
+            "UPDATE conversations SET name = $1 WHERE id = $2::uuid",
+            name,
+            conversation_id,
+        )
+    if priority is not None:
+        await conn.execute(
+            "UPDATE conversations SET priority = $1 WHERE id = $2::uuid",
+            priority,
+            conversation_id,
+        )
+    if context_node_id is not None:
+        await conn.execute(
+            "UPDATE conversations SET context_node_id = $1::uuid WHERE id = $2::uuid",
+            context_node_id,
+            conversation_id,
+        )
+    if state is not None:
+        await conn.execute(
+            "UPDATE conversations SET state = $1 WHERE id = $2::uuid",
+            state,
+            conversation_id,
+        )

--- a/db/pg_queries/notifications.py
+++ b/db/pg_queries/notifications.py
@@ -1,0 +1,208 @@
+"""Async Postgres queries — notification_channels + routing preferences.
+
+Covers the notification_channels table and the notification_routing key
+within user_preferences. RLS on notification_channels enforces per-user
+isolation; callers must have set app.current_user_id before invoking
+these functions.
+"""
+from __future__ import annotations
+
+import asyncpg
+
+
+# ---------------------------------------------------------------------------
+# notification_channels
+# ---------------------------------------------------------------------------
+
+
+async def get_notification_channels(
+    conn: asyncpg.Connection,
+    user_id: str,
+    *,
+    enabled_only: bool = True,
+) -> list[dict]:
+    """Return all notification channels for a user.
+
+    Args:
+        enabled_only: When True (default), return only enabled channels.
+    """
+    query = """
+        SELECT
+            id::text AS id,
+            user_id::text AS user_id,
+            channel_type,
+            config,
+            label,
+            enabled,
+            created_at
+        FROM notification_channels
+        WHERE user_id = $1::uuid
+    """
+    if enabled_only:
+        query += " AND enabled = true"
+    query += " ORDER BY created_at"
+
+    rows = await conn.fetch(query, user_id)
+    return [dict(r) for r in rows]
+
+
+async def get_channels_by_type(
+    conn: asyncpg.Connection,
+    user_id: str,
+    channel_type: str,
+) -> list[dict]:
+    """Return all enabled channels of a specific type for a user."""
+    rows = await conn.fetch(
+        """
+        SELECT
+            id::text AS id,
+            channel_type,
+            config,
+            label,
+            enabled
+        FROM notification_channels
+        WHERE user_id = $1::uuid
+          AND channel_type = $2
+          AND enabled = true
+        ORDER BY created_at
+        """,
+        user_id,
+        channel_type,
+    )
+    return [dict(r) for r in rows]
+
+
+async def create_notification_channel(
+    conn: asyncpg.Connection,
+    *,
+    user_id: str,
+    channel_type: str,
+    config: dict,
+    label: str | None = None,
+    enabled: bool = True,
+) -> str:
+    """Insert a new notification_channels row. Returns the new UUID as a string."""
+    row = await conn.fetchrow(
+        """
+        INSERT INTO notification_channels (user_id, channel_type, config, label, enabled)
+        VALUES ($1::uuid, $2, $3, $4, $5)
+        RETURNING id::text
+        """,
+        user_id,
+        channel_type,
+        config,
+        label,
+        enabled,
+    )
+    return row["id"]
+
+
+async def upsert_channel_enabled(
+    conn: asyncpg.Connection,
+    channel_id: str,
+    enabled: bool,
+) -> None:
+    """Enable or disable a notification channel."""
+    await conn.execute(
+        "UPDATE notification_channels SET enabled = $1 WHERE id = $2::uuid",
+        enabled,
+        channel_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Notification routing preferences (stored in user_preferences JSONB)
+# ---------------------------------------------------------------------------
+
+_ROUTING_PREF_KEY = "notification_routing"
+
+_DEFAULT_ROUTING: dict = {
+    "anchor_ping": {
+        "mode": "thread_by_key",
+        "key_template": "anchor:{anchor_id}:{date}",
+        "priority": "important",
+        "external": ["telegram"],
+    },
+    "task_followup": {
+        "mode": "thread_by_key",
+        "key_template": "anchor:{anchor_id}:{date}",
+        "priority": "important",
+        "external": ["telegram"],
+    },
+    "beacon": {
+        "mode": "bot_decides",
+        "priority": "normal",
+        "external": ["web"],
+    },
+    "meeting_event": {
+        "mode": "thread_by_key",
+        "key_template": "meeting:{request_id}",
+        "priority": "important",
+        "external": ["telegram", "web"],
+    },
+    "scheduling_update": {
+        "mode": "fixed",
+        "priority": "normal",
+        "external": ["web"],
+    },
+}
+
+
+async def get_notification_routing(
+    conn: asyncpg.Connection,
+    user_id: str,
+) -> dict | None:
+    """Return the user's notification_routing preferences dict, or None if unset.
+
+    The value is stored as JSON text in user_preferences with key='notification_routing'.
+    """
+    import json
+
+    row = await conn.fetchrow(
+        """
+        SELECT value
+        FROM user_preferences
+        WHERE user_id = $1::uuid
+          AND key = $2
+        """,
+        user_id,
+        _ROUTING_PREF_KEY,
+    )
+    if row is None or row["value"] is None:
+        return None
+    try:
+        return json.loads(row["value"])
+    except (TypeError, ValueError):
+        return None
+
+
+async def get_notification_routing_with_defaults(
+    conn: asyncpg.Connection,
+    user_id: str,
+) -> dict:
+    """Return the user's routing prefs, falling back to defaults for missing keys."""
+    stored = await get_notification_routing(conn, user_id)
+    if stored is None:
+        return dict(_DEFAULT_ROUTING)
+    return {**_DEFAULT_ROUTING, **stored}
+
+
+async def set_notification_routing(
+    conn: asyncpg.Connection,
+    user_id: str,
+    routing: dict,
+) -> None:
+    """Persist the notification_routing dict in user_preferences as JSON text."""
+    import json
+
+    await conn.execute(
+        """
+        INSERT INTO user_preferences (user_id, key, value)
+        VALUES ($1::uuid, $2, $3)
+        ON CONFLICT (user_id, key) DO UPDATE
+            SET value = $3, updated_at = now()
+        """,
+        user_id,
+        _ROUTING_PREF_KEY,
+        json.dumps(routing),
+    )


### PR DESCRIPTION
## Summary

Phase B of the notification system overhaul (plan §3, §4, §18 Phase B).

- **Alembic migration** (`a1b2c3d4e5f6`): `conversations` table + RLS, `conversation_history` additions (`conversation_id`, `source`, `channel`), `notification_channels` table + RLS, `context_nodes.summary` + `summary_updated_at`. Includes in-migration DML backfill: existing `users.telegram_chat_id` → `notification_channels` rows.
- **`bot/notify.py`**: unified `dispatch()` entry point, `_resolve_conversation()` (thread_by_key / fixed / bot_decides / new_each modes), `_send_telegram_channel()`, `_send_web_channel()` (via ws_manager), `_send_discord_channel()` / `_send_slack_channel()` (NotImplementedError stubs).
- **`db/pg_queries/conversations.py`**: full CRUD — `create_conversation`, `get_or_create_by_thread_key`, `get_conversation`, `touch_conversation`, `update_conversation`.
- **`db/pg_queries/notifications.py`**: `get_notification_channels`, `get_channels_by_type`, `create_notification_channel`, `get_notification_routing` (reads from `user_preferences` key/value), `get_notification_routing_with_defaults`, `set_notification_routing`.

Tests are in `tether-premium` branch `feature/notify-phase-b-schema` (22 tests).

## What this does NOT do (Phase C)

- Does not call `dispatch()` from existing code
- Does not modify `anchor_trigger.py`
- Does not add API endpoints

## Test plan

- [ ] `postgres-tests` CI job runs migration against a clean DB and all 22 DB tests pass
- [ ] `docker-build` CI job passes
- [ ] Verify partial unique index: two NULL `thread_key` rows allowed; same non-null key rejects on second insert
- [ ] Verify backfill: users with `telegram_chat_id` get a `notification_channels` row after migration
- [ ] Verify RLS: rows only visible when `app.current_user_id` matches `user_id`