### PR TITLE
fix: scope get_delegated_user_ids via RLS-aware get_conn

### DIFF
--- a/db/pg_queries/api_keys.py
+++ b/db/pg_queries/api_keys.py
@@ -13,6 +13,8 @@ import uuid as _uuid
 
 import asyncpg
 
+import db.postgres as pg
+
 
 def _hash(raw_key: str) -> str:
     return hashlib.sha256(raw_key.encode()).hexdigest()
@@ -115,7 +117,7 @@ async def get_delegated_user_ids(pool, bot_service_id: str) -> set[str]:
     Currently delegation keys are bot-global — the parameter is accepted so
     call sites remain forward-compatible when PR 4 adds per-bot scoping.
     """
-    async with pool.acquire() as conn:
+    async with pg.get_conn(pool, user_id=bot_service_id) as conn:
         rows = await conn.fetch(
             """
             SELECT DISTINCT user_id

--- a/tests/db/test_pg_api_keys.py
+++ b/tests/db/test_pg_api_keys.py
@@ -1,5 +1,6 @@
 """Tests for api_keys DB queries — create, list, revoke, validate."""
 from __future__ import annotations
+import os
 import pytest
 
 from tests.db.pg_conftest import auth_conn  # noqa: F401
@@ -8,7 +9,26 @@ from db.pg_queries.api_keys import (
     list_keys,
     revoke_key,
     validate_key,
+    get_delegated_user_ids,
 )
+from db.postgres import create_pool, close_pool
+
+BOT_USER_ID = "00000000-0000-0000-0000-000000000b07"
+
+
+@pytest.fixture
+def db_url():
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        pytest.skip("DATABASE_URL not set — Postgres tests skipped")
+    return url
+
+
+@pytest.fixture
+async def pool(db_url):
+    p = await create_pool()
+    yield p
+    await close_pool()
 
 TEST_USER_ID = "00000000-0000-0000-0000-000000000001"
 pytestmark = pytest.mark.asyncio
@@ -94,3 +114,18 @@ async def test_validate_revoked_key_does_not_update_last_used(auth_conn):
         "SELECT last_used_at FROM api_keys WHERE id = $1::uuid", record["id"]
     )
     assert rows[0]["last_used_at"] is None
+
+
+async def test_get_delegated_user_ids_bot_service_does_not_crash(pool):
+    """Regression: get_delegated_user_ids must not raise when called with the
+    bot service UUID.
+
+    Before the fix the function acquired a raw pool connection without setting
+    app.current_user_id. The RLS policy then evaluated
+    current_setting('app.current_user_id', true)::uuid which is '':uuid, raising
+    asyncpg.exceptions.InvalidTextRepresentationError and crashing the WS handler.
+    """
+    result = await get_delegated_user_ids(pool, BOT_USER_ID)
+    assert isinstance(result, set)
+    # No bot delegation keys exist in test DB — expect empty set.
+    assert result == set()


### PR DESCRIPTION
## Problem

`get_delegated_user_ids` in `db/pg_queries/api_keys.py` acquired a raw pool connection without setting `app.current_user_id`. The `api_keys` table has an RLS policy:

```sql
USING (user_id = current_setting('app.current_user_id', true)::uuid)
```

With no session variable set, `current_setting(..., true)` returns `''`, and `''::uuid` raises `asyncpg.exceptions.InvalidTextRepresentationError`. This crashed the WebSocket handler every time the premium bot service connected, triggering a tight reconnect loop that flooded Fly logs.

The JWT user_id is not empty — the crash comes from the unset RLS session variable, not the JWT.

## Fix

Swap `pool.acquire()` for `pg.get_conn(pool, user_id=bot_service_id)`. This runs the query inside a transaction with `SET LOCAL app.current_user_id = <bot_uuid>`, satisfying the RLS policy. The bot UUID has no delegation keys, so the query correctly returns an empty set — the intended pre-PR-4 behavior.

## Changes

- `db/pg_queries/api_keys.py` — import `db.postgres as pg`; use `pg.get_conn` in `get_delegated_user_ids`
- `tests/db/test_pg_api_keys.py` — regression test: call with bot UUID, assert empty set, no raise (skips without `DATABASE_URL`)

## Test

```
pytest tests/db/test_pg_api_keys.py::test_get_delegated_user_ids_bot_service_does_not_crash -v
```

Requires `DATABASE_URL` pointing at a Postgres instance with the schema applied.