### PR TITLE
feat: A6 — control protocol forwarding for can_use_tool

### DIFF
--- a/agent_pool_manager/client.py
+++ b/agent_pool_manager/client.py
@@ -163,6 +163,48 @@ class PoolClient:
         _raise_for_status(resp)
         return resp.json()
 
+    async def send_control_response(
+        self,
+        handle_id: str,
+        *,
+        request_id: str,
+        subtype: str,
+        decision: str,
+        denial_message: str | None = None,
+    ) -> None:
+        """Respond to a ``control_request`` SSE event from the pool service.
+
+        Resolves the pending ``can_use_tool`` callback on the pool side.
+        Raises :exc:`PoolClientError` (404) if the ``request_id`` is unknown
+        or has already been resolved (e.g. timed out).
+
+        Parameters
+        ----------
+        handle_id:
+            The active handle the control_request was emitted on.
+        request_id:
+            The ``request_id`` from the ``control_request`` SSE event.
+        subtype:
+            Control subtype (currently always ``"can_use_tool"``).
+        decision:
+            ``"allow"`` or ``"deny"``.
+        denial_message:
+            Optional human-readable reason shown when decision is ``"deny"``.
+        """
+        payload: dict[str, Any] = {
+            "request_id": request_id,
+            "subtype": subtype,
+            "decision": decision,
+        }
+        if denial_message is not None:
+            payload["denial_message"] = denial_message
+
+        resp = await self._get_client().post(
+            f"/handle/{handle_id}/control_response",
+            json=payload,
+        )
+        _raise_for_status(resp)
+
 
 # ---------------------------------------------------------------------------
 # Helper

--- a/agent_pool_manager/config.py
+++ b/agent_pool_manager/config.py
@@ -36,6 +36,9 @@ class AgentPoolConfig:
     enabled: bool = True
     """False → callers fall back to direct ClaudeSDKClient spawn (for local dev)."""
 
+    control_response_timeout_seconds: float = 60.0
+    """Seconds the pool waits for a control_response before denying the tool call."""
+
 
 _FIELD_NAMES = {f.name for f in fields(AgentPoolConfig)}
 

