### PR TITLE
fix(bot): emit turn_error SSE event on layer run_turn failure

### DIFF
--- a/bot/agent_dispatch.py
+++ b/bot/agent_dispatch.py
@@ -133,6 +133,20 @@ async def _dispatch_v2_0(
                     send_fn(event.get("final_text", ""))
                 break
 
+            if etype == "turn_error":
+                # Layer emitted an in-band error (e.g. pool exhausted) — log the
+                # real cause and fall back to 1.0 so the user still gets a response.
+                logger.warning(
+                    "dispatch_v2_0: layer turn error, falling back to 1.0"
+                    " user_id=%s: %s",
+                    user_id,
+                    event.get("message", "unknown"),
+                )
+                await handle_message(
+                    text, send_fn, pool, user_id, vault=vault, status_fn=status_fn
+                )
+                return
+
             if etype in ("status", "agent_action"):
                 if status_fn is not None:
                     if etype == "status":
@@ -159,10 +173,12 @@ async def _dispatch_v2_0(
         raise
 
     except httpx.HTTPError as exc:
-        # Covers both start_session and turn() failures. If session_id is set,
-        # the finally block cleans it up; otherwise there is nothing to end.
+        # Raw transport failure (layer unreachable, connection reset mid-stream,
+        # etc.) — distinct from turn_error which is an in-band error from a
+        # running layer. Both fall back to 1.0 so the user still gets a response.
         logger.warning(
-            "dispatch_v2_0: layer unavailable, falling back to 1.0 user_id=%s: %s",
+            "dispatch_v2_0: layer turn transport error, falling back to 1.0"
+            " user_id=%s: %s",
             user_id,
             exc,
         )

--- a/interactive_agent_layer/server.py
+++ b/interactive_agent_layer/server.py
@@ -93,8 +93,23 @@ def create_app(layer: Layer) -> FastAPI:
         require_session(session_id)
 
         async def event_generator():
-            async for event in layer.run_turn(session_id, body.prompt):
-                yield f"data: {json.dumps(event)}\n\n"
+            try:
+                async for event in layer.run_turn(session_id, body.prompt):
+                    yield f"data: {json.dumps(event)}\n\n"
+            except Exception as exc:
+                # HTTP headers are already committed — we can't change the status
+                # code. Emit a turn_error event so the client gets a parseable
+                # in-band signal instead of an abrupt connection close.
+                import logging as _log
+                _log.getLogger(__name__).exception(
+                    "run_turn failed for session %s: %s", session_id, exc
+                )
+                error_event = {
+                    "type": "turn_error",
+                    "session_id": session_id,
+                    "message": str(exc),
+                }
+                yield f"data: {json.dumps(error_event)}\n\n"
 
         return StreamingResponse(
             event_generator(),

--- a/tests/bot/test_agent_dispatch.py
+++ b/tests/bot/test_agent_dispatch.py
@@ -444,6 +444,70 @@ async def test_dispatch_2_0_unknown_events_forwarded_via_event_fn():
 
 
 # ---------------------------------------------------------------------------
+# turn_error event — layer-side failure surfaced via SSE
+# ---------------------------------------------------------------------------
+
+async def test_dispatch_2_0_turn_error_falls_back_to_1_0(caplog):
+    """When the layer yields turn_error, dispatch must fall back to 1.0 and log the real message."""
+    import logging
+    events = [
+        {"type": "turn_error", "session_id": "sid-1", "message": "pool_exhausted — retry after 5s"},
+    ]
+    constructor, _client = _make_layer_client(events=events)
+
+    with (
+        patch("bot.agent_dispatch.LayerClient", constructor),
+        patch("bot.agent_dispatch.handle_message", new=_fake_handle_1_0_response),
+        caplog.at_level(logging.WARNING, logger="bot.agent_dispatch"),
+    ):
+        from bot.agent_dispatch import dispatch_message
+
+        sent_parts: list[str] = []
+        await dispatch_message(
+            "tether-agent-2.0",
+            "hello",
+            send_fn=sent_parts.append,
+            pool=None,
+            user_id="user1",
+        )
+
+    # 1.0 fallback fires
+    assert sent_parts == ["1.0-response"], "turn_error must trigger 1.0 fallback"
+    # Log must reference the actual pool error, not the generic "layer unavailable"
+    assert any("pool_exhausted" in r.message for r in caplog.records), (
+        "WARNING log must include the pool error message from turn_error"
+    )
+    assert not any("layer unavailable" in r.message for r in caplog.records), (
+        "turn_error path must not log the misleading 'layer unavailable' message"
+    )
+
+
+async def test_dispatch_2_0_transport_error_logs_turn_transport_error(caplog):
+    """Raw httpx transport errors must log 'layer turn transport error', not 'layer unavailable'."""
+    import logging
+    constructor, client = _make_layer_client(
+        raise_on_start=httpx.ConnectError("refused")
+    )
+
+    with (
+        patch("bot.agent_dispatch.LayerClient", constructor),
+        patch("bot.agent_dispatch.handle_message", new=_fake_handle_1_0_response),
+        caplog.at_level(logging.WARNING, logger="bot.agent_dispatch"),
+    ):
+        from bot.agent_dispatch import dispatch_message
+
+        await dispatch_message(
+            "tether-agent-2.0", "hi", send_fn=lambda m: None, pool=None, user_id="u1"
+        )
+
+    # The improved log message must say "layer unreachable" or similar, not the old "unavailable"
+    assert any(
+        "layer unreachable" in r.message or "layer turn transport error" in r.message
+        for r in caplog.records
+    ), "transport error log must use improved message, not 'layer unavailable'"
+
+
+# ---------------------------------------------------------------------------
 # Existing 1.0 vault/status_fn forwarding test — unchanged
 # ---------------------------------------------------------------------------
 

--- a/tests/interactive_agent_layer/test_server.py
+++ b/tests/interactive_agent_layer/test_server.py
@@ -201,3 +201,88 @@ async def test_permission_respond_resolves_future(layer_client, layer):
 async def test_permission_respond_not_found(layer_client):
     resp = await layer_client.post("/permission/no-such-id/respond", json={"approve": False})
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# turn_error emission — pool failure during run_turn
+# ---------------------------------------------------------------------------
+
+async def _collect_sse_events(layer_client, sid: str) -> list[dict]:
+    """Helper: POST /session/{sid}/turn and collect all SSE events."""
+    events = []
+    async with layer_client.stream(
+        "POST", f"/session/{sid}/turn", json={"prompt": "fail me"}
+    ) as resp:
+        assert resp.status_code == 200
+        buffer = ""
+        async for chunk in resp.aiter_text():
+            buffer += chunk
+        for block in buffer.split("\n\n"):
+            block = block.strip()
+            if not block:
+                continue
+            for line in block.splitlines():
+                if line.startswith("data: "):
+                    events.append(json.loads(line[6:]))
+    return events
+
+
+async def test_turn_error_emitted_when_pool_raises(layer):
+    """When pool.acquire() raises, event_generator must emit a turn_error SSE event."""
+    from agent_pool_manager.client import PoolClientError
+    from interactive_agent_layer.server import create_app
+    from httpx import AsyncClient, ASGITransport
+
+    class FailingPoolClient:
+        async def acquire(self, user_id, options_hash, options, timeout_seconds=None):
+            raise PoolClientError("pool_exhausted — retry after 5s")
+
+        async def query_stream(self, handle_id, prompt, session_id="default"):
+            return
+            yield  # make it a generator
+
+        async def release(self, handle_id, *, reusable=False):
+            pass
+
+        async def interrupt(self, handle_id):
+            pass
+
+    from interactive_agent_layer.ws_publisher import WSPublisher
+    from interactive_agent_layer.session import Layer
+    import pathlib
+
+    yaml_path = pathlib.Path(__file__).parent.parent.parent / "config" / "agent_translations.yaml"
+    from interactive_agent_layer.translation import TranslationTable
+    failing_layer = Layer(
+        pool_client=FailingPoolClient(),
+        ws_publisher=WSPublisher(),
+        translation_table=TranslationTable.from_yaml(yaml_path),
+    )
+    app = create_app(failing_layer)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        start = await client.post(
+            "/session/start",
+            json={"user_id": "u1", "user_ws_id": "ws1", "agent_version": "v1", "options": {}, "user_message": "x"},
+        )
+        sid = start.json()["session_id"]
+
+        events = []
+        async with client.stream("POST", f"/session/{sid}/turn", json={"prompt": "go"}) as resp:
+            assert resp.status_code == 200
+            buffer = ""
+            async for chunk in resp.aiter_text():
+                buffer += chunk
+        for block in buffer.split("\n\n"):
+            block = block.strip()
+            if not block:
+                continue
+            for line in block.splitlines():
+                if line.startswith("data: "):
+                    events.append(json.loads(line[6:]))
+
+    types = [e["type"] for e in events]
+    assert "turn_error" in types, f"turn_error event must be emitted on pool failure, got: {types}"
+    error_event = next(e for e in events if e["type"] == "turn_error")
+    assert "pool_exhausted" in error_event.get("message", ""), (
+        f"turn_error message must include pool error: {error_event}"
+    )


### PR DESCRIPTION
## Summary

- **Root cause**: `event_generator()` in `interactive_agent_layer/server.py` had no exception handling. When `run_turn()` raised (e.g. pool exhausted/unreachable), Starlette closed the TCP connection without a terminal chunk after the 200 headers were already committed. The httpx client saw `RemoteProtocolError` and dispatch logged the misleading "layer unavailable" message.
- **Fix 1** (`interactive_agent_layer/server.py`): wrap `event_generator()` in try/except; emit `{"type": "turn_error", "message": str(exc)}` as the final SSE event on any `run_turn()` failure. Stream closes cleanly — client gets a parseable in-band signal.
- **Fix 2** (`bot/agent_dispatch.py`): handle `turn_error` events explicitly with the real error message logged at WARNING. Rename the `httpx.HTTPError` catch log to `"layer turn transport error"` to distinguish raw transport failures from pool-level errors.

## Test plan

- [ ] `test_turn_error_emitted_when_pool_raises` — pool raises `PoolClientError`; SSE stream must include a `turn_error` event with the pool error message
- [ ] `test_dispatch_2_0_turn_error_falls_back_to_1_0` — dispatch receives `turn_error`; must fall back to 1.0 and log the real pool error
- [ ] `test_dispatch_2_0_transport_error_logs_turn_transport_error` — raw `httpx.ConnectError`; log must say "layer turn transport error" not "layer unavailable"
- [ ] Full suite: 628 passed, 0 failed