### PR TITLE
feat: interactive agent layer B2 — translation, coalescing, permission gate

### DIFF
--- a/config/agent_translations.yaml
+++ b/config/agent_translations.yaml
@@ -1,0 +1,64 @@
+# Channel 1 — background visibility
+# auto-allowed always, never permission-eligible, coalesced
+
+get_anchors:
+  type: background
+  phrase: "Reading your schedule"
+
+get_plan:
+  type: background
+  phrase: "Reading your plan"
+
+search:
+  type: background
+  phrase: "Searching for '{query}'"
+
+# Premium internal tools — kept opaque
+consult_advisor:
+  type: background_hidden
+  phrase: "Working on it"
+
+initiate_meeting_coordination:
+  type: background_hidden
+  phrase: "Coordinating"
+
+session_done:
+  type: background_hidden
+  phrase: "Wrapping up"
+
+spawn_subagent:
+  type: background_hidden
+  phrase: "Working on multiple things"
+
+send_status_update:
+  type: passthrough
+
+# Channel 2 — user-action tools (permission-eligible)
+upsert_tasks:
+  type: user_action
+  phrase_short: "Updating tasks"
+  permission_summary: "Update {count} tasks"
+  permission_detail_field: "tasks"
+
+delete_tasks:
+  type: user_action
+  phrase_short: "Removing tasks"
+  permission_summary: "Delete {count} items"
+  permission_detail_field: "operations"
+
+upsert_context:
+  type: user_action
+  phrase_short: "Updating context"
+  permission_summary: "Update context: {subject}"
+  permission_detail_field: "nodes"
+
+delete_context:
+  type: user_action
+  phrase_short: "Removing context"
+  permission_summary: "Delete context: {subject}"
+  permission_detail_field: "operations"
+
+# Fallback
+_unknown:
+  type: background
+  phrase: "Working"

--- a/config/app_config.yaml
+++ b/config/app_config.yaml
@@ -62,6 +62,7 @@ agent_layer:
   base_url: "http://127.0.0.1:5003"
   enabled: true
   permission_timeout_seconds: 60
+  auto_approve_user_actions: false
   trial_monthly_quota: 10
   leaky_providers:
     - openrouter

--- a/interactive_agent_layer/coalescing.py
+++ b/interactive_agent_layer/coalescing.py
@@ -1,0 +1,54 @@
+"""CoalescingBuffer for background tool action events.
+
+Tracks recent agent_action events and coalesces repeated calls for the same
+(tool_name, phrase) key within a configurable time window.
+"""
+from __future__ import annotations
+
+import dataclasses
+import time
+import uuid
+from collections.abc import Callable
+
+
+@dataclasses.dataclass
+class _CacheEntry:
+    action_id: str
+    timestamp: float
+
+
+class CoalescingBuffer:
+    def __init__(
+        self,
+        window_seconds: float = 5.0,
+        time_fn: Callable[[], float] | None = None,
+    ) -> None:
+        self._window = window_seconds
+        self._time_fn = time_fn or time.monotonic
+        self._cache: dict[tuple[str, str], _CacheEntry] = {}
+
+    def record(self, tool_name: str, phrase: str) -> tuple[str, bool]:
+        """Record a tool call and return (action_id, coalesced).
+
+        coalesced=True means this is a repeat within the window.
+        The timestamp is updated on each hit to extend the window.
+        """
+        key = (tool_name, phrase)
+        now = self._time_fn()
+        entry = self._cache.get(key)
+        if entry is not None and (now - entry.timestamp) < self._window:
+            entry.timestamp = now
+            return entry.action_id, True
+        action_id = str(uuid.uuid4())
+        self._cache[key] = _CacheEntry(action_id=action_id, timestamp=now)
+        return action_id, False
+
+    def evict_expired(self) -> None:
+        """Remove entries older than the window.
+
+        Call periodically to prevent unbounded growth.
+        """
+        now = self._time_fn()
+        expired = [k for k, v in self._cache.items() if (now - v.timestamp) >= self._window]
+        for k in expired:
+            del self._cache[k]

--- a/interactive_agent_layer/config.py
+++ b/interactive_agent_layer/config.py
@@ -14,3 +14,7 @@ def is_enabled() -> bool:
 
 def get_permission_timeout() -> int:
     return int(config.get("agent_layer.permission_timeout_seconds", 60))
+
+
+def get_auto_approve_user_actions() -> bool:
+    return bool(config.get("agent_layer.auto_approve_user_actions", False))

--- a/interactive_agent_layer/permissions.py
+++ b/interactive_agent_layer/permissions.py
@@ -1,0 +1,103 @@
+"""Permission gate — can_use_tool callback for agent-pool-manager PoolClient.query."""
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import uuid
+from typing import Any
+
+from interactive_agent_layer.config import get_permission_timeout
+from interactive_agent_layer.translation import (
+    BackgroundEntry,
+    BackgroundHiddenEntry,
+    ForgivingMap,
+    PassthroughEntry,
+    TranslationEntry,
+    TranslationTable,
+    UserActionEntry,
+)
+
+
+@dataclasses.dataclass
+class PermissionResultAllow:
+    pass
+
+
+@dataclasses.dataclass
+class PermissionResultDeny:
+    reason: str = "denied"
+
+
+class PermissionGate:
+    """
+    Builds a can_use_tool callback for a specific session.
+
+    The callback signature matches the claude-agent-sdk CanUseTool protocol:
+        async (tool_name: str, args: dict, ctx: Any) -> PermissionResultAllow | PermissionResultDeny
+    """
+
+    def __init__(
+        self,
+        translation_table: TranslationTable,
+        ws_publisher: Any,  # WSPublisher — avoid circular import
+        session: Any,       # Session — avoid circular import
+        auto_approve_user_actions: bool = False,
+    ) -> None:
+        self._table = translation_table
+        self._ws = ws_publisher
+        self._session = session
+        self._auto_approve = auto_approve_user_actions
+
+    async def can_use_tool(
+        self,
+        tool_name: str,
+        args: dict[str, Any],
+        ctx: Any,  # ToolPermissionContext — ignored for now
+    ) -> PermissionResultAllow | PermissionResultDeny:
+        entry = self._table.lookup(tool_name)
+        return await self._dispatch(tool_name, args, entry)
+
+    async def _dispatch(
+        self,
+        tool_name: str,
+        args: dict[str, Any],
+        entry: TranslationEntry,
+    ) -> PermissionResultAllow | PermissionResultDeny:
+        if isinstance(entry, (BackgroundEntry, BackgroundHiddenEntry, PassthroughEntry)):
+            return PermissionResultAllow()
+
+        # UserActionEntry path
+        if self._auto_approve:
+            return PermissionResultAllow()
+
+        # Emit permission_request, await user response
+        request_id = str(uuid.uuid4())
+        detail = args.get(entry.permission_detail_field, [])
+        summary = entry.permission_summary.format_map(ForgivingMap(args))
+
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[bool] = loop.create_future()
+        self._session.permission_pending[request_id] = future
+
+        await self._ws.push(
+            self._session.user_ws_id,
+            {
+                "type": "permission_request",
+                "session_id": self._session.session_id,
+                "request_id": request_id,
+                "summary": summary,
+                "details": detail,
+            },
+        )
+
+        try:
+            approved = await asyncio.wait_for(
+                asyncio.shield(future),
+                timeout=get_permission_timeout(),
+            )
+        except asyncio.TimeoutError:
+            approved = False
+        finally:
+            self._session.permission_pending.pop(request_id, None)
+
+        return PermissionResultAllow() if approved else PermissionResultDeny()

