### PR TITLE
feat: notify Phase C — internal endpoint + anchor_trigger refactor + last_user_id bootstrap

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -39,6 +39,7 @@ from api.routes import api_keys as api_keys_routes
 from api.routes import events as events_routes
 from api.routes import preferences as preferences_routes
 from api.routes import ical as ical_routes
+from api.routes import internal as internal_routes
 from api.ws import manager
 from api.auth import auth_dependency, decode_jwt
 from api.limiter import limiter
@@ -184,6 +185,11 @@ def create_app(lifespan_override=None) -> FastAPI:
     app.include_router(events_routes.router, prefix="/api")
     app.include_router(preferences_routes.router, prefix="/api")
     app.include_router(ical_routes.router, prefix="/api")
+    app.include_router(
+        internal_routes.router,
+        prefix="/api/internal",
+        include_in_schema=False,
+    )
 
     # --- Premium plugin hook ---
     try:

--- a/api/routes/internal.py
+++ b/api/routes/internal.py
@@ -1,0 +1,196 @@
+"""Internal API routes — not mounted in OpenAPI schema.
+
+Called by Fly.io cron machines. All endpoints require X-Internal-Token header.
+"""
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+import os
+import secrets
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
+
+from bot.message_handler import check_followups
+from bot import notify
+
+import db.postgres as pg
+import db.pg_auth_queries as pg_auth_queries
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _verify_internal_token(request: Request) -> None:
+    token = request.headers.get("X-Internal-Token", "")
+    expected = os.environ.get("INTERNAL_TOKEN", "")
+    if not expected or not secrets.compare_digest(token, expected):
+        raise HTTPException(status_code=403)
+
+
+@router.post("/notifications/check")
+async def check_notifications(request: Request, background_tasks: BackgroundTasks):
+    """Called by Fly.io cron every minute. Queues notification check as BackgroundTask."""
+    _verify_internal_token(request)
+    pool = request.app.state.pool
+    ws_manager = getattr(request.app.state, "ws_manager", None)
+    background_tasks.add_task(_run_notification_check, pool, ws_manager)
+    return {"status": "queued"}
+
+
+@router.post("/integrations/renew-watches")
+async def renew_watches(request: Request, background_tasks: BackgroundTasks):
+    """Daily: renew expiring Google Calendar watch channels."""
+    _verify_internal_token(request)
+    background_tasks.add_task(_renew_expiring_watches, request.app.state.pool)
+    return {"status": "queued"}
+
+
+@router.post("/integrations/refresh-tokens")
+async def refresh_tokens(request: Request, background_tasks: BackgroundTasks):
+    """Hourly: refresh expiring OAuth tokens."""
+    _verify_internal_token(request)
+    background_tasks.add_task(_refresh_expiring_tokens, request.app.state.pool)
+    return {"status": "queued"}
+
+
+# ---------------------------------------------------------------------------
+# Background task implementations
+# ---------------------------------------------------------------------------
+
+
+async def _get_all_linked_users(pool) -> list[dict]:
+    """Return all users with a telegram_chat_id linked."""
+    async with pg.get_conn(pool) as conn:
+        rows = await conn.fetch(
+            """
+            SELECT u.id, tc.telegram_chat_id
+            FROM users u
+            JOIN telegram_connections tc ON tc.user_id = u.id
+            WHERE tc.telegram_chat_id IS NOT NULL
+              AND tc.telegram_chat_id != ''
+            """
+        )
+    return [{"id": str(r["id"]), "telegram_chat_id": r["telegram_chat_id"]} for r in rows]
+
+
+async def _check_anchor_transitions(pool, user_id: str, dispatch_fn) -> None:
+    """Check and fire any due anchor transitions for the given user."""
+    from datetime import datetime
+    from bot.handler_utils import get_current_anchor, is_anchor_active
+    from bot.message_handler import _get_anchors_and_plan, _init_followup_states
+    from db.pg_queries.anchors import get_anchors
+    from bot.anchor_trigger import trigger_anchor
+
+    try:
+        from datetime import date as _date
+        today = str(_date.today())
+        anchors, plan = await _get_anchors_and_plan(pool, user_id, today)
+        current_anchor = get_current_anchor(anchors)
+        if current_anchor and is_anchor_active(current_anchor):
+            if plan and current_anchor["id"] in plan.get("anchors", {}):
+                now = datetime.now()
+                await _init_followup_states(
+                    pool, user_id, today, current_anchor["id"],
+                    [t["id"] for t in plan["anchors"][current_anchor["id"]]["tasks"] if t.get("id")],
+                    now,
+                )
+                await trigger_anchor(
+                    current_anchor["id"],
+                    pool=pool,
+                    user_id=user_id,
+                    dispatch_fn=dispatch_fn,
+                )
+    except Exception as e:
+        logger.warning("Anchor transition check failed for user %s: %s", user_id, e)
+
+
+async def _run_notification_check(pool, ws_manager) -> None:
+    """For each linked user: check anchor transitions, follow-ups, meeting events."""
+    if pool is None:
+        logger.warning("_run_notification_check: no pool available, skipping")
+        return
+
+    try:
+        users = await _get_all_linked_users(pool)
+    except Exception as e:
+        logger.error("_run_notification_check: failed to load users: %s", e)
+        return
+
+    for user in users:
+        user_id = str(user["id"])
+        try:
+            dispatch_fn = functools.partial(
+                notify.dispatch, pool=pool, ws_manager=ws_manager
+            )
+            await _check_anchor_transitions(pool, user_id, dispatch_fn)
+        except Exception as e:
+            logger.warning("Anchor check failed for user %s: %s", user_id, e)
+
+        try:
+            async def _notify_send(text, uid=user_id):
+                await notify.dispatch(
+                    uid,
+                    "task_followup",
+                    text,
+                    pool,
+                    priority="important",
+                    ws_manager=ws_manager,
+                )
+
+            send_fn = lambda text, uid=user_id: asyncio.ensure_future(_notify_send(text, uid))
+            await check_followups(pool, user_id, send_fn)
+        except Exception as e:
+            logger.warning("Followup check failed for user %s: %s", user_id, e)
+
+        try:
+            from tether_premium.bot.scheduling.events import drain_meeting_events
+
+            async def _notify_meeting_send(text, uid=user_id):
+                await notify.dispatch(
+                    uid,
+                    "meeting_event",
+                    text,
+                    pool,
+                    priority="important",
+                    ws_manager=ws_manager,
+                )
+
+            meeting_send = lambda text, uid=user_id: asyncio.ensure_future(
+                _notify_meeting_send(text, uid)
+            )
+            await drain_meeting_events(pool=pool, user_id=user_id, send_fn=meeting_send)
+        except ImportError:
+            pass
+        except Exception as e:
+            logger.warning("Meeting event drain failed for user %s: %s", user_id, e)
+
+
+async def _renew_expiring_watches(pool) -> None:
+    """Renew expiring Google Calendar watch channels (daily cron)."""
+    if pool is None:
+        logger.warning("_renew_expiring_watches: no pool available")
+        return
+    try:
+        from integrations.gcal.watch_manager import renew_expiring_watches
+        await renew_expiring_watches(pool)
+    except ImportError:
+        logger.debug("_renew_expiring_watches: gcal watch manager not available")
+    except Exception as e:
+        logger.error("_renew_expiring_watches failed: %s", e)
+
+
+async def _refresh_expiring_tokens(pool) -> None:
+    """Refresh expiring OAuth tokens (hourly cron)."""
+    if pool is None:
+        logger.warning("_refresh_expiring_tokens: no pool available")
+        return
+    try:
+        from integrations.oauth_refresh import refresh_all_expiring_tokens
+        await refresh_all_expiring_tokens(pool)
+    except ImportError:
+        logger.debug("_refresh_expiring_tokens: oauth refresh not available")
+    except Exception as e:
+        logger.error("_refresh_expiring_tokens failed: %s", e)

