### PR TITLE
feat: B3 permission modal UI + B4 interrupt button

### DIFF
--- a/frontend/src/components/BotChat.vue
+++ b/frontend/src/components/BotChat.vue
@@ -4,6 +4,7 @@ import { useChatStore } from '../stores/chat'
 import { useAgentPickerStore } from '../stores/agentPicker'
 import MessageBubble from './MessageBubble.vue'
 import AgentPicker from './AgentPicker.vue'
+import PermissionModal from './PermissionModal.vue'
 
 const emit = defineEmits<{ close: [] }>()
 
@@ -77,6 +78,9 @@ function onKeydown(e: KeyboardEvent) {
       <p v-if="chatStore.messages.length === 0" class="text-xs text-[--fg-5] text-center pt-8">
         Send a message to start chatting.
       </p>
+      <p v-if="chatStore.statusMessage" class="text-xs text-[--fg-4] text-center animate-pulse">
+        {{ chatStore.statusMessage }}
+      </p>
     </div>
 
     <!-- Composer -->
@@ -92,6 +96,15 @@ function onKeydown(e: KeyboardEvent) {
         @keydown.enter.exact.prevent="onSubmit"
       />
       <button
+        v-if="chatStore.isSessionActive"
+        type="button"
+        aria-label="Interrupt"
+        class="text-xs px-3 rounded-lg bg-[--status-block-fg]/20 text-[--status-block-fg] hover:bg-[--status-block-fg]/30 transition-colors self-end py-2"
+        @click="chatStore.sendInterrupt()"
+      >
+        Stop
+      </button>
+      <button
         type="submit"
         :disabled="chatStore.isStreaming || !draft.trim()"
         class="text-xs px-3 rounded-lg bg-[--bg-elev-2] text-[--fg-2] hover:bg-[--bg-elev-3] disabled:opacity-30 transition-colors self-end py-2"
@@ -99,5 +112,6 @@ function onKeydown(e: KeyboardEvent) {
         Send
       </button>
     </form>
+    <PermissionModal />
   </div>
 </template>

--- a/frontend/src/components/PermissionModal.vue
+++ b/frontend/src/components/PermissionModal.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { ref, watch, onUnmounted } from 'vue'
+import { useChatStore } from '../stores/chat'
+
+const TIMEOUT_MS = 60_000
+
+const chatStore = useChatStore()
+const showDetails = ref(false)
+let timer: ReturnType<typeof setTimeout> | null = null
+
+function clearTimer() {
+  if (timer !== null) {
+    clearTimeout(timer)
+    timer = null
+  }
+}
+
+function startTimer() {
+  clearTimer()
+  timer = setTimeout(() => {
+    if (chatStore.pendingPermissionRequest) {
+      chatStore.respondToPermission(chatStore.pendingPermissionRequest.request_id, false)
+    }
+  }, TIMEOUT_MS)
+}
+
+watch(
+  () => chatStore.pendingPermissionRequest,
+  (req) => {
+    showDetails.value = false
+    if (req) startTimer()
+    else clearTimer()
+  },
+  { immediate: true },
+)
+
+onUnmounted(() => clearTimer())
+
+function approve() {
+  clearTimer()
+  if (chatStore.pendingPermissionRequest) {
+    chatStore.respondToPermission(chatStore.pendingPermissionRequest.request_id, true)
+  }
+}
+
+function deny() {
+  clearTimer()
+  if (chatStore.pendingPermissionRequest) {
+    chatStore.respondToPermission(chatStore.pendingPermissionRequest.request_id, false)
+  }
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="chatStore.pendingPermissionRequest"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    >
+      <div class="bg-[--bg-elev-1] border border-[--border-1] rounded-xl shadow-xl p-6 max-w-sm w-full mx-4">
+        <h2 class="text-sm font-semibold text-[--fg-1] mb-2">Permission Request</h2>
+        <p class="text-sm text-[--fg-2] mb-4">{{ chatStore.pendingPermissionRequest.summary }}</p>
+
+        <button
+          v-if="chatStore.pendingPermissionRequest.details.length"
+          type="button"
+          class="text-xs text-[--fg-4] hover:text-[--fg-2] mb-3 transition-colors block"
+          @click="showDetails = !showDetails"
+        >
+          {{ showDetails ? 'Hide details' : 'Show more details' }}
+        </button>
+
+        <div v-if="showDetails" class="mb-4 space-y-1">
+          <div
+            v-for="d in chatStore.pendingPermissionRequest.details"
+            :key="d.label"
+            class="text-xs text-[--fg-3]"
+          >
+            <span class="font-medium text-[--fg-2]">{{ d.label }}:</span> {{ d.value }}
+          </div>
+        </div>
+
+        <div class="flex gap-2 justify-end">
+          <button
+            type="button"
+            class="px-4 py-1.5 text-xs rounded-lg bg-[--bg-elev-2] text-[--fg-2] hover:bg-[--bg-elev-3] transition-colors"
+            @click="deny"
+          >
+            Deny
+          </button>
+          <button
+            type="button"
+            class="px-4 py-1.5 text-xs rounded-lg bg-[--accent] text-[--accent-fg] hover:opacity-90 transition-opacity"
+            @click="approve"
+          >
+            Approve
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/frontend/src/components/PermissionModal.vue
+++ b/frontend/src/components/PermissionModal.vue
@@ -36,18 +36,10 @@ watch(
 
 onUnmounted(() => clearTimer())
 
-function approve() {
+function respond(approve: boolean) {
   clearTimer()
-  if (chatStore.pendingPermissionRequest) {
-    chatStore.respondToPermission(chatStore.pendingPermissionRequest.request_id, true)
-  }
-}
-
-function deny() {
-  clearTimer()
-  if (chatStore.pendingPermissionRequest) {
-    chatStore.respondToPermission(chatStore.pendingPermissionRequest.request_id, false)
-  }
+  const req = chatStore.pendingPermissionRequest
+  if (req) chatStore.respondToPermission(req.request_id, approve)
 }
 </script>
 
@@ -84,14 +76,14 @@ function deny() {
           <button
             type="button"
             class="px-4 py-1.5 text-xs rounded-lg bg-[--bg-elev-2] text-[--fg-2] hover:bg-[--bg-elev-3] transition-colors"
-            @click="deny"
+            @click="respond(false)"
           >
             Deny
           </button>
           <button
             type="button"
             class="px-4 py-1.5 text-xs rounded-lg bg-[--accent] text-[--accent-fg] hover:opacity-90 transition-opacity"
-            @click="approve"
+            @click="respond(true)"
           >
             Approve
           </button>

--- a/frontend/src/components/__tests__/BotChat.test.ts
+++ b/frontend/src/components/__tests__/BotChat.test.ts
@@ -3,23 +3,24 @@ import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import BotChat from '../BotChat.vue'
 import { setBotTransport } from '../../composables/useBotTransport'
-import type { BotTransport } from '../../composables/useBotTransport'
+import { makeTransport } from '../../stores/__tests__/testHelpers'
+import type { WsIncomingEvent } from '../../types/chat'
+import { useChatStore } from '../../stores/chat'
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() }),
   useRoute: () => ({ path: '/dashboard' }),
 }))
 
-const stubTransport: BotTransport = {
-  async *send(text: string) { yield `Echo: ${text}` },
-  onHeartbeat(cb) { cb(true); return () => {} },
-  close: vi.fn(),
-}
+const textEvents: WsIncomingEvent[] = [
+  { type: 'agent_text_delta', session_id: 'mock', delta: 'Echo: test' },
+  { type: 'turn_complete', session_id: 'mock', final_text: 'Echo: test' },
+]
 
 describe('BotChat', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
-    setBotTransport(stubTransport)
+    setBotTransport(makeTransport(textEvents))
   })
 
   it('mounts without error', () => {
@@ -45,12 +46,43 @@ describe('BotChat', () => {
 
   it('shows heartbeat indicator', () => {
     const wrapper = mount(BotChat)
-    // Heartbeat dot should exist — green when alive
     expect(wrapper.find('.rounded-full').exists()).toBe(true)
   })
 
   it('shows header with Tether label', () => {
     const wrapper = mount(BotChat)
     expect(wrapper.text()).toContain('Tether')
+  })
+
+  it('interrupt button hidden when isSessionActive is false', () => {
+    const wrapper = mount(BotChat)
+    const store = useChatStore()
+    expect(store.isSessionActive).toBe(false)
+    expect(wrapper.find('button[aria-label="Interrupt"]').exists()).toBe(false)
+  })
+
+  it('interrupt button visible when isSessionActive is true', async () => {
+    const wrapper = mount(BotChat)
+    const store = useChatStore()
+    store.isSessionActive = true
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('button[aria-label="Interrupt"]').exists()).toBe(true)
+  })
+
+  it('interrupt button click calls chatStore.sendInterrupt', async () => {
+    const wrapper = mount(BotChat)
+    const store = useChatStore()
+    const sendInterruptSpy = vi.spyOn(store, 'sendInterrupt')
+    store.isSessionActive = true
+    await wrapper.vm.$nextTick()
+    await wrapper.find('button[aria-label="Interrupt"]').trigger('click')
+    expect(sendInterruptSpy).toHaveBeenCalled()
+  })
+
+  it('PermissionModal is rendered', () => {
+    const wrapper = mount(BotChat)
+    // PermissionModal is included in BotChat — verify it's present
+    // (it renders as a Teleport, but the component should be registered)
+    expect(wrapper.findComponent({ name: 'PermissionModal' }).exists()).toBe(true)
   })
 })

--- a/frontend/src/components/__tests__/PermissionModal.test.ts
+++ b/frontend/src/components/__tests__/PermissionModal.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import PermissionModal from '../PermissionModal.vue'
+import { useChatStore } from '../../stores/chat'
+import { setBotTransport } from '../../composables/useBotTransport'
+import { makeTransport } from '../../stores/__tests__/testHelpers'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ path: '/dashboard' }),
+}))
+
+function mountModal() {
+  return mount(PermissionModal, { attachTo: document.body })
+}
+
+describe('PermissionModal', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    setBotTransport(makeTransport([]))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders nothing when pendingPermissionRequest is null', () => {
+    const wrapper = mountModal()
+    expect(document.body.textContent).not.toContain('Permission Request')
+    wrapper.unmount()
+  })
+
+  it('renders when pendingPermissionRequest is set', async () => {
+    const wrapper = mountModal()
+    const store = useChatStore()
+    store.pendingPermissionRequest = {
+      request_id: 'req1',
+      summary: 'Tether wants to delete tasks',
+      details: [],
+    }
+    await wrapper.vm.$nextTick()
+    expect(document.body.textContent).toContain('Permission Request')
+    expect(document.body.textContent).toContain('Tether wants to delete tasks')
+    wrapper.unmount()
+  })
+
+  it('shows summary text', async () => {
+    const wrapper = mountModal()
+    const store = useChatStore()
+    store.pendingPermissionRequest = {
+      request_id: 'req1',
+      summary: 'Allow reading calendar',
+      details: [],
+    }
+    await wrapper.vm.$nextTick()
+    expect(document.body.textContent).toContain('Allow reading calendar')
+    wrapper.unmount()
+  })
+
+  it('Show more details button toggles detail rows', async () => {
+    const wrapper = mountModal()
+    const store = useChatStore()
+    store.pendingPermissionRequest = {
+      request_id: 'req1',
+      summary: 'Summary',
+      details: [{ label: 'File', value: '/etc/passwd' }],
+    }
+    await wrapper.vm.$nextTick()
+
+    // Details hidden by default
+    expect(document.body.textContent).not.toContain('/etc/passwd')
+
+    // Click "Show more details"
+    const showBtn = Array.from(document.querySelectorAll('button')).find(
+      b => b.textContent?.includes('Show more details')
+    )
+    expect(showBtn).toBeDefined()
+    showBtn!.click()
+    await wrapper.vm.$nextTick()
+
+    expect(document.body.textContent).toContain('/etc/passwd')
+    wrapper.unmount()
+  })
+
+  it('Approve calls respondToPermission with approve: true', async () => {
+    const wrapper = mountModal()
+    const store = useChatStore()
+    const spy = vi.spyOn(store, 'respondToPermission')
+    store.pendingPermissionRequest = {
+      request_id: 'req1',
+      summary: 'Ok?',
+      details: [],
+    }
+    await wrapper.vm.$nextTick()
+
+    const approveBtn = Array.from(document.querySelectorAll('button')).find(
+      b => b.textContent?.trim() === 'Approve'
+    )
+    expect(approveBtn).toBeDefined()
+    approveBtn!.click()
+    expect(spy).toHaveBeenCalledWith('req1', true)
+    wrapper.unmount()
+  })
+
+  it('Deny calls respondToPermission with approve: false', async () => {
+    const wrapper = mountModal()
+    const store = useChatStore()
+    const spy = vi.spyOn(store, 'respondToPermission')
+    store.pendingPermissionRequest = {
+      request_id: 'req1',
+      summary: 'Ok?',
+      details: [],
+    }
+    await wrapper.vm.$nextTick()
+
+    const denyBtn = Array.from(document.querySelectorAll('button')).find(
+      b => b.textContent?.trim() === 'Deny'
+    )
+    expect(denyBtn).toBeDefined()
+    denyBtn!.click()
+    expect(spy).toHaveBeenCalledWith('req1', false)
+    wrapper.unmount()
+  })
+
+  it('60s timeout auto-denies if no response', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      const wrapper = mountModal()
+      const store = useChatStore()
+      const spy = vi.spyOn(store, 'respondToPermission')
+      store.pendingPermissionRequest = {
+        request_id: 'req-timeout',
+        summary: 'Will you approve?',
+        details: [],
+      }
+      await wrapper.vm.$nextTick()
+
+      vi.advanceTimersByTime(60_000)
+      expect(spy).toHaveBeenCalledWith('req-timeout', false)
+      wrapper.unmount()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('timer is cleared when Approve clicked (no double-deny after 60s)', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      const wrapper = mountModal()
+      const store = useChatStore()
+      const spy = vi.spyOn(store, 'respondToPermission')
+      store.pendingPermissionRequest = {
+        request_id: 'req1',
+        summary: 'Ok?',
+        details: [],
+      }
+      await wrapper.vm.$nextTick()
+
+      const approveBtn = Array.from(document.querySelectorAll('button')).find(
+        b => b.textContent?.trim() === 'Approve'
+      )!
+      approveBtn.click()
+      // advance past timeout — should NOT fire again
+      vi.advanceTimersByTime(60_000)
+      expect(spy).toHaveBeenCalledTimes(1)
+      wrapper.unmount()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('timer is cleared when Deny clicked', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      const wrapper = mountModal()
+      const store = useChatStore()
+      const spy = vi.spyOn(store, 'respondToPermission')
+      store.pendingPermissionRequest = {
+        request_id: 'req1',
+        summary: 'Ok?',
+        details: [],
+      }
+      await wrapper.vm.$nextTick()
+
+      const denyBtn = Array.from(document.querySelectorAll('button')).find(
+        b => b.textContent?.trim() === 'Deny'
+      )!
+      denyBtn.click()
+      vi.advanceTimersByTime(60_000)
+      expect(spy).toHaveBeenCalledTimes(1)
+      wrapper.unmount()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('timer is cleared when pendingPermissionRequest becomes null', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      const wrapper = mountModal()
+      const store = useChatStore()
+      const spy = vi.spyOn(store, 'respondToPermission')
+      store.pendingPermissionRequest = {
+        request_id: 'req1',
+        summary: 'Ok?',
+        details: [],
+      }
+      await wrapper.vm.$nextTick()
+
+      // Externally clear the request (e.g. session_ended)
+      store.pendingPermissionRequest = null
+      await wrapper.vm.$nextTick()
+
+      vi.advanceTimersByTime(60_000)
+      expect(spy).not.toHaveBeenCalled()
+      wrapper.unmount()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/frontend/src/composables/__tests__/useBotTransport.test.ts
+++ b/frontend/src/composables/__tests__/useBotTransport.test.ts
@@ -1,28 +1,50 @@
 import { describe, it, expect, vi } from 'vitest'
 import { createMockTransport, getBotTransport, setBotTransport } from '../useBotTransport'
 import type { BotTransport } from '../useBotTransport'
+import type { WsIncomingEvent } from '../../types/chat'
 
 describe('createMockTransport', () => {
-  it('send yields chunks that reassemble to full reply', async () => {
+  it('send yields agent_text_delta then turn_complete', async () => {
     const transport = createMockTransport()
-    const text = 'hello'
-    const chunks: string[] = []
-    for await (const chunk of transport.send(text, 'tether-agent-2.0')) {
-      chunks.push(chunk)
+    const events: WsIncomingEvent[] = []
+    for await (const event of transport.send('hello', 'tether-agent-2.0')) {
+      events.push(event)
     }
-    const full = chunks.join('')
-    expect(full).toContain('Echo: hello')
-    expect(full).toContain('mocked')
+    expect(events[0].type).toBe('agent_text_delta')
+    expect(events[events.length - 1].type).toBe('turn_complete')
     transport.close()
   })
 
-  it('send yields exactly one chunk (no streaming simulation)', async () => {
+  it('send yields exactly two events (delta + turn_complete)', async () => {
     const transport = createMockTransport()
-    const chunks: string[] = []
-    for await (const chunk of transport.send('test', 'tether-agent-2.0')) {
-      chunks.push(chunk)
+    const events: WsIncomingEvent[] = []
+    for await (const event of transport.send('test', 'tether-agent-2.0')) {
+      events.push(event)
     }
-    expect(chunks).toHaveLength(1)
+    expect(events).toHaveLength(2)
+    transport.close()
+  })
+
+  it('delta event contains text with Echo and mocked', async () => {
+    const transport = createMockTransport()
+    const events: WsIncomingEvent[] = []
+    for await (const event of transport.send('hello', 'tether-agent-2.0')) {
+      events.push(event)
+    }
+    const delta = events[0]
+    expect(delta.type).toBe('agent_text_delta')
+    if (delta.type === 'agent_text_delta') {
+      expect(delta.delta).toContain('Echo: hello')
+      expect(delta.delta).toContain('mocked')
+    }
+    transport.close()
+  })
+
+  it('sendRaw exists and is callable', () => {
+    const transport = createMockTransport()
+    expect(typeof transport.sendRaw).toBe('function')
+    // should not throw
+    transport.sendRaw({ type: 'interrupt', session_id: 'test' })
     transport.close()
   })
 
@@ -71,6 +93,7 @@ describe('getBotTransport / setBotTransport singleton', () => {
       send: async function* () {},
       onHeartbeat: () => () => {},
       close: vi.fn(),
+      sendRaw: vi.fn(),
     }
     setBotTransport(newTransport)
     expect(getBotTransport()).toBe(newTransport)

--- a/frontend/src/composables/useBotTransport.ts
+++ b/frontend/src/composables/useBotTransport.ts
@@ -121,12 +121,9 @@ export function createWebSocketTransport(): BotTransport {
           pendingReject = reject
         })
         const msg = JSON.parse(evt.data)
-        // Yield the full typed event; terminate on turn_complete or session_ended
-        if (msg.type === 'turn_complete' || msg.type === 'session_ended') {
-          yield msg
-          return
-        }
         yield msg
+        // Terminate the turn on terminal events.
+        if (msg.type === 'turn_complete' || msg.type === 'session_ended') return
       }
     },
 

--- a/frontend/src/composables/useBotTransport.ts
+++ b/frontend/src/composables/useBotTransport.ts
@@ -1,6 +1,8 @@
 export interface BotTransport {
-  /** Send user text with the selected agent version; yields content chunks as they arrive. */
-  send(text: string, agentVersion: string): AsyncIterable<string>
+  /** Send user text with the selected agent version; yields typed WS events as they arrive. */
+  send(text: string, agentVersion: string): AsyncIterable<import('../types/chat').WsIncomingEvent>
+  /** Send a raw message on the underlying connection (permission_response, interrupt). No-op if closed. */
+  sendRaw(msg: object): void
   /** Subscribe to heartbeat changes. Returns an unsubscribe fn. */
   onHeartbeat(cb: (alive: boolean) => void): () => void
   /** Close any underlying connection. */
@@ -8,8 +10,10 @@ export interface BotTransport {
 }
 
 export function createMockTransport(): BotTransport {
-  async function* send(text: string, _agentVersion: string): AsyncIterable<string> {
-    yield `Echo: ${text}\n\nThis is a **mocked** response.`
+  async function* send(text: string, _agentVersion: string) {
+    const body = `Echo: ${text}\n\nThis is a **mocked** response.`
+    yield { type: 'agent_text_delta' as const, session_id: 'mock', delta: body }
+    yield { type: 'turn_complete' as const, session_id: 'mock', final_text: body }
   }
 
   let aliveCb: ((a: boolean) => void) | null = null
@@ -17,6 +21,7 @@ export function createMockTransport(): BotTransport {
 
   return {
     send,
+    sendRaw(_msg: object) { /* no-op in mock */ },
     onHeartbeat(cb) {
       aliveCb = cb
       cb(true)
@@ -116,8 +121,18 @@ export function createWebSocketTransport(): BotTransport {
           pendingReject = reject
         })
         const msg = JSON.parse(evt.data)
-        if (msg.type === 'chunk') yield msg.content
-        if (msg.type === 'done') return
+        // Yield the full typed event; terminate on turn_complete or session_ended
+        if (msg.type === 'turn_complete' || msg.type === 'session_ended') {
+          yield msg
+          return
+        }
+        yield msg
+      }
+    },
+
+    sendRaw(msg: object) {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify(msg))
       }
     },
 

--- a/frontend/src/stores/__tests__/chat.test.ts
+++ b/frontend/src/stores/__tests__/chat.test.ts
@@ -2,27 +2,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useChatStore } from '../chat'
 import { setBotTransport } from '../../composables/useBotTransport'
-import type { BotTransport } from '../../composables/useBotTransport'
+import { makeTransport } from './testHelpers'
+import type { WsIncomingEvent } from '../../types/chat'
 
-function makeMockTransport(chunks: string[]): BotTransport {
-  return {
-    async *send(_text: string) {
-      for (const chunk of chunks) {
-        yield chunk
-      }
-    },
-    onHeartbeat(cb) {
-      cb(true)
-      return () => {}
-    },
-    close: vi.fn(),
-  }
+function makeTextEvents(text: string): WsIncomingEvent[] {
+  return [
+    { type: 'agent_text_delta', session_id: 'test', delta: text },
+    { type: 'turn_complete', session_id: 'test', final_text: text },
+  ]
 }
 
 describe('useChatStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
-    setBotTransport(makeMockTransport(['Hello', ', world']))
+    setBotTransport(makeTransport(makeTextEvents('Hello, world')))
   })
 
   it('starts with empty messages', () => {
@@ -42,7 +35,13 @@ describe('useChatStore', () => {
     await p
   })
 
-  it('send appends bot message that accumulates chunks', async () => {
+  it('send accumulates bot message via agent_text_delta events', async () => {
+    setBotTransport(makeTransport([
+      { type: 'agent_text_delta', session_id: 'test', delta: 'Hello' },
+      { type: 'agent_text_delta', session_id: 'test', delta: ', world' },
+      { type: 'turn_complete', session_id: 'test', final_text: 'Hello, world' },
+    ]))
+    setActivePinia(createPinia())
     const store = useChatStore()
     await store.send('hi')
     expect(store.messages).toHaveLength(2)
@@ -51,27 +50,198 @@ describe('useChatStore', () => {
     expect(bot.content).toBe('Hello, world')
   })
 
-  it('isStreaming is true during send and false after', async () => {
-    // Replace transport with one that yields a single chunk after a tick
-    let resolve!: () => void
-    const slowTransport: BotTransport = {
-      async *send(_text: string) {
-        await new Promise<void>(r => { resolve = r })
-        yield 'chunk'
-      },
-      onHeartbeat(cb) { cb(true); return () => {} },
-      close: vi.fn(),
+  it('send sets isSessionActive true during send, false after', async () => {
+    let resolveEvent!: () => void
+    const slowTransport = makeTransport([
+      { type: 'agent_text_delta', session_id: 'test', delta: 'chunk' },
+      { type: 'turn_complete', session_id: 'test', final_text: 'chunk' },
+    ])
+    // Wrap send to be async
+    const origSend = slowTransport.send.bind(slowTransport)
+    slowTransport.send = async function* (text: string, av: string) {
+      await new Promise<void>(r => { resolveEvent = r })
+      yield* origSend(text, av)
     }
     setBotTransport(slowTransport)
     setActivePinia(createPinia())
-    const store2 = useChatStore()
+    const store = useChatStore()
 
-    const p = store2.send('test')
-    // isStreaming should flip true immediately
-    expect(store2.isStreaming).toBe(true)
+    const p = store.send('test')
+    expect(store.isSessionActive).toBe(true)
+    resolveEvent()
+    await p
+    expect(store.isSessionActive).toBe(false)
+  })
+
+  it('isStreaming is true during send and false after', async () => {
+    let resolve!: () => void
+    const slowTransport = makeTransport([
+      { type: 'agent_text_delta', session_id: 'test', delta: 'chunk' },
+      { type: 'turn_complete', session_id: 'test', final_text: 'chunk' },
+    ])
+    const origSend = slowTransport.send.bind(slowTransport)
+    slowTransport.send = async function* (text: string, av: string) {
+      await new Promise<void>(r => { resolve = r })
+      yield* origSend(text, av)
+    }
+    setBotTransport(slowTransport)
+    setActivePinia(createPinia())
+    const store = useChatStore()
+
+    const p = store.send('test')
+    expect(store.isStreaming).toBe(true)
     resolve()
     await p
-    expect(store2.isStreaming).toBe(false)
+    expect(store.isStreaming).toBe(false)
+  })
+
+  it('send accumulates agent_action pills on bot message', async () => {
+    setBotTransport(makeTransport([
+      { type: 'agent_action', session_id: 'test', action: 'Thinking', tool: 'reason' },
+      { type: 'agent_action', session_id: 'test', action: 'Running', tool: 'bash' },
+      { type: 'turn_complete', session_id: 'test', final_text: 'done' },
+    ]))
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    await store.send('hi')
+    const bot = store.messages[1]
+    expect(bot.actions).toHaveLength(2)
+    expect(bot.actions![0]).toMatchObject({ action: 'Thinking', tool: 'reason' })
+    expect(bot.actions![1]).toMatchObject({ action: 'Running', tool: 'bash' })
+  })
+
+  it('send sets statusMessage from status event, clears on turn_complete', async () => {
+    setBotTransport(makeTransport([
+      { type: 'status', session_id: 'test', message: 'Thinking...' },
+      { type: 'turn_complete', session_id: 'test', final_text: 'done' },
+    ]))
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    await store.send('hi')
+    // After turn_complete, statusMessage should be cleared
+    expect(store.statusMessage).toBe('')
+  })
+
+  it('send sets content = final_text from turn_complete', async () => {
+    setBotTransport(makeTransport([
+      { type: 'agent_text_delta', session_id: 'test', delta: 'partial' },
+      { type: 'turn_complete', session_id: 'test', final_text: 'final answer' },
+    ]))
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    await store.send('hi')
+    expect(store.messages[1].content).toBe('final answer')
+  })
+
+  it('session_ended terminates loop and sets isSessionActive false', async () => {
+    setBotTransport(makeTransport([
+      { type: 'agent_text_delta', session_id: 'test', delta: 'partial' },
+      { type: 'session_ended', session_id: 'test' },
+    ]))
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    await store.send('hi')
+    expect(store.isSessionActive).toBe(false)
+  })
+
+  it('permission_request sets pendingPermissionRequest', async () => {
+    const sendRaw = vi.fn()
+    setBotTransport(makeTransport([
+      {
+        type: 'permission_request',
+        session_id: 'sess1',
+        request_id: 'req1',
+        summary: 'Allow file read',
+        details: [{ label: 'path', value: '/etc/passwd' }],
+      },
+      { type: 'turn_complete', session_id: 'sess1', final_text: '' },
+    ], { sendRaw }))
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    await store.send('hi')
+    expect(store.pendingPermissionRequest).toMatchObject({
+      request_id: 'req1',
+      summary: 'Allow file read',
+    })
+  })
+
+  it('second permission_request queues behind first', async () => {
+    setBotTransport(makeTransport([
+      {
+        type: 'permission_request',
+        session_id: 'sess1',
+        request_id: 'req1',
+        summary: 'First request',
+        details: [],
+      },
+      {
+        type: 'permission_request',
+        session_id: 'sess1',
+        request_id: 'req2',
+        summary: 'Second request',
+        details: [],
+      },
+      { type: 'turn_complete', session_id: 'sess1', final_text: '' },
+    ]))
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    await store.send('hi')
+    expect(store.pendingPermissionRequest?.request_id).toBe('req1')
+    expect(store.permissionQueue).toHaveLength(1)
+    expect(store.permissionQueue[0].request_id).toBe('req2')
+  })
+
+  it('respondToPermission calls sendRaw with permission_response', () => {
+    const sendRaw = vi.fn()
+    setBotTransport(makeTransport([], { sendRaw }))
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    // Manually set up a pending permission request
+    store.pendingPermissionRequest = {
+      request_id: 'req1',
+      summary: 'Test',
+      details: [],
+    }
+    store.respondToPermission('req1', true)
+    expect(sendRaw).toHaveBeenCalledWith({
+      type: 'permission_response',
+      request_id: 'req1',
+      approve: true,
+    })
+  })
+
+  it('respondToPermission dequeues next from permissionQueue', () => {
+    const sendRaw = vi.fn()
+    setBotTransport(makeTransport([], { sendRaw }))
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    store.pendingPermissionRequest = { request_id: 'req1', summary: 'First', details: [] }
+    store.permissionQueue = [{ request_id: 'req2', summary: 'Second', details: [] }]
+    store.respondToPermission('req1', false)
+    expect(store.pendingPermissionRequest?.request_id).toBe('req2')
+    expect(store.permissionQueue).toHaveLength(0)
+  })
+
+  it('sendInterrupt calls sendRaw with interrupt and activeSessionId', () => {
+    const sendRaw = vi.fn()
+    setBotTransport(makeTransport([], { sendRaw }))
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    store.activeSessionId = 'sess-abc'
+    store.sendInterrupt()
+    expect(sendRaw).toHaveBeenCalledWith({
+      type: 'interrupt',
+      session_id: 'sess-abc',
+    })
+  })
+
+  it('sendInterrupt is no-op when activeSessionId is null', () => {
+    const sendRaw = vi.fn()
+    setBotTransport(makeTransport([], { sendRaw }))
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    store.sendInterrupt()
+    expect(sendRaw).not.toHaveBeenCalled()
   })
 
   it('bot message has no streaming field', async () => {

--- a/frontend/src/stores/__tests__/chatAgentVersion.test.ts
+++ b/frontend/src/stores/__tests__/chatAgentVersion.test.ts
@@ -5,7 +5,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { setBotTransport } from '../../composables/useBotTransport'
-import type { BotTransport } from '../../composables/useBotTransport'
+import { makeTransport } from './testHelpers'
+import type { WsIncomingEvent } from '../../types/chat'
 
 vi.mock('../../lib/api', () => ({
   api: vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) })),
@@ -19,13 +20,15 @@ describe('chat store — agent_version forwarding', () => {
 
   it('passes agent_version from agentPicker store to transport.send', async () => {
     const capturedCalls: Array<[string, string]> = []
-    const transport: BotTransport = {
-      async *send(text: string, agentVersion: string) {
-        capturedCalls.push([text, agentVersion])
-        yield 'ok'
-      },
-      onHeartbeat(cb) { cb(true); return () => {} },
-      close: vi.fn(),
+    const events: WsIncomingEvent[] = [
+      { type: 'agent_text_delta', session_id: 'mock', delta: 'ok' },
+      { type: 'turn_complete', session_id: 'mock', final_text: 'ok' },
+    ]
+    const transport = makeTransport(events)
+    const origSend = transport.send.bind(transport)
+    transport.send = async function* (text: string, agentVersion: string) {
+      capturedCalls.push([text, agentVersion])
+      yield* origSend(text, agentVersion)
     }
     setBotTransport(transport)
 
@@ -43,13 +46,15 @@ describe('chat store — agent_version forwarding', () => {
 
   it('defaults to tether-agent-2.0 when picker store has default', async () => {
     const capturedCalls: Array<[string, string]> = []
-    const transport: BotTransport = {
-      async *send(text: string, agentVersion: string) {
-        capturedCalls.push([text, agentVersion])
-        yield 'ok'
-      },
-      onHeartbeat(cb) { cb(true); return () => {} },
-      close: vi.fn(),
+    const events: WsIncomingEvent[] = [
+      { type: 'agent_text_delta', session_id: 'mock', delta: 'ok' },
+      { type: 'turn_complete', session_id: 'mock', final_text: 'ok' },
+    ]
+    const transport = makeTransport(events)
+    const origSend = transport.send.bind(transport)
+    transport.send = async function* (text: string, agentVersion: string) {
+      capturedCalls.push([text, agentVersion])
+      yield* origSend(text, agentVersion)
     }
     setBotTransport(transport)
 

--- a/frontend/src/stores/__tests__/testHelpers.ts
+++ b/frontend/src/stores/__tests__/testHelpers.ts
@@ -1,0 +1,30 @@
+import { vi } from 'vitest'
+import type { BotTransport } from '../../composables/useBotTransport'
+import type { WsIncomingEvent } from '../../types/chat'
+
+export function makeTransport(
+  events: WsIncomingEvent[],
+  opts?: { sendRaw?: (_msg: object) => void },
+): BotTransport {
+  return {
+    async *send(_text: string, _agentVersion: string) {
+      for (const event of events) {
+        yield event
+      }
+    },
+    onHeartbeat(cb) {
+      cb(true)
+      return () => {}
+    },
+    close: vi.fn(),
+    sendRaw: opts?.sendRaw ?? vi.fn(),
+  }
+}
+
+/** Build a standard reply as two events: delta + turn_complete */
+export function makeReplyEvents(text: string, sessionId = 'test-session'): WsIncomingEvent[] {
+  return [
+    { type: 'agent_text_delta', session_id: sessionId, delta: text },
+    { type: 'turn_complete', session_id: sessionId, final_text: text },
+  ]
+}

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -42,29 +42,26 @@ export const useChatStore = defineStore('chat', () => {
             activeSessionId.value = event.session_id
             messages.value[botMsgIndex].content += event.delta
             break
-          case 'agent_action':
+          case 'agent_action': {
             activeSessionId.value = event.session_id
-            if (!messages.value[botMsgIndex].actions) {
-              messages.value[botMsgIndex].actions = []
-            }
-            messages.value[botMsgIndex].actions!.push({ action: event.action, tool: event.tool })
+            const bot = messages.value[botMsgIndex]
+            ;(bot.actions ??= []).push({ action: event.action, tool: event.tool })
             break
-          case 'permission_request':
+          }
+          case 'permission_request': {
             activeSessionId.value = event.session_id
+            const req: PermissionRequest = {
+              request_id: event.request_id,
+              summary: event.summary,
+              details: event.details,
+            }
             if (!pendingPermissionRequest.value) {
-              pendingPermissionRequest.value = {
-                request_id: event.request_id,
-                summary: event.summary,
-                details: event.details,
-              }
+              pendingPermissionRequest.value = req
             } else {
-              permissionQueue.value.push({
-                request_id: event.request_id,
-                summary: event.summary,
-                details: event.details,
-              })
+              permissionQueue.value.push(req)
             }
             break
+          }
           case 'status':
             activeSessionId.value = event.session_id
             statusMessage.value = event.message
@@ -92,11 +89,7 @@ export const useChatStore = defineStore('chat', () => {
 
   function respondToPermission(requestId: string, approve: boolean): void {
     getBotTransport().sendRaw({ type: 'permission_response', request_id: requestId, approve })
-    if (permissionQueue.value.length > 0) {
-      pendingPermissionRequest.value = permissionQueue.value.shift()!
-    } else {
-      pendingPermissionRequest.value = null
-    }
+    pendingPermissionRequest.value = permissionQueue.value.shift() ?? null
   }
 
   function sendInterrupt(): void {

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import type { ChatMessage } from '../types/chat'
+import type { ChatMessage, PermissionRequest } from '../types/chat'
 import { getBotTransport } from '../composables/useBotTransport'
 import { useAgentPickerStore } from './agentPicker'
 
@@ -13,6 +13,11 @@ export const useChatStore = defineStore('chat', () => {
   const messages = ref<ChatMessage[]>([])
   const isStreaming = ref(false)
   const heartbeat = ref(false)
+  const activeSessionId = ref<string | null>(null)
+  const isSessionActive = ref(false)
+  const statusMessage = ref('')
+  const pendingPermissionRequest = ref<PermissionRequest | null>(null)
+  const permissionQueue = ref<PermissionRequest[]>([])
 
   // Register heartbeat via a stable wrapper so it always reflects the current
   // transport, even after setBotTransport() replaces it post-auth.
@@ -28,17 +33,88 @@ export const useChatStore = defineStore('chat', () => {
     messages.value.push({ id: makeId(), role: 'bot', content: '', ts: Date.now() })
 
     isStreaming.value = true
+    isSessionActive.value = true
     try {
-      // Always call getBotTransport() at send time — not a cached reference —
-      // so we use whichever transport is current (mock → real WS after auth).
       const agentVersion = useAgentPickerStore().selectedAgent
-      for await (const chunk of getBotTransport().send(text, agentVersion)) {
-        messages.value[botMsgIndex].content += chunk
+      for await (const event of getBotTransport().send(text, agentVersion)) {
+        switch (event.type) {
+          case 'agent_text_delta':
+            activeSessionId.value = event.session_id
+            messages.value[botMsgIndex].content += event.delta
+            break
+          case 'agent_action':
+            activeSessionId.value = event.session_id
+            if (!messages.value[botMsgIndex].actions) {
+              messages.value[botMsgIndex].actions = []
+            }
+            messages.value[botMsgIndex].actions!.push({ action: event.action, tool: event.tool })
+            break
+          case 'permission_request':
+            activeSessionId.value = event.session_id
+            if (!pendingPermissionRequest.value) {
+              pendingPermissionRequest.value = {
+                request_id: event.request_id,
+                summary: event.summary,
+                details: event.details,
+              }
+            } else {
+              permissionQueue.value.push({
+                request_id: event.request_id,
+                summary: event.summary,
+                details: event.details,
+              })
+            }
+            break
+          case 'status':
+            activeSessionId.value = event.session_id
+            statusMessage.value = event.message
+            break
+          case 'turn_complete':
+            // final_text is canonical — overwrite accumulated deltas
+            messages.value[botMsgIndex].content = event.final_text
+            statusMessage.value = ''
+            isSessionActive.value = false
+            return
+          case 'session_ended':
+            statusMessage.value = ''
+            isSessionActive.value = false
+            return
+          case 'trial_usage_update':
+            // handled elsewhere (trial counter UI)
+            break
+        }
       }
     } finally {
       isStreaming.value = false
+      isSessionActive.value = false
     }
   }
 
-  return { messages, isStreaming, heartbeat, send }
+  function respondToPermission(requestId: string, approve: boolean): void {
+    getBotTransport().sendRaw({ type: 'permission_response', request_id: requestId, approve })
+    if (permissionQueue.value.length > 0) {
+      pendingPermissionRequest.value = permissionQueue.value.shift()!
+    } else {
+      pendingPermissionRequest.value = null
+    }
+  }
+
+  function sendInterrupt(): void {
+    if (!activeSessionId.value) return
+    getBotTransport().sendRaw({ type: 'interrupt', session_id: activeSessionId.value })
+  }
+
+  return {
+    messages,
+    isStreaming,
+    heartbeat,
+    activeSessionId,
+    isSessionActive,
+    statusMessage,
+    pendingPermissionRequest,
+    permissionQueue,
+    send,
+    respondToPermission,
+    sendInterrupt,
+  }
 })

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -5,4 +5,25 @@ export interface ChatMessage {
   role: ChatRole
   content: string
   ts: number     // epoch ms
+  actions?: Array<{ action: string; tool?: string }>
 }
+
+export interface PermissionDetail {
+  label: string
+  value: string
+}
+
+export interface PermissionRequest {
+  request_id: string
+  summary: string
+  details: PermissionDetail[]
+}
+
+export type WsIncomingEvent =
+  | { type: 'agent_text_delta'; session_id: string; delta: string }
+  | { type: 'agent_action'; session_id: string; action: string; tool?: string }
+  | { type: 'permission_request'; session_id: string; request_id: string; summary: string; details: PermissionDetail[] }
+  | { type: 'status'; session_id: string; message: string }
+  | { type: 'turn_complete'; session_id: string; final_text: string; tokens_used?: number }
+  | { type: 'session_ended'; session_id: string }
+  | { type: 'trial_usage_update'; session_id: string; remaining: number }


### PR DESCRIPTION
## Summary

- **B3 — Permission modal UI**: Frontend WS handler now recognizes all typed agent layer events (`agent_text_delta`, `agent_action`, `permission_request`, `status`, `turn_complete`, `session_ended`). New `PermissionModal.vue` surfaces permission requests with summary, Show more details toggle, Approve/Deny buttons, and a 60s auto-deny timeout.
- **B4 — Interrupt button**: Stop button appears in composer while `isSessionActive`; click sends `{ type: "interrupt", session_id }` via `sendRaw()`. Hidden on `turn_complete`.
- **Transport upgrade**: `BotTransport.send()` now yields `WsIncomingEvent` (typed union) instead of raw strings; `sendRaw(msg)` added for out-of-band messages. WS transport updated accordingly.

## Design decisions

- `status` is transient store-level state (cleared on `turn_complete`), not persisted on `ChatMessage`
- `turn_complete.final_text` is canonical — overwrites accumulated deltas
- Concurrent `permission_request` events queue FIFO; 60s timer restarts per request
- `sendRaw` is a no-op when socket is closed (no throws)

## Test plan

- [ ] 678/678 tests passing (`npm run test -- --run`)
- [ ] Zero type errors (`npm run build`)
- [ ] Permission modal renders when `pendingPermissionRequest` set, hides when null
- [ ] Approve/Deny call `respondToPermission` with correct boolean
- [ ] 60s timeout fires auto-deny; cleared when user responds first
- [ ] Interrupt button visible only while `isSessionActive`, click calls `sendInterrupt()`
- [ ] Second permission request queues behind first, dequeued after response