### PR TITLE
fix(settings): remove extra user_id arg from set_user_setting call

### DIFF
--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -22,5 +22,5 @@ async def list_settings(request: Request, _auth=Depends(auth_dependency),
 async def put_setting(key: str, body: SetSettingBody, request: Request,
                       _auth=Depends(auth_dependency),
                       conn: asyncpg.Connection = Depends(get_db_conn)):
-    await set_user_setting(conn, request.state.user_id, key, body.value)
+    await set_user_setting(conn, key, body.value)
     return {"ok": True}


### PR DESCRIPTION
## Summary

- `PUT /api/settings/{key}` was returning 500: `TypeError: set_user_setting() takes 3 positional arguments but 4 were given`
- Call site passed `(conn, request.state.user_id, key, body.value)` but `set_user_setting(conn, key, value)` uses RLS for user scoping — no `user_id` argument needed or accepted

## Fix

One line: remove `request.state.user_id` from the call in `api/routes/settings.py:25`.

## Test plan

- [x] `pytest tests/ -k settings -v` — 1 passed, 5 skipped (DB tests need postgres)