### PR TITLE
feat(frontend): trial counter, BYOK gate, agent settings toggles

### DIFF
--- a/frontend/src/components/AgentBehaviorSection.vue
+++ b/frontend/src/components/AgentBehaviorSection.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useAgentSettingsStore } from '../stores/agentSettings'
+
+const store = useAgentSettingsStore()
+
+onMounted(() => store.fetchSettings())
+
+function toggleAutoApprove() {
+  store.setAutoApprove(!store.autoApproveUserActions)
+}
+
+function toggleDevMode() {
+  store.setDevMode(!store.devModeShowRawTools)
+}
+</script>
+
+<template>
+  <section class="mb-8">
+    <h2 class="text-sm font-semibold text-[--fg-3] uppercase tracking-wider mb-3">Agent Behaviour</h2>
+    <div class="bg-[--bg-elev-1] rounded-xl p-4 space-y-4">
+
+      <!-- Auto-approve agent actions -->
+      <div class="flex items-center justify-between">
+        <div>
+          <div class="text-sm text-[--fg-1]">Auto-approve agent actions</div>
+          <div class="text-xs text-[--fg-4]">
+            When on, the agent doesn't ask permission before writing to your data.
+            Use only if you trust the agent fully.
+          </div>
+        </div>
+        <button
+          role="switch"
+          type="button"
+          :aria-checked="store.autoApproveUserActions"
+          :class="store.autoApproveUserActions ? 'bg-[--accent]' : 'bg-[--bg-elev-3]'"
+          class="relative w-11 h-6 rounded-full transition-colors flex-shrink-0 ml-4"
+          @click="toggleAutoApprove"
+        >
+          <span
+            :class="store.autoApproveUserActions ? 'translate-x-5' : 'translate-x-0.5'"
+            class="inline-block w-5 h-5 bg-white rounded-full transition-transform transform mt-0.5"
+          />
+        </button>
+      </div>
+
+      <!-- Show raw tool names (dev mode) -->
+      <div class="flex items-center justify-between">
+        <div>
+          <div class="text-sm text-[--fg-1]">Show raw tool names</div>
+          <div class="text-xs text-[--fg-4]">
+            Developer mode: show raw tool names alongside friendly action descriptions
+            in chat. Off by default for end users.
+          </div>
+        </div>
+        <button
+          role="switch"
+          type="button"
+          :aria-checked="store.devModeShowRawTools"
+          :class="store.devModeShowRawTools ? 'bg-[--accent]' : 'bg-[--bg-elev-3]'"
+          class="relative w-11 h-6 rounded-full transition-colors flex-shrink-0 ml-4"
+          @click="toggleDevMode"
+        >
+          <span
+            :class="store.devModeShowRawTools ? 'translate-x-5' : 'translate-x-0.5'"
+            class="inline-block w-5 h-5 bg-white rounded-full transition-transform transform mt-0.5"
+          />
+        </button>
+      </div>
+
+    </div>
+  </section>
+</template>

--- a/frontend/src/components/AgentPicker.vue
+++ b/frontend/src/components/AgentPicker.vue
@@ -4,12 +4,6 @@ import { useAgentPickerStore } from '../stores/agentPicker'
 import { useAuthStore } from '../stores/auth'
 import type { AgentVersion } from '../stores/agentPicker'
 
-withDefaults(defineProps<{
-  trialMessagesLeft?: number
-}>(), {
-  trialMessagesLeft: 10,
-})
-
 const store = useAgentPickerStore()
 const authStore = useAuthStore()
 const open = ref(false)
@@ -18,24 +12,42 @@ const rootEl = ref<HTMLDivElement | null>(null)
 // Premium users bypass trial counter and BYOK modal entirely.
 const isPremium = computed(() => authStore.user?.is_paid ?? false)
 
+// Live trial count from WS events; null until first event arrives (show fallback).
+const trialRemaining = computed(() => store.trialMessagesRemaining ?? 10)
+
+// True when current provider leaks 2.5 internals — 2.5 shown as unavailable.
+const providerIsLeaky = computed(() => store.isLeakyProvider)
+
+// True when free user has exhausted their monthly 2.5 trial quota.
+const trialExhausted = computed(
+  () => !isPremium.value && store.trialMessagesRemaining === 0,
+)
+
 const AGENTS: Array<{ id: AgentVersion; label: string; sublabel: string }> = [
   { id: 'tether-agent-1.0', label: 'tether-agent-1.0', sublabel: 'Classic · free' },
   { id: 'tether-agent-2.0', label: 'tether-agent-2.0', sublabel: 'Modern · free' },
   { id: 'tether-agent-2.5', label: 'tether-agent-2.5', sublabel: 'Premium' },
 ]
 