--- a/bot/anchor_trigger.py
+++ b/bot/anchor_trigger.py
@@ -1,22 +1,21 @@
 #!/usr/bin/env python3
 """Cron-invoked: sends anchor transition message to Telegram.
 
-Phase 1 refactor — per-user Telegram migration:
-  - Accepts (pool, user_id, dispatch_fn) instead of reading globals.
-  - Replaces subprocess claude CLI with call_claude() from message_handler.
-  - Removes config.yaml read and TETHER_USER_ID env var requirement.
-  - Removes send_telegram() / direct bot_token / chat_id references.
+Phase C refactor — internal endpoint migration:
+  - trigger_anchor signature changed to keyword-only args:
+    trigger_anchor(anchor_id, *, pool, user_id, dispatch_fn)
+  - dispatch_fn is now called with notify-style kwargs (user_id=, notification_type=,
+    text=, priority=, thread_key=) rather than a bare string.
+  - main() and _run_standalone() removed — invocation now handled by the
+    internal API endpoint (api/routes/internal.py).
 
-The standalone CLI entry point (main()) still works: it bootstraps its own
-pool, loads the vault key, fetches credentials from DB, and invokes
-trigger_anchor(pool, user_id, dispatch_fn, anchor_id).
+DEPRECATED: The standalone CLI entry point has been removed. Use the internal
+HTTP endpoint POST /api/internal/notifications/check instead.
 """
 from __future__ import annotations
 
