### PR TITLE
feat: agent picker UI — M1 frontend + WS agent_version plumbing

### DIFF
--- a/api/routes/bot.py
+++ b/api/routes/bot.py
@@ -232,6 +232,11 @@ async def bot_chat(websocket: WebSocket,
                 await websocket.send_json({"type": "error", "message": "Missing content"})
                 continue
 
+            # M1: read agent_version for future dispatch wiring (M2-M4).
+            # Does not affect routing yet — existing pipeline runs regardless.
+            agent_version = data.get("agent_version", "tether-agent-2.0")
+            logger.info("bot_chat: agent_version=%s user_id=%s", agent_version, user_id)
+
             # Async status callback: called by the premium session's
             # send_status_update tool to push real-time progress frames.
             # If the WebSocket has gone away, log and re-raise so the session

--- a/frontend/src/components/AgentPicker.vue
+++ b/frontend/src/components/AgentPicker.vue
@@ -3,7 +3,7 @@ import { ref, onMounted, onBeforeUnmount } from 'vue'
 import { useAgentPickerStore } from '../stores/agentPicker'
 import type { AgentVersion } from '../stores/agentPicker'
 
-const props = withDefaults(defineProps<{
+withDefaults(defineProps<{
   trialMessagesLeft?: number
 }>(), {
   trialMessagesLeft: 10,
@@ -11,6 +11,7 @@ const props = withDefaults(defineProps<{
 
 const store = useAgentPickerStore()
 const open = ref(false)
+const rootEl = ref<HTMLDivElement | null>(null)
 
 const AGENTS: Array<{ id: AgentVersion; label: string; sublabel: string }> = [
   { id: 'tether-agent-1.0', label: 'tether-agent-1.0', sublabel: 'Classic · free' },
@@ -27,10 +28,14 @@ async function select(version: AgentVersion) {
   await store.setAgent(version)
 }
 
-// Close dropdown when clicking outside
+async function stayOn20() {
+  store.dismissByokModal()
+  await store.setAgent('tether-agent-2.0')
+}
+
+// Close dropdown when clicking outside the component's root.
 function onDocumentClick(e: MouseEvent) {
-  const el = document.getElementById('agent-picker-root')
-  if (el && !el.contains(e.target as Node)) {
+  if (rootEl.value && !rootEl.value.contains(e.target as Node)) {
     open.value = false
   }
 }
@@ -40,7 +45,7 @@ onBeforeUnmount(() => document.removeEventListener('mousedown', onDocumentClick)
 </script>
 
 <template>
-  <div id="agent-picker-root" class="relative">
+  <div ref="rootEl" class="relative">
     <!-- Trigger button -->
     <button
       type="button"
@@ -86,7 +91,7 @@ onBeforeUnmount(() => document.removeEventListener('mousedown', onDocumentClick)
               v-if="agent.id === 'tether-agent-2.5'"
               class="ml-1 inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-[--accent-veil] text-[--accent]"
             >
-              trial: {{ props.trialMessagesLeft }} left
+              trial: {{ trialMessagesLeft }} left
             </span>
           </span>
         </span>
@@ -118,7 +123,7 @@ onBeforeUnmount(() => document.removeEventListener('mousedown', onDocumentClick)
             <button
               type="button"
               class="text-xs px-3 py-1.5 rounded-lg bg-[--bg-elev-3] text-[--fg-2] hover:bg-[--bg-elev-4] transition-colors"
-              @click="store.dismissByokModal(); store.setAgent('tether-agent-2.0')"
+              @click="stayOn20"
             >
               Stay on 2.0
             </button>

--- a/frontend/src/components/AgentPicker.vue
+++ b/frontend/src/components/AgentPicker.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { useAgentPickerStore } from '../stores/agentPicker'
+import type { AgentVersion } from '../stores/agentPicker'
+
+const props = withDefaults(defineProps<{
+  trialMessagesLeft?: number
+}>(), {
+  trialMessagesLeft: 10,
+})
+
+const store = useAgentPickerStore()
+const open = ref(false)
+
+const AGENTS: Array<{ id: AgentVersion; label: string; sublabel: string }> = [
+  { id: 'tether-agent-1.0', label: 'tether-agent-1.0', sublabel: 'Classic · free' },
+  { id: 'tether-agent-2.0', label: 'tether-agent-2.0', sublabel: 'Modern · free' },
+  { id: 'tether-agent-2.5', label: 'tether-agent-2.5', sublabel: 'Premium' },
+]
+
+function toggleOpen() {
+  open.value = !open.value
+}
+
+async function select(version: AgentVersion) {
+  open.value = false
+  await store.setAgent(version)
+}
+
+// Close dropdown when clicking outside
+function onDocumentClick(e: MouseEvent) {
+  const el = document.getElementById('agent-picker-root')
+  if (el && !el.contains(e.target as Node)) {
+    open.value = false
+  }
+}
+
+onMounted(() => document.addEventListener('mousedown', onDocumentClick))
+onBeforeUnmount(() => document.removeEventListener('mousedown', onDocumentClick))
+</script>
+
+<template>
+  <div id="agent-picker-root" class="relative">
+    <!-- Trigger button -->
+    <button
+      type="button"
+      class="flex items-center gap-1 text-xs px-2 py-1 rounded-md bg-[--bg-elev-2] text-[--fg-3] hover:bg-[--bg-elev-3] hover:text-[--fg-1] transition-colors border border-[--border-1]"
+      @click="toggleOpen"
+    >
+      <span>{{ store.selectedAgent }}</span>
+      <svg class="w-3 h-3 opacity-60" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+      </svg>
+    </button>
+
+    <!-- Dropdown -->
+    <div
+      v-if="open"
+      class="absolute top-full left-0 mt-1 z-50 min-w-[220px] rounded-lg border border-[--border-1] bg-[--bg-elev-2] shadow-lg py-1"
+    >
+      <button
+        v-for="agent in AGENTS"
+        :key="agent.id"
+        type="button"
+        :data-agent="agent.id"
+        class="w-full flex items-center justify-between px-3 py-2 text-xs text-left hover:bg-[--bg-elev-3] transition-colors"
+        :class="store.selectedAgent === agent.id ? 'text-[--fg-1]' : 'text-[--fg-3]'"
+        @click="select(agent.id)"
+      >
+        <span class="flex items-center gap-2">
+          <!-- Active checkmark -->
+          <svg
+            v-if="store.selectedAgent === agent.id"
+            class="w-3 h-3 text-[--accent] flex-shrink-0"
+            fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+          <span v-else class="w-3 h-3 flex-shrink-0" />
+
+          <span>
+            <span class="font-medium">{{ agent.label }}</span>
+            <span class="ml-1 text-[--fg-4]">· {{ agent.sublabel }}</span>
+            <!-- Trial badge for 2.5 -->
+            <span
+              v-if="agent.id === 'tether-agent-2.5'"
+              class="ml-1 inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-[--accent-veil] text-[--accent]"
+            >
+              trial: {{ props.trialMessagesLeft }} left
+            </span>
+          </span>
+        </span>
+
+        <!-- Tooltip for 2.5 -->
+        <span
+          v-if="agent.id === 'tether-agent-2.5'"
+          class="ml-2 text-[--fg-5] cursor-help text-[10px]"
+          :title="'tether-agent-2.5 uses more advanced models (Sonnet) for the main reasoning steps. On bring-your-own-key plans, this consumes your monthly quota faster than 2.0 (~3-5× tokens per message vs 2.0).'"
+        >
+          ⓘ
+        </span>
+      </button>
+    </div>
+
+    <!-- BYOK first-use modal -->
+    <Teleport to="body">
+      <div
+        v-if="store.showByokModal"
+        class="fixed inset-0 z-[100] flex items-center justify-center bg-black/40"
+      >
+        <div class="bg-[--bg-elev-2] border border-[--border-1] rounded-xl shadow-2xl p-6 max-w-sm w-full mx-4">
+          <h3 class="text-sm font-semibold text-[--fg-1] mb-2">Switch to tether-agent-2.5?</h3>
+          <p class="text-xs text-[--fg-3] mb-5 leading-relaxed">
+            tether-agent-2.5 is the premium model. On bring-your-own-key plans, it uses
+            ~3–5× more of your Anthropic quota per message compared to 2.0.
+          </p>
+          <div class="flex gap-2 justify-end">
+            <button
+              type="button"
+              class="text-xs px-3 py-1.5 rounded-lg bg-[--bg-elev-3] text-[--fg-2] hover:bg-[--bg-elev-4] transition-colors"
+              @click="store.dismissByokModal(); store.setAgent('tether-agent-2.0')"
+            >
+              Stay on 2.0
+            </button>
+            <button
+              type="button"
+              class="text-xs px-3 py-1.5 rounded-lg bg-[--accent] text-white hover:opacity-90 transition-opacity"
+              @click="store.dismissByokModal()"
+            >
+              Continue
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>

--- a/frontend/src/components/BotChat.vue
+++ b/frontend/src/components/BotChat.vue
@@ -1,14 +1,21 @@
 <script setup lang="ts">
-import { ref, watch, nextTick } from 'vue'
+import { ref, watch, nextTick, onMounted } from 'vue'
 import { useChatStore } from '../stores/chat'
+import { useAgentPickerStore } from '../stores/agentPicker'
 import MessageBubble from './MessageBubble.vue'
+import AgentPicker from './AgentPicker.vue'
 
 const emit = defineEmits<{ close: [] }>()
 
 const chatStore = useChatStore()
+const agentPickerStore = useAgentPickerStore()
 const draft = ref('')
 const scrollEl = ref<HTMLDivElement | null>(null)
 const isAtBottom = ref(true)
+
+onMounted(() => {
+  agentPickerStore.fetchPreference()
+})
 
 async function onSubmit() {
   const text = draft.value.trim()
@@ -47,6 +54,7 @@ function onKeydown(e: KeyboardEvent) {
         title="Bot status"
       />
       <span class="font-semibold text-sm text-[--fg-1]">Tether</span>
+      <AgentPicker class="ml-2" />
       <button
         class="ml-auto text-[--fg-4] hover:text-[--fg-1] transition-colors p-1"
         aria-label="Close chat"

--- a/frontend/src/components/__tests__/AgentPicker.test.ts
+++ b/frontend/src/components/__tests__/AgentPicker.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ path: '/dashboard' }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) })),
+}))
+
+describe('AgentPicker', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.restoreAllMocks()
+  })
+
+  it('mounts without error', async () => {
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker)
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('renders a trigger button showing current agent', async () => {
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker)
+    // Should display the model label somewhere
+    expect(wrapper.text()).toContain('tether-agent-2.0')
+  })
+
+  it('opens dropdown on trigger click and shows all three options', async () => {
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker)
+
+    // Click trigger to open
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    const text = wrapper.text()
+    expect(text).toContain('tether-agent-1.0')
+    expect(text).toContain('tether-agent-2.0')
+    expect(text).toContain('tether-agent-2.5')
+  })
+
+  it('shows Classic label for 1.0', async () => {
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker)
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('Classic')
+  })
+
+  it('shows Modern label for 2.0', async () => {
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker)
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('Modern')
+  })
+
+  it('shows Premium label for 2.5', async () => {
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker)
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('Premium')
+  })
+
+  it('shows trial badge on 2.5 option', async () => {
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker, {
+      props: { trialMessagesLeft: 7 },
+    })
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('7')
+  })
+
+  it('selecting 1.0 calls store.setAgent and closes dropdown', async () => {
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const store = useAgentPickerStore()
+    const spy = vi.spyOn(store, 'setAgent').mockResolvedValue()
+
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker)
+
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    // Click the 1.0 option (first option button in dropdown)
+    const options = wrapper.findAll('[data-agent]')
+    const option10 = options.find(o => o.attributes('data-agent') === 'tether-agent-1.0')
+    expect(option10).toBeDefined()
+    await option10!.trigger('click')
+
+    expect(spy).toHaveBeenCalledWith('tether-agent-1.0')
+  })
+
+  it('selecting 2.5 calls store.setAgent', async () => {
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const store = useAgentPickerStore()
+    const spy = vi.spyOn(store, 'setAgent').mockResolvedValue()
+
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker)
+
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    const options = wrapper.findAll('[data-agent]')
+    const option25 = options.find(o => o.attributes('data-agent') === 'tether-agent-2.5')
+    expect(option25).toBeDefined()
+    await option25!.trigger('click')
+
+    expect(spy).toHaveBeenCalledWith('tether-agent-2.5')
+  })
+
+  it('shows BYOK modal when store.showByokModal is true', async () => {
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const store = useAgentPickerStore()
+    store.showByokModal = true
+
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    // attachTo body so Teleport can render correctly
+    mount(AgentPicker, { attachTo: document.body })
+    await new Promise(r => setTimeout(r, 0))
+
+    // Teleport renders to document.body — check there
+    expect(document.body.textContent).toContain('Continue')
+    expect(document.body.textContent).toContain('Stay on 2.0')
+  })
+
+  it('store.dismissByokModal() sets showByokModal to false', async () => {
+    // Teleported modal content is hard to interact with in jsdom;
+    // test the store action directly — the component just calls it.
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const store = useAgentPickerStore()
+    store.showByokModal = true
+
+    store.dismissByokModal()
+
+    expect(store.showByokModal).toBe(false)
+  })
+})

