### PR TITLE
fix: optimistic plan-side stub on event demotion

### DIFF
--- a/frontend/src/stores/__tests__/events.test.ts
+++ b/frontend/src/stores/__tests__/events.test.ts
@@ -262,6 +262,149 @@ describe('useEventStore', () => {
     expect(store.events).toHaveLength(0)
   })
 
+  // --- demoteEvent + optimistic plan-side stub (optimistic demote fix) ---
+
+  it('demoteEvent inserts a stub task into planStore synchronously before awaiting PATCH', async () => {
+    const { api } = await import('../../lib/api')
+    // Use a deferred promise to intercept the PATCH call mid-execution
+    let resolveApi!: (v: any) => void
+    vi.mocked(api).mockImplementationOnce(() => new Promise(r => { resolveApi = r }))
+
+    const { useEventStore } = await import('../events')
+    const { usePlanStore } = await import('../plan')
+    const eventStore = useEventStore()
+    const planStore = usePlanStore()
+
+    // Seed plan cache so insertStubTask has somewhere to write
+    planStore.plans['2024-06-10'] = {
+      date: '2024-06-10',
+      anchors: { 'anchor-1': { tasks: [], notes: '' } },
+      acknowledgements: {},
+      check_in_log: [],
+    } as any
+
+    eventStore.events.push({
+      ...BASE_EVENT_FIELDS,
+      id: 'ev-sync',
+      title: 'My Event',
+      start_time: '2024-06-10T09:00:00Z',
+      end_time: '2024-06-10T10:00:00Z',
+      task_id: 'task-sync',
+    })
+
+    // Do NOT await — we want to inspect state before the PATCH resolves
+    const demotePromise = eventStore.demoteEvent('ev-sync', 'anchor-1', '2024-06-10')
+
+    // Stub must already be in the plan cache synchronously (before PATCH returns)
+    expect(planStore.plans['2024-06-10'].anchors['anchor-1'].tasks).toHaveLength(1)
+    expect(planStore.plans['2024-06-10'].anchors['anchor-1'].tasks[0].id).toBe('task-sync')
+    expect(planStore.plans['2024-06-10'].anchors['anchor-1'].tasks[0].text).toBe('My Event')
+
+    // Now let the PATCH resolve
+    resolveApi({ ok: true, json: async () => ({}) })
+    await demotePromise
+  })
+
+  it('demoteEvent stub carries the task_id as its id (reconciliation key)', async () => {
+    const { api } = await import('../../lib/api')
+    let resolveApi!: (v: any) => void
+    vi.mocked(api).mockImplementationOnce(() => new Promise(r => { resolveApi = r }))
+
+    const { useEventStore } = await import('../events')
+    const { usePlanStore } = await import('../plan')
+    const eventStore = useEventStore()
+    const planStore = usePlanStore()
+
+    planStore.activeDate = '2024-06-10'
+    planStore.plan = {
+      date: '2024-06-10',
+      anchors: { 'anchor-1': { tasks: [], notes: '' } },
+      acknowledgements: {},
+      check_in_log: [],
+    } as any
+
+    eventStore.events.push({
+      ...BASE_EVENT_FIELDS,
+      id: 'ev-reconcile',
+      title: 'Reconcile me',
+      start_time: '2024-06-10T09:00:00Z',
+      end_time: '2024-06-10T10:00:00Z',
+      task_id: 'task-reconcile',
+    })
+
+    const demotePromise = eventStore.demoteEvent('ev-reconcile', 'anchor-1', '2024-06-10')
+
+    // The stub's id must equal the task_id so that fetchPlanRange can reconcile
+    // by id when the server response arrives (same row, same id)
+    const stub = planStore.plan!.anchors['anchor-1'].tasks[0]
+    expect(stub.id).toBe('task-reconcile')
+
+    resolveApi({ ok: true, json: async () => ({}) })
+    await demotePromise
+  })
+
+  it('demoteEvent removes the stub on PATCH network error', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockRejectedValueOnce(new Error('network'))
+
+    const { useEventStore } = await import('../events')
+    const { usePlanStore } = await import('../plan')
+    const eventStore = useEventStore()
+    const planStore = usePlanStore()
+
+    planStore.plans['2024-06-10'] = {
+      date: '2024-06-10',
+      anchors: { 'anchor-1': { tasks: [], notes: '' } },
+      acknowledgements: {},
+      check_in_log: [],
+    } as any
+
+    eventStore.events.push({
+      ...BASE_EVENT_FIELDS,
+      id: 'ev-err',
+      title: 'Error task',
+      start_time: '2024-06-10T09:00:00Z',
+      end_time: '2024-06-10T10:00:00Z',
+      task_id: 'task-err',
+    })
+
+    await eventStore.demoteEvent('ev-err', 'anchor-1', '2024-06-10')
+
+    // Stub should have been removed on error
+    expect(planStore.plans['2024-06-10'].anchors['anchor-1'].tasks).toHaveLength(0)
+  })
+
+  it('demoteEvent removes the stub when PATCH returns a non-ok response', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({ ok: false, json: async () => ({}) } as any)
+
+    const { useEventStore } = await import('../events')
+    const { usePlanStore } = await import('../plan')
+    const eventStore = useEventStore()
+    const planStore = usePlanStore()
+
+    planStore.plans['2024-06-10'] = {
+      date: '2024-06-10',
+      anchors: { 'anchor-1': { tasks: [], notes: '' } },
+      acknowledgements: {},
+      check_in_log: [],
+    } as any
+
+    eventStore.events.push({
+      ...BASE_EVENT_FIELDS,
+      id: 'ev-nonok',
+      title: 'Non-ok task',
+      start_time: '2024-06-10T09:00:00Z',
+      end_time: '2024-06-10T10:00:00Z',
+      task_id: 'task-nonok',
+    })
+
+    await eventStore.demoteEvent('ev-nonok', 'anchor-1', '2024-06-10')
+
+    // Stub should be removed when server reports failure
+    expect(planStore.plans['2024-06-10'].anchors['anchor-1'].tasks).toHaveLength(0)
+  })
+
   // --- deleteEvent ---
 
   it('deleteEvent removes event locally and calls DELETE /api/events/:id', async () => {

--- a/frontend/src/stores/__tests__/plan.test.ts
+++ b/frontend/src/stores/__tests__/plan.test.ts
@@ -394,3 +394,168 @@ describe('usePlanStore – moveTask dual-cache update (sym 3 fix)', () => {
     expect(store.plans['2026-05-10'].anchors.afternoon.tasks).toHaveLength(1)
   })
 })
