### PR TITLE
feat(bot): Telegram webhook receive — per-user header routing (Phase E)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -91,20 +91,49 @@ async def lifespan(app):
         else:
             app.state.vault = None
 
-        # Register Telegram webhook if webhook URL is configured.
+        # Register per-user Telegram webhooks if webhook URL is configured.
+        # Iterates all users with bot_token_encrypted AND webhook_secret set.
+        # Telegram's setWebhook is idempotent — safe to call on every startup.
         # When TELEGRAM_WEBHOOK_URL is not set, polling mode is used (no-op here).
         webhook_url = _startup_os.environ.get("TELEGRAM_WEBHOOK_URL")
         if webhook_url:
             try:
                 from bot.webhook_setup import register_webhook
-                from config.loader import config as tether_config
-                bot_token = tether_config.get("telegram.bot_token", "")
-                secret = _startup_os.environ.get("TELEGRAM_WEBHOOK_SECRET", "")
-                await register_webhook(bot_token, webhook_url, secret)
+                import db.postgres as _pg
+                import db.pg_auth_queries as _pg_auth
+                _wh_logger = logging.getLogger(__name__)
+                _vault = app.state.vault
+                _fernet = getattr(_vault, "_fernet", None) if _vault else None
+                if _fernet is None:
+                    _wh_logger.warning(
+                        "lifespan: TELEGRAM_WEBHOOK_URL set but vault not available — "
+                        "cannot decrypt per-user tokens; skipping webhook registration"
+                    )
+                else:
+                    async with _pg.get_conn(app.state.pool) as _conn:
+                        _users = await _pg_auth.get_users_with_webhook(_conn)
+                    registered = 0
+                    for _row in _users:
+                        try:
+                            _raw_token = _fernet.decrypt(
+                                bytes(_row["bot_token_encrypted"])
+                            ).decode()
+                            await register_webhook(
+                                _raw_token, webhook_url, _row["webhook_secret"]
+                            )
+                            registered += 1
+                        except Exception as _exc:
+                            _wh_logger.warning(
+                                "lifespan: webhook registration failed for user %s: %s",
+                                _row["user_id"], _exc,
+                            )
+                    _wh_logger.info(
+                        "lifespan: registered webhooks for %d/%d users",
+                        registered, len(_users),
+                    )
             except Exception as _wh_exc:
                 logging.getLogger(__name__).warning(
-                    "lifespan: webhook registration failed (bot may not receive messages): %s",
-                    _wh_exc,
+                    "lifespan: webhook registration loop failed: %s", _wh_exc,
                 )
 
         task = asyncio.create_task(_expiry_loop(app))

--- a/api/routes/bot.py
+++ b/api/routes/bot.py
@@ -1,9 +1,7 @@
 import asyncio
-import hmac
 import logging
-import os
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, BackgroundTasks, Depends, Request, Response, WebSocket, WebSocketDisconnect
 import asyncpg
 from db.pg_queries import get_last_bot_activity
 from db.pool_middleware import get_db_conn