--- a/frontend/src/composables/__tests__/useBotTransport.test.ts
+++ b/frontend/src/composables/__tests__/useBotTransport.test.ts
@@ -7,7 +7,7 @@ describe('createMockTransport', () => {
     const transport = createMockTransport()
     const text = 'hello'
     const chunks: string[] = []
-    for await (const chunk of transport.send(text)) {
+    for await (const chunk of transport.send(text, 'tether-agent-2.0')) {
       chunks.push(chunk)
     }
     const full = chunks.join('')
@@ -19,7 +19,7 @@ describe('createMockTransport', () => {
   it('send yields exactly one chunk (no streaming simulation)', async () => {
     const transport = createMockTransport()
     const chunks: string[] = []
-    for await (const chunk of transport.send('test')) {
+    for await (const chunk of transport.send('test', 'tether-agent-2.0')) {
       chunks.push(chunk)
     }
     expect(chunks).toHaveLength(1)

--- a/frontend/src/composables/useBotTransport.ts
+++ b/frontend/src/composables/useBotTransport.ts
@@ -1,6 +1,6 @@
 export interface BotTransport {
-  /** Send user text; yields content chunks as they arrive. */
-  send(text: string): AsyncIterable<string>
+  /** Send user text with the selected agent version; yields content chunks as they arrive. */
+  send(text: string, agentVersion: string): AsyncIterable<string>
   /** Subscribe to heartbeat changes. Returns an unsubscribe fn. */
   onHeartbeat(cb: (alive: boolean) => void): () => void
   /** Close any underlying connection. */
@@ -8,7 +8,7 @@ export interface BotTransport {
 }
 
 export function createMockTransport(): BotTransport {
-  async function* send(text: string): AsyncIterable<string> {
+  async function* send(text: string, _agentVersion: string): AsyncIterable<string> {
     yield `Echo: ${text}\n\nThis is a **mocked** response.`
   }
 
@@ -96,7 +96,7 @@ export function createWebSocketTransport(): BotTransport {
   }
 
   return {
-    async *send(text: string) {
+    async *send(text: string, agentVersion: string) {
       // C1: don't send until the socket has opened.
       await openPromise
 
@@ -104,7 +104,7 @@ export function createWebSocketTransport(): BotTransport {
       // sends don't steal each other's chunks via the shared `incoming` queue.
       const localQueue: MessageEvent[] = incoming.splice(0)
 
-      ws.send(JSON.stringify({ type: 'user', content: text }))
+      ws.send(JSON.stringify({ type: 'user', content: text, agent_version: agentVersion }))
 
       // C2: each recv registers both resolve and reject, so onerror/onclose
       // can break us out of this loop.

--- a/frontend/src/stores/__tests__/agentPicker.test.ts
+++ b/frontend/src/stores/__tests__/agentPicker.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: false, json: async () => ({}) })),
+}))
+
+describe('useAgentPickerStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.restoreAllMocks()
+  })
+
+  it('defaults selectedAgent to tether-agent-2.0', async () => {
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    expect(store.selectedAgent).toBe('tether-agent-2.0')
+  })
+
+  it('fetchPreference loads value from API and updates selectedAgent', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ preferred_agent_version: 'tether-agent-1.0' }),
+    } as any)
+
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    await store.fetchPreference()
+
+    expect(store.selectedAgent).toBe('tether-agent-1.0')
+  })
+
+  it('fetchPreference keeps 2.0 default when API returns missing key', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    } as any)
+
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    await store.fetchPreference()
+
+    expect(store.selectedAgent).toBe('tether-agent-2.0')
+  })
+
+  it('fetchPreference keeps 2.0 default on API failure', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    } as any)
+
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    await store.fetchPreference()
+
+    expect(store.selectedAgent).toBe('tether-agent-2.0')
+  })
+
+  it('setAgent updates selectedAgent and calls PUT /api/settings/preferred_agent_version', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    } as any)
+
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    await store.setAgent('tether-agent-2.5')
+
+    expect(store.selectedAgent).toBe('tether-agent-2.5')
+    expect(vi.mocked(api)).toHaveBeenCalledWith(
+      '/api/settings/preferred_agent_version',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ value: 'tether-agent-2.5' }),
+      }),
+    )
+  })
+
+  it('setAgent keeps previous value on API failure', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    } as any)
+
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    // pre-seed a non-default value
+    store.selectedAgent = 'tether-agent-1.0'
+    await store.setAgent('tether-agent-2.5')
+
+    // should roll back
+    expect(store.selectedAgent).toBe('tether-agent-1.0')
+  })
+
+  it('showByokModal is false initially', async () => {
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    expect(store.showByokModal).toBe(false)
+  })
+
+  it('setAgent triggers showByokModal for 2.5 selection', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    } as any)
+
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    await store.setAgent('tether-agent-2.5')
+
+    expect(store.showByokModal).toBe(true)
+  })
+
+  it('dismissByokModal sets showByokModal false', async () => {
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    store.showByokModal = true
+    store.dismissByokModal()
+    expect(store.showByokModal).toBe(false)
+  })
+})