+
+// ─── insertStubTask ───────────────────────────────────────────────────────────
+// New action added for optimistic demotion: inserts a minimal stub task into
+// both caches atomically so the task appears in the anchor immediately after
+// a calendar event is demoted — before the PATCH round-trip completes.
+
+describe('usePlanStore – insertStubTask', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  const STUB = {
+    id: 'task-stub',
+    text: 'My Event',
+    description: null,
+    status: 'pending' as const,
+    position: 0,
+    followup_config: null,
+    blocks: [],
+    blocked_by: [],
+    context_subject: null,
+    context_node_id: null,
+    start_time: null,
+    end_time: null,
+    anchor_id: 'anchor-a',
+    plan_date: '2026-05-10',
+    rrule: null,
+    is_recurring_master: false,
+    color: null,
+    motif: null,
+  }
+
+  it('inserts into plans.value[date] when that date is cached', async () => {
+    const { usePlanStore } = await import('../plan')
+    const store = usePlanStore()
+
+    store.plans['2026-05-10'] = {
+      date: '2026-05-10',
+      anchors: { 'anchor-a': { tasks: [], notes: '' } },
+      acknowledgements: {},
+      check_in_log: [],
+    } as any
+
+    store.insertStubTask('2026-05-10', 'anchor-a', STUB as any)
+
+    expect(store.plans['2026-05-10'].anchors['anchor-a'].tasks).toHaveLength(1)
+    expect(store.plans['2026-05-10'].anchors['anchor-a'].tasks[0].id).toBe('task-stub')
+  })
+
+  it('inserts into plan.value when date matches activeDate', async () => {
+    const { usePlanStore } = await import('../plan')
+    const store = usePlanStore()
+
+    store.activeDate = '2026-05-10'
+    store.plan = {
+      date: '2026-05-10',
+      anchors: { 'anchor-a': { tasks: [], notes: '' } },
+      acknowledgements: {},
+      check_in_log: [],
+    } as any
+
+    store.insertStubTask('2026-05-10', 'anchor-a', STUB as any)
+
+    expect(store.plan!.anchors['anchor-a'].tasks).toHaveLength(1)
+    expect(store.plan!.anchors['anchor-a'].tasks[0].id).toBe('task-stub')
+  })
+
+  it('writes to both caches atomically when they are separate objects (date !== activeDate)', async () => {
+    const { usePlanStore } = await import('../plan')
+    const store = usePlanStore()
+
+    // activeDate is different from the target date → plan.value and plans.value[date] are separate objects
+    store.activeDate = '2026-05-01'
+    store.plan = {
+      date: '2026-05-01',
+      anchors: { 'anchor-a': { tasks: [], notes: '' } },
+      acknowledgements: {},
+      check_in_log: [],
+    } as any
+    store.plans['2026-05-10'] = {
+      date: '2026-05-10',
+      anchors: { 'anchor-a': { tasks: [], notes: '' } },
+      acknowledgements: {},
+      check_in_log: [],
+    } as any
+
+    store.insertStubTask('2026-05-10', 'anchor-a', STUB as any)
+
+    // Should be inserted into plans cache for the target date
+    expect(store.plans['2026-05-10'].anchors['anchor-a'].tasks).toHaveLength(1)
+    // Should NOT affect plan.value (different date)
+    expect(store.plan!.anchors['anchor-a'].tasks).toHaveLength(0)
+  })
+
+  it('does not insert a duplicate when stub id already exists in the anchor', async () => {
+    const { usePlanStore } = await import('../plan')
+    const store = usePlanStore()
+
+    store.plans['2026-05-10'] = {
+      date: '2026-05-10',
+      anchors: { 'anchor-a': { tasks: [{ ...STUB }], notes: '' } },
+      acknowledgements: {},
+      check_in_log: [],
+    } as any
+
+    // Call twice — should remain idempotent
+    store.insertStubTask('2026-05-10', 'anchor-a', STUB as any)
+    store.insertStubTask('2026-05-10', 'anchor-a', STUB as any)
+
+    expect(store.plans['2026-05-10'].anchors['anchor-a'].tasks).toHaveLength(1)
+  })
+
+  it('creates the anchor in the day plan if it does not yet exist', async () => {
+    const { usePlanStore } = await import('../plan')
+    const store = usePlanStore()
+
+    store.plans['2026-05-10'] = {
+      date: '2026-05-10',
+      anchors: {},  // anchor-a not present
+      acknowledgements: {},
+      check_in_log: [],
+    } as any
+
+    store.insertStubTask('2026-05-10', 'anchor-a', STUB as any)
+
+    expect(store.plans['2026-05-10'].anchors['anchor-a']).toBeDefined()
+    expect(store.plans['2026-05-10'].anchors['anchor-a'].tasks).toHaveLength(1)
+  })
+
+  it('is a no-op when neither cache contains the target date', async () => {
+    const { usePlanStore } = await import('../plan')
+    const store = usePlanStore()
+
+    // No matching cache entry — should not throw
+    store.insertStubTask('2026-05-10', 'anchor-a', STUB as any)
+
+    // No crash, no side effects
+    expect(store.plans['2026-05-10']).toBeUndefined()
+  })
+
+  it('handles same-object aliasing: plan.value and plans.value[date] pointing to the same object', async () => {
+    const { usePlanStore } = await import('../plan')
+    const store = usePlanStore()
+
+    // Simulate fetchPlanRange aliasing: plan.value === plans.value[activeDate]
+    const sharedPlan = {
+      date: '2026-05-10',
+      anchors: { 'anchor-a': { tasks: [], notes: '' } },
+      acknowledgements: {},
+      check_in_log: [],
+    } as any
+    store.activeDate = '2026-05-10'
+    store.plan = sharedPlan
+    store.plans['2026-05-10'] = sharedPlan  // same object reference
+
+    store.insertStubTask('2026-05-10', 'anchor-a', STUB as any)
+
+    // The stub should appear exactly once (not duplicated via two separate inserts)
+    expect(store.plans['2026-05-10'].anchors['anchor-a'].tasks).toHaveLength(1)
+    expect(store.plan!.anchors['anchor-a'].tasks).toHaveLength(1)
+    // Verify they're still the same reference (aliasing preserved)
+    expect(store.plan).toBe(store.plans['2026-05-10'])
+  })
+})

