### PR TITLE
feat(ial): B5a trial counter + B5b BYOK leakage gate

### DIFF
--- a/db/migrations/versions/g1a2b3c4d5e6_premium_trial_usage.py
+++ b/db/migrations/versions/g1a2b3c4d5e6_premium_trial_usage.py
@@ -1,7 +1,7 @@
 """Add premium_trial_usage table for tether-agent-2.5 free-trial counter.
 
 Revision ID: g1a2b3c4d5e6
-Revises: f5a6b7c8d9e0
+Revises: d9e0f1a2b3c4
 Create Date: 2026-05-21
 """
 from typing import Sequence, Union
@@ -9,7 +9,7 @@ from typing import Sequence, Union
 from alembic import op
 
 revision: str = "g1a2b3c4d5e6"
-down_revision: Union[str, Sequence[str], None] = "f5a6b7c8d9e0"
+down_revision: Union[str, Sequence[str], None] = "d9e0f1a2b3c4"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/db/migrations/versions/g1a2b3c4d5e6_premium_trial_usage.py
+++ b/db/migrations/versions/g1a2b3c4d5e6_premium_trial_usage.py
@@ -1,0 +1,29 @@
+"""Add premium_trial_usage table for tether-agent-2.5 free-trial counter.
+
+Revision ID: g1a2b3c4d5e6
+Revises: f5a6b7c8d9e0
+Create Date: 2026-05-21
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "g1a2b3c4d5e6"
+down_revision: Union[str, Sequence[str], None] = "f5a6b7c8d9e0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE premium_trial_usage (
+            user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            year_month TEXT NOT NULL,
+            used_count INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (user_id, year_month)
+        )
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS premium_trial_usage")

--- a/db/pg_queries/__init__.py
+++ b/db/pg_queries/__init__.py
@@ -73,4 +73,5 @@ from db.pg_queries.beacon import (
 )
 from db.pg_queries.subscriptions import (
     get_user_is_paid,
+    get_user_is_paid_by_id,
 )

--- a/db/pg_queries/subscriptions.py
+++ b/db/pg_queries/subscriptions.py
@@ -29,3 +29,22 @@ async def get_user_is_paid(conn: asyncpg.Connection) -> bool:
     )
     # plan is None when no active row exists (legitimate free state).
     return plan is not None and plan != "free"
+
+
+async def get_user_is_paid_by_id(conn: asyncpg.Connection, user_id: str) -> bool:
+    """Admin-scope variant of get_user_is_paid for internal services with a known user_id.
+
+    Sets app.current_user_id via SET LOCAL within a transaction so the RLS
+    enforcement path is consistent with the user-scoped version. Use this in
+    internal services (e.g. the interactive agent layer) that know the user_id
+    from the request body but do not have a pre-scoped RLS connection.
+
+    A row with status != 'active' (e.g. 'cancelled', 'past_due') does not grant
+    paid access. A missing row is treated as free.
+    """
+    async with conn.transaction():
+        await conn.execute("SET LOCAL app.current_user_id = $1", user_id)
+        plan = await conn.fetchval(
+            "SELECT plan FROM subscriptions WHERE status = 'active' LIMIT 1"
+        )
+    return plan is not None and plan != "free"

--- a/interactive_agent_layer/config.py
+++ b/interactive_agent_layer/config.py
@@ -18,3 +18,13 @@ def get_permission_timeout() -> int:
 
 def get_auto_approve_user_actions() -> bool:
     return bool(config.get("agent_layer.auto_approve_user_actions", False))
+
+
+def get_trial_monthly_quota() -> int:
+    """Maximum tether-agent-2.5 sessions per free-tier user per calendar month."""
+    return int(config.get("agent_layer.trial_monthly_quota", 10))
+
+
+def get_leaky_providers() -> list[str]:
+    """Providers whose dashboards expose prompt content — 2.5 is disabled on these."""
+    return list(config.get("agent_layer.leaky_providers", ["openrouter", "openai"]))

--- a/interactive_agent_layer/providers.py
+++ b/interactive_agent_layer/providers.py
@@ -1,0 +1,33 @@
+"""Provider stub and BYOK leakage helpers for the interactive agent layer.
+
+For v1, all users are on Anthropic OAuth (the only supported provider).
+The full provider abstraction — user_settings table, per-user provider
+preference, multi-provider support — is future work.
+
+See tether-agent-models spec §"Future provider abstraction" for the planned
+design.  When that work lands, replace `get_user_provider` with a real lookup
+and wire it to the user_settings table.
+"""
+from __future__ import annotations
+
+from interactive_agent_layer.config import get_leaky_providers
+
+
+def get_user_provider(user_id: str) -> str:  # noqa: ARG001
+    """Return the active provider for a user.
+
+    STUB: returns 'anthropic_oauth' for all users. Replace with a user_settings
+    lookup once the full provider abstraction lands (values will be one of:
+    anthropic_oauth, anthropic_api_key, openai, openrouter, local_ollama,
+    tether_hosted).
+    """
+    return "anthropic_oauth"
+
+
+def is_leaky_provider(provider: str) -> bool:
+    """Return True if `provider` exposes prompt content in its dashboard.
+
+    Leaky providers are unsafe for tether-agent-2.5, which uses proprietary
+    prompts. The list comes from `agent_layer.leaky_providers` in config.
+    """
+    return provider in get_leaky_providers()

--- a/interactive_agent_layer/server.py
+++ b/interactive_agent_layer/server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 
 from interactive_agent_layer.session import Layer, Session
@@ -36,8 +36,50 @@ def create_app(layer: Layer) -> FastAPI:
             raise HTTPException(status_code=404, detail="Session not found")
         return session
 
+    async def check_2_5_gates(body: SessionStartRequest) -> JSONResponse | None:
+        """Enforce BYOK-leakage and free-tier trial gates for tether-agent-2.5.
+
+        Returns a 422 JSONResponse if the request is blocked, else None.
+        """
+        # B5b — BYOK leakage gate: block 2.5 on providers that expose prompt content.
+        if layer.provider_fn is not None and layer.leaky_providers is not None:
+            if layer.provider_fn(body.user_id) in layer.leaky_providers:
+                return JSONResponse(
+                    status_code=422,
+                    content={
+                        "error": "provider_unsupported_for_agent",
+                        "alternatives": ["tether-agent-2.0"],
+                    },
+                )
+
+        # B5a — trial counter (skipped entirely for premium users).
+        if layer.trial_counter is None:
+            return None
+
+        is_paid = await layer.is_paid_fn(body.user_id) if layer.is_paid_fn else False
+        if is_paid:
+            return None
+
+        allowed, remaining = await layer.trial_counter.check_and_increment(body.user_id)
+        if not allowed:
+            return JSONResponse(
+                status_code=422,
+                content={"error": "trial_exhausted", "upgrade_url": "/upgrade"},
+            )
+        # Publish live remaining count to the frontend picker.
+        await layer.ws_publisher.push(
+            body.user_ws_id,
+            {"type": "trial_usage_update", "remaining": remaining},
+        )
+        return None
+
     @app.post("/session/start")
-    async def session_start(body: SessionStartRequest) -> dict:
+    async def session_start(body: SessionStartRequest):
+        if body.agent_version == "tether-agent-2.5":
+            blocked = await check_2_5_gates(body)
+            if blocked is not None:
+                return blocked
+
         session = layer.create_session(
             user_id=body.user_id,
             user_ws_id=body.user_ws_id,

--- a/interactive_agent_layer/session.py
+++ b/interactive_agent_layer/session.py
@@ -5,6 +5,7 @@ import dataclasses
 import json
 import time
 import uuid
+from collections.abc import Callable
 from typing import AsyncIterator, Any
 
 from interactive_agent_layer.coalescing import CoalescingBuffer
@@ -41,11 +42,21 @@ class Layer:
         pool_client: PoolClient,
         ws_publisher: WSPublisher,
         translation_table: TranslationTable | None = None,
+        *,
+        trial_counter: Any = None,
+        is_paid_fn: Callable[..., Any] | None = None,
+        provider_fn: Callable[[str], str] | None = None,
+        leaky_providers: list[str] | None = None,
     ) -> None:
         self.sessions: dict[str, Session] = {}
         self.pool_client = pool_client
         self.ws_publisher = ws_publisher
         self.translation_table = translation_table or TranslationTable.from_yaml()
+        # Gate dependencies — None means no gate enforcement
+        self.trial_counter = trial_counter
+        self.is_paid_fn = is_paid_fn
+        self.provider_fn = provider_fn
+        self.leaky_providers = leaky_providers
 
     def create_session(
         self,

--- a/interactive_agent_layer/trial.py
+++ b/interactive_agent_layer/trial.py
@@ -1,0 +1,59 @@
+"""Per-user monthly trial counter for tether-agent-2.5.
+
+Backed by the `premium_trial_usage` Postgres table. Concurrent session-starts
+for the same user are serialised via `SELECT ... FOR UPDATE` so they cannot
+race past the configured quota.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from interactive_agent_layer.config import get_trial_monthly_quota
+
+
+class TrialCounter:
+    """DB-backed per-user monthly trial counter for tether-agent-2.5."""
+
+    def __init__(self, pool: Any) -> None:
+        self._pool = pool
+
+    async def check_and_increment(self, user_id: str) -> tuple[bool, int]:
+        """Atomically check quota and increment if there is room.
+
+        Returns `(allowed, remaining)`:
+        - `(True, N)`  — quota had room; counter was incremented, N sessions left.
+        - `(False, 0)` — quota exhausted; counter was NOT incremented.
+        """
+        year_month = datetime.now(timezone.utc).strftime("%Y-%m")
+        quota = get_trial_monthly_quota()
+
+        async with self._pool.acquire() as conn:
+            async with conn.transaction():
+                row = await conn.fetchrow(
+                    """
+                    SELECT used_count FROM premium_trial_usage
+                    WHERE user_id = $1 AND year_month = $2
+                    FOR UPDATE
+                    """,
+                    user_id,
+                    year_month,
+                )
+                current = row["used_count"] if row else 0
+
+                if current >= quota:
+                    return False, 0
+
+                new_count = current + 1
+                await conn.execute(
+                    """
+                    INSERT INTO premium_trial_usage (user_id, year_month, used_count)
+                    VALUES ($1, $2, $3)
+                    ON CONFLICT (user_id, year_month) DO UPDATE
+                        SET used_count = EXCLUDED.used_count
+                    """,
+                    user_id,
+                    year_month,
+                    new_count,
+                )
+                return True, quota - new_count

