### PR TITLE
chore: bump tether-premium pin to 0.0.2a8

### DIFF
--- a/requirements-premium-dev.txt
+++ b/requirements-premium-dev.txt
@@ -1,2 +1,2 @@
 --extra-index-url https://jlunder00.github.io/tether-pypi/
-tether-premium==0.0.2a7
+tether-premium==0.0.2a8


### PR DESCRIPTION
Automated pin bump triggered by tether-premium release 0.0.2a8.