--- a/interactive_agent_layer/pool_client.py
+++ b/interactive_agent_layer/pool_client.py
@@ -1,13 +1,18 @@
 """PoolClient Protocol and StubPoolClient placeholder."""
 from __future__ import annotations
 
-from typing import AsyncIterator, Protocol, runtime_checkable
+from typing import AsyncIterator, Callable, Protocol, runtime_checkable, Any, Awaitable
 
 
 @runtime_checkable
 class PoolClient(Protocol):
     async def acquire(self, user_id: str, options_hash: int) -> str: ...
-    def query(self, handle: str, prompt: str) -> AsyncIterator[dict]: ...
+    def query(
+        self,
+        handle: str,
+        prompt: str,
+        can_use_tool: Callable[[str, dict, Any], Awaitable[Any]] | None = None,
+    ) -> AsyncIterator[dict]: ...
     async def release(self, handle: str, reusable: bool = True) -> None: ...
     async def interrupt(self, handle: str) -> None: ...
 
@@ -18,7 +23,12 @@ class StubPoolClient:
     async def acquire(self, user_id: str, options_hash: int) -> str:
         raise NotImplementedError("StubPoolClient: real pool not yet implemented")
 
-    async def query(self, handle: str, prompt: str):
+    async def query(
+        self,
+        handle: str,
+        prompt: str,
+        can_use_tool: Callable[[str, dict, Any], Awaitable[Any]] | None = None,
+    ):
         raise NotImplementedError("StubPoolClient: real pool not yet implemented")
         # Make this an async generator by having an unreachable yield
         yield  # type: ignore[misc]

--- a/interactive_agent_layer/server.py
+++ b/interactive_agent_layer/server.py
@@ -22,6 +22,10 @@ class TurnRequest(BaseModel):
     prompt: str
 
 
+class PermissionRespondRequest(BaseModel):
+    approve: bool
+
+
 def create_app(layer: Layer) -> FastAPI:
     app = FastAPI(title="Interactive Agent Layer")
     app.state.layer = layer
@@ -81,5 +85,14 @@ def create_app(layer: Layer) -> FastAPI:
             "turn_count": session.turn_count,
             "created_at": session.created_at,
         }
+
+    @app.post("/permission/{request_id}/respond")
+    async def permission_respond(request_id: str, body: PermissionRespondRequest) -> dict:
+        for session in layer.sessions.values():
+            future = session.permission_pending.get(request_id)
+            if future is not None and not future.done():
+                future.set_result(body.approve)
+                return {"status": "ok"}
+        raise HTTPException(status_code=404, detail="Permission request not found")
 
     return app

--- a/interactive_agent_layer/session.py
+++ b/interactive_agent_layer/session.py
@@ -21,6 +21,7 @@ class Session:
     active_handles: list = dataclasses.field(default_factory=list)
     turn_count: int = 0
     created_at: float = dataclasses.field(default_factory=time.time)
+    permission_pending: dict = dataclasses.field(default_factory=dict)
 
 
 class Layer:

--- a/interactive_agent_layer/session.py
+++ b/interactive_agent_layer/session.py
@@ -5,9 +5,19 @@ import dataclasses
 import json
 import time
 import uuid
-from typing import AsyncIterator
+from typing import AsyncIterator, Any
 
+from interactive_agent_layer.coalescing import CoalescingBuffer
+from interactive_agent_layer.config import get_auto_approve_user_actions
+from interactive_agent_layer.permissions import PermissionGate
 from interactive_agent_layer.pool_client import PoolClient
+from interactive_agent_layer.translation import (
+    BackgroundEntry,
+    BackgroundHiddenEntry,
+    PassthroughEntry,
+    TranslationTable,
+    UserActionEntry,
+)
 from interactive_agent_layer.ws_publisher import WSPublisher
 
 
@@ -22,13 +32,20 @@ class Session:
     turn_count: int = 0
     created_at: float = dataclasses.field(default_factory=time.time)
     permission_pending: dict = dataclasses.field(default_factory=dict)
+    coalescing_buffer: CoalescingBuffer = dataclasses.field(default_factory=CoalescingBuffer)
 
 
 class Layer:
-    def __init__(self, pool_client: PoolClient, ws_publisher: WSPublisher) -> None:
+    def __init__(
+        self,
+        pool_client: PoolClient,
+        ws_publisher: WSPublisher,
+        translation_table: TranslationTable | None = None,
+    ) -> None:
         self.sessions: dict[str, Session] = {}
         self.pool_client = pool_client
         self.ws_publisher = ws_publisher