--- a/tests/db/test_subscriptions.py
+++ b/tests/db/test_subscriptions.py
@@ -1,0 +1,100 @@
+"""Unit tests for db.pg_queries.subscriptions.get_user_is_paid_by_id.
+
+Uses mock asyncpg connections — no real DB required.
+
+Tests cover:
+- No subscription row → False
+- Active premium plan → True
+- Active free plan → False
+- Cancelled premium → False (status must be 'active')
+- SET LOCAL is called with the correct user_id (RLS consistency)
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, call
+
+
+def _make_conn(fetchval_return=None):
+    """Build a minimal mock asyncpg connection for subscriptions queries."""
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=fetchval_return)
+    conn.execute = AsyncMock()
+
+    txn_cm = MagicMock()
+    txn_cm.__aenter__ = AsyncMock(return_value=None)
+    txn_cm.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=txn_cm)
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# No subscription row
+# ---------------------------------------------------------------------------
+
+async def test_get_user_is_paid_by_id_no_row_returns_false():
+    """No subscription row → False (free tier)."""
+    conn = _make_conn(fetchval_return=None)
+
+    from db.pg_queries import get_user_is_paid_by_id
+    result = await get_user_is_paid_by_id(conn, "user-abc")
+
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Active premium plan
+# ---------------------------------------------------------------------------
+
+async def test_get_user_is_paid_by_id_premium_active_returns_true():
+    """Active subscription with plan='premium' → True."""
+    conn = _make_conn(fetchval_return="premium")
+
+    from db.pg_queries import get_user_is_paid_by_id
+    result = await get_user_is_paid_by_id(conn, "user-abc")
+
+    assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Active free plan
+# ---------------------------------------------------------------------------
+
+async def test_get_user_is_paid_by_id_free_plan_returns_false():
+    """Active subscription with plan='free' → False."""
+    conn = _make_conn(fetchval_return="free")
+
+    from db.pg_queries import get_user_is_paid_by_id
+    result = await get_user_is_paid_by_id(conn, "user-abc")
+
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Cancelled premium (status != 'active' filtered in SQL)
+# ---------------------------------------------------------------------------
+
+async def test_get_user_is_paid_by_id_cancelled_returns_false():
+    """Cancelled subscription: SQL filters status='active', fetchval returns None → False."""
+    # The SQL already filters status='active'; cancelled rows don't appear.
+    conn = _make_conn(fetchval_return=None)
+
+    from db.pg_queries import get_user_is_paid_by_id
+    result = await get_user_is_paid_by_id(conn, "user-abc")
+
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# SET LOCAL is called with the correct user_id
+# ---------------------------------------------------------------------------
+
+async def test_get_user_is_paid_by_id_sets_rls_context():
+    """SET LOCAL app.current_user_id is called with the given user_id."""
+    conn = _make_conn(fetchval_return="premium")
+
+    from db.pg_queries import get_user_is_paid_by_id
+    await get_user_is_paid_by_id(conn, "user-xyz")
+
+    conn.execute.assert_called_once_with(
+        "SET LOCAL app.current_user_id = $1", "user-xyz"
+    )

--- a/tests/interactive_agent_layer/test_providers.py
+++ b/tests/interactive_agent_layer/test_providers.py
@@ -1,0 +1,67 @@
+"""Unit tests for interactive_agent_layer.providers.
+
+Tests cover:
+- get_user_provider stub returns 'anthropic_oauth' for any user_id
+- is_leaky_provider returns True for providers in the leaky_providers config list
+- is_leaky_provider returns False for safe providers (anthropic_oauth, etc.)
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# get_user_provider stub
+# ---------------------------------------------------------------------------
+
+def test_get_user_provider_returns_anthropic_oauth():
+    """Stub must return 'anthropic_oauth' for any user_id."""
+    from interactive_agent_layer.providers import get_user_provider
+
+    assert get_user_provider("user-abc") == "anthropic_oauth"
+    assert get_user_provider("user-xyz") == "anthropic_oauth"
+    assert get_user_provider("") == "anthropic_oauth"
+
+
+# ---------------------------------------------------------------------------
+# is_leaky_provider
+# ---------------------------------------------------------------------------
+
+def test_is_leaky_provider_true_for_openrouter():
+    """openrouter is in the default leaky_providers list."""
+    with patch(
+        "interactive_agent_layer.providers.get_leaky_providers",
+        return_value=["openrouter", "openai"],
+    ):
+        from interactive_agent_layer.providers import is_leaky_provider
+        assert is_leaky_provider("openrouter") is True
+
+
+def test_is_leaky_provider_true_for_openai():
+    """openai is in the default leaky_providers list."""
+    with patch(
+        "interactive_agent_layer.providers.get_leaky_providers",
+        return_value=["openrouter", "openai"],
+    ):
+        from interactive_agent_layer.providers import is_leaky_provider
+        assert is_leaky_provider("openai") is True
+
+
+def test_is_leaky_provider_false_for_anthropic_oauth():
+    """anthropic_oauth is safe — not in leaky_providers."""
+    with patch(
+        "interactive_agent_layer.providers.get_leaky_providers",
+        return_value=["openrouter", "openai"],
+    ):
+        from interactive_agent_layer.providers import is_leaky_provider
+        assert is_leaky_provider("anthropic_oauth") is False
+
+
+def test_is_leaky_provider_false_for_unknown_provider():
+    """Providers not in the list are treated as safe (not leaky)."""
+    with patch(
+        "interactive_agent_layer.providers.get_leaky_providers",
+        return_value=["openrouter", "openai"],
+    ):
+        from interactive_agent_layer.providers import is_leaky_provider
+        assert is_leaky_provider("some_new_provider") is False