@@ -50,31 +48,43 @@ async def bot_health(_auth=Depends(auth_dependency),
     return {"status": status, "last_activity": activity}
 
 
-def _verify_telegram_secret(request: Request) -> None:
-    """Verify X-Telegram-Bot-Api-Secret-Token header against TELEGRAM_WEBHOOK_SECRET env var.
+async def _resolve_user_from_webhook_header(request: Request, pool) -> str | None:
+    """Look up user_id from the X-Telegram-Bot-Api-Secret-Token header.
 
-    Raises HTTP 403 if the header is missing or does not match.
-    Uses hmac.compare_digest to prevent timing attacks.
+    Uses hmac.compare_digest for the empty-secret guard (constant time).
+    Returns the user_id string if the secret resolves to a known user, else None.
+    This is a no-RLS auth-schema lookup (telegram_connections has no RLS).
     """
-    expected = os.environ.get("TELEGRAM_WEBHOOK_SECRET", "")
+    import db.postgres as pg
+    import db.pg_auth_queries as pg_auth_queries
+
     provided = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
-    if not expected or not hmac.compare_digest(provided, expected):
-        raise HTTPException(status_code=403, detail="Invalid webhook secret")
+    if not provided:
+        return None
+
+    async with pg.get_conn(pool) as conn:
+        return await pg_auth_queries.get_user_by_webhook_secret(conn, provided)
 
 
-async def _process_telegram_update(update: dict, pool, vault) -> None:
-    """Process a single Telegram Update dict.
+async def _process_telegram_update(
+    update: dict,
+    user_id: str,
+    pool,
+    vault,
+) -> None:
+    """Process a single Telegram Update dict for a known user.
 
-    Extracts the message text and chat_id, resolves the linked user_id,
-    then calls handle_message() — the same path used by the polling loop.
-    Non-message updates (e.g. edited_message, channel_post) are silently ignored.
+    Called as a BackgroundTask after the webhook endpoint resolves the user from
+    the X-Telegram-Bot-Api-Secret-Token header.
 
-    /start and /link are handled before user resolution, matching the polling
-    loop behaviour so new users can onboard in webhook mode.
+    Non-message updates (edited_message, channel_post, etc.) are silently ignored.
+
+    First-message capture: if the user's telegram_chat_id is NULL, store
+    update.message.chat.id and reply "Connected to Tether." — no further
+    processing (the linking IS the action). Subsequent messages go to
+    handle_message() as normal.
     """
-    import random as _random
-    from config.loader import config as tether_config
-    from bot.message_handler import _resolve_user_id, _send_telegram
+    from bot.message_handler import _send_telegram
     import db.postgres as pg
     import db.pg_auth_queries as pg_auth_queries
 
@@ -93,27 +103,53 @@ async def _process_telegram_update(update: dict, pool, vault) -> None:
         logger.warning("_process_telegram_update: no chat.id in update")
         return
 
-    token = tether_config.get("telegram.bot_token", "")
+    # Resolve per-user bot token for outbound messages.
+    # Falls back to None if not set — handle_message handles its own fallbacks.
+    fernet = getattr(vault, "_fernet", None) if vault else None
+    token: str | None = None
+    if fernet is not None:
+        try:
+            async with pg.get_conn(pool) as conn:
+                token = await pg_auth_queries.get_bot_token(conn, user_id, fernet)
+        except Exception as exc:
+            logger.warning(
+                "_process_telegram_update: could not fetch per-user bot token: %s", exc
+            )
+
+    if not token:
+        from config.loader import config as tether_config
+        token = tether_config.get("telegram.bot_token", "")
+
     send_fn = lambda m, cid=incoming_chat_id: _send_telegram(token, cid, m)
 
-    # Handle /start and /link before auth check — mirrors polling loop behaviour.
-    # Unlinked users must be able to generate a link code to onboard.
-    if text in ("/start", "/link"):
-        try:
-            code = f"{_random.randint(0, 999999):06d}"
-            async with pg.get_conn(pool) as conn:  # no user_id — auth table has no RLS
-                await pg_auth_queries.store_link_code(conn, code, incoming_chat_id)
-            send_fn(f"Your link code is: {code}. Enter this in Tether settings within 5 minutes.")
-        except Exception as exc:
-            logger.error("_process_telegram_update: /link error: %s", exc, exc_info=True)
-            send_fn("[Tether error generating link code]")
+    # First-message capture: when telegram_chat_id is NULL, store it and
+    # reply "Connected to Tether." — simplified linking per Jason's override.
+    # No /link slash command, no 6-digit code needed.
+    try:
+        async with pg.get_conn(pool) as conn:
+            current_chat_id = await pg_auth_queries.get_telegram_chat_id(conn, user_id)
+    except Exception as exc:
+        logger.error(
+            "_process_telegram_update: get_telegram_chat_id failed user_id=%s: %s",
+            user_id, exc, exc_info=True,
+        )
         return
 
-    # Resolve Telegram chat_id → Tether user_id
-    user_id = await _resolve_user_id(pool, incoming_chat_id)
-    if user_id is None:
-        send_fn("I don't recognize you. Link your Tether account at your Tether URL, "
-                "then use /link to connect.")
+    if current_chat_id is None:
+        # First message — bind this chat_id to the user.
+        try:
+            async with pg.get_conn(pool) as conn:
+                await pg_auth_queries.auto_link_chat_id(conn, user_id, incoming_chat_id)
+            send_fn("Connected to Tether.")
+            logger.info(
+                "_process_telegram_update: first-message chat_id capture user_id=%s chat_id=%s",
+                user_id, incoming_chat_id,
+            )
+        except Exception as exc:
+            logger.error(
+                "_process_telegram_update: chat_id capture failed user_id=%s: %s",
+                user_id, exc, exc_info=True,
+            )
         return
 
     try:
@@ -133,16 +169,23 @@ async def telegram_webhook(
 ) -> Response:
     """Receive Telegram Update payloads (webhook mode).
 
-    Responds 200 immediately so Telegram doesn't retry.
-    Processing happens in a BackgroundTask — same handle_message() path as polling.
+    Always responds 200 immediately — Telegram retries on non-200, so we must
+    never return an error status. Unknown/missing secrets are silently discarded.
 
-    Auth: X-Telegram-Bot-Api-Secret-Token header must match TELEGRAM_WEBHOOK_SECRET env var.
+    Auth: X-Telegram-Bot-Api-Secret-Token header is used to resolve the user.
+    Lookup: SELECT user_id FROM telegram_connections WHERE webhook_secret = $1
+    (no-RLS auth-schema query). Processing happens in a BackgroundTask.
     """
-    _verify_telegram_secret(request)
-    update = await request.json()
     pool = request.app.state.pool
     vault = getattr(request.app.state, "vault", None)
-    background_tasks.add_task(_process_telegram_update, update, pool, vault)
+
+    user_id = await _resolve_user_from_webhook_header(request, pool)
+    if user_id is None:
+        # Unknown or missing secret — discard silently.
+        return Response(status_code=200)
+
+    update = await request.json()
+    background_tasks.add_task(_process_telegram_update, update, user_id, pool, vault)
     return Response(status_code=200)
 
 

--- a/db/pg_auth_queries.py
+++ b/db/pg_auth_queries.py
@@ -330,3 +330,41 @@ async def get_most_recent_telegram_user(conn: asyncpg.Connection) -> dict | None
     if row is None:
         return None
     return {"id": str(row["id"]), "telegram_chat_id": row["telegram_chat_id"]}
+
+
+async def get_users_with_webhook(
+    conn: asyncpg.Connection,
+) -> list[dict]:
+    """Return all users that have both bot_token_encrypted AND webhook_secret set.
+
+    Used at startup to register per-user webhooks with Telegram.
+    Returns a list of dicts with keys: user_id, bot_token_encrypted, webhook_secret.
+    This is a no-RLS auth-schema query — do NOT pass a scoped connection.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT user_id, bot_token_encrypted, webhook_secret
+        FROM telegram_connections
+        WHERE bot_token_encrypted IS NOT NULL
+          AND webhook_secret IS NOT NULL
+        """
+    )
+    return [dict(r) for r in rows]
+
+
+async def get_telegram_chat_id(
+    conn: asyncpg.Connection, user_id: str
+) -> str | None:
+    """Return telegram_chat_id for the given user, or None if not set.
+
+    Used by the webhook receive path to check whether this is a first-message
+    (chat_id not yet captured) or a returning user.
+    """
+    row = await conn.fetchrow(
+        "SELECT telegram_chat_id FROM telegram_connections WHERE user_id = $1",
+        _uuid.UUID(user_id),
+    )
+    if row is None:
+        return None
+    chat_id = row["telegram_chat_id"]
+    return chat_id if chat_id else None