+        self.translation_table = translation_table or TranslationTable.from_yaml()
 
     def create_session(
         self,
@@ -57,13 +74,23 @@ class Layer:
     async def run_turn(self, session_id: str, prompt: str) -> AsyncIterator[dict]:
         session = self.sessions[session_id]  # raises KeyError if missing
         options_hash = hash(json.dumps(session.options, sort_keys=True))
+        gate = PermissionGate(
+            translation_table=self.translation_table,
+            ws_publisher=self.ws_publisher,
+            session=session,
+            auto_approve_user_actions=get_auto_approve_user_actions(),
+        )
         handle = await self.pool_client.acquire(session.user_id, options_hash)
         session.active_handles.append(handle)
         try:
-            async for sdk_event in self.pool_client.query(handle, prompt):
-                layer_event = _translate_event(session_id, sdk_event)
-                await self.ws_publisher.push(session.user_ws_id, layer_event)
-                yield layer_event
+            async for sdk_event in self.pool_client.query(
+                handle, prompt, can_use_tool=gate.can_use_tool
+            ):
+                async for layer_event in _translate_event(
+                    session_id, sdk_event, self.translation_table, session
+                ):
+                    await self.ws_publisher.push(session.user_ws_id, layer_event)
+                    yield layer_event
         finally:
             if handle in session.active_handles:
                 session.active_handles.remove(handle)
@@ -78,20 +105,64 @@ class Layer:
             await self.pool_client.interrupt(handle)
 
 
-def _translate_event(session_id: str, sdk_event: dict) -> dict:
-    """Translate a raw SDK event to a layer event (B1 naive forwarding)."""
+async def _translate_event(
+    session_id: str,
+    sdk_event: dict,
+    table: TranslationTable,
+    session: Session,
+) -> AsyncIterator[dict]:
+    """Translate a raw SDK event to one or more layer events."""
     event_type = sdk_event.get("type", "")
+
     if event_type == "text_delta":
-        return {
+        yield {
             "type": "agent_text_delta",
             "session_id": session_id,
             "delta": sdk_event.get("delta", ""),
         }
+        return
+
     if event_type == "result":
-        return {
+        yield {
             "type": "turn_complete",
             "session_id": session_id,
             "final_text": sdk_event.get("final_text", ""),
             "tokens_used": sdk_event.get("tokens_used", 0),
         }
-    return {"type": "status", "session_id": session_id, "message": str(sdk_event)}
+        return
+
+    if event_type == "tool_use":
+        tool_name = sdk_event.get("tool_name", "")
+        args = sdk_event.get("args", {})
+        entry = table.lookup(tool_name)
+
+        if isinstance(entry, PassthroughEntry):
+            # Emit the status text directly
+            yield {
+                "type": "status",
+                "session_id": session_id,
+                "message": args.get("text", ""),
+            }
+            return
+
+        phrase = table.interpolate_phrase(entry, args)
+        action_id, coalesced = session.coalescing_buffer.record(tool_name, phrase)
+        yield {
+            "type": "agent_action",
+            "session_id": session_id,
+            "action_id": action_id,
+            "action": phrase,
+            "coalesced": coalesced,
+        }
+        return
+
+    if event_type == "status":
+        yield {
+            "type": "status",
+            "session_id": session_id,
+            "message": sdk_event.get("message", ""),
+        }
+        return
+
+    # Unknown event — forward as status for visibility
+    yield {"type": "status", "session_id": session_id, "message": str(sdk_event)}

--- a/interactive_agent_layer/translation.py
+++ b/interactive_agent_layer/translation.py
@@ -85,6 +85,10 @@ class _ForgivingMap(dict):
         return f"{{{key}}}"
 
 
+# Public alias for external use (e.g. permissions.py).
+ForgivingMap = _ForgivingMap
+
+
 def _parse_entry(data: dict) -> TranslationEntry:
     t = data["type"]
     if t == "background":

--- a/interactive_agent_layer/translation.py
+++ b/interactive_agent_layer/translation.py
@@ -1,0 +1,103 @@
+"""Translation table for agent tool events.
+
+Maps tool names to typed translation entries. BackgroundEntry and
+BackgroundHiddenEntry intentionally have no permission fields so that
+internal detail cannot be accidentally surfaced to users.
+"""
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+from typing import Union
+
+import yaml
+
+
+@dataclasses.dataclass(frozen=True)
+class BackgroundEntry:
+    type: str  # "background"
+    phrase: str
+
+
+@dataclasses.dataclass(frozen=True)
+class BackgroundHiddenEntry:
+    type: str  # "background_hidden"
+    phrase: str
+
+
+@dataclasses.dataclass(frozen=True)
+class PassthroughEntry:
+    type: str  # "passthrough"
+
+
+@dataclasses.dataclass(frozen=True)
+class UserActionEntry:
+    type: str  # "user_action"
+    phrase_short: str
+    permission_summary: str
+    permission_detail_field: str
+
+
+TranslationEntry = Union[BackgroundEntry, BackgroundHiddenEntry, PassthroughEntry, UserActionEntry]
+
+
+class TranslationTable:
+    def __init__(self, entries: dict[str, TranslationEntry]) -> None:
+        self._entries = entries
+
+    @classmethod
+    def from_yaml(cls, path: "pathlib.Path | str | None" = None) -> "TranslationTable":
+        """Load from YAML file. Defaults to config/agent_translations.yaml."""
+        if path is None:
+            path = pathlib.Path(__file__).parent.parent / "config" / "agent_translations.yaml"
+        raw = yaml.safe_load(pathlib.Path(path).read_text())
+        entries: dict[str, TranslationEntry] = {}
+        for name, data in raw.items():
+            entries[name] = _parse_entry(data)
+        return cls(entries)
+
+    def lookup(self, tool_name: str) -> TranslationEntry:
+        """Return entry for tool_name, falling back to _unknown."""
+        return (
+            self._entries.get(tool_name)
+            or self._entries.get("_unknown")
+            or BackgroundEntry(type="background", phrase="Working")
+        )
+
+    def interpolate_phrase(self, entry: TranslationEntry, args: dict) -> str:
+        """Interpolate the phrase with tool args. Uses format_map with forgiving fallback."""
+        if isinstance(entry, PassthroughEntry):
+            return ""
+        if isinstance(entry, UserActionEntry):
+            phrase = entry.phrase_short
+        else:
+            phrase = entry.phrase
+        try:
+            return phrase.format_map(_ForgivingMap(args))
+        except Exception:
+            return phrase
+
+
+class _ForgivingMap(dict):
+    """dict subclass that returns '{key}' for missing keys instead of raising KeyError."""
+
+    def __missing__(self, key: str) -> str:
+        return f"{{{key}}}"
+
+
+def _parse_entry(data: dict) -> TranslationEntry:
+    t = data["type"]
+    if t == "background":
+        return BackgroundEntry(type=t, phrase=data["phrase"])
+    if t == "background_hidden":
+        return BackgroundHiddenEntry(type=t, phrase=data["phrase"])
+    if t == "passthrough":
+        return PassthroughEntry(type=t)
+    if t == "user_action":
+        return UserActionEntry(
+            type=t,
+            phrase_short=data["phrase_short"],
+            permission_summary=data["permission_summary"],
+            permission_detail_field=data["permission_detail_field"],
+        )
+    raise ValueError(f"Unknown translation entry type: {t!r}")

--- a/tests/interactive_agent_layer/conftest.py
+++ b/tests/interactive_agent_layer/conftest.py
@@ -1,11 +1,22 @@
 """Fixtures for interactive_agent_layer tests."""
 from __future__ import annotations
 
+import pathlib
+
 import pytest
 from httpx import AsyncClient, ASGITransport
 
 from interactive_agent_layer.ws_publisher import WSPublisher
 from interactive_agent_layer.session import Layer
+
+
+@pytest.fixture(autouse=True)
+def patch_config_getters(monkeypatch):
+    """Avoid loading the real config (needs jwt.secret) in session.run_turn."""
+    monkeypatch.setattr(
+        "interactive_agent_layer.session.get_auto_approve_user_actions",
+        lambda: False,
+    )
 
 
 class MockPoolClient:
@@ -14,8 +25,10 @@ class MockPoolClient:
     async def acquire(self, user_id: str, options_hash: int) -> str:
         return f"mock-handle-{user_id}"
 
-    async def query(self, handle: str, prompt: str):
+    async def query(self, handle: str, prompt: str, can_use_tool=None):
         yield {"type": "text_delta", "delta": "Hello "}
+        yield {"type": "tool_use", "tool_name": "get_anchors", "args": {}}
+        yield {"type": "tool_use", "tool_name": "send_status_update", "args": {"text": "Still working"}}
         yield {"type": "text_delta", "delta": "world"}
         yield {"type": "result", "final_text": "Hello world", "tokens_used": 42}
 
@@ -38,7 +51,13 @@ def ws_publisher():
 
 @pytest.fixture
 def layer(mock_pool_client, ws_publisher):
-    return Layer(pool_client=mock_pool_client, ws_publisher=ws_publisher)
+    from interactive_agent_layer.translation import TranslationTable
+    yaml_path = pathlib.Path(__file__).parent.parent.parent / "config" / "agent_translations.yaml"
+    return Layer(
+        pool_client=mock_pool_client,
+        ws_publisher=ws_publisher,
+        translation_table=TranslationTable.from_yaml(yaml_path),
+    )
 
 
 @pytest.fixture

--- a/tests/interactive_agent_layer/test_coalescing.py
+++ b/tests/interactive_agent_layer/test_coalescing.py
@@ -1,0 +1,151 @@
+"""Tests for CoalescingBuffer."""
+from __future__ import annotations
+
+import pytest
+
+from interactive_agent_layer.coalescing import CoalescingBuffer
+
+
+def make_clock(start: float = 0.0) -> list[float]:
+    return [start]
+
+
+def test_first_call_returns_new_action_id_not_coalesced():
+    clock = make_clock()
+    buf = CoalescingBuffer(window_seconds=5.0, time_fn=lambda: clock[0])
+
+    action_id, coalesced = buf.record("get_anchors", "Reading your schedule")
+
+    assert isinstance(action_id, str)
+    assert len(action_id) > 0
+    assert coalesced is False
+
+
+def test_second_call_within_window_returns_same_id_coalesced():
+    clock = make_clock()
+    buf = CoalescingBuffer(window_seconds=5.0, time_fn=lambda: clock[0])
+
+    id1, coalesced1 = buf.record("get_anchors", "Reading your schedule")
+    assert not coalesced1
+
+    clock[0] = 3.0  # still within 5s window
+    id2, coalesced2 = buf.record("get_anchors", "Reading your schedule")
+
+    assert coalesced2 is True
+    assert id2 == id1
+
+
+def test_same_key_after_window_expires_returns_new_id():
+    clock = make_clock()
+    buf = CoalescingBuffer(window_seconds=5.0, time_fn=lambda: clock[0])
+
+    id1, _ = buf.record("get_anchors", "Reading your schedule")
+
+    clock[0] = 5.0  # exactly at window boundary — NOT within window (< not <=)
+    id2, coalesced2 = buf.record("get_anchors", "Reading your schedule")
+
+    assert coalesced2 is False
+    assert id2 != id1
+
+
+def test_different_tool_name_same_phrase_not_coalesced():
+    clock = make_clock()
+    buf = CoalescingBuffer(window_seconds=5.0, time_fn=lambda: clock[0])
+
+    id1, c1 = buf.record("get_anchors", "Reading your schedule")
+    id2, c2 = buf.record("get_tasks", "Reading your schedule")
+
+    assert c1 is False
+    assert c2 is False
+    assert id1 != id2
+
+
+def test_same_tool_name_different_phrase_not_coalesced():
+    clock = make_clock()
+    buf = CoalescingBuffer(window_seconds=5.0, time_fn=lambda: clock[0])
+
+    id1, c1 = buf.record("get_anchors", "Reading your schedule")
+    id2, c2 = buf.record("get_anchors", "Fetching data")
+
+    assert c1 is False
+    assert c2 is False
+    assert id1 != id2
+
+
+def test_multiple_keys_tracked_independently():
+    clock = make_clock()
+    buf = CoalescingBuffer(window_seconds=5.0, time_fn=lambda: clock[0])
+
+    id_a1, _ = buf.record("tool_a", "phrase_a")
+    id_b1, _ = buf.record("tool_b", "phrase_b")
+
+    clock[0] = 2.0
+    id_a2, c_a = buf.record("tool_a", "phrase_a")
+    id_b2, c_b = buf.record("tool_b", "phrase_b")
+
+    assert c_a is True
+    assert c_b is True
+    assert id_a2 == id_a1
+    assert id_b2 == id_b1
+    assert id_a1 != id_b1
+
+
+def test_evict_expired_removes_old_leaves_fresh():
+    clock = make_clock()
+    buf = CoalescingBuffer(window_seconds=5.0, time_fn=lambda: clock[0])
+
+    buf.record("old_tool", "old phrase")   # at t=0
+    clock[0] = 3.0
+    buf.record("fresh_tool", "fresh phrase")  # at t=3, still within window at t=5
+
+    clock[0] = 5.0  # old_tool entry is now expired (5 - 0 >= 5)
+    buf.evict_expired()
+
+    # old_tool should be gone: next call gets a new id, not coalesced
+    id_old_new, c_old = buf.record("old_tool", "old phrase")
+    assert c_old is False
+
+    # fresh_tool should still be in cache (5 - 3 = 2 < 5)
+    clock[0] = 6.0  # 6 - 3 = 3 < 5, still fresh
+    id_fresh2, c_fresh = buf.record("fresh_tool", "fresh phrase")
+    assert c_fresh is True
+
+
+def test_window_extension_third_call_still_coalesced():
+    """Second call within window resets the clock; third call uses the extended window."""
+    clock = make_clock()
+    buf = CoalescingBuffer(window_seconds=5.0, time_fn=lambda: clock[0])
+
+    id1, _ = buf.record("get_anchors", "Reading")  # t=0
+
+    clock[0] = 3.0
+    id2, c2 = buf.record("get_anchors", "Reading")  # t=3, extends window to t=8
+    assert c2 is True
+    assert id2 == id1
+
+    clock[0] = 6.0  # t=6, within extended window (3+5=8)
+    id3, c3 = buf.record("get_anchors", "Reading")
+    assert c3 is True
+    assert id3 == id1
+
+
+def test_injectable_clock_fully_deterministic():
+    """Verify no real time.monotonic is used when time_fn is provided."""
+    calls = []
+
+    def fake_clock():
+        # Always returns 0.0 the first time, 1.0 the second, etc.
+        t = float(len(calls))
+        calls.append(t)
+        return t
+
+    buf = CoalescingBuffer(window_seconds=5.0, time_fn=fake_clock)
+
+    id1, c1 = buf.record("tool", "phrase")  # clock returns 0.0
+    id2, c2 = buf.record("tool", "phrase")  # clock returns 1.0 (within 5s)
+
+    assert c1 is False
+    assert c2 is True
+    assert id2 == id1
+    # Confirm our fake clock was actually called
+    assert len(calls) >= 2

--- a/tests/interactive_agent_layer/test_permissions.py
+++ b/tests/interactive_agent_layer/test_permissions.py
@@ -1,0 +1,313 @@
+"""Tests for PermissionGate (TDD — written before implementation)."""
+from __future__ import annotations
+
+import asyncio
+import pathlib
+from unittest.mock import MagicMock
+
+import pytest
+
+from interactive_agent_layer.permissions import (
+    PermissionGate,
+    PermissionResultAllow,
+    PermissionResultDeny,
+)
+from interactive_agent_layer.session import Session
+from interactive_agent_layer.translation import TranslationTable
+
+
+@pytest.fixture(autouse=True)
+def patch_permission_timeout(monkeypatch):
+    """Avoid loading the real config (needs jwt.secret). Default to a generous timeout."""
+    monkeypatch.setattr(
+        "interactive_agent_layer.permissions.get_permission_timeout",
+        lambda: 30,
+    )
+
+
+@pytest.fixture
+def table():
+    yaml_path = (
+        pathlib.Path(__file__).parent.parent.parent
+        / "config"
+        / "agent_translations.yaml"
+    )
+    return TranslationTable.from_yaml(yaml_path)
+
+
+def _make_blocking_ws():
+    """
+    Return a mock ws whose push() blocks until unblocked.
+
+    Attributes:
+        ws.push_event   — asyncio.Event; set when push() is called
+        ws.release_event — asyncio.Event; push() awaits this before returning
+        ws.calls        — list of (ws_id, event) tuples
+    """
+    push_event = asyncio.Event()
+    release_event = asyncio.Event()
+    calls = []
+
+    async def _push(ws_id, event):
+        calls.append((ws_id, event))
+        push_event.set()
+        await release_event.wait()
+
+    ws = MagicMock()
+    ws.push = _push
+    ws.push_event = push_event
+    ws.release_event = release_event
+    ws.calls = calls
+    return ws
+
+
+@pytest.fixture
+def mock_ws():
+    """Simple non-blocking mock ws for tests that don't need interception."""
+    ws = MagicMock()
+
+    async def _push(ws_id, event):
+        pass
+
+    ws.push = _push
+    ws.calls = []
+    return ws
+
+
+@pytest.fixture
+def session():
+    return Session(
+        session_id="sess-1",
+        user_id="user-1",
+        user_ws_id="ws-1",
+        agent_version="tether-agent-2.0",
+        options={},
+    )
+
+
+@pytest.fixture
+def gate_auto_approve(table, mock_ws, session):
+    return PermissionGate(
+        translation_table=table,
+        ws_publisher=mock_ws,
+        session=session,
+        auto_approve_user_actions=True,
+    )
+
+
+@pytest.fixture
+def gate_no_auto(table, mock_ws, session):
+    return PermissionGate(
+        translation_table=table,
+        ws_publisher=mock_ws,
+        session=session,
+        auto_approve_user_actions=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. BackgroundEntry → always allow
+# ---------------------------------------------------------------------------
+
+async def test_background_entry_always_allow(gate_no_auto):
+    result = await gate_no_auto.can_use_tool("get_anchors", {}, None)
+    assert isinstance(result, PermissionResultAllow)
+
+
+# ---------------------------------------------------------------------------
+# 2. BackgroundHiddenEntry → always allow
+# ---------------------------------------------------------------------------
+
+async def test_background_hidden_entry_always_allow(gate_no_auto):
+    result = await gate_no_auto.can_use_tool("consult_advisor", {}, None)
+    assert isinstance(result, PermissionResultAllow)
+
+
+# ---------------------------------------------------------------------------
+# 3. PassthroughEntry → always allow
+# ---------------------------------------------------------------------------
+
+async def test_passthrough_entry_always_allow(gate_no_auto):
+    result = await gate_no_auto.can_use_tool(
+        "send_status_update", {"text": "hi"}, None
+    )
+    assert isinstance(result, PermissionResultAllow)
+
+
+# ---------------------------------------------------------------------------
+# 4. UserAction + auto_approve=True → allow, no permission_request pushed
+# ---------------------------------------------------------------------------
+
+async def test_user_action_auto_approve_allows(table, session):
+    """auto_approve should allow without touching ws at all."""
+    pushed = []
+
+    async def _noop_push(ws_id, event):
+        pushed.append(event)
+
+    ws = MagicMock()
+    ws.push = _noop_push
+
+    gate = PermissionGate(
+        translation_table=table,
+        ws_publisher=ws,
+        session=session,
+        auto_approve_user_actions=True,
+    )
+    result = await gate.can_use_tool("upsert_tasks", {"count": 3, "tasks": []}, None)
+    assert isinstance(result, PermissionResultAllow)
+    assert pushed == []
+
+
+# ---------------------------------------------------------------------------
+# Helper: run gate concurrently with a blocking ws so we can intercept
+# ---------------------------------------------------------------------------
+
+async def _run_with_blocking_ws(table, session, tool_name, args, resolve_value, *, timeout=None):
+    """
+    Run can_use_tool with a blocking ws.
+    Once the gate has pushed the permission_request, resolve the pending future
+    with resolve_value (True/False) or leave it (None → rely on natural timeout).
+    Returns (result, calls) where calls is the list of push call tuples.
+    """
+    ws = _make_blocking_ws()
+    gate = PermissionGate(
+        translation_table=table,
+        ws_publisher=ws,
+        session=session,
+        auto_approve_user_actions=False,
+    )
+
+    task = asyncio.create_task(gate.can_use_tool(tool_name, args, None))
+
+    # Wait until the gate has called push (the event is set inside _push).
+    await ws.push_event.wait()
+
+    # At this point the gate is suspended inside _push, so permission_pending is populated.
+    if resolve_value is not None:
+        # Resolve the future first, then unblock push so the gate can proceed.
+        pending_copy = dict(session.permission_pending)
+        if pending_copy:
+            request_id = next(iter(pending_copy))
+            fut = pending_copy[request_id]
+            fut.set_result(resolve_value)
+
+    # Unblock the ws.push() so the gate continues.
+    ws.release_event.set()
+
+    result = await task
+    return result, ws.calls
+
+
+# ---------------------------------------------------------------------------
+# 5. UserAction + auto_approve=False → emit permission_request → approve
+# ---------------------------------------------------------------------------
+
+async def test_user_action_no_auto_approve_and_user_approves(table, session):
+    result, calls = await _run_with_blocking_ws(
+        table, session, "upsert_tasks", {"count": 3, "tasks": ["task-1"]},
+        resolve_value=True,
+    )
+
+    assert isinstance(result, PermissionResultAllow)
+    assert len(calls) == 1
+    ws_id, event = calls[0]
+    assert ws_id == "ws-1"
+    assert event["type"] == "permission_request"
+    assert event["session_id"] == "sess-1"
+    assert "request_id" in event
+    assert "summary" in event
+    assert "details" in event
+
+
+# ---------------------------------------------------------------------------
+# 6. UserAction + auto_approve=False → timeout → deny
+# ---------------------------------------------------------------------------
+
+async def test_user_action_timeout_denies(table, session, monkeypatch):
+    monkeypatch.setattr(
+        "interactive_agent_layer.permissions.get_permission_timeout",
+        lambda: 0.01,
+    )
+
+    async def _noop_push(ws_id, event):
+        pass
+
+    ws = MagicMock()
+    ws.push = _noop_push
+
+    gate = PermissionGate(
+        translation_table=table,
+        ws_publisher=ws,
+        session=session,
+        auto_approve_user_actions=False,
+    )
+    result = await gate.can_use_tool("upsert_tasks", {"count": 1, "tasks": []}, None)
+    assert isinstance(result, PermissionResultDeny)
+
+
+# ---------------------------------------------------------------------------
+# 7. UserAction + auto_approve=False → future resolved False → deny
+# ---------------------------------------------------------------------------
+
+async def test_user_action_denied_by_user(table, session):
+    result, _ = await _run_with_blocking_ws(
+        table, session, "upsert_tasks", {"count": 1, "tasks": []},
+        resolve_value=False,
+    )
+    assert isinstance(result, PermissionResultDeny)
+
+
+# ---------------------------------------------------------------------------
+# 8. permission_summary interpolation
+# ---------------------------------------------------------------------------
+
+async def test_permission_summary_interpolation(table, session):
+    _, calls = await _run_with_blocking_ws(
+        table, session, "upsert_tasks", {"count": 3, "tasks": []},
+        resolve_value=True,
+    )
+    _, event = calls[0]
+    assert event["summary"] == "Update 3 tasks"
+
+
+# ---------------------------------------------------------------------------
+# 9. permission_pending cleaned up after approval/denial/timeout
+# ---------------------------------------------------------------------------
+
+async def test_permission_pending_cleaned_up_after_approval(table, session):
+    await _run_with_blocking_ws(
+        table, session, "upsert_tasks", {"count": 1, "tasks": []},
+        resolve_value=True,
+    )
+    assert session.permission_pending == {}
+
+
+async def test_permission_pending_cleaned_up_after_denial(table, session):
+    await _run_with_blocking_ws(
+        table, session, "upsert_tasks", {"count": 1, "tasks": []},
+        resolve_value=False,
+    )
+    assert session.permission_pending == {}
+
+
+async def test_permission_pending_cleaned_up_after_timeout(table, session, monkeypatch):
+    monkeypatch.setattr(
+        "interactive_agent_layer.permissions.get_permission_timeout",
+        lambda: 0.01,
+    )
+
+    async def _noop_push(ws_id, event):
+        pass
+
+    ws = MagicMock()
+    ws.push = _noop_push
+
+    gate = PermissionGate(
+        translation_table=table,
+        ws_publisher=ws,
+        session=session,
+        auto_approve_user_actions=False,
+    )
+    await gate.can_use_tool("upsert_tasks", {"count": 1, "tasks": []}, None)
+    assert session.permission_pending == {}

--- a/tests/interactive_agent_layer/test_server.py
+++ b/tests/interactive_agent_layer/test_server.py
@@ -174,3 +174,30 @@ async def test_turn_increments_turn_count(layer_client, layer):
             pass
 
     assert layer.sessions[sid].turn_count == 1
+
+
+async def test_permission_respond_resolves_future(layer_client, layer):
+    """POST /permission/{id}/respond sets the Future in session.permission_pending."""
+    import asyncio
+    start_resp = await layer_client.post(
+        "/session/start",
+        json={"user_id": "u1", "user_ws_id": "ws1", "agent_version": "v1", "options": {}, "user_message": "x"},
+    )
+    sid = start_resp.json()["session_id"]
+    session = layer.sessions[sid]
+
+    # Manually plant a future
+    loop = asyncio.get_event_loop()
+    fut = loop.create_future()
+    session.permission_pending["req-1"] = fut
+
+    resp = await layer_client.post("/permission/req-1/respond", json={"approve": True})
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+    assert fut.done()
+    assert fut.result() is True
+
+
+async def test_permission_respond_not_found(layer_client):
+    resp = await layer_client.post("/permission/no-such-id/respond", json={"approve": False})
+    assert resp.status_code == 404

--- a/tests/interactive_agent_layer/test_session.py
+++ b/tests/interactive_agent_layer/test_session.py
@@ -1,8 +1,11 @@
 """Tests for Session dataclass and Layer class."""
 from __future__ import annotations
 
+import pathlib
+
 import pytest
 from interactive_agent_layer.session import Session, Layer
+from interactive_agent_layer.translation import TranslationTable
 from interactive_agent_layer.ws_publisher import WSPublisher
 
 
@@ -10,8 +13,10 @@ class _MockPoolClient:
     async def acquire(self, user_id: str, options_hash: int) -> str:
         return f"mock-handle-{user_id}"
 
-    async def query(self, handle: str, prompt: str):
+    async def query(self, handle: str, prompt: str, can_use_tool=None):
         yield {"type": "text_delta", "delta": "Hello "}
+        yield {"type": "tool_use", "tool_name": "get_anchors", "args": {}}
+        yield {"type": "tool_use", "tool_name": "send_status_update", "args": {"text": "Still working"}}
         yield {"type": "text_delta", "delta": "world"}
         yield {"type": "result", "final_text": "Hello world", "tokens_used": 42}
 
@@ -26,7 +31,12 @@ class _MockPoolClient:
 def layer():
     publisher = WSPublisher()
     pool = _MockPoolClient()
-    return Layer(pool_client=pool, ws_publisher=publisher)
+    yaml_path = pathlib.Path(__file__).parent.parent.parent / "config" / "agent_translations.yaml"
+    return Layer(
+        pool_client=pool,
+        ws_publisher=publisher,
+        translation_table=TranslationTable.from_yaml(yaml_path),
+    )
 
 
 def test_session_dataclass_fields():
@@ -115,3 +125,48 @@ async def test_layer_run_turn_increments_turn_count(layer):
     async for _ in layer.run_turn(s.session_id, "second"):
         pass
     assert s.turn_count == 2
+
+
+async def test_tool_use_emits_agent_action(layer):
+    """tool_use event for background tool → agent_action with correct phrase."""
+    s = layer.create_session("user1", "wsid1", "v1", {})
+    events = []
+    async for event in layer.run_turn(s.session_id, "hi"):
+        events.append(event)
+
+    agent_actions = [e for e in events if e["type"] == "agent_action"]
+    assert len(agent_actions) >= 1
+    # get_anchors maps to "Reading your schedule"
+    actions_text = [e["action"] for e in agent_actions]
+    assert "Reading your schedule" in actions_text
+
+
+async def test_passthrough_emits_status(layer):
+    """send_status_update tool_use → status event with raw text."""
+    s = layer.create_session("user1", "wsid1", "v1", {})
+    events = []
+    async for event in layer.run_turn(s.session_id, "hi"):
+        events.append(event)
+
+    status_events = [e for e in events if e["type"] == "status"]
+    messages = [e["message"] for e in status_events]
+    assert "Still working" in messages
+
+
+async def test_coalescing_same_tool_deduplicates(layer):
+    """Two calls to same background tool within window → same action_id, second coalesced."""
+    s = layer.create_session("user1", "wsid1", "v1", {})
+    events = []
+    async for event in layer.run_turn(s.session_id, "first turn"):
+        events.append(event)
+    async for event in layer.run_turn(s.session_id, "second turn"):
+        events.append(event)
+
+    # get_anchors appears in both turns — second should be coalesced
+    get_anchors_events = [
+        e for e in events
+        if e["type"] == "agent_action" and e.get("action") == "Reading your schedule"
+    ]
+    assert len(get_anchors_events) == 2
+    assert get_anchors_events[0]["action_id"] == get_anchors_events[1]["action_id"]
+    assert get_anchors_events[1]["coalesced"] is True

--- a/tests/interactive_agent_layer/test_translation.py
+++ b/tests/interactive_agent_layer/test_translation.py
@@ -1,0 +1,153 @@
+"""Tests for the agent translation table (B2)."""
+from __future__ import annotations
+
+import pathlib
+import pytest
+
+from interactive_agent_layer.translation import (
+    TranslationTable,
+    BackgroundEntry,
+    BackgroundHiddenEntry,
+    PassthroughEntry,
+    UserActionEntry,
+)
+
+
+YAML_PATH = (
+    pathlib.Path(__file__).parent.parent.parent / "config" / "agent_translations.yaml"
+)
+
+
+@pytest.fixture(scope="module")
+def table() -> TranslationTable:
+    return TranslationTable.from_yaml(YAML_PATH)
+
+
+# --- from_yaml loads correctly ---
+
+def test_from_yaml_loads_background(table):
+    entry = table.lookup("get_anchors")
+    assert isinstance(entry, BackgroundEntry)
+
+
+def test_from_yaml_loads_background_hidden(table):
+    entry = table.lookup("consult_advisor")
+    assert isinstance(entry, BackgroundHiddenEntry)
+
+
+def test_from_yaml_loads_passthrough(table):
+    entry = table.lookup("send_status_update")
+    assert isinstance(entry, PassthroughEntry)
+
+
+def test_from_yaml_loads_user_action(table):
+    entry = table.lookup("upsert_tasks")
+    assert isinstance(entry, UserActionEntry)
+
+
+# --- Specific field values ---
+
+def test_get_anchors_phrase(table):
+    entry = table.lookup("get_anchors")
+    assert entry.phrase == "Reading your schedule"
+
+
+def test_get_plan_phrase(table):
+    entry = table.lookup("get_plan")
+    assert isinstance(entry, BackgroundEntry)
+    assert entry.phrase == "Reading your plan"
+
+
+def test_consult_advisor_is_background_hidden(table):
+    entry = table.lookup("consult_advisor")
+    assert isinstance(entry, BackgroundHiddenEntry)
+    assert entry.phrase == "Working on it"
+
+
+def test_upsert_tasks_fields(table):
+    entry = table.lookup("upsert_tasks")
+    assert isinstance(entry, UserActionEntry)
+    assert entry.phrase_short == "Updating tasks"
+    assert entry.permission_summary == "Update {count} tasks"
+    assert entry.permission_detail_field == "tasks"
+
+
+def test_delete_tasks_fields(table):
+    entry = table.lookup("delete_tasks")
+    assert isinstance(entry, UserActionEntry)
+    assert entry.phrase_short == "Removing tasks"
+    assert entry.permission_detail_field == "operations"
+
+
+def test_upsert_context_fields(table):
+    entry = table.lookup("upsert_context")
+    assert isinstance(entry, UserActionEntry)
+    assert entry.permission_summary == "Update context: {subject}"
+    assert entry.permission_detail_field == "nodes"
+
+
+# --- Fallback to _unknown ---
+
+def test_unknown_tool_falls_back_to_unknown_entry(table):
+    entry = table.lookup("nonexistent_tool_xyz")
+    assert isinstance(entry, BackgroundEntry)
+    assert entry.phrase == "Working"
+
+
+# --- Structural: no permission fields on background types ---
+
+def test_background_entry_has_no_permission_summary(table):
+    entry = table.lookup("get_anchors")
+    assert isinstance(entry, BackgroundEntry)
+    assert not hasattr(entry, "permission_summary")
+    assert not hasattr(entry, "permission_detail_field")
+
+
+def test_background_hidden_entry_has_no_permission_summary(table):
+    entry = table.lookup("consult_advisor")
+    assert isinstance(entry, BackgroundHiddenEntry)
+    assert not hasattr(entry, "permission_summary")
+    assert not hasattr(entry, "permission_detail_field")
+
+
+def test_user_action_entry_has_permission_fields(table):
+    entry = table.lookup("upsert_tasks")
+    assert isinstance(entry, UserActionEntry)
+    assert hasattr(entry, "permission_summary")
+    assert hasattr(entry, "permission_detail_field")
+
+
+# --- interpolate_phrase ---
+
+def test_interpolate_search_with_query_arg(table):
+    entry = table.lookup("search")
+    assert isinstance(entry, BackgroundEntry)
+    result = table.interpolate_phrase(entry, {"query": "hello"})
+    assert result == "Searching for 'hello'"
+
+
+def test_interpolate_missing_arg_is_forgiving(table):
+    entry = table.lookup("search")
+    result = table.interpolate_phrase(entry, {})
+    # Missing key should leave literal {query}
+    assert "{query}" in result
+
+
+def test_interpolate_user_action_uses_phrase_short(table):
+    entry = table.lookup("upsert_tasks")
+    result = table.interpolate_phrase(entry, {"count": 3})
+    # Should use phrase_short, not permission_summary
+    assert result == "Updating tasks"
+
+
+def test_interpolate_passthrough_returns_empty_string(table):
+    entry = table.lookup("send_status_update")
+    assert isinstance(entry, PassthroughEntry)
+    result = table.interpolate_phrase(entry, {})
+    assert result == ""
+
+
+def test_interpolate_background_hidden(table):
+    entry = table.lookup("consult_advisor")
+    result = table.interpolate_phrase(entry, {})
+    assert result == "Working on it"


### PR DESCRIPTION
## Summary

- **Translation table** (`config/agent_translations.yaml` + `translation.py`): two-channel architecture with typed frozen dataclasses (`BackgroundEntry`, `BackgroundHiddenEntry`, `PassthroughEntry`, `UserActionEntry`). Structural IP protection — background_hidden entries have no `permission_*` fields, so detail can never surface to users regardless of UI bugs or user settings.
- **Coalescing buffer** (`coalescing.py`): 5-second window deduplification for background tool actions. Same `(tool_name, phrase)` key within window → same `action_id`, `coalesced: True`. Injectable clock for deterministic tests.
- **Permission gate** (`permissions.py`): `can_use_tool` callback for agent SDK. Background/passthrough → auto-allow. `user_action` → emit `permission_request` event, await `asyncio.Future[bool]` with 60s timeout, deny on timeout.
- **Session wiring** (`session.py`): `Session` gains `permission_pending` dict + `coalescing_buffer`. `Layer` gains `translation_table`. `run_turn` builds `PermissionGate` per turn, passes `can_use_tool` callback to pool, routes `tool_use` events through translation.
- **Server** (`server.py`): Added `POST /permission/{request_id}/respond` endpoint that resolves the pending Future.
- **Pool client** (`pool_client.py`): `query` Protocol updated with optional `can_use_tool` callback param.

## Test plan

- [ ] 77 tests pass: `pytest tests/interactive_agent_layer/ -v`
- [ ] Translation table: 19 tests — type correctness, structural isolation (no permission fields on background types), interpolation, fallback
- [ ] Coalescing: 9 tests — first call, within-window, expiry, key discrimination, eviction, window extension (all deterministic via injectable clock)
- [ ] Permissions: 11 tests — auto-allow for background/passthrough, user_action approve/deny/timeout, permission_summary interpolation, pending cleanup
- [ ] Session wiring: 3 new tests — tool_use → agent_action, passthrough → status, coalescing across turns
- [ ] Server: 2 new tests — permission respond resolves Future, 404 on unknown request_id

## Out of scope (later phases)

Dev-mode raw tool toggle, frontend modal, BYOK gate, trial counter, interrupt wiring (B3–B5).