--- a/tests/interactive_agent_layer/test_trial.py
+++ b/tests/interactive_agent_layer/test_trial.py
@@ -1,0 +1,150 @@
+"""Unit tests for interactive_agent_layer.trial.TrialCounter.
+
+Tests cover:
+- First use returns (True, quota-1)
+- Subsequent uses decrement remaining
+- At-quota use returns (True, 0) — last allowed
+- Over-quota attempt returns (False, 0) — exhausted
+- year_month rollover: different month = fresh counter (fresh pool mock)
+- Quota read from config (default 10)
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _make_pool(fetchrow_return=None, execute_return=None):
+    """Build a minimal mock asyncpg pool."""
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=fetchrow_return)
+    conn.execute = AsyncMock(return_value=execute_return)
+
+    # transaction() returns an async context manager that yields conn
+    txn_cm = MagicMock()
+    txn_cm.__aenter__ = AsyncMock(return_value=None)
+    txn_cm.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=txn_cm)
+
+    # pool.acquire() returns an async context manager yielding conn
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+    acquire_cm.__aexit__ = AsyncMock(return_value=False)
+
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=acquire_cm)
+    return pool, conn
+
+
+# ---------------------------------------------------------------------------
+# First use — no existing row
+# ---------------------------------------------------------------------------
+
+async def test_trial_counter_first_use_allowed():
+    """First use with no existing row: allowed=True, remaining=quota-1."""
+    pool, conn = _make_pool(fetchrow_return=None)  # no existing row
+    conn.execute = AsyncMock()
+
+    with patch("interactive_agent_layer.trial.get_trial_monthly_quota", return_value=10):
+        from interactive_agent_layer.trial import TrialCounter
+        counter = TrialCounter(pool)
+        allowed, remaining = await counter.check_and_increment("user-1")
+
+    assert allowed is True
+    assert remaining == 9
+
+
+# ---------------------------------------------------------------------------
+# Subsequent use — existing row under quota
+# ---------------------------------------------------------------------------
+
+async def test_trial_counter_increments_and_returns_remaining():
+    """Existing row with used=5: allowed=True, remaining=quota-6."""
+    existing_row = {"used_count": 5}
+    pool, conn = _make_pool(fetchrow_return=existing_row)
+
+    with patch("interactive_agent_layer.trial.get_trial_monthly_quota", return_value=10):
+        from interactive_agent_layer.trial import TrialCounter
+        counter = TrialCounter(pool)
+        allowed, remaining = await counter.check_and_increment("user-1")
+
+    assert allowed is True
+    assert remaining == 4  # quota(10) - new_count(6) = 4
+
+
+# ---------------------------------------------------------------------------
+# Last allowed use — used goes to exactly quota
+# ---------------------------------------------------------------------------
+
+async def test_trial_counter_last_allowed_use():
+    """used=9 → last slot: allowed=True, remaining=0."""
+    pool, conn = _make_pool(fetchrow_return={"used_count": 9})
+
+    with patch("interactive_agent_layer.trial.get_trial_monthly_quota", return_value=10):
+        from interactive_agent_layer.trial import TrialCounter
+        counter = TrialCounter(pool)
+        allowed, remaining = await counter.check_and_increment("user-1")
+
+    assert allowed is True
+    assert remaining == 0
+
+
+# ---------------------------------------------------------------------------
+# Exhausted — used already at quota
+# ---------------------------------------------------------------------------
+
+async def test_trial_counter_exhausted_returns_false():
+    """used=10 (at quota): allowed=False, remaining=0. Counter NOT incremented."""
+    pool, conn = _make_pool(fetchrow_return={"used_count": 10})
+
+    with patch("interactive_agent_layer.trial.get_trial_monthly_quota", return_value=10):
+        from interactive_agent_layer.trial import TrialCounter
+        counter = TrialCounter(pool)
+        allowed, remaining = await counter.check_and_increment("user-1")
+
+    assert allowed is False
+    assert remaining == 0
+    # execute() must NOT have been called — we don't write when exhausted
+    conn.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Over-quota — used > quota (shouldn't normally happen but be defensive)
+# ---------------------------------------------------------------------------
+
+async def test_trial_counter_over_quota_returns_false():
+    """used=12 (over quota): allowed=False, counter not incremented."""
+    pool, conn = _make_pool(fetchrow_return={"used_count": 12})
+
+    with patch("interactive_agent_layer.trial.get_trial_monthly_quota", return_value=10):
+        from interactive_agent_layer.trial import TrialCounter
+        counter = TrialCounter(pool)
+        allowed, remaining = await counter.check_and_increment("user-1")
+
+    assert allowed is False
+    conn.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# year_month is derived from current UTC time
+# ---------------------------------------------------------------------------
+
+async def test_trial_counter_uses_utc_year_month():
+    """TrialCounter queries with the current UTC year_month string."""
+    pool, conn = _make_pool(fetchrow_return=None)
+    year_month_used = []
+
+    async def capture_fetchrow(sql, user_id, year_month, *args):
+        year_month_used.append(year_month)
+        return None
+
+    conn.fetchrow = capture_fetchrow
+
+    with patch("interactive_agent_layer.trial.get_trial_monthly_quota", return_value=10):
+        with patch("interactive_agent_layer.trial.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 5, 15, tzinfo=timezone.utc)
+            from interactive_agent_layer.trial import TrialCounter
+            counter = TrialCounter(pool)
+            await counter.check_and_increment("user-1")
+
+    assert "2026-05" in year_month_used

--- a/tests/interactive_agent_layer/test_trial_server.py
+++ b/tests/interactive_agent_layer/test_trial_server.py
@@ -1,0 +1,216 @@
+"""Server integration tests for B5a trial counter + B5b BYOK leakage gate.
+
+Tests verify that POST /session/start enforces:
+- tether-agent-2.5 + leaky provider → 422 provider_unsupported_for_agent
+- tether-agent-2.5 + is_paid=True → counter bypassed, session created
+- tether-agent-2.5 + is_paid=False + counter allows → session created, trial_usage_update published
+- tether-agent-2.5 + is_paid=False + counter exhausted → 422 trial_exhausted
+- tether-agent-1.0 / 2.0 → no gate, always allowed
+
+These tests inject mock trial_counter, is_paid_fn, and provider_fn via the Layer
+constructor (no real DB needed).
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+
+_START_BODY_BASE = {
+    "user_ws_id": "ws-001",
+    "options": {},
+    "user_message": "hello",
+}
+
+
+def _start_body(user_id: str = "user-1", agent_version: str = "tether-agent-2.5") -> dict:
+    return {"user_id": user_id, "agent_version": agent_version, **_START_BODY_BASE}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+class _MockTrialCounter:
+    def __init__(self, allowed: bool = True, remaining: int = 5):
+        self._allowed = allowed
+        self._remaining = remaining
+        self.calls: list[str] = []
+
+    async def check_and_increment(self, user_id: str):
+        self.calls.append(user_id)
+        return self._allowed, self._remaining
+
+
+def _make_layer(
+    *,
+    is_paid: bool = False,
+    trial_allowed: bool = True,
+    trial_remaining: int = 5,
+    provider: str = "anthropic_oauth",
+    leaky_providers: list[str] | None = None,
+):
+    """Build a Layer with injected mock gate dependencies."""
+    import pathlib
+    from interactive_agent_layer.ws_publisher import WSPublisher
+    from interactive_agent_layer.session import Layer
+    from interactive_agent_layer.translation import TranslationTable
+
+    if leaky_providers is None:
+        leaky_providers = ["openrouter", "openai"]
+
+    yaml_path = (
+        pathlib.Path(__file__).parent.parent.parent / "config" / "agent_translations.yaml"
+    )
+    translation_table = TranslationTable.from_yaml(yaml_path)
+
+    class _FakePool:
+        async def acquire(self):
+            return None
+
+    trial_counter = _MockTrialCounter(allowed=trial_allowed, remaining=trial_remaining)
+    is_paid_fn = AsyncMock(return_value=is_paid)
+    provider_fn = MagicMock(return_value=provider)
+
+    ws_publisher = WSPublisher()
+
+    # MockPoolClient is only needed for run_turn, not session_start
+    class _MockPoolClient:
+        async def acquire(self, *a, **kw): return "handle"
+        async def query(self, *a, **kw): return; yield  # noqa: E704
+        async def release(self, *a, **kw): pass
+        async def interrupt(self, *a, **kw): pass
+
+    return Layer(
+        pool_client=_MockPoolClient(),
+        ws_publisher=ws_publisher,
+        translation_table=translation_table,
+        trial_counter=trial_counter,
+        is_paid_fn=is_paid_fn,
+        provider_fn=provider_fn,
+        leaky_providers=leaky_providers,
+    ), trial_counter, is_paid_fn, ws_publisher
+
+
+@asynccontextmanager
+async def _client_for(layer):
+    from interactive_agent_layer.server import create_app
+    app = create_app(layer)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# B5b — BYOK leakage gate
+# ---------------------------------------------------------------------------
+
+async def test_session_start_2_5_leaky_provider_rejected():
+    """tether-agent-2.5 with a leaky provider returns 422 provider_unsupported_for_agent."""
+    layer, _, _, _ = _make_layer(provider="openrouter", leaky_providers=["openrouter", "openai"])
+    async with _client_for(layer) as client:
+        resp = await client.post("/session/start", json=_start_body(agent_version="tether-agent-2.5"))
+
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body.get("error") == "provider_unsupported_for_agent"
+    assert "tether-agent-2.0" in body.get("alternatives", [])
+
+
+async def test_session_start_2_5_safe_provider_allowed():
+    """tether-agent-2.5 with anthropic_oauth (safe provider) passes the leakage gate."""
+    layer, _, _, _ = _make_layer(provider="anthropic_oauth", trial_allowed=True)
+    async with _client_for(layer) as client:
+        resp = await client.post("/session/start", json=_start_body(agent_version="tether-agent-2.5"))
+
+    assert resp.status_code == 200
+    assert "session_id" in resp.json()
+
+
+# ---------------------------------------------------------------------------
+# B5a — trial counter: premium bypass
+# ---------------------------------------------------------------------------
+
+async def test_session_start_2_5_premium_bypasses_counter():
+    """is_paid=True: trial counter is never called, session is created."""
+    layer, trial_counter, _, _ = _make_layer(is_paid=True, trial_allowed=False)
+    async with _client_for(layer) as client:
+        resp = await client.post("/session/start", json=_start_body(agent_version="tether-agent-2.5"))
+
+    assert resp.status_code == 200
+    assert "session_id" in resp.json()
+    assert trial_counter.calls == [], "premium user must not touch the trial counter"
+
+
+# ---------------------------------------------------------------------------
+# B5a — trial counter: free user allowed
+# ---------------------------------------------------------------------------
+
+async def test_session_start_2_5_free_user_counter_increments():
+    """is_paid=False + counter allows: session created, counter incremented."""
+    layer, trial_counter, _, _ = _make_layer(is_paid=False, trial_allowed=True, trial_remaining=4)
+    async with _client_for(layer) as client:
+        resp = await client.post("/session/start", json=_start_body(user_id="free-user"))
+
+    assert resp.status_code == 200
+    assert "session_id" in resp.json()
+    assert "free-user" in trial_counter.calls, "trial counter must be called for free user"
+
+
+# ---------------------------------------------------------------------------
+# B5a — trial counter: free user exhausted
+# ---------------------------------------------------------------------------
+
+async def test_session_start_2_5_trial_exhausted():
+    """is_paid=False + counter exhausted: returns 422 trial_exhausted."""
+    layer, _, _, _ = _make_layer(is_paid=False, trial_allowed=False, trial_remaining=0)
+    async with _client_for(layer) as client:
+        resp = await client.post("/session/start", json=_start_body(agent_version="tether-agent-2.5"))
+
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body.get("error") == "trial_exhausted"
+    assert "upgrade_url" in body
+
+
+# ---------------------------------------------------------------------------
+# B5a — trial_usage_update published after allowed 2.5 session
+# ---------------------------------------------------------------------------
+
+async def test_session_start_2_5_publishes_trial_usage_update():
+    """Successful 2.5 session start publishes trial_usage_update WS event with remaining count."""
+    layer, _, _, ws_publisher = _make_layer(is_paid=False, trial_allowed=True, trial_remaining=7)
+    published: list[dict] = []
+    ws_publisher.push = AsyncMock(side_effect=lambda ws_id, event: published.append(event))
+
+    async with _client_for(layer) as client:
+        await client.post("/session/start", json=_start_body(user_id="user-trial"))
+
+    trial_events = [e for e in published if e.get("type") == "trial_usage_update"]
+    assert trial_events, "trial_usage_update event must be published"
+    event = trial_events[0]
+    assert event["remaining"] == 7
+
+
+# ---------------------------------------------------------------------------
+# No gate for 1.0 and 2.0
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("version", ["tether-agent-1.0", "tether-agent-2.0"])
+async def test_session_start_no_gate_for_1_0_and_2_0(version):
+    """1.0 and 2.0 bypass all gate checks — always allowed regardless of provider or tier."""
+    # Leaky provider + exhausted counter + free user: still must succeed for 1.0/2.0
+    layer, trial_counter, is_paid_fn, _ = _make_layer(
+        is_paid=False,
+        trial_allowed=False,
+        provider="openrouter",
+        leaky_providers=["openrouter"],
+    )
+    async with _client_for(layer) as client:
+        resp = await client.post("/session/start", json=_start_body(agent_version=version))
+
+    assert resp.status_code == 200, f"{version} must bypass gate (got {resp.status_code})"
+    assert trial_counter.calls == [], f"{version} must not touch trial counter"
+    is_paid_fn.assert_not_called()