--- a/frontend/src/stores/__tests__/chatAgentVersion.test.ts
+++ b/frontend/src/stores/__tests__/chatAgentVersion.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests that chat.send() passes agent_version from the agentPicker store
+ * through to the transport.send() call.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { setBotTransport } from '../../composables/useBotTransport'
+import type { BotTransport } from '../../composables/useBotTransport'
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) })),
+}))
+
+describe('chat store — agent_version forwarding', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.restoreAllMocks()
+  })
+
+  it('passes agent_version from agentPicker store to transport.send', async () => {
+    const capturedCalls: Array<[string, string]> = []
+    const transport: BotTransport = {
+      async *send(text: string, agentVersion: string) {
+        capturedCalls.push([text, agentVersion])
+        yield 'ok'
+      },
+      onHeartbeat(cb) { cb(true); return () => {} },
+      close: vi.fn(),
+    }
+    setBotTransport(transport)
+
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const pickerStore = useAgentPickerStore()
+    pickerStore.selectedAgent = 'tether-agent-1.0'
+
+    const { useChatStore } = await import('../chat')
+    const chatStore = useChatStore()
+    await chatStore.send('hello')
+
+    expect(capturedCalls).toHaveLength(1)
+    expect(capturedCalls[0][1]).toBe('tether-agent-1.0')
+  })
+
+  it('defaults to tether-agent-2.0 when picker store has default', async () => {
+    const capturedCalls: Array<[string, string]> = []
+    const transport: BotTransport = {
+      async *send(text: string, agentVersion: string) {
+        capturedCalls.push([text, agentVersion])
+        yield 'ok'
+      },
+      onHeartbeat(cb) { cb(true); return () => {} },
+      close: vi.fn(),
+    }
+    setBotTransport(transport)
+
+    const { useChatStore } = await import('../chat')
+    const chatStore = useChatStore()
+    await chatStore.send('hello')
+
+    expect(capturedCalls[0][1]).toBe('tether-agent-2.0')
+  })
+})