--- a/tests/api/test_telegram_webhook.py
+++ b/tests/api/test_telegram_webhook.py
@@ -1,11 +1,19 @@
-"""Integration tests for POST /api/bot/telegram-webhook endpoint."""
+"""Integration tests for POST /api/bot/telegram-webhook endpoint.
+
+Phase E: header-based per-user routing.
+- Endpoint ALWAYS returns 200 (Telegram retries on non-200).
+- Unknown or missing X-Telegram-Bot-Api-Secret-Token → 200, no dispatch.
+- Valid secret resolves via DB lookup → BackgroundTask dispatched.
+"""
 from __future__ import annotations
 
 import os
-import pytest
-from unittest.mock import AsyncMock, patch
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+from contextlib import asynccontextmanager
 
-# Valid Telegram Update payload (minimal message update)
+import pytest
+
 SAMPLE_UPDATE = {
     "update_id": 123456789,
     "message": {
@@ -17,79 +25,57 @@ SAMPLE_UPDATE = {
     },
 }
 
-VALID_SECRET = "test-webhook-secret"
-WRONG_SECRET = "wrong-secret"
+VALID_SECRET = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+TEST_USER_ID = "00000000-0000-0000-0000-000000000001"
+
+
+def _make_db_fixtures(user_id: str | None):
+    """Build mock pool + get_conn context that returns user_id (or None)."""
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(
+        return_value={"user_id": uuid.UUID(user_id)} if user_id else None
+    )
+    mock_pool = MagicMock()
+
+    @asynccontextmanager
+    async def _fake_get_conn(p, uid=None):
+        yield mock_conn
+
+    return mock_pool, _fake_get_conn
 
 
 @pytest.fixture
-def webhook_app_no_db():
-    """App with TELEGRAM_WEBHOOK_SECRET set but no real DB pool (for auth rejection tests)."""
-    os.environ["TELEGRAM_WEBHOOK_SECRET"] = VALID_SECRET
+def webhook_app_valid_secret():
+    """App whose DB lookup resolves VALID_SECRET to TEST_USER_ID."""
+    mock_pool, fake_get_conn = _make_db_fixtures(TEST_USER_ID)
     from api.main import create_app
-
     app = create_app()
-    # Minimal state — no pool needed for 403 rejection (happens before DB access)
-    app.state.pool = None
+    app.state.pool = mock_pool
     app.state.vault = None
-    yield app
-    os.environ.pop("TELEGRAM_WEBHOOK_SECRET", None)
+    with patch("db.postgres.get_conn", new=fake_get_conn):
+        yield app
 
 
 @pytest.fixture
-def webhook_app(pool):
-    """App with TELEGRAM_WEBHOOK_SECRET set and real pool for processing tests."""
-    os.environ["TELEGRAM_WEBHOOK_SECRET"] = VALID_SECRET
+def webhook_app_unknown_secret():
+    """App whose DB lookup returns None for any secret."""
+    mock_pool, fake_get_conn = _make_db_fixtures(None)
     from api.main import create_app
-
     app = create_app()
-    app.state.pool = pool
+    app.state.pool = mock_pool
     app.state.vault = None
-    yield app
-    os.environ.pop("TELEGRAM_WEBHOOK_SECRET", None)
+    with patch("db.postgres.get_conn", new=fake_get_conn):
+        yield app
 
 
 @pytest.mark.asyncio
-async def test_webhook_invalid_secret_returns_403(webhook_app_no_db):
-    """Wrong secret header → 403 immediately, no processing."""
-    from httpx import AsyncClient, ASGITransport
-
-    async with AsyncClient(
-        transport=ASGITransport(app=webhook_app_no_db),
-        base_url="http://test",
-    ) as client:
-        resp = await client.post(
-            "/api/bot/telegram-webhook",
-            json=SAMPLE_UPDATE,
-            headers={"X-Telegram-Bot-Api-Secret-Token": WRONG_SECRET},
-        )
-    assert resp.status_code == 403
-
-
-@pytest.mark.asyncio
-async def test_webhook_missing_secret_returns_403(webhook_app_no_db):
-    """Missing secret header → 403."""
-    from httpx import AsyncClient, ASGITransport
-
-    async with AsyncClient(
-        transport=ASGITransport(app=webhook_app_no_db),
-        base_url="http://test",
-    ) as client:
-        resp = await client.post(
-            "/api/bot/telegram-webhook",
-            json=SAMPLE_UPDATE,
-            # No header
-        )
-    assert resp.status_code == 403
-
-
-@pytest.mark.asyncio
-async def test_webhook_valid_secret_returns_200(webhook_app):
-    """Valid secret header → 200, message queued for background processing."""
+async def test_webhook_always_returns_200_for_valid_secret(webhook_app_valid_secret):
+    """Valid secret → 200."""
     from httpx import AsyncClient, ASGITransport
 
     with patch("api.routes.bot._process_telegram_update", new_callable=AsyncMock):
         async with AsyncClient(
-            transport=ASGITransport(app=webhook_app),
+            transport=ASGITransport(app=webhook_app_valid_secret),
             base_url="http://test",
         ) as client:
             resp = await client.post(
@@ -101,8 +87,49 @@ async def test_webhook_valid_secret_returns_200(webhook_app):
 
 
 @pytest.mark.asyncio
-async def test_webhook_non_message_update_returns_200(webhook_app):
-    """Non-message updates (e.g. edited_message) are accepted silently."""
+async def test_webhook_returns_200_for_unknown_secret(webhook_app_unknown_secret):
+    """Unknown secret → 200 (not 403), no BackgroundTask dispatched."""
+    from httpx import AsyncClient, ASGITransport
+
+    with patch(
+        "api.routes.bot._process_telegram_update", new_callable=AsyncMock
+    ) as mock_dispatch:
+        async with AsyncClient(
+            transport=ASGITransport(app=webhook_app_unknown_secret),
+            base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/api/bot/telegram-webhook",
+                json=SAMPLE_UPDATE,
+                headers={"X-Telegram-Bot-Api-Secret-Token": "wrong-secret"},
+            )
+    assert resp.status_code == 200
+    mock_dispatch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_webhook_returns_200_for_missing_header(webhook_app_unknown_secret):
+    """Missing header → 200, no dispatch."""
+    from httpx import AsyncClient, ASGITransport
+
+    with patch(
+        "api.routes.bot._process_telegram_update", new_callable=AsyncMock
+    ) as mock_dispatch:
+        async with AsyncClient(
+            transport=ASGITransport(app=webhook_app_unknown_secret),
+            base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/api/bot/telegram-webhook",
+                json=SAMPLE_UPDATE,
+            )
+    assert resp.status_code == 200
+    mock_dispatch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_webhook_non_message_update_returns_200(webhook_app_valid_secret):
+    """Non-message updates are accepted and return 200."""
     from httpx import AsyncClient, ASGITransport
 
     edited_update = {
@@ -114,10 +141,9 @@ async def test_webhook_non_message_update_returns_200(webhook_app):
             "text": "edited",
         },
     }
-
     with patch("api.routes.bot._process_telegram_update", new_callable=AsyncMock):
         async with AsyncClient(
-            transport=ASGITransport(app=webhook_app),
+            transport=ASGITransport(app=webhook_app_valid_secret),
             base_url="http://test",
         ) as client:
             resp = await client.post(


### PR DESCRIPTION
## Summary

Phase E of the notification overhaul + Telegram Migration Phase 3. Per-user Telegram webhook receive with header-based routing.

- **Header routing**: `X-Telegram-Bot-Api-Secret-Token` header → `SELECT user_id FROM telegram_connections WHERE webhook_secret = $1` (no-RLS lookup). Single endpoint `POST /api/bot/telegram-webhook` (no path suffix).
- **Always 200**: Unknown/missing secrets silently discarded — Telegram retries on non-200.
- **First-message capture**: When `telegram_chat_id IS NULL`, stores `chat.id` and replies "Connected to Tether." No `/link` command or 6-digit code required.
- **Per-user bot token**: `send_fn` uses `bot_token_encrypted` from DB. Falls back to global config.
- **Startup hook**: Iterates users with `bot_token_encrypted AND webhook_secret`, calls `register_webhook` for each (idempotent).
- **New DB helpers**: `get_users_with_webhook()`, `get_telegram_chat_id()` in `db/pg_auth_queries.py`.
- `supervisord.conf` and `bot/webhook_setup.py` already correct — no changes needed.

## Fly secrets needed

- `TELEGRAM_WEBHOOK_URL` — e.g. `https://tether-dev.fly.dev/api/bot/telegram-webhook`
- `TELEGRAM_WEBHOOK_SECRET` — kept for backwards compatibility (random UUID)

## Companion PR

tether-premium companion PR required — contains tests in `tether-premium/tests/bot/test_telegram_webhook.py`.

## Test plan

1. `TELEGRAM_WEBHOOK_URL` unset → polling mode unchanged, bot starts normally
2. `TELEGRAM_WEBHOOK_URL` set → bot sleeps, startup registers per-user webhooks
3. First message → "Connected to Tether." reply, `telegram_chat_id` stored
4. Subsequent messages → processed via `handle_message`
5. Unknown/missing secret → 200, no processing