### PR DESCRIPTION
## Summary

- **B5a — Trial counter:** `premium_trial_usage` Alembic migration + `TrialCounter` class with atomic `SELECT ... FOR UPDATE` quota enforcement. Premium users bypass counter. Successful 2.5 start publishes `trial_usage_update` WS event with remaining count.
- **B5b — BYOK leakage gate:** `providers.py` with `get_user_provider` stub (returns `anthropic_oauth` for all users, clearly marked TODO for future provider abstraction) and `is_leaky_provider`. Rejects 2.5 on leaky providers with `provider_unsupported_for_agent`.
- Gate lives in `check_2_5_gates()` helper inside `server.py` — only runs for `tether-agent-2.5`; 1.0 and 2.0 bypass entirely.
- `Layer` accepts `trial_counter`, `is_paid_fn`, `provider_fn`, `leaky_providers` as optional constructor args (None = no enforcement), keeping existing tests unaffected.
- Config keys: `agent_layer.trial_monthly_quota` (default 10), `agent_layer.leaky_providers` (default `[openrouter, openai]`).

## Spec

Per `cc-context-store/tether/plans/infrastructure/2026-05-20-interactive-agent-layer.md` phase B5, and `2026-05-20-tether-agent-models.md` "Free-trial mechanics" + "BYOK leakage policy" sections.

## Test plan

- [ ] `pytest tests/interactive_agent_layer/test_trial.py` — 6 TrialCounter unit tests
- [ ] `pytest tests/interactive_agent_layer/test_providers.py` — 5 provider/leakage unit tests
- [ ] `pytest tests/interactive_agent_layer/test_trial_server.py` — 8 server integration tests (gate matrix)
- [ ] `pytest tests/` — 569 passed, 0 failed