### PR TITLE
fix: wire real PoolClient in layer __main__

### DIFF
--- a/interactive_agent_layer/__main__.py
+++ b/interactive_agent_layer/__main__.py
@@ -5,7 +5,7 @@ import argparse
 
 import uvicorn
 
-from interactive_agent_layer.pool_client import StubPoolClient
+from interactive_agent_layer.pool_client import PoolClient
 from interactive_agent_layer.server import create_app
 from interactive_agent_layer.session import Layer
 from interactive_agent_layer.ws_publisher import WSPublisher
@@ -18,7 +18,7 @@ def main() -> None:
     args = parser.parse_args()
 
     publisher = WSPublisher()
-    pool = StubPoolClient()  # replaced with real pool client in follow-up PR
+    pool = PoolClient()
     layer = Layer(pool_client=pool, ws_publisher=publisher)
     app = create_app(layer)
 


### PR DESCRIPTION
StubPoolClient was removed from pool_client.py in PR #394 (now re-exports real PoolClient from agent_pool_manager), but __main__.py was never updated. Caused interactive-agent-layer to crash on startup post-deploy.

Single-line fix: import PoolClient instead of StubPoolClient, instantiate it directly.