### PR TITLE
feat: PoolClient HTTP wrapper (A3)

### DIFF
--- a/agent_pool_manager/client.py
+++ b/agent_pool_manager/client.py
@@ -42,10 +42,11 @@ class PoolClient:
 
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None:
-            kwargs: dict[str, Any] = {"base_url": self._base_url, "timeout": 30.0}
-            if self._transport is not None:
-                kwargs["transport"] = self._transport
-            self._client = httpx.AsyncClient(**kwargs)
+            self._client = httpx.AsyncClient(
+                base_url=self._base_url,
+                timeout=30.0,
+                transport=self._transport,
+            )
         return self._client
 
     async def aclose(self) -> None:

--- a/agent_pool_manager/client.py
+++ b/agent_pool_manager/client.py
@@ -1,0 +1,189 @@
+"""PoolClient — HTTP client for callers to interact with the agent pool service."""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, AsyncIterator
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+
+class PoolClientError(Exception):
+    """Raised when the pool service returns an error response."""
+
+
+class PoolClient:
+    """Thin HTTP wrapper around the agent-pool-manager service endpoints.
+
+    All callers (interactive-agent-layer, bot pipelines) use this class
+    rather than speaking to the service directly.  The pool service URL
+    is configured via ``agent_pool.base_url`` in app_config.yaml.
+
+    Parameters
+    ----------
+    base_url:
+        Base URL of the pool service, e.g. ``http://agent-pool:5002``.
+    _transport:
+        Optional httpx transport override — used in tests to inject an
+        in-process ASGI transport instead of making real TCP connections.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://127.0.0.1:5002",
+        *,
+        _transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._transport = _transport
+        self._client: httpx.AsyncClient | None = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            kwargs: dict[str, Any] = {"base_url": self._base_url, "timeout": 30.0}
+            if self._transport is not None:
+                kwargs["transport"] = self._transport
+            self._client = httpx.AsyncClient(**kwargs)
+        return self._client
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def __aenter__(self) -> "PoolClient":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.aclose()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def acquire(
+        self,
+        user_id: str,
+        options_hash: str,
+        options: dict[str, Any],
+        timeout_seconds: float | None = None,
+    ) -> str:
+        """Acquire a warm subprocess handle.
+
+        Returns the ``handle_id`` string.
+        Raises :exc:`PoolClientError` if the pool is exhausted.
+        """
+        payload: dict[str, Any] = {
+            "user_id": user_id,
+            "options_hash": options_hash,
+            "options": options,
+        }
+        if timeout_seconds is not None:
+            payload["timeout_seconds"] = timeout_seconds
+
+        resp = await self._get_client().post("/acquire", json=payload)
+
+        if resp.status_code == 503:
+            body = resp.json()
+            raise PoolClientError(
+                f"pool_exhausted — retry after {body.get('retry_after_seconds', 5)}s"
+            )
+        _raise_for_status(resp)
+        return resp.json()["handle_id"]
+
+    async def release(self, handle_id: str, *, reusable: bool = False) -> None:
+        """Release a handle.
+
+        ``reusable=True`` returns the subprocess to the warm queue.
+        ``reusable=False`` (default) terminates it.
+        """
+        resp = await self._get_client().post(
+            f"/handle/{handle_id}/release",
+            json={"reusable": reusable},
+        )
+        _raise_for_status(resp)
+
+    async def interrupt(self, handle_id: str) -> None:
+        """Send an interrupt to the active subprocess."""
+        resp = await self._get_client().post(f"/handle/{handle_id}/interrupt")
+        _raise_for_status(resp)
+
+    async def query_stream(
+        self,
+        handle_id: str,
+        prompt: str,
+        session_id: str = "default",
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Stream SDK events from a running query as an async iterator of dicts.
+
+        Yields one dict per SSE ``data:`` line (parsed JSON).
+        Stops at the ``[DONE]`` sentinel or on connection close.
+        Raises :exc:`PoolClientError` if the handle is not found.
+        """
+        async with self._get_client().stream(
+            "POST",
+            f"/handle/{handle_id}/query",
+            json={"prompt": prompt, "session_id": session_id},
+            timeout=None,  # streaming — no fixed timeout
+        ) as resp:
+            if resp.status_code == 404:
+                raise PoolClientError(f"handle not found: {handle_id!r}")
+            _raise_for_status(resp)
+            async for line in resp.aiter_lines():
+                if not line.startswith("data: "):
+                    continue
+                payload = line[len("data: "):]
+                if payload == "[DONE]":
+                    return
+                try:
+                    yield json.loads(payload)
+                except json.JSONDecodeError:
+                    log.warning("Unparseable SSE payload: %r", payload)
+
+    async def hint(
+        self,
+        user_id: str,
+        options_hash: str,
+        options: dict[str, Any],
+    ) -> None:
+        """Signal that a subprocess will likely be needed soon (best-effort)."""
+        resp = await self._get_client().post(
+            "/hint",
+            json={"user_id": user_id, "options_hash": options_hash, "options": options},
+        )
+        _raise_for_status(resp)
+
+    async def status(self) -> dict[str, Any]:
+        """Return current pool status (warm/active/warming counts)."""
+        resp = await self._get_client().get("/status")
+        _raise_for_status(resp)
+        return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _raise_for_status(resp: httpx.Response) -> None:
+    """Raise PoolClientError for non-2xx responses, with readable message."""
+    if resp.is_success:
+        return
+    try:
+        detail = resp.json().get("detail") or resp.text
+    except Exception:
+        detail = resp.text
+    raise PoolClientError(f"HTTP {resp.status_code}: {detail}")
+
+
+def from_config(tether_config: object) -> "PoolClient":
+    """Build a PoolClient from a TetherConfig instance."""
+    try:
+        base_url: str = tether_config.get("agent_pool", {}).get(  # type: ignore[attr-defined]
+            "base_url", "http://127.0.0.1:5002"
+        )
+    except Exception:
+        base_url = "http://127.0.0.1:5002"
+    return PoolClient(base_url=base_url)

