### PR TITLE
fix: true optimistic insert in promoteTask + drop fetchPlanRange RTT in DayTimeline

### DIFF
--- a/frontend/src/components/DayTimeline.vue
+++ b/frontend/src/components/DayTimeline.vue
@@ -201,10 +201,9 @@ async function handleSlotDrop(payload: DropPayload, time: string) {
   } else {
     const endISO = new Date(slotStartMs + 30 * 60_000).toISOString()
     await eventStore.promoteTask(taskId, slotStart, endISO, title)
-    // Use fetchPlanRange (not fetchPlan) — fetchPlan flips loading=true which causes
-    // PlanView's v-if="planStore.loading" to destroy and remount the entire grid.
-    // fetchPlanRange updates plans.value directly without touching loading.
-    await planStore.fetchPlanRange(props.date, props.date)
+    // CalendarView pattern: remove task from plans immediately (optimistic).
+    // No round-trip needed — promoteTask already inserted the event optimistically.
+    planStore.removeTaskFromPlans(taskId)
   }
 }
 

--- a/frontend/src/components/__tests__/DayTimelineDropZone.test.ts
+++ b/frontend/src/components/__tests__/DayTimelineDropZone.test.ts
@@ -35,6 +35,7 @@ const mockPromoteTask = vi.fn()
 const mockMoveEvent = vi.fn()
 const mockFetchPlan = vi.fn()
 const mockFetchPlanRange = vi.fn()
