### PR TITLE
feat: Telegram Phase 2 — bot-token registration endpoints

### DIFF
--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 
 import logging
+import os
 from datetime import datetime, timedelta, timezone
 from typing import Optional
+from uuid import uuid4
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
@@ -450,3 +452,154 @@ async def telegram_link(body: TelegramLinkBody, request: Request, _auth=Depends(
             raise HTTPException(status_code=400, detail="Invalid or expired link code")
         await auth_queries.set_telegram_connection(conn, request.state.user_id, chat_id)
     return {"ok": True, "telegram_chat_id": chat_id}
+
+
+# ---------------------------------------------------------------------------
+# Telegram bot token registration (Phase 2 — per-user bot tokens)
+# ---------------------------------------------------------------------------
+
+_TELEGRAM_API = "https://api.telegram.org"
+_log = logging.getLogger(__name__)
+
+
+class TelegramBotBody(BaseModel):
+    token: str
+
+
+async def _get_me(bot_token: str) -> dict:
+    """Call Telegram getMe for bot_token. Returns the result dict on success.
+
+    Raises HTTPException(400) if the token is invalid or Telegram returns an error.
+    """
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{_TELEGRAM_API}/bot{bot_token}/getMe")
+
+    if resp.status_code != 200:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid bot token: Telegram returned HTTP {resp.status_code}",
+        )
+    data = resp.json()
+    if not data.get("ok"):
+        description = data.get("description", "unknown error")
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid bot token: {description}",
+        )
+    return data["result"]
+
+
+@router.post("/auth/telegram-bot")
+async def register_telegram_bot(
+    body: TelegramBotBody,
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    """Validate a BotFather token, encrypt it, and store it for this user.
+
+    Steps:
+    1. Calls Telegram getMe to validate the token.
+    2. Fernet-encrypts the token using the existing CredentialsVault key.
+    3. Generates a webhook_secret UUID and upserts into telegram_connections.
+    4. If TELEGRAM_WEBHOOK_URL is set, calls webhook_setup.register_webhook
+       (no-ops gracefully if Phase E is not merged yet).
+    5. Returns {ok: true, bot_username: "@..."}
+    """
+    vault = request.app.state.vault
+    if vault is None:
+        raise HTTPException(status_code=500, detail="Vault not configured")
+
+    bot_info = await _get_me(body.token)
+    bot_username = "@" + bot_info["username"]
+
+    webhook_secret = str(uuid4())
+
+    async with pg.get_conn(request.app.state.pool) as conn:
+        await auth_queries.upsert_telegram_bot_token(
+            conn,
+            request.state.user_id,
+            vault._fernet,
+            body.token,
+            webhook_secret,
+        )
+
+    webhook_url = os.environ.get("TELEGRAM_WEBHOOK_URL")
+    if webhook_url:
+        try:
+            from bot.webhook_setup import register_webhook  # type: ignore[import]
+            await register_webhook(body.token, webhook_url, webhook_secret)
+        except ImportError:
+            _log.debug("bot.webhook_setup not available — webhook registration deferred")
+        except Exception:
+            _log.exception("register_webhook failed — token stored, webhook not registered")
+
+    return {"ok": True, "bot_username": bot_username}
+
+
+@router.delete("/auth/telegram-bot")
+async def deregister_telegram_bot(
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    """Disconnect this user's personal Telegram bot.
+
+    Decrypts the stored token to call Telegram's deleteWebhook (if Phase E is
+    available and TELEGRAM_WEBHOOK_URL is set), then clears both columns.
+    Always returns 200 — idempotent even if no bot is registered.
+    """
+    vault = request.app.state.vault
+
+    async with pg.get_conn(request.app.state.pool) as conn:
+        row = await auth_queries.get_telegram_bot_row(conn, request.state.user_id)
+
+    encrypted = row.get("bot_token_encrypted") if row else None
+
+    if encrypted and os.environ.get("TELEGRAM_WEBHOOK_URL") and vault is not None:
+        try:
+            from bot.webhook_setup import deregister_webhook  # type: ignore[import]
+            raw_token = vault._fernet.decrypt(bytes(encrypted)).decode()
+            await deregister_webhook(raw_token)
+        except ImportError:
+            _log.debug("bot.webhook_setup not available — skipping deregister_webhook")
+        except Exception:
+            _log.exception("deregister_webhook failed — clearing token regardless")
+
+    async with pg.get_conn(request.app.state.pool) as conn:
+        await auth_queries.clear_telegram_bot_token(conn, request.state.user_id)
+
+    return {"ok": True}
+
+
+@router.get("/auth/telegram-bot")
+async def get_telegram_bot_status(
+    request: Request,
+    _auth=Depends(auth_dependency),
+):
+    """Return the connection status for this user's personal Telegram bot.
+
+    If connected (bot_token_encrypted IS NOT NULL), calls Telegram getMe to
+    retrieve the current bot username.  Returns:
+      {connected: bool, bot_username: string | null}
+    """
+    vault = request.app.state.vault
+
+    async with pg.get_conn(request.app.state.pool) as conn:
+        row = await auth_queries.get_telegram_bot_row(conn, request.state.user_id)
+
+    encrypted = row.get("bot_token_encrypted") if row else None
+    if not encrypted:
+        return {"connected": False, "bot_username": None}
+
+    if vault is None:
+        # Vault not configured — report connected but can't retrieve username
+        return {"connected": True, "bot_username": None}
+
+    try:
+        raw_token = vault._fernet.decrypt(bytes(encrypted)).decode()
+        bot_info = await _get_me(raw_token)
+        bot_username = "@" + bot_info["username"]
+    except Exception:
+        _log.exception("getMe failed for stored bot token")
+        return {"connected": True, "bot_username": None}
+
+    return {"connected": True, "bot_username": bot_username}

--- a/db/migrations/versions/d9e0f1a2b3c4_telegram_chat_id_nullable.py
+++ b/db/migrations/versions/d9e0f1a2b3c4_telegram_chat_id_nullable.py
@@ -1,0 +1,42 @@
+"""Make telegram_connections.telegram_chat_id nullable
+
+Phase 2 of the per-user Telegram migration introduces a new UX flow where
+users register their BotFather token (POST /api/auth/telegram-bot) BEFORE
+linking their Telegram chat. This requires inserting a row in
+telegram_connections without a chat_id.
+
+With telegram_chat_id NOT NULL (the initial schema), that insert fails.
+This migration drops the NOT NULL constraint.
+
+The UNIQUE constraint stays — in Postgres, NULL != NULL for unique indexes,
+so multiple users with telegram_chat_id = NULL do not conflict. Once a user
+links their chat (POST /api/auth/telegram-link), the column is populated.
+
+Revision ID: d9e0f1a2b3c4
+Revises: c8d9e0f1a2b3
+Create Date: 2026-05-14
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "d9e0f1a2b3c4"
+down_revision: Union[str, Sequence[str], None] = "c8d9e0f1a2b3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Drop NOT NULL — UNIQUE stays (NULLs are distinct in Postgres unique indexes)
+    op.execute(
+        "ALTER TABLE telegram_connections "
+        "ALTER COLUMN telegram_chat_id DROP NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    # Re-add NOT NULL only if no existing NULLs (safe for single-user environments)
+    op.execute(
+        "ALTER TABLE telegram_connections "
+        "ALTER COLUMN telegram_chat_id SET NOT NULL"
+    )

--- a/db/pg_auth_queries.py
+++ b/db/pg_auth_queries.py
@@ -306,3 +306,65 @@ async def get_user_by_webhook_secret(
     if row is None:
         return None
     return str(row["user_id"])
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — bot token registration endpoints
+# ---------------------------------------------------------------------------
+
+async def upsert_telegram_bot_token(
+    conn: asyncpg.Connection,
+    user_id: str,
+    fernet: Fernet,
+    raw_token: str,
+    webhook_secret: str,
+) -> None:
+    """Fernet-encrypt raw_token and upsert into telegram_connections.
+
+    Handles both:
+    - New user who hasn't linked Telegram yet (inserts with NULL telegram_chat_id —
+      requires the d9e0f1a2b3c4 migration making that column nullable).
+    - Existing user updating their bot token (ON CONFLICT preserves chat_id).
+    """
+    blob: bytes = fernet.encrypt(raw_token.encode())
+    await conn.execute(
+        """
+        INSERT INTO telegram_connections (user_id, bot_token_encrypted, webhook_secret)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (user_id) DO UPDATE
+            SET bot_token_encrypted = EXCLUDED.bot_token_encrypted,
+                webhook_secret      = EXCLUDED.webhook_secret
+        """,
+        _uuid.UUID(user_id),
+        blob,
+        webhook_secret,
+    )
+
+
+async def get_telegram_bot_row(
+    conn: asyncpg.Connection, user_id: str
+) -> dict | None:
+    """Return the telegram_connections row for this user, or None if absent."""
+    row = await conn.fetchrow(
+        "SELECT bot_token_encrypted, webhook_secret FROM telegram_connections WHERE user_id = $1",
+        _uuid.UUID(user_id),
+    )
+    return _row(row)
+
+
+async def clear_telegram_bot_token(
+    conn: asyncpg.Connection, user_id: str
+) -> None:
+    """Clear bot_token_encrypted and webhook_secret for this user.
+
+    Does nothing (no error) if the user has no telegram_connections row.
+    """
+    await conn.execute(
+        """
+        UPDATE telegram_connections
+           SET bot_token_encrypted = NULL,
+               webhook_secret      = NULL
+         WHERE user_id = $1
+        """,
+        _uuid.UUID(user_id),
+    )

--- a/tests/api/test_telegram_bot_endpoints.py
+++ b/tests/api/test_telegram_bot_endpoints.py
@@ -443,8 +443,9 @@ async def test_get_telegram_bot_connected_returns_username(
             json={"token": SAMPLE_BOT_TOKEN},
         )
 
-    # Now GET — should call getMe again
-    with patch("httpx.AsyncClient.get", return_value=mock_resp):
+    # Now GET — patch _get_me directly to avoid intercepting the test client's
+    # own .get() call (test client is also an httpx.AsyncClient).
+    with patch("api.routes.auth._get_me", return_value=SAMPLE_GET_ME_RESPONSE["result"]):
         resp = await client.get("/auth/telegram-bot")
 
     assert resp.status_code == 200

--- a/tests/api/test_telegram_bot_endpoints.py
+++ b/tests/api/test_telegram_bot_endpoints.py
@@ -183,7 +183,7 @@ async def test_post_telegram_bot_invalid_token_ok_false(telegram_bot_client):
     )
     with patch("httpx.AsyncClient.get", return_value=mock_resp):
         resp = await client.post(
-            "/api/auth/telegram-bot",
+            "/auth/telegram-bot",
             json={"token": "bad-token"},
         )
 
@@ -199,7 +199,7 @@ async def test_post_telegram_bot_http_error_returns_400(telegram_bot_client):
     mock_resp = _make_mock_httpx_response({}, status_code=404)
     with patch("httpx.AsyncClient.get", return_value=mock_resp):
         resp = await client.post(
-            "/api/auth/telegram-bot",
+            "/auth/telegram-bot",
             json={"token": "bad-token"},
         )
 
@@ -220,7 +220,7 @@ async def test_post_telegram_bot_valid_token_stores_and_returns(
     mock_resp = _make_mock_httpx_response(SAMPLE_GET_ME_RESPONSE)
     with patch("httpx.AsyncClient.get", return_value=mock_resp):
         resp = await client.post(
-            "/api/auth/telegram-bot",
+            "/auth/telegram-bot",
             json={"token": SAMPLE_BOT_TOKEN},
         )
 
@@ -255,7 +255,7 @@ async def test_post_telegram_bot_upserts_when_connection_exists(
     mock_resp = _make_mock_httpx_response(SAMPLE_GET_ME_RESPONSE)
     with patch("httpx.AsyncClient.get", return_value=mock_resp):
         resp = await client.post(
-            "/api/auth/telegram-bot",
+            "/auth/telegram-bot",
             json={"token": SAMPLE_BOT_TOKEN},
         )
 
@@ -299,7 +299,7 @@ async def test_post_telegram_bot_webhook_setup_called_when_url_set(
     with patch("httpx.AsyncClient.get", return_value=mock_resp):
         with patch.dict("sys.modules", {"bot.webhook_setup": mock_module}):
             resp = await client.post(
-                "/api/auth/telegram-bot",
+                "/auth/telegram-bot",
                 json={"token": SAMPLE_BOT_TOKEN},
             )
 
@@ -322,7 +322,7 @@ async def test_post_telegram_bot_webhook_setup_import_error_still_succeeds(
         # Force ImportError for the webhook_setup module
         with patch.dict("sys.modules", {"bot.webhook_setup": None}):
             resp = await client.post(
-                "/api/auth/telegram-bot",
+                "/auth/telegram-bot",
                 json={"token": SAMPLE_BOT_TOKEN},
             )
 
@@ -343,13 +343,13 @@ async def test_delete_telegram_bot_clears_columns(telegram_bot_client_with_exist
     mock_resp = _make_mock_httpx_response(SAMPLE_GET_ME_RESPONSE)
     with patch("httpx.AsyncClient.get", return_value=mock_resp):
         post_resp = await client.post(
-            "/api/auth/telegram-bot",
+            "/auth/telegram-bot",
             json={"token": SAMPLE_BOT_TOKEN},
         )
     assert post_resp.status_code == 200
 
     # Now delete
-    resp = await client.delete("/api/auth/telegram-bot")
+    resp = await client.delete("/auth/telegram-bot")
     assert resp.status_code == 200
 
     async with pool.acquire() as conn:
@@ -366,7 +366,7 @@ async def test_delete_telegram_bot_clears_columns(telegram_bot_client_with_exist
 async def test_delete_telegram_bot_no_connection_row_returns_200(telegram_bot_client):
     """DELETE when user has no telegram_connections row still returns 200."""
     client, _ = telegram_bot_client
-    resp = await client.delete("/api/auth/telegram-bot")
+    resp = await client.delete("/auth/telegram-bot")
     assert resp.status_code == 200
 
 
@@ -382,7 +382,7 @@ async def test_delete_telegram_bot_deregister_webhook_called(
     mock_resp = _make_mock_httpx_response(SAMPLE_GET_ME_RESPONSE)
     with patch("httpx.AsyncClient.get", return_value=mock_resp):
         await client.post(
-            "/api/auth/telegram-bot",
+            "/auth/telegram-bot",
             json={"token": SAMPLE_BOT_TOKEN},
         )
 
@@ -395,7 +395,7 @@ async def test_delete_telegram_bot_deregister_webhook_called(
     mock_module.deregister_webhook = mock_deregister
 
     with patch.dict("sys.modules", {"bot.webhook_setup": mock_module}):
-        resp = await client.delete("/api/auth/telegram-bot")
+        resp = await client.delete("/auth/telegram-bot")
 
     assert resp.status_code == 200
     assert len(deregister_called) == 1
@@ -410,7 +410,7 @@ async def test_delete_telegram_bot_deregister_webhook_called(
 async def test_get_telegram_bot_not_connected_no_row(telegram_bot_client):
     """User with no telegram_connections row → connected:false."""
     client, _ = telegram_bot_client
-    resp = await client.get("/api/auth/telegram-bot")
+    resp = await client.get("/auth/telegram-bot")
     assert resp.status_code == 200
     data = resp.json()
     assert data["connected"] is False
@@ -422,7 +422,7 @@ async def test_get_telegram_bot_not_connected_no_token(
 ):
     """User with telegram_connections row but no bot_token → connected:false."""
     client, _ = telegram_bot_client_with_existing_connection
-    resp = await client.get("/api/auth/telegram-bot")
+    resp = await client.get("/auth/telegram-bot")
     assert resp.status_code == 200
     data = resp.json()
     assert data["connected"] is False
@@ -439,13 +439,13 @@ async def test_get_telegram_bot_connected_returns_username(
     mock_resp = _make_mock_httpx_response(SAMPLE_GET_ME_RESPONSE)
     with patch("httpx.AsyncClient.get", return_value=mock_resp):
         await client.post(
-            "/api/auth/telegram-bot",
+            "/auth/telegram-bot",
             json={"token": SAMPLE_BOT_TOKEN},
         )
 
     # Now GET — should call getMe again
     with patch("httpx.AsyncClient.get", return_value=mock_resp):
-        resp = await client.get("/api/auth/telegram-bot")
+        resp = await client.get("/auth/telegram-bot")
 
     assert resp.status_code == 200
     data = resp.json()

--- a/tests/api/test_telegram_bot_endpoints.py
+++ b/tests/api/test_telegram_bot_endpoints.py
@@ -1,0 +1,453 @@
+"""Integration tests for POST/DELETE/GET /api/auth/telegram-bot endpoints.
+
+TDD: tests written before implementation, confirmed to fail for the right reason.
+
+Schema dependency: these tests require telegram_connections.telegram_chat_id
+to be nullable (migration d9e0f1a2b3c4_telegram_chat_id_nullable.py). If the
+column is NOT NULL, the upsert tests will fail at the DB layer.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncpg
+import pytest
+from cryptography.fernet import Fernet
+from httpx import AsyncClient, ASGITransport
+
+from api.auth import create_jwt
+from db.postgres import register_jsonb_codec
+from tests.api.conftest import TEST_USER_ID, TEST_USERNAME
+
+pytestmark = pytest.mark.asyncio
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+SAMPLE_GET_ME_RESPONSE = {
+    "ok": True,
+    "result": {
+        "id": 123456789,
+        "is_bot": True,
+        "first_name": "Test Bot",
+        "username": "testbot",
+    },
+}
+
+SAMPLE_BOT_TOKEN = "1234567890:ABCDefghijklMNOpqrstuvwxyz"
+
+
+def _make_mock_httpx_response(json_data: dict, status_code: int = 200) -> MagicMock:
+    """Build a mock httpx Response."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.json.return_value = json_data
+    return mock_resp
+
+
+def _db_url() -> str:
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        pytest.skip("DATABASE_URL not set — API tests skipped")
+    return url
+
+
+async def _ensure_test_user(url: str) -> None:
+    c = await asyncpg.connect(dsn=url)
+    try:
+        await c.execute(
+            """
+            INSERT INTO users (id, username, email, password_hash, is_admin)
+            VALUES ($1::uuid, $2, 'test@example.com', 'x', false)
+            ON CONFLICT (id) DO NOTHING
+            """,
+            TEST_USER_ID,
+            TEST_USERNAME,
+        )
+    finally:
+        await c.close()
+
+
+async def _cleanup_telegram_connection(url: str) -> None:
+    """Remove any telegram_connections row for the test user between tests."""
+    c = await asyncpg.connect(dsn=url)
+    try:
+        await c.execute(
+            "DELETE FROM telegram_connections WHERE user_id = $1::uuid",
+            TEST_USER_ID,
+        )
+    finally:
+        await c.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def pool():
+    url = _db_url()
+    p = await asyncpg.create_pool(dsn=url, init=register_jsonb_codec)
+    yield p
+    await p.close()
+
+
+@pytest.fixture
+async def telegram_bot_client(pool):
+    """AsyncClient pre-configured with auth cookie + vault for telegram-bot endpoints.
+
+    Yields (client, fernet) so tests can verify encrypted storage.
+    """
+    from api.main import create_app
+    from api.credentials_vault import CredentialsVault
+
+    url = _db_url()
+    await _ensure_test_user(url)
+    await _cleanup_telegram_connection(url)
+
+    fernet_key = Fernet.generate_key()
+    app = create_app()
+    app.state.pool = pool
+    app.state.vault = CredentialsVault(pool, fernet_key)
+    fernet = Fernet(fernet_key)
+
+    token = create_jwt(TEST_USER_ID, TEST_USERNAME, is_admin=False)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"tether_token": token},
+    ) as client:
+        yield client, fernet
+
+    await _cleanup_telegram_connection(url)
+
+
+@pytest.fixture
+async def telegram_bot_client_with_existing_connection(pool):
+    """Client where the test user already has a telegram_connections row
+    (simulates a user who previously linked their Telegram chat)."""
+    from api.main import create_app
+    from api.credentials_vault import CredentialsVault
+
+    url = _db_url()
+    await _ensure_test_user(url)
+    await _cleanup_telegram_connection(url)
+
+    # Insert an existing telegram_connections row with a known chat_id
+    c = await asyncpg.connect(dsn=url)
+    try:
+        await c.execute(
+            """
+            INSERT INTO telegram_connections (user_id, telegram_chat_id)
+            VALUES ($1::uuid, $2)
+            ON CONFLICT (user_id) DO NOTHING
+            """,
+            TEST_USER_ID,
+            "existing_chat_id_123",
+        )
+    finally:
+        await c.close()
+
+    fernet_key = Fernet.generate_key()
+    app = create_app()
+    app.state.pool = pool
+    app.state.vault = CredentialsVault(pool, fernet_key)
+    fernet = Fernet(fernet_key)
+
+    token = create_jwt(TEST_USER_ID, TEST_USERNAME, is_admin=False)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"tether_token": token},
+    ) as client:
+        yield client, fernet
+
+    await _cleanup_telegram_connection(url)
+
+
+# ---------------------------------------------------------------------------
+# POST /api/auth/telegram-bot — invalid token → 400
+# ---------------------------------------------------------------------------
+
+
+async def test_post_telegram_bot_invalid_token_ok_false(telegram_bot_client):
+    """Telegram returns ok:false → 400 with error message."""
+    client, _ = telegram_bot_client
+
+    mock_resp = _make_mock_httpx_response(
+        {"ok": False, "error_code": 401, "description": "Unauthorized"}
+    )
+    with patch("httpx.AsyncClient.get", return_value=mock_resp):
+        resp = await client.post(
+            "/api/auth/telegram-bot",
+            json={"token": "bad-token"},
+        )
+
+    assert resp.status_code == 400
+    data = resp.json()
+    assert "invalid" in data["detail"].lower() or "unauthorized" in data["detail"].lower()
+
+
+async def test_post_telegram_bot_http_error_returns_400(telegram_bot_client):
+    """Telegram API returns HTTP non-200 → 400."""
+    client, _ = telegram_bot_client
+
+    mock_resp = _make_mock_httpx_response({}, status_code=404)
+    with patch("httpx.AsyncClient.get", return_value=mock_resp):
+        resp = await client.post(
+            "/api/auth/telegram-bot",
+            json={"token": "bad-token"},
+        )
+
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# POST /api/auth/telegram-bot — valid token → stores + returns bot_username
+# ---------------------------------------------------------------------------
+
+
+async def test_post_telegram_bot_valid_token_stores_and_returns(
+    telegram_bot_client, pool
+):
+    """Valid token: encrypts + stores in telegram_connections, returns bot_username."""
+    client, fernet = telegram_bot_client
+
+    mock_resp = _make_mock_httpx_response(SAMPLE_GET_ME_RESPONSE)
+    with patch("httpx.AsyncClient.get", return_value=mock_resp):
+        resp = await client.post(
+            "/api/auth/telegram-bot",
+            json={"token": SAMPLE_BOT_TOKEN},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["bot_username"] == "@testbot"
+
+    # Verify the token was encrypted and stored
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT bot_token_encrypted, webhook_secret FROM telegram_connections "
+            "WHERE user_id = $1::uuid",
+            TEST_USER_ID,
+        )
+    assert row is not None
+    assert row["bot_token_encrypted"] is not None
+    assert row["webhook_secret"] is not None
+    # Decrypt and verify
+    decrypted = fernet.decrypt(bytes(row["bot_token_encrypted"])).decode()
+    assert decrypted == SAMPLE_BOT_TOKEN
+    # webhook_secret is a UUID
+    uuid.UUID(row["webhook_secret"])  # raises if not valid UUID
+
+
+async def test_post_telegram_bot_upserts_when_connection_exists(
+    telegram_bot_client_with_existing_connection, pool
+):
+    """POST with existing telegram_connections row (has chat_id) updates token columns."""
+    client, fernet = telegram_bot_client_with_existing_connection
+
+    mock_resp = _make_mock_httpx_response(SAMPLE_GET_ME_RESPONSE)
+    with patch("httpx.AsyncClient.get", return_value=mock_resp):
+        resp = await client.post(
+            "/api/auth/telegram-bot",
+            json={"token": SAMPLE_BOT_TOKEN},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+    # The existing chat_id should be preserved
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT telegram_chat_id, bot_token_encrypted FROM telegram_connections "
+            "WHERE user_id = $1::uuid",
+            TEST_USER_ID,
+        )
+    assert row is not None
+    assert row["telegram_chat_id"] == "existing_chat_id_123"  # preserved
+    assert row["bot_token_encrypted"] is not None  # newly added
+
+
+# ---------------------------------------------------------------------------
+# POST /api/auth/telegram-bot — webhook_setup integration
+# ---------------------------------------------------------------------------
+
+
+async def test_post_telegram_bot_webhook_setup_called_when_url_set(
+    telegram_bot_client, monkeypatch
+):
+    """When TELEGRAM_WEBHOOK_URL is set and webhook_setup is importable,
+    register_webhook is called."""
+    client, _ = telegram_bot_client
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_URL", "https://example.com")
+
+    register_called: list[tuple] = []
+
+    async def mock_register(bot_token: str, public_url: str, webhook_secret: str) -> None:
+        register_called.append((bot_token, public_url, webhook_secret))
+
+    mock_module = MagicMock()
+    mock_module.register_webhook = mock_register
+
+    mock_resp = _make_mock_httpx_response(SAMPLE_GET_ME_RESPONSE)
+    with patch("httpx.AsyncClient.get", return_value=mock_resp):
+        with patch.dict("sys.modules", {"bot.webhook_setup": mock_module}):
+            resp = await client.post(
+                "/api/auth/telegram-bot",
+                json={"token": SAMPLE_BOT_TOKEN},
+            )
+
+    assert resp.status_code == 200
+    assert len(register_called) == 1
+    assert register_called[0][0] == SAMPLE_BOT_TOKEN
+    assert register_called[0][1] == "https://example.com"
+
+
+async def test_post_telegram_bot_webhook_setup_import_error_still_succeeds(
+    telegram_bot_client, monkeypatch
+):
+    """When TELEGRAM_WEBHOOK_URL is set but webhook_setup is not importable,
+    the endpoint still succeeds (ImportError is swallowed)."""
+    client, _ = telegram_bot_client
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_URL", "https://example.com")
+
+    mock_resp = _make_mock_httpx_response(SAMPLE_GET_ME_RESPONSE)
+    with patch("httpx.AsyncClient.get", return_value=mock_resp):
+        # Force ImportError for the webhook_setup module
+        with patch.dict("sys.modules", {"bot.webhook_setup": None}):
+            resp = await client.post(
+                "/api/auth/telegram-bot",
+                json={"token": SAMPLE_BOT_TOKEN},
+            )
+
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/auth/telegram-bot — clears token + webhook secret
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_telegram_bot_clears_columns(telegram_bot_client_with_existing_connection, pool):
+    """DELETE clears bot_token_encrypted and webhook_secret."""
+    client, fernet = telegram_bot_client_with_existing_connection
+
+    # First set a bot token
+    mock_resp = _make_mock_httpx_response(SAMPLE_GET_ME_RESPONSE)
+    with patch("httpx.AsyncClient.get", return_value=mock_resp):
+        post_resp = await client.post(
+            "/api/auth/telegram-bot",
+            json={"token": SAMPLE_BOT_TOKEN},
+        )
+    assert post_resp.status_code == 200
+
+    # Now delete
+    resp = await client.delete("/api/auth/telegram-bot")
+    assert resp.status_code == 200
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT bot_token_encrypted, webhook_secret FROM telegram_connections "
+            "WHERE user_id = $1::uuid",
+            TEST_USER_ID,
+        )
+    assert row is not None
+    assert row["bot_token_encrypted"] is None
+    assert row["webhook_secret"] is None
+
+
+async def test_delete_telegram_bot_no_connection_row_returns_200(telegram_bot_client):
+    """DELETE when user has no telegram_connections row still returns 200."""
+    client, _ = telegram_bot_client
+    resp = await client.delete("/api/auth/telegram-bot")
+    assert resp.status_code == 200
+
+
+async def test_delete_telegram_bot_deregister_webhook_called(
+    telegram_bot_client_with_existing_connection, pool, monkeypatch
+):
+    """DELETE calls deregister_webhook when TELEGRAM_WEBHOOK_URL is set and
+    webhook_setup is importable."""
+    client, fernet = telegram_bot_client_with_existing_connection
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_URL", "https://example.com")
+
+    # First set a bot token
+    mock_resp = _make_mock_httpx_response(SAMPLE_GET_ME_RESPONSE)
+    with patch("httpx.AsyncClient.get", return_value=mock_resp):
+        await client.post(
+            "/api/auth/telegram-bot",
+            json={"token": SAMPLE_BOT_TOKEN},
+        )
+
+    deregister_called: list[str] = []
+
+    async def mock_deregister(bot_token: str) -> None:
+        deregister_called.append(bot_token)
+
+    mock_module = MagicMock()
+    mock_module.deregister_webhook = mock_deregister
+
+    with patch.dict("sys.modules", {"bot.webhook_setup": mock_module}):
+        resp = await client.delete("/api/auth/telegram-bot")
+
+    assert resp.status_code == 200
+    assert len(deregister_called) == 1
+    assert deregister_called[0] == SAMPLE_BOT_TOKEN
+
+
+# ---------------------------------------------------------------------------
+# GET /api/auth/telegram-bot — status
+# ---------------------------------------------------------------------------
+
+
+async def test_get_telegram_bot_not_connected_no_row(telegram_bot_client):
+    """User with no telegram_connections row → connected:false."""
+    client, _ = telegram_bot_client
+    resp = await client.get("/api/auth/telegram-bot")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["connected"] is False
+    assert data["bot_username"] is None
+
+
+async def test_get_telegram_bot_not_connected_no_token(
+    telegram_bot_client_with_existing_connection,
+):
+    """User with telegram_connections row but no bot_token → connected:false."""
+    client, _ = telegram_bot_client_with_existing_connection
+    resp = await client.get("/api/auth/telegram-bot")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["connected"] is False
+    assert data["bot_username"] is None
+
+
+async def test_get_telegram_bot_connected_returns_username(
+    telegram_bot_client_with_existing_connection,
+):
+    """User with bot token set → connected:true, bot_username from getMe."""
+    client, _ = telegram_bot_client_with_existing_connection
+
+    # First store a token
+    mock_resp = _make_mock_httpx_response(SAMPLE_GET_ME_RESPONSE)
+    with patch("httpx.AsyncClient.get", return_value=mock_resp):
+        await client.post(
+            "/api/auth/telegram-bot",
+            json={"token": SAMPLE_BOT_TOKEN},
+        )
+
+    # Now GET — should call getMe again
+    with patch("httpx.AsyncClient.get", return_value=mock_resp):
+        resp = await client.get("/api/auth/telegram-bot")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["connected"] is True
+    assert data["bot_username"] == "@testbot"


### PR DESCRIPTION
## Summary

- **POST /api/auth/telegram-bot** — validates a BotFather token via Telegram `getMe`, Fernet-encrypts it using the existing `CredentialsVault` key, upserts `bot_token_encrypted` + `webhook_secret` into `telegram_connections`, calls `register_webhook` if `TELEGRAM_WEBHOOK_URL` is set (graceful `ImportError` guard for Phase E not merged yet)
- **DELETE /api/auth/telegram-bot** — decrypts stored token to call `deregister_webhook` (Phase E optional), then clears both columns; idempotent (no row = 200)
- **GET /api/auth/telegram-bot** — returns `{connected: bool, bot_username: string | null}` by calling `getMe` on the stored token

## Schema change

Migration `d9e0f1a2b3c4` drops `NOT NULL` on `telegram_connections.telegram_chat_id`. Required because the new UX flow registers the bot token **before** the user links their Telegram chat. Postgres UNIQUE indexes treat NULLs as distinct so the existing uniqueness semantics are preserved.

Note: `auto_link_chat_id()` from Phase 1 already anticipates `telegram_chat_id IS NULL` — this migration was always part of the plan.

## DB queries added

- `upsert_telegram_bot_token` — INSERT … ON CONFLICT DO UPDATE (preserves existing `telegram_chat_id`)
- `get_telegram_bot_row` — SELECT for status/delete
- `clear_telegram_bot_token` — NULL-out both columns

## Tests

`tests/api/test_telegram_bot_endpoints.py` — 12 cases:
- Invalid token (ok:false) → 400
- HTTP non-200 → 400
- Valid token → encrypts, stores, returns `@username`
- Upsert preserves existing `telegram_chat_id`
- `webhook_setup` called when `TELEGRAM_WEBHOOK_URL` set
- `ImportError` swallowed, endpoint still succeeds
- DELETE clears columns
- DELETE no-row → 200
- DELETE calls `deregister_webhook` when available
- GET not connected (no row) → `{connected: false}`
- GET not connected (no token) → `{connected: false}`
- GET connected → `{connected: true, bot_username: "@..."}`

## Coordination

- Imports `bot.webhook_setup` inside `try/except ImportError` — can merge before Phase E (`notify-phase-e-telegram-webhook`) with no breakage
- Uses `app.state.vault._fernet` — same Fernet key as existing `CredentialsVault`, no new secrets needed

## Test plan

- [ ] CI `test` job passes (DB-backed API tests)
- [ ] `test_post_telegram_bot_valid_token_stores_and_returns` — confirm encrypt/decrypt roundtrip
- [ ] `test_post_telegram_bot_webhook_setup_import_error_still_succeeds` — confirm graceful guard
- [ ] After Phase E merges: re-run with `TELEGRAM_WEBHOOK_URL` set end-to-end