### PR TITLE
fix: handle asyncpg datetime objects and pool lifecycle (post-Postgres migration)

### DIFF
--- a/bot/message_handler.py
+++ b/bot/message_handler.py
@@ -130,7 +130,7 @@ def _format_history(history: list[dict]) -> str:
     lines = []
     for row in history:
         label = "User" if row["role"] == "user" else "Bot"
-        ts = row["ts"][:16] if row["ts"] else ""
+        ts = (row["ts"].strftime("%Y-%m-%d %H:%M") if hasattr(row["ts"], "strftime") else row["ts"][:16]) if row["ts"] else ""
         body = row["body"]
         if len(body) > _HISTORY_BODY_MAX:
             body = body[:_HISTORY_BODY_MAX] + "…"
@@ -1474,7 +1474,7 @@ def main() -> None:
             )
             time.sleep(30)
     finally:
-        _startup_loop.run_until_complete(_pool.close())
+        _startup_loop.run_until_complete(pg.close_pool())
         _startup_loop.close()
 
     token, chat_id, poll_user_id = credentials

--- a/db/pg_queries/conversation.py
+++ b/db/pg_queries/conversation.py
@@ -242,5 +242,5 @@ async def get_last_bot_activity(conn: asyncpg.Connection) -> dict | None:
         "stage": row["stage"],
         "response": row["response"][:200] if row["response"] else None,
         "error": row["error"],
-        "ts": row["ts"],
+        "ts": row["ts"].isoformat() if row["ts"] else None,
     }


### PR DESCRIPTION
## Summary

Three bugs surfaced after the SQLite→Postgres migration where code expected string timestamps but asyncpg returns native `datetime` objects for `TIMESTAMPTZ` columns. Also fixes a pool lifecycle bug in the bot startup sequence.

- **Issue A** (`_format_history`, `bot/message_handler.py:133`): `row["ts"][:16]` crashed with `TypeError` on datetime objects. Fixed with `strftime("%Y-%m-%d %H:%M")` with fallback for string test fixtures.
- **Issue B** (bootstrap warning, `bot/message_handler.py` `main()`): `_pool.close()` closed the asyncpg pool but left `pg._pool` pointing to it (non-None). `run_polling()` then got a closed pool from `pg.create_pool()`. Fixed by calling `pg.close_pool()` which nulls the reference.
- **Issue C** (`bot_health`, `db/pg_queries/conversation.py`): `get_last_bot_activity()` returned raw `datetime` for `ts`; `fromisoformat()` in `bot.py` crashed. Fixed by serialising to ISO string at the query layer.

## Test plan

- [x] `pytest tests/ -v -q` — 429 passed, 0 failed, 613 skipped
- [ ] Deploy to tether-dev and verify web chat works (Issue A)
- [ ] Confirm no "pool is closed" WARNING in bot logs at startup (Issue B)
- [ ] Confirm `GET /api/bot/health` returns 200 with valid timestamp (Issue C)