--- a/frontend/src/stores/agentPicker.ts
+++ b/frontend/src/stores/agentPicker.ts
@@ -1,0 +1,59 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { api } from '../lib/api'
+
+export type AgentVersion = 'tether-agent-1.0' | 'tether-agent-2.0' | 'tether-agent-2.5'
+
+const DEFAULT_AGENT: AgentVersion = 'tether-agent-2.0'
+const SETTING_KEY = 'preferred_agent_version'
+
+function isValidAgent(v: unknown): v is AgentVersion {
+  return v === 'tether-agent-1.0' || v === 'tether-agent-2.0' || v === 'tether-agent-2.5'
+}
+
+export const useAgentPickerStore = defineStore('agentPicker', () => {
+  const selectedAgent = ref<AgentVersion>(DEFAULT_AGENT)
+  const showByokModal = ref(false)
+
+  async function fetchPreference(): Promise<void> {
+    try {
+      const resp = await api('/api/settings')
+      if (!resp.ok) return
+      const data = await resp.json()
+      const val = data[SETTING_KEY]
+      if (isValidAgent(val)) {
+        selectedAgent.value = val
+      }
+    } catch {
+      // Network failure — keep default
+    }
+  }
+
+  async function setAgent(version: AgentVersion): Promise<void> {
+    const previous = selectedAgent.value
+    selectedAgent.value = version
+
+    if (version === 'tether-agent-2.5') {
+      showByokModal.value = true
+    }
+
+    try {
+      const resp = await api(`/api/settings/${SETTING_KEY}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value: version }),
+      })
+      if (!resp.ok) {
+        selectedAgent.value = previous
+      }
+    } catch {
+      selectedAgent.value = previous
+    }
+  }
+
+  function dismissByokModal(): void {
+    showByokModal.value = false
+  }
+
+  return { selectedAgent, showByokModal, fetchPreference, setAgent, dismissByokModal }
+})

--- a/frontend/src/stores/agentPicker.ts
+++ b/frontend/src/stores/agentPicker.ts
@@ -2,13 +2,14 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { api } from '../lib/api'
 
-export type AgentVersion = 'tether-agent-1.0' | 'tether-agent-2.0' | 'tether-agent-2.5'
+const AGENT_VERSIONS = ['tether-agent-1.0', 'tether-agent-2.0', 'tether-agent-2.5'] as const
+export type AgentVersion = (typeof AGENT_VERSIONS)[number]
 
 const DEFAULT_AGENT: AgentVersion = 'tether-agent-2.0'
 const SETTING_KEY = 'preferred_agent_version'
 
 function isValidAgent(v: unknown): v is AgentVersion {
-  return v === 'tether-agent-1.0' || v === 'tether-agent-2.0' || v === 'tether-agent-2.5'
+  return typeof v === 'string' && (AGENT_VERSIONS as readonly string[]).includes(v)
 }
 
 export const useAgentPickerStore = defineStore('agentPicker', () => {

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import type { ChatMessage } from '../types/chat'
 import { getBotTransport } from '../composables/useBotTransport'
+import { useAgentPickerStore } from './agentPicker'
 
 function makeId(): string {
   if (location.protocol === 'https:') return crypto.randomUUID()
@@ -30,7 +31,8 @@ export const useChatStore = defineStore('chat', () => {
     try {
       // Always call getBotTransport() at send time — not a cached reference —
       // so we use whichever transport is current (mock → real WS after auth).
-      for await (const chunk of getBotTransport().send(text)) {
+      const agentVersion = useAgentPickerStore().selectedAgent
+      for await (const chunk of getBotTransport().send(text, agentVersion)) {
         messages.value[botMsgIndex].content += chunk
       }
     } finally {


### PR DESCRIPTION
## Summary

- **AgentPicker.vue** — dropdown at top of chat with 3 options (1.0 Classic, 2.0 Modern, 2.5 Premium), trial badge (hardcoded N=10 for M1), 2.5 tooltip, BYOK placeholder modal (Continue / Stay on 2.0)
- **useAgentPickerStore** — loads/persists `preferred_agent_version` via existing `PUT /api/settings/preferred_agent_version` KV endpoint; defaults to `tether-agent-2.0`
- **BotTransport.send(text, agentVersion)** — extended interface; WebSocket payload now includes `agent_version` field; mock transport accepts and ignores it
- **chat store** — reads `selectedAgent` from picker store at send time, forwards to transport
- **BotChat.vue** — AgentPicker integrated in header row; `fetchPreference()` on mount
- **api/routes/bot.py** — reads and logs `agent_version` from WS messages; no routing change (M1 scope)

## Spec deviation (intentional)

Spec said "Add `preferred_agent_version` column to user_settings table (Alembic migration)." `user_settings` is a `(user_id, key, value)` KV table — there is no column to add. Using the existing KV endpoint and key `preferred_agent_version` is correct. No migration needed. Confirmed with team lead.

## Out of scope (later PRs)

- Actual dispatch routing on `agent_version` — M2/M3/M4
- Trial counter live updates — B5
- BYOK leakage gate — M6
- Real Sonnet vs Haiku model wiring — later phases

## Test plan

- [ ] 644 Vitest tests passing (63 files) — `npm run test`
- [ ] Zero TypeScript errors — `npm run build`
- [ ] agentPicker store: default 2.0, fetchPreference loads from API, setAgent persists, rollback on failure, showByokModal flag
- [ ] AgentPicker component: renders 3 options, labels, trial badge, dropdown open/close, option selection calls store
- [ ] chatAgentVersion: transport receives correct agentVersion on send