+/**
+ * Whether the 2.5 option is locked (unselectable).
+ * Locks when: provider is leaky, OR trial is exhausted.
+ * Premium users are never locked.
+ */
+function is25Locked(id: AgentVersion): boolean {
+  if (id !== 'tether-agent-2.5') return false
+  if (isPremium.value) return false
+  return providerIsLeaky.value || trialExhausted.value
+}
+
 function toggleOpen() {
   open.value = !open.value
 }
 
 async function select(version: AgentVersion) {
+  if (is25Locked(version)) return // silently ignore clicks on locked option
   open.value = false
   await store.setAgent(version)
-}
-
-// "Stay on 2.0" — cancel the pending 2.5 selection, keep current agent.
-function stayOn20() {
-  store.cancelByokModal()
 }
 
 // Close dropdown when clicking outside the component's root.
@@ -73,38 +85,65 @@ onBeforeUnmount(() => document.removeEventListener('mousedown', onDocumentClick)
         :key="agent.id"
         type="button"
         :data-agent="agent.id"
-        class="w-full flex items-center justify-between px-3 py-2 text-xs text-left hover:bg-[--bg-elev-3] transition-colors"
-        :class="store.selectedAgent === agent.id ? 'text-[--fg-1]' : 'text-[--fg-3]'"
+        :disabled="is25Locked(agent.id)"
+        class="w-full flex items-center justify-between px-3 py-2 text-xs text-left transition-colors"
+        :class="[
+          is25Locked(agent.id)
+            ? 'opacity-50 cursor-not-allowed'
+            : 'hover:bg-[--bg-elev-3]',
+          store.selectedAgent === agent.id ? 'text-[--fg-1]' : 'text-[--fg-3]',
+        ]"
         @click="select(agent.id)"
       >
-        <span class="flex items-center gap-2">
-          <!-- Active checkmark -->
-          <svg
-            v-if="store.selectedAgent === agent.id"
-            class="w-3 h-3 text-[--accent] flex-shrink-0"
-            fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"
-          >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
-          </svg>
-          <span v-else class="w-3 h-3 flex-shrink-0" />
-
-          <span>
-            <span class="font-medium">{{ agent.label }}</span>
-            <span class="ml-1 text-[--fg-4]">· {{ agent.sublabel }}</span>
-            <!-- Trial badge for 2.5 — hidden for premium users -->
-            <span
-              v-if="agent.id === 'tether-agent-2.5' && !isPremium"
-              class="ml-1 inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-[--accent-veil] text-[--accent]"
+        <span class="flex flex-col gap-0.5 flex-1 min-w-0">
+          <span class="flex items-center gap-2">
+            <!-- Active checkmark -->
+            <svg
+              v-if="store.selectedAgent === agent.id"
+              class="w-3 h-3 text-[--accent] flex-shrink-0"
+              fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"
             >
-              trial: {{ trialMessagesLeft }} left
+              <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+            <span v-else class="w-3 h-3 flex-shrink-0" />
+
+            <span>
+              <span class="font-medium">{{ agent.label }}</span>
+              <span v-if="!providerIsLeaky || agent.id !== 'tether-agent-2.5'" class="ml-1 text-[--fg-4]">
+                · {{ agent.sublabel }}
+              </span>
+
+              <!-- Trial badge for 2.5 — hidden for premium users and leaky-provider users -->
+              <span
+                v-if="agent.id === 'tether-agent-2.5' && !isPremium && !providerIsLeaky"
+                class="ml-1 inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-[--accent-veil] text-[--accent]"
+              >
+                trial: {{ trialRemaining }} left
+              </span>
             </span>
+          </span>
+
+          <!-- Leaky-provider explanation line -->
+          <span
+            v-if="agent.id === 'tether-agent-2.5' && providerIsLeaky && !isPremium"
+            class="ml-5 text-[--fg-5] text-[10px] leading-tight"
+          >
+            Unavailable on current provider · Switch to Anthropic to use this model
+          </span>
+
+          <!-- Trial exhausted explanation line -->
+          <span
+            v-else-if="agent.id === 'tether-agent-2.5' && trialExhausted"
+            class="ml-5 text-[--fg-5] text-[10px] leading-tight"
+          >
+            Upgrade to continue
           </span>
         </span>
 
-        <!-- Tooltip for 2.5 -->
+        <!-- Tooltip for 2.5 (hidden when leaky/exhausted — explanation is inline) -->
         <span