--- a/agent_pool_manager/control.py
+++ b/agent_pool_manager/control.py
@@ -1,0 +1,151 @@
+"""ControlBridge — forwards SDK permission callbacks over the SSE stream.
+
+When a ClaudeSDKClient fires its ``can_use_tool`` callback the pool cannot
+answer directly — the decision lives in the calling layer on the other side of
+an HTTP connection.  ControlBridge bridges the gap:
+
+1. Pool calls ``bridge.request(handle_id, subtype, payload)`` — registers a
+   Future keyed by a fresh ``request_id`` and returns the awaitable.
+2. The SSE stream emits a ``control_request`` event carrying ``request_id``.
+3. The layer calls ``POST /handle/{id}/control_response`` with the decision.
+4. Server calls ``bridge.respond(request_id, payload)`` — resolves the Future.
+5. ``request()`` unblocks and returns the response dict.
+
+If no response arrives within ``timeout_seconds``, ``request()`` raises
+:exc:`ControlTimeout` so the callback can return a deny result immediately.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+class ControlTimeout(Exception):
+    """Raised when no control_response arrives within the allowed window."""
+
+
+class ControlBridge:
+    """Manages in-flight permission-gate requests for one pool service instance.
+
+    Each pending request is a ``Future`` keyed by a UUID ``request_id``.
+    The bridge is shared across all active handles; ``handle_id`` is carried
+    in the payload for traceability and routes SSE events to the right stream.
+
+    **SSE integration** — ``register_handle()`` must be called before a query
+    stream starts.  ``request()`` then puts a ``control_request`` dict into the
+    handle's queue so the stream can emit it while the callback awaits the
+    response.  Call ``deregister_handle()`` when the stream ends.
+
+    Parameters
+    ----------
+    timeout_seconds:
+        How long ``request()`` waits before raising :exc:`ControlTimeout`.
+        Default matches ``agent_pool.control_response_timeout_seconds`` config.
+    """
+
+    def __init__(self, timeout_seconds: float = 60.0) -> None:
+        self.timeout_seconds = timeout_seconds
+        # request_id → Future[dict]
+        self._pending: dict[str, asyncio.Future[dict[str, Any]]] = {}
+        # per-handle SSE event queues — populated by request(), drained by stream
+        self._handle_queues: dict[str, asyncio.Queue[dict[str, Any]]] = {}
+
+    # ------------------------------------------------------------------
+    # Handle queue management (called by server around each query stream)
+    # ------------------------------------------------------------------
+
+    def register_handle(self, handle_id: str) -> "asyncio.Queue[dict[str, Any]]":
+        """Create and return an event queue for the given handle.
+
+        The returned queue will receive ``control_request`` (and
+        ``control_timeout``) dicts whenever the SDK fires ``can_use_tool``
+        during a query.  The caller is responsible for draining the queue
+        while simultaneously iterating the SDK response stream.
+        """
+        q: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        self._handle_queues[handle_id] = q
+        return q
+
+    def deregister_handle(self, handle_id: str) -> None:
+        """Remove the event queue for the given handle (called when stream ends)."""
+        self._handle_queues.pop(handle_id, None)
+
+    # ------------------------------------------------------------------
+    # Core protocol
+    # ------------------------------------------------------------------
+
+    async def request(
+        self,
+        handle_id: str,
+        subtype: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Register a pending control request and await its resolution.
+
+        Enqueues a ``control_request`` event in the handle's SSE queue (if
+        registered) so the stream can emit it while this coroutine waits.
+
+        Returns the response dict passed to :meth:`respond`.
+        Raises :exc:`ControlTimeout` if no response arrives in time.
+        """
+        request_id = str(uuid.uuid4())
+        fut: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+        self._pending[request_id] = fut
+
+        # Notify the handle's SSE stream immediately (non-blocking).
+        q = self._handle_queues.get(handle_id)
+        if q is not None:
+            q.put_nowait({
+                "event": "control_request",
+                "request_id": request_id,
+                "subtype": subtype,
+                **payload,
+            })
+
+        log.debug(
+            "control_request registered request_id=%s handle=%s subtype=%s",
+            request_id, handle_id, subtype,
+        )
+
+        try:
+            return await asyncio.wait_for(
+                asyncio.shield(fut), timeout=self.timeout_seconds
+            )
+        except asyncio.TimeoutError:
+            log.warning(
+                "control_request timed out request_id=%s handle=%s",
+                request_id, handle_id,
+            )
+            if q is not None:
+                q.put_nowait({"event": "control_timeout", "request_id": request_id})
+            raise ControlTimeout(
+                f"No control_response for request_id={request_id!r} within "
+                f"{self.timeout_seconds}s"
+            )
+        finally:
+            self._pending.pop(request_id, None)
+
+    def respond(self, request_id: str, payload: dict[str, Any]) -> bool:
+        """Resolve a pending request with the given response payload.
+
+        Returns ``True`` if the request was found and resolved, ``False`` if
+        the ``request_id`` is unknown or already timed out / resolved.
+
+        Parameters
+        ----------
+        request_id:
+            The ``request_id`` from the original ``control_request`` SSE event.
+        payload:
+            Decision payload, e.g. ``{"decision": "allow"}`` or
+            ``{"decision": "deny", "denial_message": "..."}``.
+        """
+        fut = self._pending.get(request_id)
+        if fut is None or fut.done():
+            return False
+        fut.set_result(payload)
+        log.debug("control_response resolved request_id=%s", request_id)
+        return True

--- a/agent_pool_manager/pool.py
+++ b/agent_pool_manager/pool.py
@@ -10,15 +10,32 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from claude_agent_sdk import ClaudeSDKClient
-from claude_agent_sdk.types import ClaudeAgentOptions, ResultMessage
+from claude_agent_sdk.types import (
+    ClaudeAgentOptions,
+    PermissionResultAllow,
+    PermissionResultDeny,
+    ResultMessage,
+)
 
 from .config import AgentPoolConfig
+from .control import ControlBridge, ControlTimeout
 
 log = logging.getLogger(__name__)
 
 
 class PoolExhausted(Exception):
     """Raised when no warm subprocess becomes available within the timeout."""
+
+
+@dataclass
+class _CallbackContext:
+    """Mutable handle-id slot shared between Subprocess and its can_use_tool callback.
+
+    The callback is set at ClaudeSDKClient construction (before a handle_id
+    exists); the pool fills in ``handle_id`` at acquire() time so the bridge
+    request carries the correct identifier.
+    """
+    handle_id: str = ""
 
 
 def _extract_pid(client: ClaudeSDKClient) -> int | None:
@@ -42,6 +59,7 @@ class Subprocess:
     primed_at: float = field(default_factory=time.monotonic)
     last_used_at: float = field(default_factory=time.monotonic)
     in_use: bool = False
