### PR TITLE
fix: picker — premium trial badge + BYOK modal Continue flow

### DIFF
--- a/frontend/src/components/AgentPicker.vue
+++ b/frontend/src/components/AgentPicker.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useAgentPickerStore } from '../stores/agentPicker'
+import { useAuthStore } from '../stores/auth'
 import type { AgentVersion } from '../stores/agentPicker'
 
 withDefaults(defineProps<{
@@ -10,8 +11,12 @@ withDefaults(defineProps<{
 })
 
 const store = useAgentPickerStore()
+const authStore = useAuthStore()
 const open = ref(false)
 const rootEl = ref<HTMLDivElement | null>(null)
+
+// Premium users bypass trial counter and BYOK modal entirely.
+const isPremium = computed(() => authStore.user?.is_paid ?? false)
 
 const AGENTS: Array<{ id: AgentVersion; label: string; sublabel: string }> = [
   { id: 'tether-agent-1.0', label: 'tether-agent-1.0', sublabel: 'Classic · free' },
@@ -28,9 +33,9 @@ async function select(version: AgentVersion) {
   await store.setAgent(version)
 }
 
-async function stayOn20() {
-  store.dismissByokModal()
-  await store.setAgent('tether-agent-2.0')
+// "Stay on 2.0" — cancel the pending 2.5 selection, keep current agent.
+function stayOn20() {
+  store.cancelByokModal()
 }
 
 // Close dropdown when clicking outside the component's root.
@@ -86,9 +91,9 @@ onBeforeUnmount(() => document.removeEventListener('mousedown', onDocumentClick)
           <span>
             <span class="font-medium">{{ agent.label }}</span>
             <span class="ml-1 text-[--fg-4]">· {{ agent.sublabel }}</span>
-            <!-- Trial badge for 2.5 -->
+            <!-- Trial badge for 2.5 — hidden for premium users -->
             <span
-              v-if="agent.id === 'tether-agent-2.5'"
+              v-if="agent.id === 'tether-agent-2.5' && !isPremium"
               class="ml-1 inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-[--accent-veil] text-[--accent]"
             >
               trial: {{ trialMessagesLeft }} left
@@ -130,7 +135,7 @@ onBeforeUnmount(() => document.removeEventListener('mousedown', onDocumentClick)
             <button
               type="button"
               class="text-xs px-3 py-1.5 rounded-lg bg-[--accent] text-white hover:opacity-90 transition-opacity"
-              @click="store.dismissByokModal()"
+              @click="store.confirmByokModal()"
             >
               Continue
             </button>

--- a/frontend/src/components/__tests__/AgentPicker.test.ts
+++ b/frontend/src/components/__tests__/AgentPicker.test.ts
@@ -143,4 +143,59 @@ describe('AgentPicker', () => {
 
     expect(store.showByokModal).toBe(false)
   })
+
+  // ── Bug 1 regression: trial badge hidden for premium users ──
+
+  it('[Bug 1] trial badge shown for free users (is_paid=false)', async () => {
+    const { useAuthStore } = await import('../../stores/auth')
+    const authStore = useAuthStore()
+    authStore.user = { user_id: 'u1', username: 'test', is_admin: false, is_paid: false }
+
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker, { props: { trialMessagesLeft: 7 } })
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('7')
+    expect(wrapper.text()).toContain('trial')
+  })
+
+  it('[Bug 1] trial badge hidden for premium users (is_paid=true)', async () => {
+    const { useAuthStore } = await import('../../stores/auth')
+    const authStore = useAuthStore()
+    authStore.user = { user_id: 'u1', username: 'test', is_admin: false, is_paid: true }
+
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker, { props: { trialMessagesLeft: 7 } })
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).not.toContain('trial')
+  })
+
+  // ── Bug 2 regression: "Continue" wired to confirmByokModal ──
+  // DOM click through Teleport content is unreliable in jsdom; test that
+  // store.confirmByokModal() produces correct observable state instead.
+
+  it('[Bug 2] confirmByokModal() commits pending 2.5 and closes modal', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({
+      ok: true, status: 200, json: async () => ({ ok: true }),
+    } as any)
+
+    const { useAuthStore } = await import('../../stores/auth')
+    const authStore = useAuthStore()
+    authStore.user = { user_id: 'u1', username: 'test', is_admin: false, is_paid: false }
+
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const store = useAgentPickerStore()
+    // Simulate state after setAgent('tether-agent-2.5') opened the modal
+    store.pendingAgent = 'tether-agent-2.5'
+    store.showByokModal = true
+
+    await store.confirmByokModal()
+
+    expect(store.showByokModal).toBe(false)
+    expect(store.selectedAgent).toBe('tether-agent-2.5')
+  })
 })