-          v-if="agent.id === 'tether-agent-2.5'"
-          class="ml-2 text-[--fg-5] cursor-help text-[10px]"
+          v-if="agent.id === 'tether-agent-2.5' && !providerIsLeaky && !trialExhausted"
+          class="ml-2 text-[--fg-5] cursor-help text-[10px] flex-shrink-0"
           :title="'tether-agent-2.5 uses more advanced models (Sonnet) for the main reasoning steps. On bring-your-own-key plans, this consumes your monthly quota faster than 2.0 (~3-5× tokens per message vs 2.0).'"
         >
           ⓘ
@@ -128,7 +167,7 @@ onBeforeUnmount(() => document.removeEventListener('mousedown', onDocumentClick)
             <button
               type="button"
               class="text-xs px-3 py-1.5 rounded-lg bg-[--bg-elev-3] text-[--fg-2] hover:bg-[--bg-elev-4] transition-colors"
-              @click="stayOn20"
+              @click="store.cancelByokModal()"
             >
               Stay on 2.0
             </button>

--- a/frontend/src/components/__tests__/AgentBehaviorSection.test.ts
+++ b/frontend/src/components/__tests__/AgentBehaviorSection.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for AgentBehaviorSection — settings toggles (Part 3).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) })),
+}))
+
+describe('AgentBehaviorSection', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('mounts without error', async () => {
+    const { default: AgentBehaviorSection } = await import('../AgentBehaviorSection.vue')
+    const wrapper = mount(AgentBehaviorSection)
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('renders "Auto-approve agent actions" toggle', async () => {
+    const { default: AgentBehaviorSection } = await import('../AgentBehaviorSection.vue')
+    const wrapper = mount(AgentBehaviorSection)
+    expect(wrapper.text()).toContain('Auto-approve agent actions')
+  })
+
+  it('renders "Show raw tool names" toggle', async () => {
+    const { default: AgentBehaviorSection } = await import('../AgentBehaviorSection.vue')
+    const wrapper = mount(AgentBehaviorSection)
+    expect(wrapper.text()).toContain('Show raw tool names')
+  })
+
+  it('toggles reflect store state — both default false', async () => {
+    const { useAgentSettingsStore } = await import('../../stores/agentSettings')
+    const store = useAgentSettingsStore()
+    expect(store.autoApproveUserActions).toBe(false)
+    expect(store.devModeShowRawTools).toBe(false)
+
+    const { default: AgentBehaviorSection } = await import('../AgentBehaviorSection.vue')
+    const wrapper = mount(AgentBehaviorSection)
+    await flushPromises()
+
+    // Toggle buttons should exist — they should reflect OFF state
+    const toggleButtons = wrapper.findAll('button[role="switch"]')
+    expect(toggleButtons.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('clicking auto-approve toggle calls store.setAutoApprove', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({ ok: true, json: async () => ({}) } as any)
+
+    const { useAgentSettingsStore } = await import('../../stores/agentSettings')
+    const store = useAgentSettingsStore()
+    const spy = vi.spyOn(store, 'setAutoApprove').mockResolvedValue()
+
+    const { default: AgentBehaviorSection } = await import('../AgentBehaviorSection.vue')
+    const wrapper = mount(AgentBehaviorSection)
+
+    const toggleButtons = wrapper.findAll('button[role="switch"]')
+    await toggleButtons[0].trigger('click')
+
+    expect(spy).toHaveBeenCalledWith(true)
+  })
+
+  it('clicking dev-mode toggle calls store.setDevMode', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({ ok: true, json: async () => ({}) } as any)
+
+    const { useAgentSettingsStore } = await import('../../stores/agentSettings')
+    const store = useAgentSettingsStore()
+    const spy = vi.spyOn(store, 'setDevMode').mockResolvedValue()
+
+    const { default: AgentBehaviorSection } = await import('../AgentBehaviorSection.vue')
+    const wrapper = mount(AgentBehaviorSection)
+
+    const toggleButtons = wrapper.findAll('button[role="switch"]')
+    await toggleButtons[1].trigger('click')
+
+    expect(spy).toHaveBeenCalledWith(true)
+  })
+
+  it('clicking auto-approve toggle when ON calls setAutoApprove(false)', async () => {
+    const { useAgentSettingsStore } = await import('../../stores/agentSettings')
+    const store = useAgentSettingsStore()
+    store.autoApproveUserActions = true
+    const spy = vi.spyOn(store, 'setAutoApprove').mockResolvedValue()
+
+    const { default: AgentBehaviorSection } = await import('../AgentBehaviorSection.vue')
+    const wrapper = mount(AgentBehaviorSection)
+
+    const toggleButtons = wrapper.findAll('button[role="switch"]')
+    await toggleButtons[0].trigger('click')
+
+    expect(spy).toHaveBeenCalledWith(false)
+  })
+})

--- a/frontend/src/components/__tests__/AgentPicker.test.ts
+++ b/frontend/src/components/__tests__/AgentPicker.test.ts
@@ -69,10 +69,12 @@ describe('AgentPicker', () => {
   })
 
   it('shows trial badge on 2.5 option', async () => {
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const store = useAgentPickerStore()
+    store.setTrialRemaining(7)
+
     const { default: AgentPicker } = await import('../AgentPicker.vue')
-    const wrapper = mount(AgentPicker, {
-      props: { trialMessagesLeft: 7 },
-    })
+    const wrapper = mount(AgentPicker)
     await wrapper.find('button').trigger('click')
     await wrapper.vm.$nextTick()
     expect(wrapper.text()).toContain('7')
@@ -151,8 +153,12 @@ describe('AgentPicker', () => {
     const authStore = useAuthStore()
     authStore.user = { user_id: 'u1', username: 'test', is_admin: false, is_paid: false }
 
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const pickerStore = useAgentPickerStore()
+    pickerStore.setTrialRemaining(7)
+
     const { default: AgentPicker } = await import('../AgentPicker.vue')
-    const wrapper = mount(AgentPicker, { props: { trialMessagesLeft: 7 } })
+    const wrapper = mount(AgentPicker)
     await wrapper.find('button').trigger('click')
     await wrapper.vm.$nextTick()
 
@@ -165,8 +171,12 @@ describe('AgentPicker', () => {
     const authStore = useAuthStore()
     authStore.user = { user_id: 'u1', username: 'test', is_admin: false, is_paid: true }
 
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const pickerStore = useAgentPickerStore()
+    pickerStore.setTrialRemaining(7)
+
     const { default: AgentPicker } = await import('../AgentPicker.vue')
-    const wrapper = mount(AgentPicker, { props: { trialMessagesLeft: 7 } })
+    const wrapper = mount(AgentPicker)
     await wrapper.find('button').trigger('click')
     await wrapper.vm.$nextTick()
 

--- a/frontend/src/components/__tests__/AgentPickerTrialByok.test.ts
+++ b/frontend/src/components/__tests__/AgentPickerTrialByok.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for AgentPicker trial counter and BYOK leakage gate UI (Parts 1 & 2).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ path: '/dashboard' }),
+}))
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) })),
+}))
+
+describe('AgentPicker — Part 1: live trial counter from store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.restoreAllMocks()
+  })
+
+  it('shows trialMessagesRemaining from store when set', async () => {
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const store = useAgentPickerStore()
+    store.setTrialRemaining(7)
+
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker)
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('7')
+    expect(wrapper.text()).toContain('trial')
+  })
+
+  it('shows default count when trialMessagesRemaining is null (not yet loaded)', async () => {
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const store = useAgentPickerStore()
+    // trialMessagesRemaining defaults to null
+    expect(store.trialMessagesRemaining).toBeNull()
+
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker)
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    // Should still show the trial badge (with fallback value)
+    expect(wrapper.text()).toContain('trial')
+  })
+
+  it('shows "Upgrade to continue" overlay when trialMessagesRemaining is 0 and user is free', async () => {
+    const { useAuthStore } = await import('../../stores/auth')
+    const authStore = useAuthStore()
+    authStore.user = { user_id: 'u1', username: 'test', is_admin: false, is_paid: false }
+
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const store = useAgentPickerStore()
+    store.setTrialRemaining(0)
+
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker)
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('Upgrade')
+  })
+
+  it('2.5 selection blocked when trialMessagesRemaining is 0 and user is free', async () => {
+    const { useAuthStore } = await import('../../stores/auth')
+    const authStore = useAuthStore()
+    authStore.user = { user_id: 'u1', username: 'test', is_admin: false, is_paid: false }
+
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const store = useAgentPickerStore()
+    store.setTrialRemaining(0)
+    const spy = vi.spyOn(store, 'setAgent')
+
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker)
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    const option25 = wrapper.findAll('[data-agent]').find(o => o.attributes('data-agent') === 'tether-agent-2.5')
+    expect(option25).toBeDefined()
+    await option25!.trigger('click')
+
+    // Should not call setAgent since 2.5 is locked
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('premium user sees no trial badge even when trialMessagesRemaining is set', async () => {
+    const { useAuthStore } = await import('../../stores/auth')
+    const authStore = useAuthStore()
+    authStore.user = { user_id: 'u1', username: 'test', is_admin: false, is_paid: true }
+
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const store = useAgentPickerStore()
+    store.setTrialRemaining(5)
+
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker)
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).not.toContain('trial')
+  })
+})
+
+describe('AgentPicker — Part 2: BYOK leakage gate', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.restoreAllMocks()
+  })
+
+  it('2.5 is shown as disabled with explanation when provider is leaky', async () => {
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const store = useAgentPickerStore()
+    store.currentProvider = 'openrouter'
+
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker)
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    // Should show the disabled/unavailable state text
+    const text = wrapper.text()
+    expect(text).toContain('Unavailable')
+  })
+
+  it('2.5 is not shown as disabled when provider is safe', async () => {
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const store = useAgentPickerStore()
+    store.currentProvider = 'anthropic_oauth'
+
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker)
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).not.toContain('Unavailable')
+  })
+
+  it('clicking 2.5 does nothing when provider is leaky (no modal, no commit)', async () => {
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const store = useAgentPickerStore()
+    store.currentProvider = 'openai'
+    store.selectedAgent = 'tether-agent-2.0'
+    const spy = vi.spyOn(store, 'setAgent')
+
+    const { default: AgentPicker } = await import('../AgentPicker.vue')
+    const wrapper = mount(AgentPicker)
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    const option25 = wrapper.findAll('[data-agent]').find(o => o.attributes('data-agent') === 'tether-agent-2.5')
+    await option25!.trigger('click')
+
+    expect(spy).not.toHaveBeenCalled()
+    expect(store.selectedAgent).toBe('tether-agent-2.0')
+  })
+})