-import argparse
-import asyncio
 import logging
-import sys
+from datetime import date
 from pathlib import Path
 from typing import Callable, Awaitable
 
@@ -32,19 +31,20 @@ PROMPTS_DIR = Path(__file__).parent.parent / "prompts"
 
 
 async def trigger_anchor(
+    anchor_id: str,
+    *,
     pool,
     user_id: str,
-    dispatch_fn: Callable[[str], Awaitable[None]],
-    anchor_id: str,
+    dispatch_fn: Callable[..., Awaitable[None]],
 ) -> None:
     """Generate and send an anchor transition message for the given user.
 
     Args:
+        anchor_id: the anchor being triggered (e.g. 'grind_am').
         pool: asyncpg connection pool (already open).
         user_id: Tether user UUID string.
-        dispatch_fn: async callable that sends a text message to the user,
-            e.g. ``lambda msg: _send_telegram(token, chat_id, msg)``.
-        anchor_id: the anchor being triggered (e.g. 'grind_am').
+        dispatch_fn: async callable accepting notify-style keyword args:
+            user_id, notification_type, text, priority, thread_key.
     """
 
     async with pg.get_conn(pool, user_id) as conn:
@@ -73,71 +73,10 @@ async def trigger_anchor(
     )
 
     message = await call_claude(prompt)
