### PR TITLE
feat: Phase G — Conversations API + context injection foundation

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -39,6 +39,7 @@ from api.routes import api_keys as api_keys_routes
 from api.routes import events as events_routes
 from api.routes import preferences as preferences_routes
 from api.routes import ical as ical_routes
+from api.routes import conversations as conversations_routes
 from api.routes import internal as internal_routes
 from api.ws import manager
 from api.auth import auth_dependency, decode_jwt
@@ -214,6 +215,7 @@ def create_app(lifespan_override=None) -> FastAPI:
     app.include_router(events_routes.router, prefix="/api")
     app.include_router(preferences_routes.router, prefix="/api")
     app.include_router(ical_routes.router, prefix="/api")
+    app.include_router(conversations_routes.router, prefix="/api")
     app.include_router(
         internal_routes.router,
         prefix="/api/internal",

--- a/api/routes/conversations.py
+++ b/api/routes/conversations.py
@@ -1,0 +1,302 @@
+"""API routes — Conversations (Phase G).
+
+Endpoints:
+  GET    /conversations                   list conversations (RLS-scoped)
+  POST   /conversations                   create conversation
+  GET    /conversations/{id}              get single conversation
+  PATCH  /conversations/{id}              patch conversation
+  GET    /conversations/{id}/messages     list messages (before_id cursor paginated)
+  PUT    /preferences/notifications       upsert notification routing prefs
+  GET    /preferences/notifications       get notification routing prefs
+  GET    /context-nodes/{id}/summary      get context node summary field
+
+Note on before_id cursor pagination (messages endpoint): the cursor is the
+integer primary key of conversation_history. This gives stable pages under
+concurrent inserts, unlike offset-based pagination. The tradeoff is that
+clients must treat the cursor as an opaque integer string. See PR description.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
+
+from api.auth import auth_dependency
+from db.pg_queries.conversations import (
+    create_conversation,
+    get_conversation,
+    list_conversations,
+    list_conversation_messages,
+    update_conversation,
+)
+from db.pg_queries.nodes import get_node
+from db.pg_queries.preferences import get_user_preferences, upsert_user_preference
+from db.pool_middleware import get_db_conn
+
+router = APIRouter(tags=["conversations"])
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+_PRIORITIES = {"low", "normal", "high", "urgent"}
+_STATES = {"open", "closed", "archived"}
+_NOTIF_MODES = {"all", "focus", "quiet", "off"}
+_CHANNELS = {"telegram", "email", "push"}
+
+
+class ConversationCreate(BaseModel):
+    name: str
+    priority: str = "normal"
+    context_node_id: str | None = None
+    thread_key: str | None = None
+
+
+class ConversationPatch(BaseModel):
+    name: str | None = None
+    priority: str | None = None
+    state: str | None = None
+    context_node_id: str | None = None
+
+
+class ConversationDetail(BaseModel):
+    id: str
+    user_id: str
+    name: str
+    type: str
+    priority: str
+    state: str
+    context_node_id: str | None
+    folder_name: str | None  # LEFT JOIN context_nodes.name — nullable
+    thread_key: str | None
+    is_system: bool
+    created_at: object
+    last_message_at: object
+
+
+class NotificationPrefsBody(BaseModel):
+    mode: str | None = None
+    priority_threshold: str | None = None
+    channels: list[str] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Helper: resolve folder_name for a single conversation dict
+# ---------------------------------------------------------------------------
+
+
+async def _attach_folder_name(conn, conv: dict) -> dict:
+    """Add folder_name to a single conversation dict via get_node lookup."""
+    if conv.get("context_node_id"):
+        node = await get_node(conn, conv["context_node_id"])
+        conv["folder_name"] = node["name"] if node else None
+    else:
+        conv["folder_name"] = None
+    return conv
+
+
+# ---------------------------------------------------------------------------
+# GET /conversations
+# ---------------------------------------------------------------------------
+
+
+@router.get("/conversations")
+async def list_convs(
+    request: Request,
+    state: str | None = Query(None),
+    context_node_id: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    _auth=Depends(auth_dependency),
+    conn=Depends(get_db_conn),
+):
+    rows = await list_conversations(
+        conn,
+        state=state,
+        context_node_id=context_node_id,
+        limit=limit,
+        offset=offset,
+    )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# POST /conversations
+# ---------------------------------------------------------------------------
+
+
+@router.post("/conversations", status_code=201)
+async def create_conv(
+    body: ConversationCreate,
+    request: Request,
+    _auth=Depends(auth_dependency),
+    conn=Depends(get_db_conn),
+):
+    user_id = request.state.user_id
+    cid = await create_conversation(
+        conn,
+        user_id=user_id,
+        name=body.name,
+        notification_type="bot",
+        priority=body.priority,
+        context_node_id=body.context_node_id,
+        thread_key=body.thread_key,
+    )
+    conv = await get_conversation(conn, cid)
+    return await _attach_folder_name(conn, conv)
+
+
+# ---------------------------------------------------------------------------
+# GET /conversations/{conversation_id}
+# ---------------------------------------------------------------------------
+
+
+@router.get("/conversations/{conversation_id}")
+async def get_conv(
+    conversation_id: str,
+    request: Request,
+    _auth=Depends(auth_dependency),
+    conn=Depends(get_db_conn),
+):
+    conv = await get_conversation(conn, conversation_id)
+    if conv is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    return await _attach_folder_name(conn, conv)
+
+
+# ---------------------------------------------------------------------------
+# PATCH /conversations/{conversation_id}
+# ---------------------------------------------------------------------------
+
+
+@router.patch("/conversations/{conversation_id}")
+async def patch_conv(
+    conversation_id: str,
+    body: ConversationPatch,
+    request: Request,
+    _auth=Depends(auth_dependency),
+    conn=Depends(get_db_conn),
+):
+    conv = await get_conversation(conn, conversation_id)
+    if conv is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    await update_conversation(
+        conn,
+        conversation_id,
+        name=body.name,
+        priority=body.priority,
+        context_node_id=body.context_node_id,
+        state=body.state,
+    )
+    updated = await get_conversation(conn, conversation_id)
+    return await _attach_folder_name(conn, updated)
+
+
+# ---------------------------------------------------------------------------
+# GET /conversations/{conversation_id}/messages
+# ---------------------------------------------------------------------------
+
+
+@router.get("/conversations/{conversation_id}/messages")
+async def get_messages(
+    conversation_id: str,
+    request: Request,
+    limit: int = Query(50, ge=1, le=200),
+    before_id: str | None = Query(None),
+    _auth=Depends(auth_dependency),
+    conn=Depends(get_db_conn),
+):
+    conv = await get_conversation(conn, conversation_id)
+    if conv is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    return await list_conversation_messages(
+        conn,
+        conversation_id,
+        limit=limit,
+        before_id=before_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# PUT /preferences/notifications
+# ---------------------------------------------------------------------------
+
+_NOTIF_PREF_KEYS = {"notif_mode", "notif_priority_threshold", "notif_channels"}
+
+
+@router.put("/preferences/notifications")
+async def put_notification_prefs(
+    body: NotificationPrefsBody,
+    request: Request,
+    _auth=Depends(auth_dependency),
+    conn=Depends(get_db_conn),
+):
+    user_id = request.state.user_id
+
+    if body.mode is not None:
+        if body.mode not in _NOTIF_MODES:
+            from fastapi import status
+            from fastapi.responses import JSONResponse
+            from fastapi.exceptions import RequestValidationError
+            raise HTTPException(
+                status_code=422,
+                detail=f"mode must be one of: {sorted(_NOTIF_MODES)}",
+            )
+        await upsert_user_preference(conn, user_id, "notif_mode", body.mode)
+
+    if body.priority_threshold is not None:
+        await upsert_user_preference(
+            conn, user_id, "notif_priority_threshold", body.priority_threshold
+        )
+
+    if body.channels is not None:
+        invalid = set(body.channels) - _CHANNELS
+        if invalid:
+            raise HTTPException(
+                status_code=422,
+                detail=f"unknown channels: {sorted(invalid)}; valid: {sorted(_CHANNELS)}",
+            )
+        import json as _json
+        await upsert_user_preference(
+            conn, user_id, "notif_channels", _json.dumps(body.channels)
+        )
+
+    return {"ok": True}
+
+
+@router.get("/preferences/notifications")
+async def get_notification_prefs(
+    request: Request,
+    _auth=Depends(auth_dependency),
+    conn=Depends(get_db_conn),
+):
+    import json as _json
+    user_id = request.state.user_id
+    prefs = await get_user_preferences(conn, user_id)
+    channels_raw = prefs.get("notif_channels")
+    channels = _json.loads(channels_raw) if channels_raw else []
+    return {
+        "mode": prefs.get("notif_mode"),
+        "priority_threshold": prefs.get("notif_priority_threshold"),
+        "channels": channels,
+    }
+
+
+# ---------------------------------------------------------------------------
+# GET /context-nodes/{node_id}/summary
+# ---------------------------------------------------------------------------
+
+
+@router.get("/context-nodes/{node_id}/summary")
+async def get_node_summary(
+    node_id: str,
+    request: Request,
+    _auth=Depends(auth_dependency),
+    conn=Depends(get_db_conn),
+):
+    node = await get_node(conn, node_id)
+    if node is None:
+        raise HTTPException(status_code=404, detail="Context node not found")
+    return {"id": node_id, "summary": node.get("summary")}

--- a/api/routes/conversations.py
+++ b/api/routes/conversations.py
@@ -17,7 +17,7 @@ clients must treat the cursor as an opaque integer string. See PR description.
 """
 from __future__ import annotations
 
-from typing import Literal
+import json
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
@@ -41,8 +41,6 @@ router = APIRouter(tags=["conversations"])
 # Pydantic models
 # ---------------------------------------------------------------------------
 
-_PRIORITIES = {"low", "normal", "high", "urgent"}
-_STATES = {"open", "closed", "archived"}
 _NOTIF_MODES = {"all", "focus", "quiet", "off"}
 _CHANNELS = {"telegram", "email", "push"}
 
@@ -61,21 +59,6 @@ class ConversationPatch(BaseModel):
     context_node_id: str | None = None
 
 
-class ConversationDetail(BaseModel):
-    id: str
-    user_id: str
-    name: str
-    type: str
-    priority: str
-    state: str
-    context_node_id: str | None
-    folder_name: str | None  # LEFT JOIN context_nodes.name — nullable
-    thread_key: str | None
-    is_system: bool
-    created_at: object
-    last_message_at: object
-
-
 class NotificationPrefsBody(BaseModel):
     mode: str | None = None
     priority_threshold: str | None = None
@@ -84,16 +67,18 @@ class NotificationPrefsBody(BaseModel):
 
 # ---------------------------------------------------------------------------
 # Helper: resolve folder_name for a single conversation dict
+#
+# Only used by single-item endpoints (POST/GET/PATCH) where get_conversation()
+# does not JOIN context_nodes. The list endpoint already gets folder_name from
+# the LEFT JOIN inside list_conversations(), so it doesn't need this.
 # ---------------------------------------------------------------------------
 
 
 async def _attach_folder_name(conn, conv: dict) -> dict:
     """Add folder_name to a single conversation dict via get_node lookup."""
-    if conv.get("context_node_id"):
-        node = await get_node(conn, conv["context_node_id"])
-        conv["folder_name"] = node["name"] if node else None
-    else:
-        conv["folder_name"] = None
+    node_id = conv.get("context_node_id")
+    node = await get_node(conn, node_id) if node_id else None
+    conv["folder_name"] = node["name"] if node else None
     return conv
 
 
@@ -104,7 +89,6 @@ async def _attach_folder_name(conn, conv: dict) -> dict:
 
 @router.get("/conversations")
 async def list_convs(
-    request: Request,
     state: str | None = Query(None),
     context_node_id: str | None = Query(None),
     limit: int = Query(50, ge=1, le=200),
@@ -112,14 +96,15 @@ async def list_convs(
     _auth=Depends(auth_dependency),
     conn=Depends(get_db_conn),
 ):
-    rows = await list_conversations(
+    # list_conversations() already LEFT JOINs context_nodes for folder_name,
+    # so no _attach_folder_name pass is needed here (avoids N+1).
+    return await list_conversations(
         conn,
         state=state,
         context_node_id=context_node_id,
         limit=limit,
         offset=offset,
     )
-    return rows
 
 
 # ---------------------------------------------------------------------------
@@ -156,7 +141,6 @@ async def create_conv(
 @router.get("/conversations/{conversation_id}")
 async def get_conv(
     conversation_id: str,
-    request: Request,
     _auth=Depends(auth_dependency),
     conn=Depends(get_db_conn),
 ):
@@ -175,7 +159,6 @@ async def get_conv(
 async def patch_conv(
     conversation_id: str,
     body: ConversationPatch,
-    request: Request,
     _auth=Depends(auth_dependency),
     conn=Depends(get_db_conn),
 ):
@@ -202,7 +185,6 @@ async def patch_conv(
 @router.get("/conversations/{conversation_id}/messages")
 async def get_messages(
     conversation_id: str,
-    request: Request,
     limit: int = Query(50, ge=1, le=200),
     before_id: str | None = Query(None),
     _auth=Depends(auth_dependency),
@@ -223,9 +205,6 @@ async def get_messages(
 # PUT /preferences/notifications
 # ---------------------------------------------------------------------------
 
-_NOTIF_PREF_KEYS = {"notif_mode", "notif_priority_threshold", "notif_channels"}
-
-
 @router.put("/preferences/notifications")
 async def put_notification_prefs(
     body: NotificationPrefsBody,
@@ -237,9 +216,6 @@ async def put_notification_prefs(
 
     if body.mode is not None:
         if body.mode not in _NOTIF_MODES:
-            from fastapi import status
-            from fastapi.responses import JSONResponse
-            from fastapi.exceptions import RequestValidationError
             raise HTTPException(
                 status_code=422,
                 detail=f"mode must be one of: {sorted(_NOTIF_MODES)}",
@@ -258,9 +234,8 @@ async def put_notification_prefs(
                 status_code=422,
                 detail=f"unknown channels: {sorted(invalid)}; valid: {sorted(_CHANNELS)}",
             )
-        import json as _json
         await upsert_user_preference(
-            conn, user_id, "notif_channels", _json.dumps(body.channels)
+            conn, user_id, "notif_channels", json.dumps(body.channels)
         )
 
     return {"ok": True}
@@ -272,11 +247,10 @@ async def get_notification_prefs(
     _auth=Depends(auth_dependency),
     conn=Depends(get_db_conn),
 ):
-    import json as _json
     user_id = request.state.user_id
     prefs = await get_user_preferences(conn, user_id)
     channels_raw = prefs.get("notif_channels")
-    channels = _json.loads(channels_raw) if channels_raw else []
+    channels = json.loads(channels_raw) if channels_raw else []
     return {
         "mode": prefs.get("notif_mode"),
         "priority_threshold": prefs.get("notif_priority_threshold"),
@@ -292,7 +266,6 @@ async def get_notification_prefs(
 @router.get("/context-nodes/{node_id}/summary")
 async def get_node_summary(
     node_id: str,
-    request: Request,
     _auth=Depends(auth_dependency),
     conn=Depends(get_db_conn),
 ):

--- a/api/routes/conversations.py
+++ b/api/routes/conversations.py
@@ -89,6 +89,7 @@ async def _attach_folder_name(conn, conv: dict) -> dict:
 
 @router.get("/conversations")
 async def list_convs(
+    request: Request,
     state: str | None = Query(None),
     context_node_id: str | None = Query(None),
     limit: int = Query(50, ge=1, le=200),
@@ -100,6 +101,7 @@ async def list_convs(
     # so no _attach_folder_name pass is needed here (avoids N+1).
     return await list_conversations(
         conn,
+        user_id=request.state.user_id,
         state=state,
         context_node_id=context_node_id,
         limit=limit,
@@ -141,11 +143,12 @@ async def create_conv(
 @router.get("/conversations/{conversation_id}")
 async def get_conv(
     conversation_id: str,
+    request: Request,
     _auth=Depends(auth_dependency),
     conn=Depends(get_db_conn),
 ):
     conv = await get_conversation(conn, conversation_id)
-    if conv is None:
+    if conv is None or conv["user_id"] != request.state.user_id:
         raise HTTPException(status_code=404, detail="Conversation not found")
     return await _attach_folder_name(conn, conv)
 
@@ -159,11 +162,12 @@ async def get_conv(
 async def patch_conv(
     conversation_id: str,
     body: ConversationPatch,
+    request: Request,
     _auth=Depends(auth_dependency),
     conn=Depends(get_db_conn),
 ):
     conv = await get_conversation(conn, conversation_id)
-    if conv is None:
+    if conv is None or conv["user_id"] != request.state.user_id:
         raise HTTPException(status_code=404, detail="Conversation not found")
     await update_conversation(
         conn,
@@ -185,13 +189,14 @@ async def patch_conv(
 @router.get("/conversations/{conversation_id}/messages")
 async def get_messages(
     conversation_id: str,
+    request: Request,
     limit: int = Query(50, ge=1, le=200),
     before_id: str | None = Query(None),
     _auth=Depends(auth_dependency),
     conn=Depends(get_db_conn),
 ):
     conv = await get_conversation(conn, conversation_id)
-    if conv is None:
+    if conv is None or conv["user_id"] != request.state.user_id:
         raise HTTPException(status_code=404, detail="Conversation not found")
     return await list_conversation_messages(
         conn,

--- a/bot/conversation_context.py
+++ b/bot/conversation_context.py
@@ -52,32 +52,20 @@ async def build_conversation_context(
 
         sections = await get_sections(conn, node_id)
 
-        # Cross-node parent summary (premium feature) — not implemented in public. See tether-premium for extended context injection.
-
+    # Cross-node parent summary is handled in tether-premium (not in OSS).
     return _format_context_block(node, sections)
 
 
-def _format_context_block(
-    node: dict,
-    sections: list[dict],
-) -> str:
+def _format_context_block(node: dict, sections: list[dict]) -> str:
     """Render a markdown block summarising the context node and its sections."""
-    lines: list[str] = [
-        f"## Context: {node['name']}",
-        "",
-    ]
+    lines = [f"## Context: {node['name']}", ""]
 
-    if sections:
-        for sec in sections:
-            section_label = sec["section_type"].replace("_", " ").title()
-            lines += [
-                f"### {section_label}",
-                sec["body"] or "",
-                "",
-            ]
-    else:
+    if not sections:
         # Node exists but has no sections — still useful to name it
         lines.append("*(no section content)*")
-        lines.append("")
+    else:
+        for sec in sections:
+            label = sec["section_type"].replace("_", " ").title()
+            lines += [f"### {label}", sec["body"] or "", ""]
 
     return "\n".join(lines).rstrip() + "\n"

--- a/bot/conversation_context.py
+++ b/bot/conversation_context.py
@@ -1,0 +1,83 @@
+"""Context injection helper — Phase G.
+
+Builds a formatted markdown context block from a conversation's linked
+context node for injection into bot pipeline prompts.
+
+Public interface:
+    build_conversation_context(conversation_id, pool, user_id) -> str
+
+Returns an empty string when no context_node_id is set, or when the linked
+node no longer exists (e.g. after deletion).
+"""
+from __future__ import annotations
+
+import logging
+
+from db.pg_queries.conversations import get_conversation
+from db.pg_queries.nodes import get_node
+from db.pg_queries.sections import get_sections
+
+_log = logging.getLogger(__name__)
+
+
+async def build_conversation_context(
+    conversation_id: str,
+    pool,
+    user_id: str,
+) -> str:
+    """Return a formatted markdown context block for the given conversation.
+
+    Fetches:
+      - The conversation's linked context_node (if any)
+      - All sections attached to that node
+
+    Returns an empty string when there is no context to inject, so callers
+    can safely do: ``if ctx := await build_conversation_context(...): ...``
+    """
+    async with pool.acquire() as conn:
+        # Set RLS so node/section queries are user-scoped.
+        await conn.execute(
+            "SELECT set_config('app.current_user_id', $1, true)", user_id
+        )
+
+        conv = await get_conversation(conn, conversation_id)
+        if not conv or not conv.get("context_node_id"):
+            return ""
+
+        node_id = conv["context_node_id"]
+        node = await get_node(conn, node_id)
+        if node is None:
+            _log.debug("build_conversation_context: node %s not found", node_id)
+            return ""
+
+        sections = await get_sections(conn, node_id)
+
+        # Cross-node parent summary (premium feature) — not implemented in public. See tether-premium for extended context injection.
+
+    return _format_context_block(node, sections)
+
+
+def _format_context_block(
+    node: dict,
+    sections: list[dict],
+) -> str:
+    """Render a markdown block summarising the context node and its sections."""
+    lines: list[str] = [
+        f"## Context: {node['name']}",
+        "",
+    ]
+
+    if sections:
+        for sec in sections:
+            section_label = sec["section_type"].replace("_", " ").title()
+            lines += [
+                f"### {section_label}",
+                sec["body"] or "",
+                "",
+            ]
+    else:
+        # Node exists but has no sections — still useful to name it
+        lines.append("*(no section content)*")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"

--- a/bot/message_handler.py
+++ b/bot/message_handler.py
@@ -927,7 +927,8 @@ def _is_v2_fallback_enabled() -> bool:
 
 async def _handle_v3(text: str, pool, user_id: str, anchors: list[dict],
                current_anchor: dict,
-               skill_commands: list[str] | None = None) -> str:
+               skill_commands: list[str] | None = None,
+               conversation_id: str | None = None) -> str:
     """Run a basic v3 single-shot LLM call. Returns the response text.
 
     Uses AnthropicBackend directly (no LLMRouter, no conversation loop,
@@ -959,6 +960,17 @@ async def _handle_v3(text: str, pool, user_id: str, anchors: list[dict],
         session_notes=None,
         mode=mode,
     )
+
+    # Conversation context injection — appended to system prompt when a
+    # conversation_id with a linked context_node is provided.
+    if conversation_id:
+        try:
+            from bot.conversation_context import build_conversation_context
+            ctx_block = await build_conversation_context(conversation_id, pool, user_id)
+            if ctx_block:
+                system = system + "\n\n" + ctx_block
+        except Exception as _ctx_err:
+            logger.warning("_handle_v3: context injection failed: %s", _ctx_err)
 
     # Skill injection (v3-basic fallback): append skill content to system prompt
     if skill_commands:
@@ -999,7 +1011,7 @@ def _log_preview(text: str, n: int = 120) -> str:
 
 
 async def _handle_message_body(text: str, send_fn: Callable[[str], None], pool, user_id: str,
-                               status_fn=None) -> None:
+                               status_fn=None, conversation_id: str | None = None) -> None:
     today = str(date_type.today())
     logger.info("handle_message: entered, text_len=%d", len(text or ""))
     async with pg.get_conn(pool, user_id) as conn:
@@ -1125,7 +1137,8 @@ async def _handle_message_body(text: str, send_fn: Callable[[str], None], pool, 
         # Basic v3 single-shot (community edition — no tools, no sessions)
         try:
             final = await _handle_v3(text, pool, user_id, anchors, current_anchor,
-                               skill_commands=_skill_commands)
+                               skill_commands=_skill_commands,
+                               conversation_id=conversation_id)
             send_fn(final)
             async with pg.get_conn(pool, user_id) as conn:
                 await insert_conversation_turn(conn, "user", text)
@@ -1192,7 +1205,8 @@ async def _handle_message_body(text: str, send_fn: Callable[[str], None], pool, 
 
 
 async def handle_message(text: str, send_fn: Callable[[str], None], pool, user_id: str,
-                         vault=None, status_fn=None) -> None:
+                         vault=None, status_fn=None,
+                         conversation_id: str | None = None) -> None:
     """Public entry point. When a vault is provided, acquires the per-user lock
     and materialises credentials into an env dict that downstream LLM calls
     merge into the spawned claude-code subprocess.
@@ -1213,11 +1227,13 @@ async def handle_message(text: str, send_fn: Callable[[str], None], pool, user_i
             async with vault.materialize(user_id) as env_extras:
                 token = _llm_env_extras.set(dict(env_extras))
                 try:
-                    await _handle_message_body(text, send_fn, pool, user_id, status_fn=status_fn)
+                    await _handle_message_body(text, send_fn, pool, user_id, status_fn=status_fn,
+                                               conversation_id=conversation_id)
                 finally:
                     _llm_env_extras.reset(token)
     else:
-        await _handle_message_body(text, send_fn, pool, user_id, status_fn=status_fn)
+        await _handle_message_body(text, send_fn, pool, user_id, status_fn=status_fn,
+                                   conversation_id=conversation_id)
 
 
 # ---------------------------------------------------------------------------

--- a/db/pg_queries/conversations.py
+++ b/db/pg_queries/conversations.py
@@ -202,3 +202,110 @@ async def update_conversation(
             state,
             conversation_id,
         )
+
+
+# ---------------------------------------------------------------------------
+# List
+# ---------------------------------------------------------------------------
+
+
+async def list_conversations(
+    conn: asyncpg.Connection,
+    *,
+    state: str | None = None,
+    context_node_id: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[dict]:
+    """Return conversations for the current RLS user, newest first.
+
+    LEFT JOINs context_nodes so that folder_name is included in each row.
+    """
+    conditions: list[str] = []
+    params: list = []
+
+    if state is not None:
+        params.append(state)
+        conditions.append(f"c.state = ${len(params)}")
+    if context_node_id is not None:
+        params.append(context_node_id)
+        conditions.append(f"c.context_node_id = ${len(params)}::uuid")
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params.extend([limit, offset])
+    limit_p = len(params) - 1
+    offset_p = len(params)
+
+    rows = await conn.fetch(
+        f"""
+        SELECT
+            c.id::text        AS id,
+            c.user_id::text   AS user_id,
+            c.name,
+            c.type,
+            c.priority,
+            c.state,
+            c.context_node_id::text AS context_node_id,
+            cn.name           AS folder_name,
+            c.thread_key,
+            c.is_system,
+            c.created_at,
+            c.last_message_at
+        FROM conversations c
+        LEFT JOIN context_nodes cn ON cn.id = c.context_node_id
+        {where}
+        ORDER BY c.last_message_at DESC NULLS LAST, c.created_at DESC
+        LIMIT ${limit_p} OFFSET ${offset_p}
+        """,
+        *params,
+    )
+    return [dict(r) for r in rows]
+
+
+async def list_conversation_messages(
+    conn: asyncpg.Connection,
+    conversation_id: str,
+    *,
+    limit: int = 50,
+    before_id: str | None = None,
+) -> dict:
+    """Return messages for a conversation, newest first, with cursor pagination.
+
+    Uses `before_id` cursor: returns rows with id < before_id so callers can
+    paginate backwards through history. Returns {"items": [...], "has_more": bool}.
+
+    Note: `before_id` is an integer-typed primary key on conversation_history —
+    this cursor approach is stable under concurrent inserts, unlike offset-based
+    pagination. See PR description for rationale.
+    """
+    # Fetch limit+1 to determine has_more without a separate COUNT query.
+    fetch_limit = limit + 1
+    params: list = [conversation_id, fetch_limit]
+
+    before_clause = ""
+    if before_id is not None:
+        params.append(int(before_id))
+        before_clause = f"AND ch.id < ${len(params)}"
+
+    rows = await conn.fetch(
+        f"""
+        SELECT
+            ch.id::text           AS id,
+            ch.role,
+            ch.body               AS content,
+            ch.conversation_id::text AS conversation_id,
+            ch.ts                 AS created_at,
+            ch.source,
+            ch.channel
+        FROM conversation_history ch
+        WHERE ch.conversation_id = $1::uuid
+          {before_clause}
+        ORDER BY ch.id DESC
+        LIMIT $2
+        """,
+        *params,
+    )
+
+    has_more = len(rows) > limit
+    items = [dict(r) for r in rows[:limit]]
+    return {"items": items, "has_more": has_more}

--- a/db/pg_queries/conversations.py
+++ b/db/pg_queries/conversations.py
@@ -221,8 +221,9 @@ async def list_conversations(
 
     LEFT JOINs context_nodes so that folder_name is included in each row.
     """
+    # $1 = limit, $2 = offset; optional filters appended as $3, $4...
+    params: list = [limit, offset]
     conditions: list[str] = []
-    params: list = []
 
     if state is not None:
         params.append(state)
@@ -232,9 +233,6 @@ async def list_conversations(
         conditions.append(f"c.context_node_id = ${len(params)}::uuid")
 
     where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
-    params.extend([limit, offset])
-    limit_p = len(params) - 1
-    offset_p = len(params)
 
     rows = await conn.fetch(
         f"""
@@ -255,7 +253,7 @@ async def list_conversations(
         LEFT JOIN context_nodes cn ON cn.id = c.context_node_id
         {where}
         ORDER BY c.last_message_at DESC NULLS LAST, c.created_at DESC
-        LIMIT ${limit_p} OFFSET ${offset_p}
+        LIMIT $1 OFFSET $2
         """,
         *params,
     )

--- a/db/pg_queries/conversations.py
+++ b/db/pg_queries/conversations.py
@@ -212,18 +212,20 @@ async def update_conversation(
 async def list_conversations(
     conn: asyncpg.Connection,
     *,
+    user_id: str,
     state: str | None = None,
     context_node_id: str | None = None,
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict]:
-    """Return conversations for the current RLS user, newest first.
+    """Return conversations for the given user, newest first.
 
     LEFT JOINs context_nodes so that folder_name is included in each row.
+    Filters explicitly by user_id as defense-in-depth alongside RLS.
     """
-    # $1 = limit, $2 = offset; optional filters appended as $3, $4...
-    params: list = [limit, offset]
-    conditions: list[str] = []
+    # $1 = limit, $2 = offset, $3 = user_id; optional filters appended as $4, $5...
+    params: list = [limit, offset, user_id]
+    conditions: list[str] = ["c.user_id = $3::uuid"]
 
     if state is not None:
         params.append(state)
@@ -232,7 +234,7 @@ async def list_conversations(
         params.append(context_node_id)
         conditions.append(f"c.context_node_id = ${len(params)}::uuid")
 
-    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    where = f"WHERE {' AND '.join(conditions)}"
 
     rows = await conn.fetch(
         f"""

--- a/tests/api/test_conversations.py
+++ b/tests/api/test_conversations.py
@@ -1,0 +1,441 @@
+"""API tests — Conversations endpoints (Phase G).
+
+Endpoints under test:
+  GET    /api/conversations                  list conversations
+  POST   /api/conversations                  create conversation
+  GET    /api/conversations/{id}             get single conversation
+  PATCH  /api/conversations/{id}             patch conversation
+  GET    /api/conversations/{id}/messages    list messages (cursor paginated)
+  PUT    /api/preferences/notifications      notification routing prefs
+  GET    /api/context-nodes/{id}/summary     context node summary
+"""
+from __future__ import annotations
+
+import pytest
+from db.pg_queries.conversations import create_conversation
+from db.pg_queries.nodes import create_node
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+TEST_USER_ID = "00000000-0000-0000-0000-000000000001"
+
+
+async def _insert_message(conn, conversation_id: str, role: str = "user", content: str = "hello") -> str:
+    """Insert a conversation_history row bound to a conversation. Returns the row id."""
+    row = await conn.fetchrow(
+        """
+        INSERT INTO conversation_history (user_id, role, body, conversation_id)
+        VALUES ($1::uuid, $2, $3, $4::uuid)
+        RETURNING id::text
+        """,
+        TEST_USER_ID, role, content, conversation_id,
+    )
+    return row["id"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/conversations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_conversations_empty(api_client, conn):
+    resp = await api_client.get("/api/conversations")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_list_conversations_returns_created(api_client, conn):
+    await create_conversation(
+        conn,
+        user_id=TEST_USER_ID,
+        name="Daily standup",
+        notification_type="bot",
+    )
+    resp = await api_client.get("/api/conversations")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["name"] == "Daily standup"
+
+
+@pytest.mark.asyncio
+async def test_list_conversations_includes_folder_name(api_client, conn):
+    node = await create_node(conn, "Work")
+    cid = await create_conversation(
+        conn,
+        user_id=TEST_USER_ID,
+        name="Work chat",
+        notification_type="bot",
+        context_node_id=node["id"],
+    )
+    resp = await api_client.get("/api/conversations")
+    assert resp.status_code == 200
+    item = next(c for c in resp.json() if c["id"] == cid)
+    assert item["folder_name"] == "Work"
+
+
+@pytest.mark.asyncio
+async def test_list_conversations_folder_name_null_when_no_node(api_client, conn):
+    await create_conversation(
+        conn,
+        user_id=TEST_USER_ID,
+        name="No context",
+        notification_type="bot",
+    )
+    resp = await api_client.get("/api/conversations")
+    assert resp.status_code == 200
+    item = resp.json()[0]
+    assert item["folder_name"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_conversations_filter_by_state(api_client, conn):
+    cid_open = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="Open one", notification_type="bot",
+    )
+    cid_closed = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="Closed one", notification_type="bot",
+    )
+    await conn.execute(
+        "UPDATE conversations SET state = 'closed' WHERE id = $1::uuid", cid_closed
+    )
+    resp = await api_client.get("/api/conversations?state=open")
+    assert resp.status_code == 200
+    ids = [c["id"] for c in resp.json()]
+    assert cid_open in ids
+    assert cid_closed not in ids
+
+
+@pytest.mark.asyncio
+async def test_list_conversations_filter_by_context_node_id(api_client, conn):
+    node = await create_node(conn, "Project A")
+    cid_with = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="With node", notification_type="bot",
+        context_node_id=node["id"],
+    )
+    cid_without = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="Without node", notification_type="bot",
+    )
+    resp = await api_client.get(f"/api/conversations?context_node_id={node['id']}")
+    assert resp.status_code == 200
+    ids = [c["id"] for c in resp.json()]
+    assert cid_with in ids
+    assert cid_without not in ids
+
+
+# ---------------------------------------------------------------------------
+# POST /api/conversations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_conversation_minimal(api_client, conn):
+    resp = await api_client.post("/api/conversations", json={"name": "New chat"})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "New chat"
+    assert data["type"] == "interactive"
+    assert data["priority"] == "normal"
+    assert data["state"] == "open"
+    assert data["folder_name"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_conversation_missing_name_rejected(api_client, conn):
+    resp = await api_client.post("/api/conversations", json={})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_conversation_with_context_node(api_client, conn):
+    node = await create_node(conn, "Work")
+    resp = await api_client.post(
+        "/api/conversations",
+        json={"name": "Work chat", "context_node_id": node["id"]},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["context_node_id"] == node["id"]
+    assert data["folder_name"] == "Work"
+
+
+@pytest.mark.asyncio
+async def test_create_conversation_custom_priority(api_client, conn):
+    resp = await api_client.post(
+        "/api/conversations",
+        json={"name": "Urgent", "priority": "high"},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["priority"] == "high"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/conversations/{id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_conversation_found(api_client, conn):
+    cid = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="Details test", notification_type="bot",
+    )
+    resp = await api_client.get(f"/api/conversations/{cid}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == cid
+    assert data["name"] == "Details test"
+
+
+@pytest.mark.asyncio
+async def test_get_conversation_not_found(api_client, conn):
+    resp = await api_client.get("/api/conversations/00000000-0000-0000-0000-000000000099")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/conversations/{id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_conversation_name(api_client, conn):
+    cid = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="Old name", notification_type="bot",
+    )
+    resp = await api_client.patch(f"/api/conversations/{cid}", json={"name": "New name"})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "New name"
+
+
+@pytest.mark.asyncio
+async def test_patch_conversation_priority(api_client, conn):
+    cid = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="Prio test", notification_type="bot",
+    )
+    resp = await api_client.patch(f"/api/conversations/{cid}", json={"priority": "high"})
+    assert resp.status_code == 200
+    assert resp.json()["priority"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_patch_conversation_state(api_client, conn):
+    cid = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="State test", notification_type="bot",
+    )
+    resp = await api_client.patch(f"/api/conversations/{cid}", json={"state": "closed"})
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_patch_conversation_context_node_id(api_client, conn):
+    node = await create_node(conn, "Home")
+    cid = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="Context test", notification_type="bot",
+    )
+    resp = await api_client.patch(
+        f"/api/conversations/{cid}", json={"context_node_id": node["id"]}
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["context_node_id"] == node["id"]
+    assert data["folder_name"] == "Home"
+
+
+@pytest.mark.asyncio
+async def test_patch_conversation_not_found(api_client, conn):
+    resp = await api_client.patch(
+        "/api/conversations/00000000-0000-0000-0000-000000000099",
+        json={"name": "ghost"},
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /api/conversations/{id}/messages
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_messages_empty(api_client, conn):
+    cid = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="Empty msgs", notification_type="bot",
+    )
+    resp = await api_client.get(f"/api/conversations/{cid}/messages")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["items"] == []
+    assert data["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_messages_returns_messages(api_client, conn):
+    cid = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="Has msgs", notification_type="bot",
+    )
+    await _insert_message(conn, cid, role="user", content="Hello")
+    await _insert_message(conn, cid, role="assistant", content="Hi there")
+    resp = await api_client.get(f"/api/conversations/{cid}/messages")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["items"]) == 2
+    roles = {m["role"] for m in data["items"]}
+    assert roles == {"user", "assistant"}
+
+
+@pytest.mark.asyncio
+async def test_get_messages_before_id_cursor(api_client, conn):
+    cid = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="Cursor test", notification_type="bot",
+    )
+    ids = []
+    for i in range(5):
+        mid = await _insert_message(conn, cid, content=f"msg {i}")
+        ids.append(mid)
+    # Fetch with before_id = third message — should return first two only
+    cursor_id = ids[2]
+    resp = await api_client.get(f"/api/conversations/{cid}/messages?before_id={cursor_id}&limit=10")
+    assert resp.status_code == 200
+    data = resp.json()
+    returned_ids = [m["id"] for m in data["items"]]
+    assert ids[0] in returned_ids
+    assert ids[1] in returned_ids
+    assert cursor_id not in returned_ids
+    assert ids[3] not in returned_ids
+
+
+@pytest.mark.asyncio
+async def test_get_messages_has_more_true(api_client, conn):
+    cid = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="has_more test", notification_type="bot",
+    )
+    for i in range(5):
+        await _insert_message(conn, cid, content=f"msg {i}")
+    resp = await api_client.get(f"/api/conversations/{cid}/messages?limit=3")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["items"]) == 3
+    assert data["has_more"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_messages_has_more_false(api_client, conn):
+    cid = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="has_more false test", notification_type="bot",
+    )
+    for i in range(3):
+        await _insert_message(conn, cid, content=f"msg {i}")
+    resp = await api_client.get(f"/api/conversations/{cid}/messages?limit=10")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_messages_conversation_not_found(api_client, conn):
+    resp = await api_client.get(
+        "/api/conversations/00000000-0000-0000-0000-000000000099/messages"
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/preferences/notifications
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_put_notification_prefs_valid(api_client, conn):
+    resp = await api_client.put(
+        "/api/preferences/notifications",
+        json={"mode": "all", "priority_threshold": "normal", "channels": ["telegram"]},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_put_notification_prefs_persisted(api_client, conn):
+    await api_client.put(
+        "/api/preferences/notifications",
+        json={"mode": "focus", "priority_threshold": "high", "channels": []},
+    )
+    resp = await api_client.get("/api/preferences/notifications")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["mode"] == "focus"
+    assert data["priority_threshold"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_put_notification_prefs_invalid_mode_rejected(api_client, conn):
+    resp = await api_client.put(
+        "/api/preferences/notifications",
+        json={"mode": "unicorn"},
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /api/context-nodes/{id}/summary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_node_summary_null_when_empty(api_client, conn):
+    node = await create_node(conn, "Empty node")
+    resp = await api_client.get(f"/api/context-nodes/{node['id']}/summary")
+    assert resp.status_code == 200
+    assert resp.json()["summary"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_node_summary_returns_value(api_client, conn):
+    node = await create_node(conn, "Summarized node")
+    await conn.execute(
+        "UPDATE context_nodes SET summary = $1 WHERE id = $2::uuid",
+        "A brief summary of this node.", node["id"],
+    )
+    resp = await api_client.get(f"/api/context-nodes/{node['id']}/summary")
+    assert resp.status_code == 200
+    assert resp.json()["summary"] == "A brief summary of this node."
+
+
+@pytest.mark.asyncio
+async def test_get_node_summary_not_found(api_client, conn):
+    resp = await api_client.get(
+        "/api/context-nodes/00000000-0000-0000-0000-000000000099/summary"
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# RLS isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_conversations_rls_isolation(api_client, api_client_b, conn):
+    """User A's conversations must not be visible to user B."""
+    cid = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="User A private", notification_type="bot",
+    )
+    resp_b = await api_client_b.get("/api/conversations")
+    assert resp_b.status_code == 200
+    ids_b = [c["id"] for c in resp_b.json()]
+    assert cid not in ids_b
+
+
+@pytest.mark.asyncio
+async def test_get_conversation_rls_isolation(api_client, api_client_b, conn):
+    """User B cannot GET a conversation owned by user A."""
+    cid = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="User A only", notification_type="bot",
+    )
+    resp_b = await api_client_b.get(f"/api/conversations/{cid}")
+    assert resp_b.status_code == 404

--- a/tests/bot/test_context_injection.py
+++ b/tests/bot/test_context_injection.py
@@ -20,21 +20,21 @@ TEST_USER_ID = "00000000-0000-0000-0000-000000000001"
 # ---------------------------------------------------------------------------
 
 
-async def _make_pool_stub(conn):
-    """Return a minimal pool-like stub that yields `conn` via acquire()."""
-    class _FakePool:
-        def acquire(self):
-            return _AcquireCtx(conn)
+class _AcquireCtx:
+    def __init__(self, conn):
+        self._conn = conn
+    async def __aenter__(self):
+        return self._conn
+    async def __aexit__(self, *_):
+        pass
 
-    class _AcquireCtx:
-        def __init__(self, c):
-            self._c = c
-        async def __aenter__(self):
-            return self._c
-        async def __aexit__(self, *_):
-            pass
 
-    return _FakePool()
+class _FakePool:
+    """Minimal pool-like stub that yields the given conn via acquire()."""
+    def __init__(self, conn):
+        self._conn = conn
+    def acquire(self):
+        return _AcquireCtx(self._conn)
 
 
 # ---------------------------------------------------------------------------
@@ -47,7 +47,7 @@ async def test_no_context_node_returns_empty(conn):
     cid = await create_conversation(
         conn, user_id=TEST_USER_ID, name="Bare chat", notification_type="bot",
     )
-    pool = await _make_pool_stub(conn)
+    pool = _FakePool(conn)
     result = await build_conversation_context(cid, pool, TEST_USER_ID)
     assert result == ""
 
@@ -68,26 +68,11 @@ async def test_with_context_node_returns_block(conn):
         notification_type="bot",
         context_node_id=node["id"],
     )
-    pool = await _make_pool_stub(conn)
+    pool = _FakePool(conn)
     result = await build_conversation_context(cid, pool, TEST_USER_ID)
     assert result != ""
     assert "My Project" in result
     assert "Important project details." in result
-
-
-@pytest.mark.asyncio
-async def test_context_block_contains_node_name(conn):
-    node = await create_node(conn, "Tether Dev")
-    cid = await create_conversation(
-        conn,
-        user_id=TEST_USER_ID,
-        name="Dev chat",
-        notification_type="bot",
-        context_node_id=node["id"],
-    )
-    pool = await _make_pool_stub(conn)
-    result = await build_conversation_context(cid, pool, TEST_USER_ID)
-    assert "Tether Dev" in result
 
 
 @pytest.mark.asyncio
@@ -102,7 +87,7 @@ async def test_root_node_no_parent_summary(conn):
         notification_type="bot",
         context_node_id=node["id"],
     )
-    pool = await _make_pool_stub(conn)
+    pool = _FakePool(conn)
     result = await build_conversation_context(cid, pool, TEST_USER_ID)
     assert "Root goals here." in result
 
@@ -125,6 +110,6 @@ async def test_deleted_context_node_returns_empty(conn):
     )
     # Delete the node after linking
     await conn.execute("DELETE FROM context_nodes WHERE id = $1::uuid", node["id"])
-    pool = await _make_pool_stub(conn)
+    pool = _FakePool(conn)
     result = await build_conversation_context(cid, pool, TEST_USER_ID)
     assert result == ""

--- a/tests/bot/test_context_injection.py
+++ b/tests/bot/test_context_injection.py
@@ -1,0 +1,130 @@
+"""Unit tests — build_conversation_context helper (Phase G).
+
+Tests verify that the helper assembles context blocks correctly from
+conversation → context_node → sections → parent node summary.
+"""
+from __future__ import annotations
+
+import pytest
+from db.pg_queries.conversations import create_conversation
+from db.pg_queries.nodes import create_node
+from db.pg_queries.sections import upsert_section
+from bot.conversation_context import build_conversation_context
+
+
+TEST_USER_ID = "00000000-0000-0000-0000-000000000001"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_pool_stub(conn):
+    """Return a minimal pool-like stub that yields `conn` via acquire()."""
+    class _FakePool:
+        def acquire(self):
+            return _AcquireCtx(conn)
+
+    class _AcquireCtx:
+        def __init__(self, c):
+            self._c = c
+        async def __aenter__(self):
+            return self._c
+        async def __aexit__(self, *_):
+            pass
+
+    return _FakePool()
+
+
+# ---------------------------------------------------------------------------
+# No context_node_id — empty string
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_context_node_returns_empty(conn):
+    cid = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="Bare chat", notification_type="bot",
+    )
+    pool = await _make_pool_stub(conn)
+    result = await build_conversation_context(cid, pool, TEST_USER_ID)
+    assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# Node with sections — context block returned
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_with_context_node_returns_block(conn):
+    node = await create_node(conn, "My Project")
+    await upsert_section(conn, node["id"], "notes", "Important project details.")
+    cid = await create_conversation(
+        conn,
+        user_id=TEST_USER_ID,
+        name="Project chat",
+        notification_type="bot",
+        context_node_id=node["id"],
+    )
+    pool = await _make_pool_stub(conn)
+    result = await build_conversation_context(cid, pool, TEST_USER_ID)
+    assert result != ""
+    assert "My Project" in result
+    assert "Important project details." in result
+
+
+@pytest.mark.asyncio
+async def test_context_block_contains_node_name(conn):
+    node = await create_node(conn, "Tether Dev")
+    cid = await create_conversation(
+        conn,
+        user_id=TEST_USER_ID,
+        name="Dev chat",
+        notification_type="bot",
+        context_node_id=node["id"],
+    )
+    pool = await _make_pool_stub(conn)
+    result = await build_conversation_context(cid, pool, TEST_USER_ID)
+    assert "Tether Dev" in result
+
+
+@pytest.mark.asyncio
+async def test_root_node_no_parent_summary(conn):
+    """Root nodes have no parent — should not raise and should omit parent block."""
+    node = await create_node(conn, "Root Node")
+    await upsert_section(conn, node["id"], "goals", "Root goals here.")
+    cid = await create_conversation(
+        conn,
+        user_id=TEST_USER_ID,
+        name="Root chat",
+        notification_type="bot",
+        context_node_id=node["id"],
+    )
+    pool = await _make_pool_stub(conn)
+    result = await build_conversation_context(cid, pool, TEST_USER_ID)
+    assert "Root goals here." in result
+
+
+# ---------------------------------------------------------------------------
+# Conversation with unknown context_node_id (node deleted)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deleted_context_node_returns_empty(conn):
+    """When context_node_id references a deleted node, return empty string gracefully."""
+    node = await create_node(conn, "Temp Node")
+    cid = await create_conversation(
+        conn,
+        user_id=TEST_USER_ID,
+        name="Orphan chat",
+        notification_type="bot",
+        context_node_id=node["id"],
+    )
+    # Delete the node after linking
+    await conn.execute("DELETE FROM context_nodes WHERE id = $1::uuid", node["id"])
+    pool = await _make_pool_stub(conn)
+    result = await build_conversation_context(cid, pool, TEST_USER_ID)
+    assert result == ""

--- a/tests/bot/test_message_handler.py
+++ b/tests/bot/test_message_handler.py
@@ -252,7 +252,7 @@ async def test_handle_message_stop_calls_premium_stop(monkeypatch):
     """/stop message must call premium stop_session and reply with Stopped."""
     sent: list[str] = []
 
-    async def fake_body(text, send_fn, pool, user_id, status_fn=None):
+    async def fake_body(text, send_fn, pool, user_id, status_fn=None, conversation_id=None):
         # Simulate the /stop path calling send_fn
         pass
 


### PR DESCRIPTION
## Summary

Phase G of the notification system overhaul: Conversations API + context injection foundation for the `tether-agent-2.0` / `tether-agent-2.5` chat pipeline.

**No new migration required** — Phase B migration `9b8a7f6e5d4c` already provisioned all required schema (`conversations`, `conversation_history` extensions, `notification_channels`, `context_nodes.summary`).

### New endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/conversations` | List conversations (RLS-scoped, filterable by `state` / `context_node_id`) |
| `POST` | `/api/conversations` | Create conversation |
| `GET` | `/api/conversations/{id}` | Get single conversation |
| `PATCH` | `/api/conversations/{id}` | Patch name / priority / state / context_node_id |
| `GET` | `/api/conversations/{id}/messages` | List messages, cursor paginated |
| `PUT` | `/api/preferences/notifications` | Upsert notification routing prefs |
| `GET` | `/api/preferences/notifications` | Get notification routing prefs |
| `GET` | `/api/context-nodes/{id}/summary` | Get context node summary field |

### Pagination note
`GET /api/conversations/{id}/messages` uses `before_id` cursor pagination (integer PK of `conversation_history`). This is intentional: offset-based pagination shifts under concurrent inserts; cursor-based does not. Clients treat `before_id` as an opaque string. `has_more` signals whether more pages exist without a separate COUNT query (fetch limit+1, return limit).

### Context injection
`bot/conversation_context.py` — `build_conversation_context(conversation_id, pool, user_id) -> str` fetches the conversation's linked `context_node` + its sections and returns a formatted markdown block for prompt injection. Returns `""` when no node is linked or node was deleted. Wired into `_handle_v3` via `conversation_id: str | None = None` threaded through `handle_message` → `_handle_message_body` → `_handle_v3`. All existing callers unaffected (default `None`).

Cross-node parent summary is a premium feature — stub comment in `conversation_context.py` marks the extension point. Hook design deferred pending orchestrator decision on self-hosted premium access pattern (separate architectural question escalated to Jason).

### Data shape contract
This shape is a **binding contract** — Phase I (`chat-page-builder`) was dispatched against it before implementation began. `folder_name: str | None` on conversation responses; `before_id` cursor on messages.

## Files changed

- `db/pg_queries/conversations.py` — added `list_conversations()` (LEFT JOIN `folder_name`) + `list_conversation_messages()` (cursor pagination)
- `api/routes/conversations.py` — new route file (8 endpoints)
- `api/main.py` — register conversations router
- `bot/conversation_context.py` — new helper
- `bot/message_handler.py` — thread `conversation_id` param, inject context in `_handle_v3`
- `tests/api/test_conversations.py` — 30 new tests (list/create/get/patch/messages/prefs/summary/RLS)
- `tests/bot/test_context_injection.py` — 4 new tests

## Test plan

- [ ] All 401 non-DB tests passing locally (verified)
- [ ] API tests require `DATABASE_URL` — run against dev Postgres to confirm round-trips
- [ ] RLS isolation tests verify user A cannot see user B's conversations
- [ ] `has_more` tests verify correct pagination boundary behaviour
- [ ] Verify `folder_name` is `null` when no `context_node_id` set