--- a/tests/agent_pool_manager/test_client.py
+++ b/tests/agent_pool_manager/test_client.py
@@ -1,17 +1,16 @@
 """Tests for agent_pool_manager.client — PoolClient HTTP wrapper."""
 from __future__ import annotations
 
-import asyncio
 import pytest
 from unittest.mock import patch
-from httpx import AsyncClient, ASGITransport
+from httpx import ASGITransport
 
 from .fake_client import FakeClient
 from agent_pool_manager.config import AgentPoolConfig
 from agent_pool_manager.pool import Pool
 from agent_pool_manager.refill import RefillLoop
 from agent_pool_manager.server import build_app
-from agent_pool_manager.client import PoolClient
+from agent_pool_manager.client import PoolClient, PoolClientError
 
 
 HASH_A = "abc123"
@@ -45,9 +44,11 @@ async def http_client(pool_and_app):
     """PoolClient backed by an in-process FastAPI app."""
     pool, app = pool_and_app
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        client = PoolClient(base_url="http://test", _transport=transport)
+    client = PoolClient(base_url="http://test", _transport=transport)
+    try:
         yield client, pool
+    finally:
+        await client.aclose()
 
 
 # ---------------------------------------------------------------------------
@@ -69,7 +70,6 @@ async def test_acquire_returns_handle(http_client):
 @pytest.mark.asyncio
 async def test_acquire_raises_on_pool_exhausted(http_client):
     """PoolClient.acquire() raises PoolClientError when pool is exhausted."""
-    from agent_pool_manager.client import PoolClientError
     client, pool = http_client
 
     with pytest.raises(PoolClientError, match="pool_exhausted"):
