### PR TITLE
Wire pipeline config keys and fix classifier timeout

### DIFF
--- a/bot/message_handler.py
+++ b/bot/message_handler.py
@@ -69,12 +69,13 @@ PROMPTS_DIR = Path(__file__).parent.parent / "prompts"
 
 _jinja = Environment(loader=FileSystemLoader(str(PROMPTS_DIR)), trim_blocks=True)
 
-HISTORY_EXCHANGES = 5
+HISTORY_EXCHANGES = int(tether_config.get("pipeline.history_exchanges", 5))
 
 # v2 pipeline constants
-MAX_PLANNING_ROUNDS = 4
-MAX_REPAIR_ATTEMPTS = 3
-MAX_SATISFACTION_RETRIES = 2
+MAX_PLANNING_ROUNDS = int(tether_config.get("pipeline.max_planning_rounds", 4))
+MAX_REPAIR_ATTEMPTS = int(tether_config.get("pipeline.max_repair_attempts", 3))
+MAX_SATISFACTION_RETRIES = int(tether_config.get("pipeline.max_satisfaction_retries", 2))
+_CLASSIFIER_TIMEOUT = 45
 
 # Module-level log context — set once per _run_v2_planning_loop call.
 # Safe because the bot is single-threaded.
@@ -793,7 +794,8 @@ async def _classify_message(text: str, current_anchor: dict, today: str) -> str:
         date=today,
     )
     try:
-        raw = await call_claude(prompt, timeout=15, model_role="quick_classifier",
+        _timeout = int(tether_config.get("pipeline.classifier_timeout_seconds", _CLASSIFIER_TIMEOUT))
+        raw = await call_claude(prompt, timeout=_timeout, model_role="quick_classifier",
                           stage="quick_classifier")
         data = _parse_json(raw)
         route = data.get("route", "full")

--- a/config/app_config.yaml
+++ b/config/app_config.yaml
@@ -13,6 +13,7 @@ pipeline:
   max_planning_rounds: 4
   max_repair_attempts: 3
   max_satisfaction_retries: 2
+  classifier_timeout_seconds: 45
 
 server:
   api_port: 8000

--- a/tests/bot/test_message_handler.py
+++ b/tests/bot/test_message_handler.py
@@ -336,3 +336,51 @@ def test_stale_beacon_block_removed():
     assert "Beacon anchor transition check failed" not in src, (
         "Stale SQLite-era Beacon block still present in message_handler.py — remove it."
     )
+
+
+# ---------------------------------------------------------------------------
+# Pipeline config — wired constants and classifier timeout
+# ---------------------------------------------------------------------------
+
+def test_pipeline_constants_read_from_config():
+    """HISTORY_EXCHANGES, MAX_PLANNING_ROUNDS, MAX_REPAIR_ATTEMPTS, MAX_SATISFACTION_RETRIES
+    must be assigned via tether_config.get(), not hardcoded integers."""
+    import inspect
+    from bot import message_handler
+    src = inspect.getsource(message_handler)
+
+    for key in (
+        "pipeline.history_exchanges",
+        "pipeline.max_planning_rounds",
+        "pipeline.max_repair_attempts",
+        "pipeline.max_satisfaction_retries",
+    ):
+        assert key in src, (
+            f"Expected tether_config.get('{key}', ...) in message_handler.py — "
+            "pipeline constants must be wired to config."
+        )
+
+
+@pytest.mark.asyncio
+async def test_classify_message_uses_config_timeout():
+    """_classify_message must pass a timeout derived from tether_config, not hardcoded 15."""
+    from claude_agent_sdk import AssistantMessage, TextBlock
+
+    captured_timeouts: list[int] = []
+
+    async def _fake_call_claude(prompt, timeout=180, model_role=None, stage=""):
+        captured_timeouts.append(timeout)
+        return '{"route": "quick"}'
+
+    with patch("bot.message_handler.call_claude", side_effect=_fake_call_claude), \
+         patch("bot.message_handler.tether_config") as mc:
+        mc.get.side_effect = lambda key, default=None: (
+            60 if key == "pipeline.classifier_timeout_seconds" else default
+        )
+        from bot.message_handler import _classify_message
+        await _classify_message("hello", {}, "2026-01-01")
+
+    assert len(captured_timeouts) == 1
+    assert captured_timeouts[0] == 60, (
+        f"Expected classifier timeout=60 from config, got {captured_timeouts[0]}"
+    )


### PR DESCRIPTION
## Summary

- Four module-level pipeline constants (`HISTORY_EXCHANGES`, `MAX_PLANNING_ROUNDS`, `MAX_REPAIR_ATTEMPTS`, `MAX_SATISFACTION_RETRIES`) were hardcoded despite `config/app_config.yaml` already defining them under `pipeline:`. Wired each to `tether_config.get()` with prior values as fallbacks.
- `_classify_message()` used `timeout=15`, well below the 45s used elsewhere in the pipeline. Added `_CLASSIFIER_TIMEOUT = 45` fallback and reads `pipeline.classifier_timeout_seconds` from config.
- Added `classifier_timeout_seconds: 45` to `config/app_config.yaml`.

## Files changed

- `bot/message_handler.py` — wire 4 constants + classifier timeout to config
- `config/app_config.yaml` — add `classifier_timeout_seconds: 45` to pipeline block
- `tests/bot/test_message_handler.py` — two new tests (source-inspection guard for config keys; mock-based assert for classifier timeout forwarding)

## Test plan

- [ ] `TETHER_JWT_SECRET=test-secret pytest tests/bot/test_message_handler.py` — 22 pass
- [ ] Classifier route no longer times out on slow responses (was 15s, now 45s)