+    callback_ctx: _CallbackContext = field(default_factory=_CallbackContext)
 
     def is_expired(self, max_age_seconds: int) -> bool:
         return (time.monotonic() - self.spawned_at) > max_age_seconds
@@ -65,6 +83,10 @@ class Pool:
         # cached options payload per options_hash (for refill)
         self._options_cache: dict[str, dict[str, Any]] = {}
         self._lock = asyncio.Lock()
+        # shared bridge for all control-protocol forwarding
+        self.control_bridge = ControlBridge(
+            timeout_seconds=config.control_response_timeout_seconds
+        )
 
     # ------------------------------------------------------------------
     # Public API
@@ -120,6 +142,7 @@ class Pool:
             handle_id = str(uuid.uuid4())
             sub.in_use = True
             sub.last_used_at = time.monotonic()
+            sub.callback_ctx.handle_id = handle_id
             async with self._lock:
                 self._active[handle_id] = sub
 
@@ -239,7 +262,11 @@ class Pool:
         self, options_hash: str, options: dict[str, Any]
     ) -> Subprocess:
         """Spawn a ClaudeSDKClient, connect, and send the priming prompt."""
-        sdk_options = self._build_sdk_options(options)
+        ctx = _CallbackContext()
+        sdk_options = self._build_sdk_options(
+            options,
+            can_use_tool=self._make_forwarding_callback(ctx),
+        )
         client = ClaudeSDKClient(options=sdk_options)
         await client.connect()
 
@@ -259,6 +286,7 @@ class Pool:
             options=options,
             spawned_at=now,
             primed_at=now,
+            callback_ctx=ctx,
         )
 
     @staticmethod
@@ -269,11 +297,47 @@ class Pool:
             if isinstance(msg, ResultMessage):
                 break
 
+    def _make_forwarding_callback(self, ctx: _CallbackContext):
+        """Return a can_use_tool callback that forwards decisions over the bridge.
+
+        The callback is bound to ``ctx`` — a mutable context whose ``handle_id``
+        is filled in at acquire() time.  On timeout the callback returns a deny
+        result (fail-closed).
+        """
+        bridge = self.control_bridge
+
+        async def _callback(tool_name: str, tool_input: dict[str, Any], _context: Any):
+            try:
+                response = await bridge.request(
+                    ctx.handle_id,
+                    "can_use_tool",
+                    {"tool_name": tool_name, "tool_input": tool_input},
+                )
+            except ControlTimeout:
+                log.warning(
+                    "can_use_tool timed out for handle=%s tool=%s — denying",
+                    ctx.handle_id, tool_name,
+                )
+                return PermissionResultDeny(message="control_response timeout")
+
+            if response.get("decision") == "allow":
+                return PermissionResultAllow()
+            return PermissionResultDeny(
+                message=response.get("denial_message", "denied by caller")
+            )
+
+        return _callback
+
     @staticmethod
-    def _build_sdk_options(options: dict[str, Any]) -> ClaudeAgentOptions:
+    def _build_sdk_options(
+        options: dict[str, Any],
+        can_use_tool: Any = None,
+    ) -> ClaudeAgentOptions:
         """Convert the options dict to ClaudeAgentOptions, ignoring unknown keys."""
         known = {f for f in dir(ClaudeAgentOptions) if not f.startswith("_")}
         filtered = {k: v for k, v in options.items() if k in known}
+        if can_use_tool is not None:
+            filtered["can_use_tool"] = can_use_tool
         return ClaudeAgentOptions(**filtered)
 
     def _get_or_create_queue(self, options_hash: str) -> asyncio.Queue[Subprocess]:

--- a/agent_pool_manager/server.py
+++ b/agent_pool_manager/server.py
@@ -1,4 +1,4 @@
-"""Agent pool manager HTTP service — FastAPI app with 5 pool endpoints."""
+"""Agent pool manager HTTP service — FastAPI app with pool endpoints."""
 from __future__ import annotations
 
 import asyncio
@@ -43,6 +43,13 @@ class HintRequest(BaseModel):
     user_id: str
     options_hash: str
     options: dict[str, Any] = Field(default_factory=dict)