--- a/frontend/src/stores/events.ts
+++ b/frontend/src/stores/events.ts
@@ -151,6 +151,12 @@ export const useEventStore = defineStore('events', () => {
    *      planStore.removeTaskFromPlans so the UI doesn't show stale phantom data.
    *      We check resp.ok explicitly (not just catch) because a non-ok response
    *      is a real failure — a stuck stub is more disorienting than a missing event.
+   *
+   * Note: on failure the event is NOT re-inserted into events.value (matching the
+   * convention of moveEvent/deleteEvent elsewhere in this store). The event will
+   * reappear on the next fetchEvents call. A phantom stub is more confusing than
+   * a temporarily missing event, which is why step 4 removes the stub but leaves
+   * the event removal in place.
    */
   async function demoteEvent(eventId: string, anchorId: string, planDate: string): Promise<void> {
     const ev = events.value.find(e => e.id === eventId)

--- a/frontend/src/stores/events.ts
+++ b/frontend/src/stores/events.ts
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import { api } from '../lib/api'
 import type { CalendarEvent } from '../types/events'
 import type { RecurrenceEditScope } from '../types/recurrence'
+import { usePlanStore } from './plan'
 
 export const useEventStore = defineStore('events', () => {
   const events = ref<CalendarEvent[]>([])
@@ -139,7 +140,17 @@ export const useEventStore = defineStore('events', () => {
   /**
    * Demote a calendar event to a plain anchor-bound task.
    * Finds the linked task_id and PATCHes it with null times + anchorId + planDate.
-   * Optimistic: removes the event locally first.
+   *
+   * Optimistic (two-phase):
+   *   1. Remove the event from events.value immediately — calendar hides it at once.
+   *   2. Insert a stub task into planStore SYNCHRONOUSLY (before any await) so the
+   *      task appears in the anchor the moment the event disappears. The stub carries
+   *      the real task id, so fetchPlanRange's subsequent write reconciles by id.
+   *   3. Await the PATCH.
+   *   4. On any failure (thrown error OR non-ok response): remove the stub via
+   *      planStore.removeTaskFromPlans so the UI doesn't show stale phantom data.
+   *      We check resp.ok explicitly (not just catch) because a non-ok response
+   *      is a real failure — a stuck stub is more disorienting than a missing event.
    */
   async function demoteEvent(eventId: string, anchorId: string, planDate: string): Promise<void> {
     const ev = events.value.find(e => e.id === eventId)
@@ -147,14 +158,49 @@ export const useEventStore = defineStore('events', () => {
       console.warn('Cannot demote event with no task_id — skipping')
       return
     }
+
+    // Step 1 — optimistically remove event from calendar
     events.value = events.value.filter(e => e.id !== eventId)
+
+    // Step 2 — optimistically insert stub task into plan caches (synchronous, before any await)
+    const planStore = usePlanStore()
+    const stubTask = {
+      id: ev.task_id,
+      text: ev.title,
+      description: null,
+      status: 'pending' as const,
+      position: 0,
+      followup_config: null,
+      blocks: [] as string[],
+      blocked_by: [] as string[],
+      context_subject: ev.context_subject,
+      context_node_id: null,
+      start_time: null,
+      end_time: null,
+      anchor_id: anchorId,
+      plan_date: planDate,
+      rrule: null,
+      is_recurring_master: false,
+      color: ev.color,
+      motif: null,
+    }
+    planStore.insertStubTask(planDate, anchorId, stubTask)
+
+    // Step 3 — PATCH the task on the server
     try {
-      await api(`/api/tasks/${ev.task_id}`, {
+      const resp = await api(`/api/tasks/${ev.task_id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ start_time: null, end_time: null, anchor_id: anchorId, plan_date: planDate }),
       })
-    } catch { /* ignore — optimistic update stays */ }
+      // Step 4a — non-ok response: roll back stub
+      if (!resp.ok) {
+        planStore.removeTaskFromPlans(ev.task_id)
+      }
+    } catch {
+      // Step 4b — network error: roll back stub
+      planStore.removeTaskFromPlans(ev.task_id)
+    }
   }
 
   /**

--- a/frontend/src/stores/plan.ts
+++ b/frontend/src/stores/plan.ts
@@ -289,6 +289,40 @@ export const usePlanStore = defineStore('plan', () => {
   }
 
   /**
+   * Optimistically insert a stub task into both plan caches immediately.
+   * Call this before awaiting the PATCH in eventStore.demoteEvent so the task
+   * appears in the anchor the moment the calendar event disappears — before
+   * the round-trip completes. The stub is keyed by its real task id, so the
+   * subsequent fetchPlanRange reconciles by id when the server response arrives.
+   *
+   * Uses the same dual-cache pattern as moveTask: writes to both plan.value
+   * (single-day cache read by AnchorBlocks in PlanView) and plans.value[date]
+   * (range cache read by CalendarView). A `seen` set prevents a double-insert
+   * when the two references point to the same object (fetchPlanRange aliases them).
+   *
+   * If neither cache contains the target date, this is a no-op — the task will
+   * appear after the next fetchPlanRange.
+   */
+  function insertStubTask(date: string, anchorId: string, task: Task): void {
+    const candidates: (DayPlan | null)[] = [
+      plans.value[date] ?? null,
+      date === activeDate.value ? plan.value : null,
+    ]
+    const seen = new Set<DayPlan>()
+    for (const dayPlan of candidates) {
+      if (!dayPlan || seen.has(dayPlan)) continue
+      seen.add(dayPlan)
+      if (!dayPlan.anchors[anchorId]) {
+        dayPlan.anchors[anchorId] = { tasks: [], notes: '' }
+      }
+      // Idempotent: skip if a task with this id is already present
+      if (!dayPlan.anchors[anchorId].tasks.find(t => t.id === task.id)) {
+        dayPlan.anchors[anchorId].tasks.push(task)
+      }
+    }
+  }
+
+  /**
    * Optimistically remove a task from ALL plan caches by id.
    * Call this immediately after eventStore.promoteTask to hide the source task
    * from AnchorBlocks without a network round-trip. The event store's promoteTask
@@ -297,6 +331,9 @@ export const usePlanStore = defineStore('plan', () => {
    *
    * Sym 4 fix: replaces the full-week fetchPlanRange call in CalendarView's
    * drop handler, eliminating the network-induced lag between drop and source hide.
+   *
+   * Also used by demoteEvent error path to roll back a stub task inserted by
+   * insertStubTask when the PATCH request fails.
    */
   function removeTaskFromPlans(taskId: string): void {
     // Remove from range cache (all cached days)
@@ -352,6 +389,7 @@ export const usePlanStore = defineStore('plan', () => {
     fetchPlan,
     fetchPlanRange, moveTask, moveTaskToAnchor, reorderTask,
     updateAnchorTasks, updateTaskStatus, patchTaskFields,
-    scheduleTask, moveToBacklog, createPlanTask, removeTaskFromPlans,
+    scheduleTask, moveToBacklog, createPlanTask,
+    insertStubTask, removeTaskFromPlans,
   }
 })


### PR DESCRIPTION
## Summary

- **Root cause:** `demoteEvent` in `events.ts` removed the calendar event optimistically but had no plan-side optimistic insert — the task didn't appear in the anchor until `fetchPlanRange` completed, creating a visible blank gap (~50–200ms).
- **Fix A — `planStore.insertStubTask`:** New action in `plan.ts` that writes a minimal stub task into both `plan.value` (single-day cache used by AnchorBlocks in PlanView) and `plans.value[date]` (range cache used by CalendarView) atomically. Uses the same dual-cache `seen`-set pattern as `moveTask`. Idempotent on duplicate id. No-op if neither cache has the target date.
- **Fix B — `demoteEvent` wiring:** Restructured to call `planStore.insertStubTask` synchronously before any `await` so the stub appears in the anchor the instant the event disappears. Rolls back via `planStore.removeTaskFromPlans` on both thrown errors and non-ok responses.

## Test plan

- [ ] `usePlanStore – insertStubTask` suite (7 cases): single-cache write, dual-cache write, separate-object write, idempotency, anchor creation, no-op on uncached date, same-object aliasing guard
- [ ] `demoteEvent` integration (4 new cases): synchronous stub insertion verified before PATCH resolves (deferred promise pattern), stub id equals task_id for reconciliation, stub removed on network error, stub removed on non-ok response
- [ ] All 618 existing tests still pass
- [ ] `npx vue-tsc -b` — zero type errors
- [ ] Browser: drag a calendar event onto an anchor column → event disappears AND task appears simultaneously with no blank gap