+const mockRemoveTaskFromPlans = vi.fn()
 
 const mockTimedEvent: CalendarEvent = {
   id: 'ev-timed',
@@ -80,6 +81,7 @@ vi.mock('../../stores/plan', () => ({
     plans: {},
     fetchPlan: mockFetchPlan,
     fetchPlanRange: mockFetchPlanRange,
+    removeTaskFromPlans: mockRemoveTaskFromPlans,
     today: '2024-06-10',
     activeDate: { value: '2024-06-10' },
   }),
@@ -120,6 +122,7 @@ describe('DayTimeline – 15-min slot drop targets', () => {
     mockMoveEvent.mockReset()
     mockFetchPlan.mockReset()
     mockFetchPlanRange.mockReset()
+    mockRemoveTaskFromPlans.mockReset()
   })
 
   it('each 15-min slot has data-date and data-time attributes', async () => {
@@ -151,16 +154,17 @@ describe('DayTimeline – 15-min slot drop targets', () => {
     expect(mockPromoteTask).toHaveBeenCalledWith('task-99', expected09, expected0930, 'Do the thing')
   })
 
-  it('after promoting a task, fetchPlanRange(date, date) is called — not fetchPlan — to avoid loading flash', async () => {
-    // Bug 1 + 3: fetchPlan flips loading=true which destroys the entire plan grid (v-if in PlanView).
-    // Fix: fetchPlanRange(date, date) updates plans.value without touching loading, so no remount.
+  it('after promoting a task, removeTaskFromPlans(taskId) is called — eliminates the second RTT', async () => {
+    // Optimistic promotion: after promoteTask the task is already gone client-side via
+    // removeTaskFromPlans (same pattern as CalendarView). No fetchPlanRange round-trip needed.
     const { default: DayTimeline } = await import('../DayTimeline.vue')
     const wrapper = mount(DayTimeline, { props: { date: '2024-06-10' } })
     const slot = wrapper.find('[data-time="09:00"]')
     const payload = { type: 'task', taskId: 'task-99', title: 'Do the thing' }
     await slot.trigger('drop', { dataTransfer: { getData: (t: string) => t === 'application/json' ? JSON.stringify(payload) : '' } })
     expect(mockPromoteTask).toHaveBeenCalled()
-    expect(mockFetchPlanRange).toHaveBeenCalledWith('2024-06-10', '2024-06-10')
+    expect(mockRemoveTaskFromPlans).toHaveBeenCalledWith('task-99')
+    expect(mockFetchPlanRange).not.toHaveBeenCalled()
     expect(mockFetchPlan).not.toHaveBeenCalled()
   })
 

--- a/frontend/src/stores/__tests__/events.test.ts
+++ b/frontend/src/stores/__tests__/events.test.ts
@@ -356,4 +356,79 @@ describe('useEventStore', () => {
     const store = useEventStore()
     await expect(store.updateEventColor('nonexistent', '#ff0000')).resolves.toBeUndefined()
   })
+
+  // --- promoteTask — true optimistic insert ---
+
+  it('promoteTask inserts optimistic event synchronously before API resolves', async () => {
+    const { api } = await import('../../lib/api')
+    // Hold the API response until we explicitly resolve it
+    let resolveApi!: (v: Response) => void
+    vi.mocked(api).mockReturnValueOnce(new Promise(r => { resolveApi = r }) as any)
+
+    const { useEventStore } = await import('../events')
+    const store = useEventStore()
+
+    // Start promotion but do NOT await — we want to inspect state mid-flight
+    const promise = store.promoteTask('task-opt', '2024-06-10T09:00:00Z', '2024-06-10T09:30:00Z', 'Optimistic Task')
+
+    // The optimistic event must appear synchronously (before any microtask boundary)
+    expect(store.events).toHaveLength(1)
+    expect(store.events[0].task_id).toBe('task-opt')
+    expect(store.events[0].title).toBe('Optimistic Task')
+    expect(store.events[0].id).toMatch(/^optimistic-/)
+
+    // Resolve the API call to clean up
+    resolveApi({ ok: false, json: async () => ({}) } as any)
+    await promise
+  })
+
+  it('promoteTask replaces optimistic event with server response on 2xx', async () => {
+    const { api } = await import('../../lib/api')
+    const serverEvent = {
+      ...BASE_EVENT_FIELDS,
+      id: 'server-123',
+      title: 'Reconciled Task',
+      start_time: '2024-06-10T09:00:00Z',
+      end_time: '2024-06-10T09:30:00Z',
+      task_id: 'task-opt',
+    }
+    vi.mocked(api).mockResolvedValueOnce({ ok: true, json: async () => serverEvent } as any)
+
+    const { useEventStore } = await import('../events')
+    const store = useEventStore()
+
+    const result = await store.promoteTask('task-opt', '2024-06-10T09:00:00Z', '2024-06-10T09:30:00Z', 'Reconciled Task')
+
+    // After API resolves, exactly one event — the server-confirmed one
+    expect(store.events).toHaveLength(1)
+    expect(store.events[0].id).toBe('server-123')
+    expect(result?.id).toBe('server-123')
+  })
+
+  it('promoteTask removes optimistic event on network error', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockRejectedValueOnce(new Error('network failure'))
+
+    const { useEventStore } = await import('../events')
+    const store = useEventStore()
+
+    const result = await store.promoteTask('task-err', '2024-06-10T09:00:00Z', '2024-06-10T09:30:00Z', 'Error Task')
+
+    // Optimistic event must be cleaned up on failure
+    expect(store.events).toHaveLength(0)
+    expect(result).toBeNull()
+  })
+
+  it('promoteTask removes optimistic event when API returns non-2xx', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({ ok: false, json: async () => ({}) } as any)
+
+    const { useEventStore } = await import('../events')
+    const store = useEventStore()
+
+    const result = await store.promoteTask('task-fail', '2024-06-10T09:00:00Z', '2024-06-10T09:30:00Z', 'Failed Task')
+
+    expect(store.events).toHaveLength(0)
+    expect(result).toBeNull()
+  })
 })

--- a/frontend/src/stores/events.ts
+++ b/frontend/src/stores/events.ts
@@ -30,23 +30,16 @@ export const useEventStore = defineStore('events', () => {
   /**
    * Promote a task to a calendar event (sets start/end time).
    * POST /api/events — creates a calendar event with the given time range.
+   *
+   * True optimistic insert: the event appears in the store immediately (before the
+   * network round-trip) with a temp ID prefixed "optimistic-". On 2xx the temp
+   * entry is replaced with the server-confirmed event (preserving list order). On
+   * any failure the temp entry is removed.
    */
   async function promoteTask(taskId: string, startTime: string, endTime: string, title: string): Promise<CalendarEvent | null> {
-    try {
-      const resp = await api('/api/events', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ task_id: taskId, start_time: startTime, end_time: endTime, title }),
-      })
-      if (resp.ok) {
-        const event: CalendarEvent = await resp.json()
-        events.value.push(event)
-        return event
-      }
-    } catch { /* fall through */ }
-    // Optimistic local insert until backend ships
+    const tempId = `optimistic-${crypto.randomUUID?.() ?? (Math.random().toString(36).slice(2) + Date.now().toString(36))}`
     const optimistic: CalendarEvent = {
-      id: crypto.randomUUID?.() ?? (Math.random().toString(36).slice(2) + Date.now().toString(36)),
+      id: tempId,
       title,
       start_time: startTime,
       end_time: endTime,
@@ -62,7 +55,24 @@ export const useEventStore = defineStore('events', () => {
       context_subject: null,
     }
     events.value.push(optimistic)
-    return optimistic
+
+    try {
+      const resp = await api('/api/events', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ task_id: taskId, start_time: startTime, end_time: endTime, title }),
+      })
+      if (resp.ok) {
+        const confirmed: CalendarEvent = await resp.json()
+        const idx = events.value.findIndex(e => e.id === tempId)
+        if (idx !== -1) events.value[idx] = confirmed
+        return confirmed
+      }
+    } catch { /* fall through to cleanup */ }
+
+    // On failure: remove the optimistic entry
+    events.value = events.value.filter(e => e.id !== tempId)
+    return null
   }
 
   /**


### PR DESCRIPTION
## Summary

- **`eventStore.promoteTask`** restructured for true optimistic insert: event appears in the store _synchronously_ (before network round-trip) with a temp `optimistic-<uuid>` ID. On 2xx the entry is replaced in-place with the server-confirmed event; on any failure (network error or non-2xx) it is removed. Eliminates the ~50-200ms lag where the user had to wait for the API before seeing the event on the timeline.

- **`DayTimeline.vue` drop handler** now calls `planStore.removeTaskFromPlans(taskId)` instead of `await planStore.fetchPlanRange(date, date)`, matching the pattern CalendarView already uses. Removes the second blocking RTT on promotion via the day timeline.

## Tests added

- `promoteTask inserts optimistic event synchronously before API resolves`
- `promoteTask replaces optimistic event with server response on 2xx`
- `promoteTask removes optimistic event on network error`
- `promoteTask removes optimistic event when API returns non-2xx`
- `after promoting a task, removeTaskFromPlans(taskId) is called — eliminates the second RTT`

## Verification

- All 611 Vitest tests pass
- `npx vue-tsc -b` zero errors