-    await dispatch_fn(message)
-
-
-async def _run_standalone(anchor_id: str) -> None:
-    """Bootstrap credentials from DB and call trigger_anchor.
-
-    Used by the cron-invoked CLI entry point. No env vars needed —
-    vault key comes from config, token from telegram_connections.
-    """
-    import db.postgres as pg
-    import db.pg_auth_queries as pg_auth_queries
-    from bot.message_handler import _fetch_poll_credentials, _send_telegram
-    from bot.message_handler import tether_config
-    from cryptography.fernet import Fernet
-
-    vault_key_str = tether_config.get("vault.key")
-    if not vault_key_str:
-        logger.error("vault.key not configured — cannot decrypt bot token")
-        sys.exit(1)
-
-    fernet = Fernet(
-        vault_key_str.encode() if isinstance(vault_key_str, str) else vault_key_str
+    await dispatch_fn(
+        user_id=user_id,
+        notification_type="anchor_ping",
+        text=message,
+        priority="important",
+        thread_key=f"anchor:{anchor_id}:{date.today()}",
     )
-
-    pool = await pg.create_pool()
-    try:
-        credentials = await _fetch_poll_credentials(pool, fernet)
-        if credentials is None:
-            logger.error(
-                "No per-user bot token in DB. "
-                "Run scripts/migrate_telegram_to_per_user.py first."
-            )
-            sys.exit(1)
-
-        token, chat_id, user_id = credentials
-
-        if not chat_id:
-            # User has a bot token but hasn't linked a chat_id yet (no inbound
-            # message received since migration). Skip this anchor — sending to an
-            # empty chat_id would silently fail at the Telegram API.
-            logger.warning(
-                "Anchor %s skipped: user %s has no chat_id linked yet "
-                "(send any message to the bot first)",
-                anchor_id, user_id,
-            )
-            return
-
-        async def dispatch(msg: str) -> None:
-            _send_telegram(token, chat_id, msg)
-
-        await trigger_anchor(pool, user_id, dispatch, anchor_id)
-    finally:
-        await pool.close()
-
-
-def main() -> None:
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
-    parser = argparse.ArgumentParser(description="Tether anchor trigger")
-    parser.add_argument("anchor_id", help="Anchor to trigger (e.g. grind_am)")
-    args = parser.parse_args()
-    asyncio.run(_run_standalone(args.anchor_id))
-
-
-if __name__ == "__main__":
-    main()

--- a/bot/message_handler.py
+++ b/bot/message_handler.py
@@ -1298,6 +1298,12 @@ async def _auto_link_chat(pool, user_id: str, chat_id: str) -> bool:
         return await pg_auth_queries.auto_link_chat_id(conn, user_id, chat_id)
 
 
+async def _bootstrap_last_user(pool) -> dict | None:
+    """Fetch the most recently active telegram-linked user from DB for cold-start."""
+    async with pg.get_conn(pool) as conn:
+        return await pg_auth_queries.get_most_recent_telegram_user(conn)
+
+
 def run_polling(token: str, chat_id: str, poll_user_id: str | None = None) -> None:
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
@@ -1308,6 +1314,15 @@ def run_polling(token: str, chat_id: str, poll_user_id: str | None = None) -> No
     # These get set when a message is processed and remembered for background checks.
     last_user_id: str | None = None
     last_chat_id: str | None = None
+    # Bootstrap last_user_id from DB so followup pings work immediately after restart
+    try:
+        _bootstrap = loop.run_until_complete(_bootstrap_last_user(pool))
+        if _bootstrap:
+            last_user_id = _bootstrap["id"]
+            last_chat_id = _bootstrap.get("telegram_chat_id")
+            logger.info("run_polling: bootstrapped user_id=%s from DB", last_user_id)
+    except Exception as _be:
+        logger.warning("run_polling: failed to bootstrap last_user_id from DB: %s", _be)
     logger.info("Tether bot polling started (offset=%d)", offset)
     # Start premium meeting event listener if available
     try:

--- a/db/pg_auth_queries.py
+++ b/db/pg_auth_queries.py
@@ -306,3 +306,27 @@ async def get_user_by_webhook_secret(
     if row is None:
         return None
     return str(row["user_id"])
+
+
+async def get_most_recent_telegram_user(conn: asyncpg.Connection) -> dict | None:
+    """Return the user with the most recent telegram link or message turn.
+
+    'Most recent' = latest created_at in telegram_connections (for users who have a telegram_chat_id set).
+    Falls back to users ordered by conversation_history recency if available.
+
+    Returns dict with 'id' (str UUID) and 'telegram_chat_id' (str), or None.
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT u.id, tc.telegram_chat_id
+        FROM users u
+        JOIN telegram_connections tc ON tc.user_id = u.id
+        WHERE tc.telegram_chat_id IS NOT NULL
+          AND tc.telegram_chat_id != ''
+        ORDER BY tc.created_at DESC NULLS LAST
+        LIMIT 1
+        """
+    )
+    if row is None:
+        return None
+    return {"id": str(row["id"]), "telegram_chat_id": row["telegram_chat_id"]}

--- a/tests/bot/test_anchor_trigger.py
+++ b/tests/bot/test_anchor_trigger.py
@@ -1,8 +1,9 @@
 """Tests for bot/anchor_trigger — mocked DB layer.
 
-Updated for Phase 1 per-user Telegram migration:
-  - trigger_anchor(pool, user_id, dispatch_fn, anchor_id) new signature
-  - dispatch_fn replaces send_telegram() — caller controls how message is sent
+Updated for Phase C internal endpoint migration:
+  - trigger_anchor(anchor_id, *, pool, user_id, dispatch_fn) new signature
+  - dispatch_fn receives notify-style kwargs (user_id=, notification_type=,
+    text=, priority=, thread_key=) rather than a bare string
   - call_claude imported from bot.message_handler (async, agent SDK)
   - No TETHER_USER_ID env var, no config.yaml, no send_telegram
 """
@@ -46,17 +47,17 @@ async def test_trigger_calls_claude_with_anchor_name():
     mock_pool, mock_get_conn, _ = _make_mock_pool([
         {"id": ANCHOR_ID, "name": "The Grind"},
     ])
-    dispatched: list[str] = []
+    captured: list[dict] = []
 
-    async def dispatch(msg: str) -> None:
-        dispatched.append(msg)
+    async def dispatch(**kwargs) -> None:
+        captured.append(kwargs)
 
     with patch("db.postgres.get_conn", mock_get_conn), \
          patch("db.pg_queries.anchors.get_anchors", AsyncMock(return_value=[{"id": ANCHOR_ID, "name": "The Grind"}])), \
          patch("bot.anchor_trigger.load_plan", AsyncMock(return_value=_make_plan(True))), \
          patch("bot.anchor_trigger.load_context", AsyncMock(return_value="")), \
          patch("bot.anchor_trigger.call_claude", AsyncMock(return_value="Time to grind!")) as mock_claude:
-        await trigger_anchor(mock_pool, USER_ID, dispatch, ANCHOR_ID)
+        await trigger_anchor(ANCHOR_ID, pool=mock_pool, user_id=USER_ID, dispatch_fn=dispatch)
 
     mock_claude.assert_called_once()
     assert "The Grind" in mock_claude.call_args[0][0]
@@ -65,17 +66,17 @@ async def test_trigger_calls_claude_with_anchor_name():
 @pytest.mark.asyncio
 async def test_trigger_calls_claude_with_tasks():
     mock_pool, mock_get_conn, _ = _make_mock_pool([])
-    dispatched: list[str] = []
+    captured: list[dict] = []
 
-    async def dispatch(msg: str) -> None:
-        dispatched.append(msg)
+    async def dispatch(**kwargs) -> None:
+        captured.append(kwargs)
 
     with patch("db.postgres.get_conn", mock_get_conn), \
          patch("db.pg_queries.anchors.get_anchors", AsyncMock(return_value=[{"id": ANCHOR_ID, "name": "The Grind"}])), \
          patch("bot.anchor_trigger.load_plan", AsyncMock(return_value=_make_plan(True))), \
          patch("bot.anchor_trigger.load_context", AsyncMock(return_value="")), \
          patch("bot.anchor_trigger.call_claude", AsyncMock(return_value="Go!")) as mock_claude:
-        await trigger_anchor(mock_pool, USER_ID, dispatch, ANCHOR_ID)
+        await trigger_anchor(ANCHOR_ID, pool=mock_pool, user_id=USER_ID, dispatch_fn=dispatch)
 
     assert "Apply to 3 jobs" in mock_claude.call_args[0][0]
 
@@ -83,34 +84,35 @@ async def test_trigger_calls_claude_with_tasks():
 @pytest.mark.asyncio
 async def test_trigger_dispatches_claude_response_via_dispatch_fn():
     mock_pool, mock_get_conn, _ = _make_mock_pool([])
-    dispatched: list[str] = []
+    captured: list[dict] = []
 
-    async def dispatch(msg: str) -> None:
-        dispatched.append(msg)
+    async def dispatch(**kwargs) -> None:
+        captured.append(kwargs)
 
     with patch("db.postgres.get_conn", mock_get_conn), \
          patch("db.pg_queries.anchors.get_anchors", AsyncMock(return_value=[{"id": ANCHOR_ID, "name": "The Grind"}])), \
          patch("bot.anchor_trigger.load_plan", AsyncMock(return_value=_make_plan(True))), \
          patch("bot.anchor_trigger.load_context", AsyncMock(return_value="")), \
          patch("bot.anchor_trigger.call_claude", AsyncMock(return_value="Time to grind!")):
-        await trigger_anchor(mock_pool, USER_ID, dispatch, ANCHOR_ID)
+        await trigger_anchor(ANCHOR_ID, pool=mock_pool, user_id=USER_ID, dispatch_fn=dispatch)
 
-    assert dispatched == ["Time to grind!"]
+    assert len(captured) == 1
+    assert captured[0]["text"] == "Time to grind!"
 
 
 @pytest.mark.asyncio
 async def test_trigger_skips_silently_when_anchor_not_in_plan():
     mock_pool, mock_get_conn, _ = _make_mock_pool([])
 
-    async def dispatch(msg: str) -> None:
-        raise AssertionError(f"dispatch should not be called: {msg}")
+    async def dispatch(**kwargs) -> None:
+        raise AssertionError(f"dispatch should not be called: {kwargs}")
 
     with patch("db.postgres.get_conn", mock_get_conn), \
          patch("db.pg_queries.anchors.get_anchors", AsyncMock(return_value=[{"id": ANCHOR_ID, "name": "The Grind"}])), \
          patch("bot.anchor_trigger.load_plan", AsyncMock(return_value=_make_plan(False))), \
          patch("bot.anchor_trigger.load_context", AsyncMock(return_value="")), \
          patch("bot.anchor_trigger.call_claude", AsyncMock()) as mock_claude:
-        await trigger_anchor(mock_pool, USER_ID, dispatch, ANCHOR_ID)
+        await trigger_anchor(ANCHOR_ID, pool=mock_pool, user_id=USER_ID, dispatch_fn=dispatch)
 
     mock_claude.assert_not_called()
 
@@ -120,12 +122,12 @@ async def test_trigger_returns_silently_for_unknown_anchor():
     """Unknown anchor_id logs an error and returns without raising or dispatching."""
     mock_pool, mock_get_conn, _ = _make_mock_pool([])
 
-    async def dispatch(msg: str) -> None:
-        raise AssertionError(f"dispatch should not be called: {msg}")
+    async def dispatch(**kwargs) -> None:
+        raise AssertionError(f"dispatch should not be called: {kwargs}")
 
     with patch("db.postgres.get_conn", mock_get_conn), \
          patch("db.pg_queries.anchors.get_anchors", AsyncMock(return_value=[])), \
          patch("bot.anchor_trigger.load_plan", AsyncMock(return_value=_make_plan(False))), \
          patch("bot.anchor_trigger.load_context", AsyncMock(return_value="")):
         # Should not raise — just logs error and returns
-        await trigger_anchor(mock_pool, USER_ID, dispatch, "not_a_real_anchor")
+        await trigger_anchor("not_a_real_anchor", pool=mock_pool, user_id=USER_ID, dispatch_fn=dispatch)


### PR DESCRIPTION
## Summary

- **New `api/routes/internal.py`**: Three internal cron endpoints gated by `X-Internal-Token` header (`secrets.compare_digest`), mounted at `/api/internal` with `include_in_schema=False`
  - `POST /api/internal/notifications/check` — queues `_run_notification_check` as BackgroundTask (checks anchor transitions + followups + meeting events for all linked users)
  - `POST /api/internal/integrations/renew-watches` — queues GCal watch renewal
  - `POST /api/internal/integrations/refresh-tokens` — queues OAuth token refresh
- **Refactored `bot/anchor_trigger.py`**: signature changed to `trigger_anchor(anchor_id, *, pool, user_id, dispatch_fn)` with keyword-only args; `dispatch_fn` now called with notify-style kwargs (`user_id=`, `notification_type=`, `text=`, `priority=`, `thread_key=`); `main()` and `_run_standalone()` removed; deprecation docstring added
- **`db/pg_auth_queries.py`**: Added `get_most_recent_telegram_user(conn)` — returns most recently linked telegram user for cold-start bootstrap
- **`bot/message_handler.py`**: `run_polling()` now bootstraps `last_user_id` from DB at startup so followup pings work immediately after restart without waiting for a user message
- **`api/main.py`**: Mounts internal router

## Part of notification system overhaul Phase C

Spec: `cc-context-store/tether/plans/notification-system-overhaul.md` §5, §6, §7, §18 Phase C

Companion tether-premium PR: See jlunder00/tether-premium#50 (tests)

## Test plan

- [ ] All 135 existing bot tests still pass (no regressions)
- [ ] `POST /api/internal/notifications/check` — 403 without token, 403 with wrong token, 200 with correct token
- [ ] `POST /api/internal/integrations/renew-watches` — same auth behavior
- [ ] `POST /api/internal/integrations/refresh-tokens` — same auth behavior
- [ ] Internal routes excluded from OpenAPI schema
- [ ] `trigger_anchor(ANCHOR_ID, pool=..., user_id=..., dispatch_fn=...)` keyword signature works
- [ ] dispatch_fn receives `user_id=`, `notification_type=`, `text=`, `priority=`, `thread_key=` kwargs
- [ ] `get_most_recent_telegram_user` returns None when no linked user, dict when linked