--- a/frontend/src/components/__tests__/AgentPicker.test.ts
+++ b/frontend/src/components/__tests__/AgentPicker.test.ts
@@ -132,14 +132,14 @@ describe('AgentPicker', () => {
     expect(document.body.textContent).toContain('Stay on 2.0')
   })
 
-  it('store.dismissByokModal() sets showByokModal to false', async () => {
+  it('store.cancelByokModal() sets showByokModal to false', async () => {
     // Teleported modal content is hard to interact with in jsdom;
     // test the store action directly — the component just calls it.
     const { useAgentPickerStore } = await import('../../stores/agentPicker')
     const store = useAgentPickerStore()
     store.showByokModal = true
 
-    store.dismissByokModal()
+    store.cancelByokModal()
 
     expect(store.showByokModal).toBe(false)
   })

--- a/frontend/src/stores/__tests__/agentPicker.test.ts
+++ b/frontend/src/stores/__tests__/agentPicker.test.ts
@@ -5,9 +5,23 @@ vi.mock('../../lib/api', () => ({
   api: vi.fn(() => Promise.resolve({ ok: false, json: async () => ({}) })),
 }))
 
+// Helper: seed the auth store's user value without triggering any fetches
+async function setAuthUser(opts: { is_paid?: boolean } = {}) {
+  const { useAuthStore } = await import('../auth')
+  const store = useAuthStore()
+  store.user = {
+    user_id: 'test-user',
+    username: 'testuser',
+    is_admin: false,
+    is_paid: opts.is_paid ?? false,
+  }
+  return store
+}
+
 describe('useAgentPickerStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
+    vi.clearAllMocks()   // clear call history on vi.fn() mocks (restoreAllMocks only resets spies)
     vi.restoreAllMocks()
   })
 
@@ -62,7 +76,7 @@ describe('useAgentPickerStore', () => {
     expect(store.selectedAgent).toBe('tether-agent-2.0')
   })
 
-  it('setAgent updates selectedAgent and calls PUT /api/settings/preferred_agent_version', async () => {
+  it('setAgent 1.0 commits immediately without modal', async () => {
     const { api } = await import('../../lib/api')
     vi.mocked(api).mockResolvedValueOnce({
       ok: true,
@@ -72,9 +86,74 @@ describe('useAgentPickerStore', () => {
 
     const { useAgentPickerStore } = await import('../agentPicker')
     const store = useAgentPickerStore()
+    await store.setAgent('tether-agent-1.0')
+
+    expect(store.selectedAgent).toBe('tether-agent-1.0')
+    expect(store.showByokModal).toBe(false)
+    expect(vi.mocked(api)).toHaveBeenCalledWith(
+      '/api/settings/preferred_agent_version',
+      expect.objectContaining({ method: 'PUT' }),
+    )
+  })
+
+  it('setAgent 2.0 commits immediately without modal', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({
+      ok: true, status: 200, json: async () => ({ ok: true }),
+    } as any)
+
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    store.selectedAgent = 'tether-agent-1.0'
+    await store.setAgent('tether-agent-2.0')
+
+    expect(store.selectedAgent).toBe('tether-agent-2.0')
+    expect(store.showByokModal).toBe(false)
+  })
+
+  it('setAgent keeps previous value on API failure for non-2.5', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({
+      ok: false, status: 500, json: async () => ({}),
+    } as any)
+
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    store.selectedAgent = 'tether-agent-1.0'
+    await store.setAgent('tether-agent-2.0')
+
+    expect(store.selectedAgent).toBe('tether-agent-1.0')
+  })
+
+  // ── Bug 2 regression: modal is a confirmation gate, not a post-commit overlay ──
+
+  it('[Bug 2] setAgent 2.5 on free user shows modal and does NOT call API', async () => {
+    const { api } = await import('../../lib/api')
+    await setAuthUser({ is_paid: false })
+
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
     await store.setAgent('tether-agent-2.5')
 
+    expect(store.showByokModal).toBe(true)
+    expect(store.selectedAgent).toBe('tether-agent-2.0')  // unchanged
+    expect(vi.mocked(api)).not.toHaveBeenCalled()         // API not touched yet
+  })
+
+  it('[Bug 2] confirmByokModal commits 2.5 via API and closes modal', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({
+      ok: true, status: 200, json: async () => ({ ok: true }),
+    } as any)
+    await setAuthUser({ is_paid: false })
+
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    await store.setAgent('tether-agent-2.5')  // opens modal, no commit
+    await store.confirmByokModal()            // user clicked "Continue"
+
     expect(store.selectedAgent).toBe('tether-agent-2.5')
+    expect(store.showByokModal).toBe(false)
     expect(vi.mocked(api)).toHaveBeenCalledWith(
       '/api/settings/preferred_agent_version',
       expect.objectContaining({
@@ -84,50 +163,59 @@ describe('useAgentPickerStore', () => {
     )
   })
 
-  it('setAgent keeps previous value on API failure', async () => {
+  it('[Bug 2] cancelByokModal closes modal without changing selectedAgent', async () => {
     const { api } = await import('../../lib/api')
-    vi.mocked(api).mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-      json: async () => ({}),
-    } as any)
+    await setAuthUser({ is_paid: false })
 
     const { useAgentPickerStore } = await import('../agentPicker')
     const store = useAgentPickerStore()
-    // pre-seed a non-default value
+    store.selectedAgent = 'tether-agent-1.0'
+    await store.setAgent('tether-agent-2.5')  // opens modal
+    store.cancelByokModal()                   // user clicked "Stay on 2.0"
+
+    expect(store.selectedAgent).toBe('tether-agent-1.0')  // unchanged
+    expect(store.showByokModal).toBe(false)
+    expect(vi.mocked(api)).not.toHaveBeenCalled()
+  })
+
+  it('[Bug 2] confirmByokModal rollback if API fails — modal closes, selection unchanged', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({
+      ok: false, status: 500, json: async () => ({}),
+    } as any)
+    await setAuthUser({ is_paid: false })
+
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
     store.selectedAgent = 'tether-agent-1.0'
     await store.setAgent('tether-agent-2.5')
+    await store.confirmByokModal()
 
-    // should roll back
-    expect(store.selectedAgent).toBe('tether-agent-1.0')
+    expect(store.selectedAgent).toBe('tether-agent-1.0')  // rolled back
+    expect(store.showByokModal).toBe(false)
+  })
+
+  // ── Bug 1 regression: premium users bypass modal and trial badge ──
+
+  it('[Bug 1] setAgent 2.5 on premium user commits directly — no modal', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({
+      ok: true, status: 200, json: async () => ({ ok: true }),
+    } as any)
+    await setAuthUser({ is_paid: true })
+
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    await store.setAgent('tether-agent-2.5')
+
+    expect(store.selectedAgent).toBe('tether-agent-2.5')
+    expect(store.showByokModal).toBe(false)
+    expect(vi.mocked(api)).toHaveBeenCalled()
   })
 
   it('showByokModal is false initially', async () => {
     const { useAgentPickerStore } = await import('../agentPicker')
     const store = useAgentPickerStore()
-    expect(store.showByokModal).toBe(false)
-  })
-
-  it('setAgent triggers showByokModal for 2.5 selection', async () => {
-    const { api } = await import('../../lib/api')
-    vi.mocked(api).mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => ({ ok: true }),
-    } as any)
-
-    const { useAgentPickerStore } = await import('../agentPicker')
-    const store = useAgentPickerStore()
-    await store.setAgent('tether-agent-2.5')
-
-    expect(store.showByokModal).toBe(true)
-  })
-
-  it('dismissByokModal sets showByokModal false', async () => {
-    const { useAgentPickerStore } = await import('../agentPicker')
-    const store = useAgentPickerStore()
-    store.showByokModal = true
-    store.dismissByokModal()
     expect(store.showByokModal).toBe(false)
   })
 })

--- a/frontend/src/stores/agentPicker.ts
+++ b/frontend/src/stores/agentPicker.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { api } from '../lib/api'
+import { useAuthStore } from './auth'
 
 const AGENT_VERSIONS = ['tether-agent-1.0', 'tether-agent-2.0', 'tether-agent-2.5'] as const
 export type AgentVersion = (typeof AGENT_VERSIONS)[number]
@@ -15,6 +16,8 @@ function isValidAgent(v: unknown): v is AgentVersion {
 export const useAgentPickerStore = defineStore('agentPicker', () => {
   const selectedAgent = ref<AgentVersion>(DEFAULT_AGENT)
   const showByokModal = ref(false)
+  // Holds the pending 2.5 selection while the BYOK modal awaits confirmation.
+  const pendingAgent = ref<AgentVersion | null>(null)
 
   async function fetchPreference(): Promise<void> {
     try {
@@ -30,14 +33,10 @@ export const useAgentPickerStore = defineStore('agentPicker', () => {
     }
   }
 
-  async function setAgent(version: AgentVersion): Promise<void> {
+  /** Persist a version to the backend and update selectedAgent; rollback on failure. */
+  async function _commitAgent(version: AgentVersion): Promise<void> {
     const previous = selectedAgent.value
     selectedAgent.value = version
-
-    if (version === 'tether-agent-2.5') {
-      showByokModal.value = true
-    }
-
     try {
       const resp = await api(`/api/settings/${SETTING_KEY}`, {
         method: 'PUT',
@@ -52,9 +51,53 @@ export const useAgentPickerStore = defineStore('agentPicker', () => {
     }
   }
 
-  function dismissByokModal(): void {
+  /**
+   * Select an agent version.
+   *
+   * For tether-agent-2.5 on free users: opens the BYOK confirmation modal
+   * WITHOUT committing. The selection is only persisted after confirmByokModal().
+   *
+   * For premium users (is_paid) or any other version: commits immediately.
+   */
+  async function setAgent(version: AgentVersion): Promise<void> {
+    const isPremium = useAuthStore().user?.is_paid ?? false
+
+    if (version === 'tether-agent-2.5' && !isPremium) {
+      pendingAgent.value = version
+      showByokModal.value = true
+      return // wait for confirmByokModal() or cancelByokModal()
+    }
+
+    await _commitAgent(version)
+  }
+
+  /** User clicked "Continue" in the BYOK modal — commit the pending selection. */
+  async function confirmByokModal(): Promise<void> {
+    const version = pendingAgent.value
+    pendingAgent.value = null
+    showByokModal.value = false
+    if (version) await _commitAgent(version)
+  }
+
+  /** User clicked "Stay on 2.0" — discard the pending selection, close modal. */
+  function cancelByokModal(): void {
+    pendingAgent.value = null
     showByokModal.value = false
   }
 
-  return { selectedAgent, showByokModal, fetchPreference, setAgent, dismissByokModal }
+  // Keep dismissByokModal as an alias for cancelByokModal for backwards compatibility.
+  function dismissByokModal(): void {
+    cancelByokModal()
+  }
+
+  return {
+    selectedAgent,
+    showByokModal,
+    pendingAgent,
+    fetchPreference,
+    setAgent,
+    confirmByokModal,
+    cancelByokModal,
+    dismissByokModal,
+  }
 })

--- a/frontend/src/stores/agentPicker.ts
+++ b/frontend/src/stores/agentPicker.ts
@@ -85,11 +85,6 @@ export const useAgentPickerStore = defineStore('agentPicker', () => {
     showByokModal.value = false
   }
 
-  // Keep dismissByokModal as an alias for cancelByokModal for backwards compatibility.
-  function dismissByokModal(): void {
-    cancelByokModal()
-  }
-
   return {
     selectedAgent,
     showByokModal,
@@ -98,6 +93,5 @@ export const useAgentPickerStore = defineStore('agentPicker', () => {
     setAgent,
     confirmByokModal,
     cancelByokModal,
-    dismissByokModal,
   }
 })


### PR DESCRIPTION
## Summary

Two bugs found in #377 during user testing.

**Bug 1 — Premium account trial badge shown incorrectly**
- `AgentPicker.vue` now reads `is_paid` from `useAuthStore` via a `isPremium` computed
- Trial badge hidden when `is_paid = true`
- `setAgent('tether-agent-2.5')` skips the BYOK modal entirely for premium users and commits directly
- `is_paid` is already present in `/auth/me` response — no backend changes needed

**Bug 2 — "Continue" in BYOK modal didn't commit the 2.5 selection**
- Root cause: `setAgent` previously both fired the API PUT and showed the modal simultaneously. If the PUT failed and rolled back `selectedAgent`, clicking "Continue" only closed the modal — leaving the picker on the rolled-back prior value.
- Fix: modal is now a confirmation gate **before** the API call. `setAgent('tether-agent-2.5')` for free users stores `pendingAgent` and opens the modal without touching the backend. `confirmByokModal()` commits. `cancelByokModal()` discards.
- "Continue" button wired to `store.confirmByokModal()` (was `store.dismissByokModal()`)
- "Stay on 2.0" button wired to `store.cancelByokModal()` — no API call, no selection change

## Premium mechanism used

`useAuthStore().user?.is_paid` — already populated by `/auth/me` response. No new backend endpoints or migrations needed. When real subscription tier lands, this field is the hook.

## Test plan

- [ ] 651 tests passing — `npm run test`
- [ ] Zero TypeScript errors — `npm run build`
- [ ] Bug 1: trial badge hidden for `is_paid=true`, shown for `is_paid=false`
- [ ] Bug 1: `setAgent('tether-agent-2.5')` on premium commits directly, no modal
- [ ] Bug 2: `setAgent('tether-agent-2.5')` on free user opens modal, no API call yet
- [ ] Bug 2: `confirmByokModal()` commits to backend, closes modal, updates picker
- [ ] Bug 2: `cancelByokModal()` closes modal, leaves picker on prior selection, no API call
- [ ] Bug 2: API failure in `confirmByokModal()` rolls back and closes modal cleanly