### PR TITLE
fix(bot): self-heal on missing per-user token instead of crash-loop

### DIFF
--- a/bot/message_handler.py
+++ b/bot/message_handler.py
@@ -1443,19 +1443,24 @@ def main() -> None:
         sys.exit(1)
     fernet = Fernet(vault_key_str.encode() if isinstance(vault_key_str, str) else vault_key_str)
 
+    # Soft config: per-user token not yet in DB (migration not yet run).
+    # Loop until the token appears — once the ops migration script runs, the bot
+    # picks it up without supervisord intervention.
     _startup_loop = asyncio.new_event_loop()
     _pool = _startup_loop.run_until_complete(pg.create_pool())
-    credentials = _startup_loop.run_until_complete(_fetch_poll_credentials(_pool, fernet))
-    _startup_loop.run_until_complete(_pool.close())
-    _startup_loop.close()
-
-    if credentials is None:
-        logger.error(
-            "No per-user bot token found in DB. "
-            "Run scripts/migrate_telegram_to_per_user.py first."
-        )
-        import sys
-        sys.exit(1)
+    try:
+        while True:
+            credentials = _startup_loop.run_until_complete(_fetch_poll_credentials(_pool, fernet))
+            if credentials is not None:
+                break
+            logger.warning(
+                "No per-user bot token found in DB. "
+                "Sleeping 30 s — run scripts/migrate_telegram_to_per_user.py to resolve."
+            )
+            time.sleep(30)
+    finally:
+        _startup_loop.run_until_complete(_pool.close())
+        _startup_loop.close()
 
     token, chat_id, poll_user_id = credentials
     logger.info("Polling as user %s (chat_id=%s)", poll_user_id, chat_id or "<none yet>")

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -25,3 +25,4 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 autorestart=true
+startsecs=10


### PR DESCRIPTION
## Summary

- Replace `sys.exit(1)` on missing `bot_token_encrypted` in DB with a warning + 30-second sleep-retry loop
- Bot now waits for the migration script to populate the token, then starts polling automatically — no supervisord intervention needed
- Keep `sys.exit(1)` for missing `vault.key` (genuinely hard config error, cannot resolve at runtime)
- Bump supervisord `startsecs` to `10` so a tight crash loop exhausts the retry counter instead of satisfying the 1-second window

## Root cause

After the Telegram per-user Phase 1 deploy (PR #362), the bot crash-loops because `scripts/migrate_telegram_to_per_user.py` hadn't yet been run, leaving `bot_token_encrypted` NULL. The old code treated this as fatal, exiting with status 1. With `startsecs=1`, supervisord considered every restart "successful" and respawned indefinitely.

## Behaviour after fix

1. Bot starts, vault key loads OK
2. DB check: no per-user token found
3. Logs `WARNING: No per-user bot token found in DB. Sleeping 30 s — run scripts/migrate_telegram_to_per_user.py to resolve.`
4. Sleeps 30 s, re-checks
5. Once the migration script runs and populates the token, the next poll finds it and `run_polling` starts

## Test plan

- [x] `test_missing_token_retries_and_does_not_exit` — retries twice (sleeping 30 s each), then starts polling when credentials appear
- [x] `test_missing_token_no_sys_exit` — no `SystemExit` on missing DB token
- [x] `test_missing_vault_key_exits` — `SystemExit(1)` fires immediately on missing `vault.key`, no DB access
- [x] `test_credentials_present_immediately_no_sleep` — no sleep when token is present immediately
- [x] Full tether test suite: 425 passed, 591 skipped

## Companion PR

tether-premium companion (tests): jlunder00/tether-premium#fix/bot-self-heal-missing-token