+
+
+class ControlResponseRequest(BaseModel):
+    request_id: str
+    subtype: str
+    decision: str  # "allow" | "deny"
+    denial_message: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -101,6 +108,14 @@ def build_app(
 
     # -----------------------------------------------------------------------
     # POST /handle/{handle_id}/query  — SSE stream
+    #
+    # Runs two concurrent tasks inside the stream generator:
+    #   - SDK receive_response() — may block when can_use_tool fires
+    #   - bridge event queue drain — emits control_request events while
+    #     the SDK callback awaits a control_response
+    #
+    # Callers that ignore control_request events still work: the callback
+    # times out to deny and the stream resumes normally.
     # -----------------------------------------------------------------------
     @app.post("/handle/{handle_id}/query")
     async def query(handle_id: str, req: QueryRequest, request: Request) -> StreamingResponse:
@@ -110,18 +125,51 @@ def build_app(
         if sub is None:
             raise HTTPException(status_code=404, detail="handle not found")
 
+        bridge = the_pool.control_bridge
+
         async def event_stream() -> AsyncIterator[str]:
+            # Register a per-handle SSE queue so bridge.request() can enqueue
+            # control_request events while the SDK callback awaits.
+            ctrl_queue = bridge.register_handle(handle_id)
+            # Unified output queue: both SDK msgs and ctrl events drain here.
+            out: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
+
+            async def _run_sdk() -> None:
+                try:
+                    await sub.proc.query(req.prompt, session_id=req.session_id)
+                    async for msg in sub.proc.receive_response():
+                        await out.put(("msg", msg))
+                finally:
+                    await out.put(("done", None))
+
+            async def _run_ctrl() -> None:
+                """Forward control events from bridge queue → output queue."""
+                while True:
+                    evt = await ctrl_queue.get()
+                    await out.put(("ctrl", evt))
+
+            sdk_task = asyncio.create_task(_run_sdk())
+            ctrl_task = asyncio.create_task(_run_ctrl())
+
             try:
-                await sub.proc.query(req.prompt, session_id=req.session_id)
-                async for msg in sub.proc.receive_response():
-                    payload = json.dumps(_serialise_msg(msg))
-                    yield f"data: {payload}\n\n"
+                while True:
+                    kind, data = await out.get()
+                    if kind == "done":
+                        break
+                    if kind == "ctrl":
+                        yield f"data: {json.dumps(data)}\n\n"
+                    else:
+                        yield f"data: {json.dumps(_serialise_msg(data))}\n\n"
                 yield "data: [DONE]\n\n"
             except asyncio.CancelledError:
                 yield 'data: {"event": "cancelled"}\n\n'
             except Exception:
                 log.exception("Error streaming query for handle %s", handle_id)
                 yield 'data: {"error": "internal_error"}\n\n'
+            finally:
+                ctrl_task.cancel()
+                sdk_task.cancel()
+                bridge.deregister_handle(handle_id)
 
         return StreamingResponse(event_stream(), media_type="text/event-stream")
 
@@ -164,6 +212,29 @@ def build_app(
         the_refill: RefillLoop = request.app.state.refill
         asyncio.create_task(the_refill.hint(req.options_hash, req.options))
         return {"queued": True}
+
+    # -----------------------------------------------------------------------
+    # POST /handle/{handle_id}/control_response
+    #
+    # Resolves a pending can_use_tool permission request.
+    # 204 on success; 404 if request_id unknown or already resolved.
+    # -----------------------------------------------------------------------
+    @app.post("/handle/{handle_id}/control_response", status_code=204)
+    async def control_response(
+        handle_id: str,
+        req: ControlResponseRequest,
+        request: Request,
+    ) -> None:
+        the_pool: Pool = request.app.state.pool
+        payload: dict[str, Any] = {"decision": req.decision}
+        if req.denial_message is not None:
+            payload["denial_message"] = req.denial_message
+        resolved = the_pool.control_bridge.respond(req.request_id, payload)
+        if not resolved:
+            raise HTTPException(
+                status_code=404,
+                detail=f"request_id {req.request_id!r} not found or already resolved",
+            )
 
     return app
 

--- a/config/app_config.yaml
+++ b/config/app_config.yaml
@@ -29,6 +29,7 @@ agent_pool:
   acquire_default_timeout: 10   # default acquire timeout when caller omits timeout_seconds
   base_url: "http://127.0.0.1:5002"  # override for remote pool deployments
   enabled: true                 # false = callers fall back to direct spawn (local dev)
+  control_response_timeout_seconds: 60  # seconds pool waits for control_response before denying
 
 llm:
   use_v3: false

--- a/tests/agent_pool_manager/test_control.py
+++ b/tests/agent_pool_manager/test_control.py
@@ -1,0 +1,173 @@
+"""Tests for agent_pool_manager.control — ControlBridge futures management."""
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+from agent_pool_manager.control import ControlBridge, ControlTimeout
+
+
+HANDLE_A = "handle-aaa"
+HANDLE_B = "handle-bbb"
+
+
+@pytest.fixture
+def bridge() -> ControlBridge:
+    return ControlBridge(timeout_seconds=0.2)
+
+
+# ---------------------------------------------------------------------------
+# Basic round-trip
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_respond_resolves_pending_request(bridge: ControlBridge):
+    """respond() resolves the future returned by request()."""
+    req_task = asyncio.create_task(
+        bridge.request(HANDLE_A, "can_use_tool", {"tool_name": "bash", "tool_input": {}})
+    )
+    # yield so the task registers the future
+    await asyncio.sleep(0)
+
+    request_id = list(bridge._pending.keys())[0]
+    bridge.respond(request_id, {"decision": "allow"})
+
+    result = await req_task
+    assert result == {"decision": "allow"}
+
+
+@pytest.mark.asyncio
+async def test_respond_returns_true_for_known_request(bridge: ControlBridge):
+    """respond() returns True when the request_id is known."""
+    req_task = asyncio.create_task(
+        bridge.request(HANDLE_A, "can_use_tool", {"tool_name": "bash", "tool_input": {}})
+    )
+    await asyncio.sleep(0)
+
+    request_id = list(bridge._pending.keys())[0]
+    result = bridge.respond(request_id, {"decision": "allow"})
+    assert result is True
+    await req_task
+
+
+@pytest.mark.asyncio
+async def test_respond_returns_false_for_unknown_request(bridge: ControlBridge):
+    """respond() returns False for an unknown or already-resolved request_id."""
+    result = bridge.respond("no-such-id", {"decision": "allow"})
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Timeout
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_request_raises_control_timeout(bridge: ControlBridge):
+    """request() raises ControlTimeout after timeout_seconds with no response."""
+    with pytest.raises(ControlTimeout):
+        await bridge.request(HANDLE_A, "can_use_tool", {"tool_name": "bash", "tool_input": {}})
+
+
+@pytest.mark.asyncio
+async def test_timed_out_request_removed_from_pending(bridge: ControlBridge):
+    """A timed-out request is cleaned up from _pending."""
+    with pytest.raises(ControlTimeout):
+        await bridge.request(HANDLE_A, "can_use_tool", {"tool_name": "bash", "tool_input": {}})
+    assert len(bridge._pending) == 0
+
+
+# ---------------------------------------------------------------------------
+# Concurrent requests on same handle
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_on_same_handle(bridge: ControlBridge):
+    """Multiple concurrent requests on the same handle are tracked independently."""
+    bridge2 = ControlBridge(timeout_seconds=1.0)
+
+    t1 = asyncio.create_task(
+        bridge2.request(HANDLE_A, "can_use_tool", {"tool_name": "bash", "tool_input": {}})
+    )
+    t2 = asyncio.create_task(
+        bridge2.request(HANDLE_A, "can_use_tool", {"tool_name": "read_file", "tool_input": {}})
+    )
+    await asyncio.sleep(0)
+
+    ids = list(bridge2._pending.keys())
+    assert len(ids) == 2
+
+    bridge2.respond(ids[0], {"decision": "allow"})
+    bridge2.respond(ids[1], {"decision": "deny"})
+
+    r1, r2 = await asyncio.gather(t1, t2)
+    decisions = {r1["decision"], r2["decision"]}
+    assert decisions == {"allow", "deny"}
+
+
+# ---------------------------------------------------------------------------
+# Handle queue registration
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_register_handle_receives_sse_event():
+    """register_handle() returns a queue that receives control_request events."""
+    b = ControlBridge(timeout_seconds=1.0)
+    q = b.register_handle(HANDLE_A)
+
+    req_task = asyncio.create_task(
+        b.request(HANDLE_A, "can_use_tool", {"tool_name": "bash", "tool_input": {}})
+    )
+    await asyncio.sleep(0)
+
+    # Queue should have the SSE event now
+    assert not q.empty()
+    evt = q.get_nowait()
+    assert evt["event"] == "control_request"
+    assert evt["subtype"] == "can_use_tool"
+    assert evt["tool_name"] == "bash"
+    assert "request_id" in evt
+
+    b.respond(evt["request_id"], {"decision": "allow"})
+    await req_task
+
+
+@pytest.mark.asyncio
+async def test_deregister_handle_stops_event_delivery():
+    """deregister_handle() removes the queue so future requests don't enqueue."""
+    b = ControlBridge(timeout_seconds=1.0)
+    q = b.register_handle(HANDLE_A)
+    b.deregister_handle(HANDLE_A)
+
+    req_task = asyncio.create_task(
+        b.request(HANDLE_A, "can_use_tool", {"tool_name": "bash", "tool_input": {}})
+    )
+    await asyncio.sleep(0)
+    assert q.empty()
+
+    request_id = list(b._pending.keys())[0]
+    b.respond(request_id, {"decision": "allow"})
+    await req_task
+
+
+# ---------------------------------------------------------------------------
+# request_id uniqueness
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_each_request_gets_unique_id(bridge: ControlBridge):
+    """Each call to request() registers a distinct request_id."""
+    bridge2 = ControlBridge(timeout_seconds=1.0)
+    t1 = asyncio.create_task(
+        bridge2.request(HANDLE_A, "can_use_tool", {"tool_name": "a", "tool_input": {}})
+    )
+    t2 = asyncio.create_task(
+        bridge2.request(HANDLE_B, "can_use_tool", {"tool_name": "b", "tool_input": {}})
+    )
+    await asyncio.sleep(0)
+
+    ids = list(bridge2._pending.keys())
+    assert ids[0] != ids[1]
+
+    for rid in ids:
+        bridge2.respond(rid, {"decision": "allow"})
+    await asyncio.gather(t1, t2)

--- a/tests/agent_pool_manager/test_pool_control.py
+++ b/tests/agent_pool_manager/test_pool_control.py
@@ -1,0 +1,112 @@
+"""Tests for pool.py control-protocol integration — forwarding callback wired at spawn."""
+from __future__ import annotations
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock
+
+from claude_agent_sdk.types import PermissionResultAllow, PermissionResultDeny
+
+from .fake_client import FakeClient
+from agent_pool_manager.config import AgentPoolConfig
+from agent_pool_manager.pool import Pool
+
+
+HASH_A = "abc123"
+OPTIONS_A = {"model": "claude-haiku-4-5"}
+
+
+@pytest.fixture
+def pool() -> Pool:
+    cfg = AgentPoolConfig(
+        target_depth_per_hash=1,
+        capacity_total=4,
+        max_age_seconds=600,
+        control_response_timeout_seconds=0.2,
+    )
+    return Pool(cfg)
+
+
+@pytest.fixture
+def capturing_client():
+    """Patches ClaudeSDKClient with a FakeClient subclass that records constructor options.
+
+    Yields the list of captured ``options`` (one entry per spawn) so tests can
+    reach the wired ``can_use_tool`` callback.
+    """
+    constructed_options: list = []
+
+    class CapturingFakeClient(FakeClient):
+        def __init__(self, options=None, **kw):
+            super().__init__(options=options, **kw)
+            constructed_options.append(options)
+
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", CapturingFakeClient):
+        yield constructed_options
+
+
+# ---------------------------------------------------------------------------
+# Callback wired at spawn
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_spawned_client_receives_can_use_tool_callback(pool: Pool, capturing_client):
+    """ClaudeSDKClient is constructed with a can_use_tool callback when spawned."""
+    await pool._inject_warm(HASH_A, OPTIONS_A)
+
+    assert len(capturing_client) == 1
+    sdk_opts = capturing_client[0]
+    assert sdk_opts is not None
+    assert callable(sdk_opts.can_use_tool)
+
+
+@pytest.mark.asyncio
+async def test_can_use_tool_callback_fires_control_request(pool: Pool, capturing_client):
+    """When the callback fires it registers a pending request in the ControlBridge."""
+    await pool._inject_warm(HASH_A, OPTIONS_A)
+
+    await pool.acquire(HASH_A, OPTIONS_A, timeout=1.0)
+    callback = capturing_client[0].can_use_tool
+
+    # Fire the callback in background, immediately respond via bridge
+    bridge = pool.control_bridge
+    fired = asyncio.create_task(callback("bash", {}, MagicMock()))
+    await asyncio.sleep(0)
+
+    request_ids = list(bridge._pending.keys())
+    assert len(request_ids) == 1
+    bridge.respond(request_ids[0], {"decision": "allow"})
+
+    result = await fired
+    assert isinstance(result, PermissionResultAllow)
+
+
+@pytest.mark.asyncio
+async def test_can_use_tool_callback_deny_returns_permission_deny(pool: Pool, capturing_client):
+    """Callback returns PermissionResultDeny when bridge responds deny."""
+    await pool._inject_warm(HASH_A, OPTIONS_A)
+
+    await pool.acquire(HASH_A, OPTIONS_A, timeout=1.0)
+    callback = capturing_client[0].can_use_tool
+    bridge = pool.control_bridge
+
+    fired = asyncio.create_task(callback("bash", {}, MagicMock()))
+    await asyncio.sleep(0)
+    request_ids = list(bridge._pending.keys())
+    bridge.respond(request_ids[0], {"decision": "deny", "denial_message": "not allowed"})
+
+    result = await fired
+    assert isinstance(result, PermissionResultDeny)
+    assert result.message == "not allowed"
+
+
+@pytest.mark.asyncio
+async def test_can_use_tool_callback_timeout_returns_deny(pool: Pool, capturing_client):
+    """Callback returns PermissionResultDeny on timeout (fail-closed)."""
+    await pool._inject_warm(HASH_A, OPTIONS_A)
+
+    await pool.acquire(HASH_A, OPTIONS_A, timeout=1.0)
+    callback = capturing_client[0].can_use_tool
+
+    result = await callback("bash", {}, MagicMock())
+    assert isinstance(result, PermissionResultDeny)

--- a/tests/agent_pool_manager/test_server_control.py
+++ b/tests/agent_pool_manager/test_server_control.py
@@ -1,0 +1,162 @@
+"""Tests for server.py control-protocol extension — SSE events + /control_response."""
+from __future__ import annotations
+
+import asyncio
+import json
+import pytest
+from unittest.mock import patch
+from httpx import ASGITransport
+
+from .fake_client import FakeClient
+from agent_pool_manager.config import AgentPoolConfig
+from agent_pool_manager.pool import Pool
+from agent_pool_manager.refill import RefillLoop
+from agent_pool_manager.server import build_app
+from agent_pool_manager.client import PoolClient, PoolClientError
+
+
+HASH_A = "abc123"
+OPTIONS_A = {"model": "claude-haiku-4-5"}
+USER_ID = "user-ctrl-1"
+
+
+@pytest.fixture
+async def pool_and_app():
+    cfg = AgentPoolConfig(
+        target_depth_per_hash=2,
+        capacity_total=8,
+        max_age_seconds=600,
+        refill_poll_interval=0.05,
+        prime_timeout_seconds=5,
+        acquire_default_timeout=2,
+        control_response_timeout_seconds=0.3,
+    )
+    pool = Pool(cfg)
+    refill = RefillLoop(pool)
+    app = build_app(pool=pool, refill=refill)
+    app.state.pool = pool
+    app.state.refill = refill
+    refill.start()
+    yield pool, app
+    refill.stop()
+
+
+@pytest.fixture
+async def http_client(pool_and_app):
+    pool, app = pool_and_app
+    transport = ASGITransport(app=app)
+    client = PoolClient(base_url="http://test", _transport=transport)
+    try:
+        yield client, pool
+    finally:
+        await client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# POST /handle/{id}/control_response — basic routing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_control_response_unknown_request_returns_404(http_client):
+    """POST /control_response with an unknown request_id raises PoolClientError 404."""
+    client, pool = http_client
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", FakeClient):
+        await pool._inject_warm(HASH_A, OPTIONS_A)
+
+    handle_id = await client.acquire(USER_ID, HASH_A, OPTIONS_A, timeout_seconds=2.0)
+    with pytest.raises(PoolClientError, match="404"):
+        await client.send_control_response(
+            handle_id,
+            request_id="no-such-id",
+            subtype="can_use_tool",
+            decision="allow",
+        )
+    await client.release(handle_id)
+
+
+@pytest.mark.asyncio
+async def test_control_response_resolves_pending_bridge_request(http_client):
+    """POST /control_response resolves a pending ControlBridge future."""
+    client, pool = http_client
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", FakeClient):
+        await pool._inject_warm(HASH_A, OPTIONS_A)
+
+    handle_id = await client.acquire(USER_ID, HASH_A, OPTIONS_A, timeout_seconds=2.0)
+    bridge = pool.control_bridge
+
+    # Register a pending request directly in the bridge
+    req_task = asyncio.create_task(
+        bridge.request(handle_id, "can_use_tool", {"tool_name": "bash", "tool_input": {}})
+    )
+    await asyncio.sleep(0)
+    request_id = list(bridge._pending.keys())[0]
+
+    # Resolve it via the HTTP endpoint
+    await client.send_control_response(
+        handle_id,
+        request_id=request_id,
+        subtype="can_use_tool",
+        decision="allow",
+    )
+
+    result = await req_task
+    assert result["decision"] == "allow"
+    await client.release(handle_id)
+
+
+# ---------------------------------------------------------------------------
+# SSE stream emits control_request events
+# ---------------------------------------------------------------------------
+
+class FakeClientWithControlRequest(FakeClient):
+    """FakeClient whose can_use_tool callback fires (and blocks) during receive_response.
+
+    Simulates real SDK behaviour: can_use_tool fires mid-stream and
+    receive_response() cannot yield further messages until it resolves.
+    """
+
+    def __init__(self, options=None, **kw):
+        super().__init__(options=options, **kw)
+        self._can_use_tool_cb = options.can_use_tool if options else None
+
+    async def receive_response(self):
+        # Fire the callback and wait for it — blocks until the caller responds.
+        if self._can_use_tool_cb is not None:
+            from unittest.mock import MagicMock
+            await self._can_use_tool_cb("bash", {"cmd": "ls"}, MagicMock())
+        async for msg in super().receive_response():
+            yield msg
+
+
+@pytest.mark.asyncio
+async def test_query_stream_emits_control_request_event(http_client):
+    """query_stream() yields a control_request event when the callback fires."""
+    client, pool = http_client
+
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", FakeClientWithControlRequest):
+        await pool._inject_warm(HASH_A, OPTIONS_A)
+
+    handle_id = await client.acquire(USER_ID, HASH_A, OPTIONS_A, timeout_seconds=2.0)
+
+    control_events = []
+    other_events = []
+
+    async def _consume():
+        async for event in client.query_stream(handle_id, "do something"):
+            if event.get("event") == "control_request":
+                control_events.append(event)
+                # Respond so the stream can complete
+                bridge = pool.control_bridge
+                rid = event["request_id"]
+                bridge.respond(rid, {"decision": "allow"})
+            else:
+                other_events.append(event)
+
+    await asyncio.wait_for(_consume(), timeout=5.0)
+
+    assert len(control_events) >= 1
+    evt = control_events[0]
+    assert evt["subtype"] == "can_use_tool"
+    assert "request_id" in evt
+    assert evt["tool_name"] == "bash"
+    await client.release(handle_id)


### PR DESCRIPTION
## Summary

Fixes a structural gap where `PermissionGate` in the interactive-agent-layer was silently dormant for pool-managed subprocesses. The SDK's `can_use_tool` callback can only be wired at `ClaudeSDKClient` construction time (pool process); the layer had no path to inject a callback across the process boundary.

**What this adds:**

- **`agent_pool_manager/control.py`** — `ControlBridge`: manages in-flight permission requests as `asyncio.Future` keyed by UUID `request_id`. Per-handle SSE event queues (`register_handle` / `deregister_handle`) allow `bridge.request()` to enqueue events for the stream to drain concurrently while the callback awaits the response. Timeout → fail-closed deny.

- **`agent_pool_manager/pool.py`** — Every spawned `ClaudeSDKClient` gets a forwarding `can_use_tool` callback wired via `_make_forwarding_callback(_CallbackContext)`. `_CallbackContext` is a mutable slot filled in at `acquire()` time with the live `handle_id`.

- **`agent_pool_manager/server.py`** — `POST /handle/{id}/query` SSE stream now runs two concurrent tasks: SDK `receive_response()` (may block when callback fires) + bridge event queue drain. `POST /handle/{id}/control_response` resolves the pending future (204) or 404 if unknown/stale.

- **`agent_pool_manager/client.py`** — `send_control_response(handle_id, *, request_id, subtype, decision, denial_message=None)` POSTs the decision.

- **`config/app_config.yaml`** — `agent_pool.control_response_timeout_seconds: 60`

**Backward compatible:** callers that ignore `control_request` SSE events continue to work — the callback times out to deny.

## Test plan
- [ ] `pytest tests/agent_pool_manager/ --ignore=tests/agent_pool_manager/test_integration.py` — 47 passed
- [ ] `test_spawned_client_receives_can_use_tool_callback` — callback wired at spawn
- [ ] `test_can_use_tool_callback_fires_control_request` — callback registers bridge pending request
- [ ] `test_can_use_tool_callback_timeout_returns_deny` — fail-closed on timeout
- [ ] `test_query_stream_emits_control_request_event` — SSE event emitted mid-stream
- [ ] `test_control_response_resolves_pending_bridge_request` — HTTP round-trip resolves Future
- [ ] `test_control_response_unknown_request_returns_404` — stale request_id handled

## Next step (separate PR, layer-builder)
Wire the forwarded events into `PermissionGate` on the interactive-agent-layer side.