--- a/frontend/src/constants/agentProvider.ts
+++ b/frontend/src/constants/agentProvider.ts
@@ -1,0 +1,15 @@
+/**
+ * Agent provider constants shared between the picker store and settings.
+ *
+ * LEAKY_PROVIDERS — providers where premium 2.5 is unavailable because their
+ * dashboards expose prompt/response content, leaking proprietary intelligence
+ * design. Matches the backend's interactive_agent_layer config.
+ */
+export const LEAKY_PROVIDERS = ['openrouter', 'openai'] as const
+export type LeakyProvider = (typeof LEAKY_PROVIDERS)[number]
+
+export const DEFAULT_PROVIDER = 'anthropic_oauth'
+
+export function isLeakyProvider(provider: string): boolean {
+  return (LEAKY_PROVIDERS as readonly string[]).includes(provider)
+}

--- a/frontend/src/stores/__tests__/agentPickerTrialByok.test.ts
+++ b/frontend/src/stores/__tests__/agentPickerTrialByok.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for trial counter (Part 1) and BYOK leakage gate (Part 2) additions
+ * to useAgentPickerStore.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { setBotTransport } from '../../composables/useBotTransport'
+import { makeTransport } from './testHelpers'
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: false, json: async () => ({}) })),
+}))
+
+// ─── Part 1: trial counter ───────────────────────────────────────────────────
+
+describe('useAgentPickerStore — trial counter', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('trialMessagesRemaining defaults to null (not yet loaded)', async () => {
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    expect(store.trialMessagesRemaining).toBeNull()
+  })
+
+  it('setTrialRemaining updates trialMessagesRemaining', async () => {
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    store.setTrialRemaining(5)
+    expect(store.trialMessagesRemaining).toBe(5)
+  })
+
+  it('setTrialRemaining(0) sets count to 0', async () => {
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    store.setTrialRemaining(0)
+    expect(store.trialMessagesRemaining).toBe(0)
+  })
+})
+
+// ─── Part 1: chat store forwards trial_usage_update ──────────────────────────
+
+describe('useChatStore — trial_usage_update updates agentPicker', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('trial_usage_update event updates agentPickerStore.trialMessagesRemaining', async () => {
+    setBotTransport(makeTransport([
+      { type: 'trial_usage_update', session_id: 'sess1', remaining: 3 },
+      { type: 'turn_complete', session_id: 'sess1', final_text: '' },
+    ]))
+
+    const { useChatStore } = await import('../chat')
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const chatStore = useChatStore()
+    const pickerStore = useAgentPickerStore()
+
+    await chatStore.send('hi')
+
+    expect(pickerStore.trialMessagesRemaining).toBe(3)
+  })
+
+  it('multiple trial_usage_update events keep the last value', async () => {
+    setBotTransport(makeTransport([
+      { type: 'trial_usage_update', session_id: 'sess1', remaining: 5 },
+      { type: 'trial_usage_update', session_id: 'sess1', remaining: 4 },
+      { type: 'turn_complete', session_id: 'sess1', final_text: 'done' },
+    ]))
+
+    const { useChatStore } = await import('../chat')
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const chatStore = useChatStore()
+    const pickerStore = useAgentPickerStore()
+
+    await chatStore.send('hi')
+
+    expect(pickerStore.trialMessagesRemaining).toBe(4)
+  })
+})
+
+// ─── Part 2: BYOK leakage gate ───────────────────────────────────────────────
+
+describe('useAgentPickerStore — BYOK leakage gate', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('currentProvider defaults to anthropic_oauth', async () => {
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    expect(store.currentProvider).toBe('anthropic_oauth')
+  })
+
+  it('isLeakyProvider is false for anthropic_oauth', async () => {
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    expect(store.isLeakyProvider).toBe(false)
+  })
+
+  it('isLeakyProvider is true for openrouter', async () => {
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    store.currentProvider = 'openrouter'
+    expect(store.isLeakyProvider).toBe(true)
+  })
+
+  it('isLeakyProvider is true for openai', async () => {
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    store.currentProvider = 'openai'
+    expect(store.isLeakyProvider).toBe(true)
+  })
+
+  it('isLeakyProvider is false for anthropic_api', async () => {
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    store.currentProvider = 'anthropic_api'
+    expect(store.isLeakyProvider).toBe(false)
+  })
+
+  it('setAgent 2.5 is blocked when provider is leaky — no modal opened, agent unchanged', async () => {
+    const { useAgentPickerStore } = await import('../agentPicker')
+    const store = useAgentPickerStore()
+    store.currentProvider = 'openrouter'
+    store.selectedAgent = 'tether-agent-2.0'
+
+    await store.setAgent('tether-agent-2.5')
+
+    expect(store.selectedAgent).toBe('tether-agent-2.0')
+    expect(store.showByokModal).toBe(false)
+  })
+})