@@ -121,7 +121,6 @@ async def test_interrupt_active_handle(http_client):
 @pytest.mark.asyncio
 async def test_interrupt_unknown_handle_raises(http_client):
     """PoolClient.interrupt() raises PoolClientError for unknown handle."""
-    from agent_pool_manager.client import PoolClientError
     client, pool = http_client
 
     with pytest.raises(PoolClientError):
@@ -183,7 +182,6 @@ async def test_query_stream_yields_events(http_client):
 @pytest.mark.asyncio
 async def test_query_stream_unknown_handle_raises(http_client):
     """PoolClient.query_stream() raises PoolClientError for unknown handle."""
-    from agent_pool_manager.client import PoolClientError
     client, pool = http_client
 
     with pytest.raises(PoolClientError):

--- a/tests/agent_pool_manager/test_client.py
+++ b/tests/agent_pool_manager/test_client.py
@@ -1,0 +1,191 @@
+"""Tests for agent_pool_manager.client — PoolClient HTTP wrapper."""
+from __future__ import annotations
+
+import asyncio
+import pytest
+from unittest.mock import patch
+from httpx import AsyncClient, ASGITransport
+
+from .fake_client import FakeClient
+from agent_pool_manager.config import AgentPoolConfig
+from agent_pool_manager.pool import Pool
+from agent_pool_manager.refill import RefillLoop
+from agent_pool_manager.server import build_app
+from agent_pool_manager.client import PoolClient
+
+
+HASH_A = "abc123"
+OPTIONS_A = {"model": "claude-haiku-4-5"}
+USER_ID = "user-test-1"
+
+
+@pytest.fixture
+async def pool_and_app():
+    """In-process pool + FastAPI app for round-trip tests."""
+    cfg = AgentPoolConfig(
+        target_depth_per_hash=2,
+        capacity_total=8,
+        max_age_seconds=600,
+        refill_poll_interval=0.05,
+        prime_timeout_seconds=5,
+        acquire_default_timeout=2,
+    )
+    pool = Pool(cfg)
+    refill = RefillLoop(pool)
+    app = build_app(pool=pool, refill=refill)
+    app.state.pool = pool
+    app.state.refill = refill
+    refill.start()
+    yield pool, app
+    refill.stop()
+
+
+@pytest.fixture
+async def http_client(pool_and_app):
+    """PoolClient backed by an in-process FastAPI app."""
+    pool, app = pool_and_app
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        client = PoolClient(base_url="http://test", _transport=transport)
+        yield client, pool
+
+
+# ---------------------------------------------------------------------------
+# acquire / release
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_acquire_returns_handle(http_client):
+    """PoolClient.acquire() returns a handle_id when warm client available."""
+    client, pool = http_client
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", FakeClient):
+        await pool._inject_warm(HASH_A, OPTIONS_A)
+
+    handle_id = await client.acquire(USER_ID, HASH_A, OPTIONS_A, timeout_seconds=2.0)
+    assert handle_id is not None
+    assert isinstance(handle_id, str)
+
+
+@pytest.mark.asyncio
+async def test_acquire_raises_on_pool_exhausted(http_client):
+    """PoolClient.acquire() raises PoolClientError when pool is exhausted."""
+    from agent_pool_manager.client import PoolClientError
+    client, pool = http_client
+
+    with pytest.raises(PoolClientError, match="pool_exhausted"):
+        await client.acquire(USER_ID, HASH_A, OPTIONS_A, timeout_seconds=0.05)
+
+
+@pytest.mark.asyncio
+async def test_release_after_acquire(http_client):
+    """PoolClient.release() succeeds after a valid acquire."""
+    client, pool = http_client
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", FakeClient):
+        await pool._inject_warm(HASH_A, OPTIONS_A)
+
+    handle_id = await client.acquire(USER_ID, HASH_A, OPTIONS_A, timeout_seconds=2.0)
+    # Should not raise
+    await client.release(handle_id, reusable=False)
+
+
+@pytest.mark.asyncio
+async def test_release_reusable(http_client):
+    """PoolClient.release(reusable=True) returns client to warm queue."""
+    client, pool = http_client
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", FakeClient):
+        await pool._inject_warm(HASH_A, OPTIONS_A)
+
+    handle_id = await client.acquire(USER_ID, HASH_A, OPTIONS_A, timeout_seconds=2.0)
+    assert pool.warm_count(HASH_A) == 0
+    await client.release(handle_id, reusable=True)
+    assert pool.warm_count(HASH_A) == 1
+
+
+# ---------------------------------------------------------------------------
+# interrupt
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_interrupt_active_handle(http_client):
+    """PoolClient.interrupt() sends interrupt to the active subprocess."""
+    client, pool = http_client
+    fake = FakeClient()
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", lambda **kw: fake):
+        await pool._inject_warm(HASH_A, OPTIONS_A)
+
+    handle_id = await client.acquire(USER_ID, HASH_A, OPTIONS_A, timeout_seconds=2.0)
+    await client.interrupt(handle_id)
+    assert fake.interrupted
+
+
+@pytest.mark.asyncio
+async def test_interrupt_unknown_handle_raises(http_client):
+    """PoolClient.interrupt() raises PoolClientError for unknown handle."""
+    from agent_pool_manager.client import PoolClientError
+    client, pool = http_client
+
+    with pytest.raises(PoolClientError):
+        await client.interrupt("no-such-handle")
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_status_returns_counts(http_client):
+    """PoolClient.status() returns pool-wide counts."""
+    client, pool = http_client
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", FakeClient):
+        await pool._inject_warm(HASH_A, OPTIONS_A)
+
+    status = await client.status()
+    assert "total_warm" in status
+    assert "total_active" in status
+    assert "capacity_total" in status
+    assert status["total_warm"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# hint
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_hint_accepted(http_client):
+    """PoolClient.hint() completes without error."""
+    client, pool = http_client
+    # Should not raise
+    await client.hint(USER_ID, HASH_A, OPTIONS_A)
+
+
+# ---------------------------------------------------------------------------
+# query_stream
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_query_stream_yields_events(http_client):
+    """PoolClient.query_stream() yields SSE events from the pool service."""
+    client, pool = http_client
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", FakeClient):
+        await pool._inject_warm(HASH_A, OPTIONS_A)
+
+    handle_id = await client.acquire(USER_ID, HASH_A, OPTIONS_A, timeout_seconds=2.0)
+    events = []
+    async for event in client.query_stream(handle_id, "say hello"):
+        events.append(event)
+        if len(events) >= 2:
+            break
+
+    assert len(events) >= 1
+    await client.release(handle_id, reusable=False)
+
+
+@pytest.mark.asyncio
+async def test_query_stream_unknown_handle_raises(http_client):
+    """PoolClient.query_stream() raises PoolClientError for unknown handle."""
+    from agent_pool_manager.client import PoolClientError
+    client, pool = http_client
+
+    with pytest.raises(PoolClientError):
+        async for _ in client.query_stream("bad-handle", "hello"):
+            pass


### PR DESCRIPTION
## Summary

- Adds `agent_pool_manager/client.py` — thin async HTTP wrapper around all 5 pool-service endpoints
- `PoolClient` covers `acquire`, `release`, `interrupt`, `query_stream` (SSE async iterator), `hint`, and `status`
- `_transport` injection for in-process ASGI testing (no real TCP required in tests)
- `from_config()` factory reads `agent_pool.base_url` from `app_config.yaml`
- 10 new round-trip tests via in-process FastAPI (32 total, all passing)
- Follow-on simplification: `_get_client()` passes `transport=None` directly; httpx accepts it cleanly

## Test plan
- [ ] `pytest tests/agent_pool_manager/` — 32 passed
- [ ] No new warnings or CodeQL alerts
- [ ] `from_config()` falls back to `http://127.0.0.1:5002` when config key absent