--- a/frontend/src/stores/__tests__/agentSettings.test.ts
+++ b/frontend/src/stores/__tests__/agentSettings.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for useAgentSettingsStore — auto-approve + dev_mode toggles (Part 3).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) })),
+}))
+
+describe('useAgentSettingsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('autoApproveUserActions defaults to false', async () => {
+    const { useAgentSettingsStore } = await import('../agentSettings')
+    const store = useAgentSettingsStore()
+    expect(store.autoApproveUserActions).toBe(false)
+  })
+
+  it('devModeShowRawTools defaults to false', async () => {
+    const { useAgentSettingsStore } = await import('../agentSettings')
+    const store = useAgentSettingsStore()
+    expect(store.devModeShowRawTools).toBe(false)
+  })
+
+  it('fetchSettings loads autoApproveUserActions from API', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        auto_approve_user_actions: 'true',
+        dev_mode_show_raw_tools: 'false',
+      }),
+    } as any)
+
+    const { useAgentSettingsStore } = await import('../agentSettings')
+    const store = useAgentSettingsStore()
+    await store.fetchSettings()
+
+    expect(store.autoApproveUserActions).toBe(true)
+  })
+
+  it('fetchSettings loads devModeShowRawTools from API', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        auto_approve_user_actions: 'false',
+        dev_mode_show_raw_tools: 'true',
+      }),
+    } as any)
+
+    const { useAgentSettingsStore } = await import('../agentSettings')
+    const store = useAgentSettingsStore()
+    await store.fetchSettings()
+
+    expect(store.devModeShowRawTools).toBe(true)
+  })
+
+  it('fetchSettings keeps defaults when API fails', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({ ok: false, json: async () => ({}) } as any)
+
+    const { useAgentSettingsStore } = await import('../agentSettings')
+    const store = useAgentSettingsStore()
+    await store.fetchSettings()
+
+    expect(store.autoApproveUserActions).toBe(false)
+    expect(store.devModeShowRawTools).toBe(false)
+  })
+
+  it('setAutoApprove(true) PUTs to /api/settings/auto_approve_user_actions', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({ ok: true, json: async () => ({}) } as any)
+
+    const { useAgentSettingsStore } = await import('../agentSettings')
+    const store = useAgentSettingsStore()
+    await store.setAutoApprove(true)
+
+    expect(vi.mocked(api)).toHaveBeenCalledWith(
+      '/api/settings/auto_approve_user_actions',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ value: 'true' }),
+      }),
+    )
+    expect(store.autoApproveUserActions).toBe(true)
+  })
+
+  it('setAutoApprove(false) PUTs false value', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({ ok: true, json: async () => ({}) } as any)
+
+    const { useAgentSettingsStore } = await import('../agentSettings')
+    const store = useAgentSettingsStore()
+    store.autoApproveUserActions = true
+    await store.setAutoApprove(false)
+
+    expect(store.autoApproveUserActions).toBe(false)
+  })
+
+  it('setAutoApprove rolls back on API failure', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({ ok: false, json: async () => ({}) } as any)
+
+    const { useAgentSettingsStore } = await import('../agentSettings')
+    const store = useAgentSettingsStore()
+    store.autoApproveUserActions = false
+    await store.setAutoApprove(true)
+
+    expect(store.autoApproveUserActions).toBe(false)
+  })
+
+  it('setDevMode(true) PUTs to /api/settings/dev_mode_show_raw_tools', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({ ok: true, json: async () => ({}) } as any)
+
+    const { useAgentSettingsStore } = await import('../agentSettings')
+    const store = useAgentSettingsStore()
+    await store.setDevMode(true)
+
+    expect(vi.mocked(api)).toHaveBeenCalledWith(
+      '/api/settings/dev_mode_show_raw_tools',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ value: 'true' }),
+      }),
+    )
+    expect(store.devModeShowRawTools).toBe(true)
+  })
+
+  it('setDevMode rolls back on API failure', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValueOnce({ ok: false, json: async () => ({}) } as any)
+
+    const { useAgentSettingsStore } = await import('../agentSettings')
+    const store = useAgentSettingsStore()
+    store.devModeShowRawTools = false
+    await store.setDevMode(true)
+
+    expect(store.devModeShowRawTools).toBe(false)
+  })
+})

--- a/frontend/src/stores/agentPicker.ts
+++ b/frontend/src/stores/agentPicker.ts
@@ -1,7 +1,8 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { api } from '../lib/api'
 import { useAuthStore } from './auth'
+import { isLeakyProvider as checkLeaky, DEFAULT_PROVIDER } from '../constants/agentProvider'
 
 const AGENT_VERSIONS = ['tether-agent-1.0', 'tether-agent-2.0', 'tether-agent-2.5'] as const
 export type AgentVersion = (typeof AGENT_VERSIONS)[number]
@@ -19,6 +20,20 @@ export const useAgentPickerStore = defineStore('agentPicker', () => {
   // Holds the pending 2.5 selection while the BYOK modal awaits confirmation.
   const pendingAgent = ref<AgentVersion | null>(null)
 
+  // Trial counter: null = not yet received from server (show default); 0 = exhausted.
+  const trialMessagesRemaining = ref<number | null>(null)
+
+  // Provider: defaults to anthropic_oauth (safe). Set from user settings when available.
+  const currentProvider = ref<string>(DEFAULT_PROVIDER)
+
+  // True when the current provider leaks premium 2.5 internals.
+  const isLeakyProvider = computed(() => checkLeaky(currentProvider.value))
+
+  /** Called by chat store when a trial_usage_update WS event arrives. */
+  function setTrialRemaining(remaining: number): void {
+    trialMessagesRemaining.value = remaining
+  }
+
   async function fetchPreference(): Promise<void> {
     try {
       const resp = await api('/api/settings')
@@ -27,6 +42,10 @@ export const useAgentPickerStore = defineStore('agentPicker', () => {
       const val = data[SETTING_KEY]
       if (isValidAgent(val)) {
         selectedAgent.value = val
+      }
+      // Load provider if present (future: user sets this in settings)
+      if (typeof data.current_provider === 'string') {
+        currentProvider.value = data.current_provider
       }
     } catch {
       // Network failure — keep default
@@ -54,12 +73,19 @@ export const useAgentPickerStore = defineStore('agentPicker', () => {
   /**
    * Select an agent version.
    *
-   * For tether-agent-2.5 on free users: opens the BYOK confirmation modal
-   * WITHOUT committing. The selection is only persisted after confirmByokModal().
+   * For tether-agent-2.5 on leaky providers: silently blocked — provider
+   * cannot run 2.5 due to IP-leakage policy. Picker handles the UI state.
+   *
+   * For tether-agent-2.5 on free users (safe provider): opens the BYOK
+   * confirmation modal WITHOUT committing. The selection is only persisted
+   * after confirmByokModal().
    *
    * For premium users (is_paid) or any other version: commits immediately.
    */
   async function setAgent(version: AgentVersion): Promise<void> {
+    // Leaky provider gate — silently block 2.5 regardless of tier.
+    if (version === 'tether-agent-2.5' && isLeakyProvider.value) return
+
     const isPremium = useAuthStore().user?.is_paid ?? false
 
     if (version === 'tether-agent-2.5' && !isPremium) {
@@ -89,6 +115,10 @@ export const useAgentPickerStore = defineStore('agentPicker', () => {
     selectedAgent,
     showByokModal,
     pendingAgent,
+    trialMessagesRemaining,
+    currentProvider,
+    isLeakyProvider,
+    setTrialRemaining,
     fetchPreference,
     setAgent,
     confirmByokModal,

--- a/frontend/src/stores/agentSettings.ts
+++ b/frontend/src/stores/agentSettings.ts
@@ -1,0 +1,63 @@
+import { defineStore } from 'pinia'
+import { ref, type Ref } from 'vue'
+import { api } from '../lib/api'
+
+/**
+ * Stores user-configurable agent behaviour toggles:
+ *   - autoApproveUserActions: skip per-tool confirmation for user_action tools
+ *   - devModeShowRawTools: show raw tool names alongside friendly phrases in chat
+ *
+ * Call fetchSettings() once on app init or when the settings page mounts.
+ */
+export const useAgentSettingsStore = defineStore('agentSettings', () => {
+  const autoApproveUserActions = ref(false)
+  const devModeShowRawTools = ref(false)
+
+  async function fetchSettings(): Promise<void> {
+    try {
+      const resp = await api('/api/settings')
+      if (!resp.ok) return
+      const data = await resp.json()
+      if (data.auto_approve_user_actions !== undefined) {
+        autoApproveUserActions.value = data.auto_approve_user_actions === 'true'
+      }
+      if (data.dev_mode_show_raw_tools !== undefined) {
+        devModeShowRawTools.value = data.dev_mode_show_raw_tools === 'true'
+      }
+    } catch {
+      // Network failure — keep defaults
+    }
+  }
+
+  /** Optimistically persist a boolean setting; rollback on failure. */
+  async function commitToggle(key: string, target: Ref<boolean>, enabled: boolean): Promise<void> {
+    const previous = target.value
+    target.value = enabled
+    try {
+      const resp = await api(`/api/settings/${key}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value: String(enabled) }),
+      })
+      if (!resp.ok) target.value = previous
+    } catch {
+      target.value = previous
+    }
+  }
+
+  function setAutoApprove(enabled: boolean): Promise<void> {
+    return commitToggle('auto_approve_user_actions', autoApproveUserActions, enabled)
+  }
+
+  function setDevMode(enabled: boolean): Promise<void> {
+    return commitToggle('dev_mode_show_raw_tools', devModeShowRawTools, enabled)
+  }
+
+  return {
+    autoApproveUserActions,
+    devModeShowRawTools,
+    fetchSettings,
+    setAutoApprove,
+    setDevMode,
+  }
+})

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -77,7 +77,7 @@ export const useChatStore = defineStore('chat', () => {
             isSessionActive.value = false
             return
           case 'trial_usage_update':
-            // handled elsewhere (trial counter UI)
+            useAgentPickerStore().setTrialRemaining(event.remaining)
             break
         }
       }

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -8,6 +8,7 @@ import AnthropicAccountSection from '../components/AnthropicAccountSection.vue'
 import ConnectionsSection from '../components/ConnectionsSection.vue'
 import ApiKeysSection from '../components/ApiKeysSection.vue'
 import ICalSection from '../components/ICalSection.vue'
+import AgentBehaviorSection from '../components/AgentBehaviorSection.vue'
 
 const auth = useAuthStore()
 
@@ -386,6 +387,9 @@ async function linkTelegram() {
           </p>
         </div>
       </section>
+
+      <!-- Agent Behaviour -->
+      <AgentBehaviorSection />
 
       <!-- LLM Configuration -->
       <section v-if="llmConfig" class="mb-8">


### PR DESCRIPTION
## Summary

- **Part 1 — Live trial counter**: `trial_usage_update` WS events now update `trialMessagesRemaining` in `agentPicker` store. `AgentPicker.vue` reads the live count instead of a hardcoded prop; shows "Upgrade to continue" overlay and locks 2.5 when count hits 0 for free users.
- **Part 2 — BYOK leakage gate**: `constants/agentProvider.ts` defines `LEAKY_PROVIDERS = ['openrouter', 'openai']`. `agentPicker` store exposes `currentProvider` + `isLeakyProvider` computed; `setAgent()` silently blocks 2.5 on leaky providers. Picker shows "Unavailable on current provider · Switch to Anthropic" explanation and disables the button.
- **Part 3 — Settings toggles**: New `useAgentSettingsStore` with `auto_approve_user_actions` + `dev_mode_show_raw_tools`, each with optimistic PUT + rollback. New `AgentBehaviorSection.vue` component added to `SettingsView.vue`.

## Test plan

- [ ] 74 test files, 761 tests all passing (`npm run test -- --run`)
- [ ] Zero TypeScript errors (`npm run build` clean)
- [ ] Simplification pass run — `agentSettings.ts` uses shared `commitToggle()` helper; `AgentPicker.vue` inlines modal button handlers
- [ ] `trial_usage_update` WS event → picker badge updates live
- [ ] `trialMessagesRemaining === 0` → 2.5 locked with "Upgrade to continue"
- [ ] `currentProvider = 'openrouter'` → 2.5 shows "Unavailable" and click is no-op
- [ ] Settings toggles PUT to correct endpoints, roll back on failure