### PR TITLE
feat: context node sidebar for chat page

### DIFF
--- a/frontend/src/components/chat/ContextNodeSidebar.vue
+++ b/frontend/src/components/chat/ContextNodeSidebar.vue
@@ -1,0 +1,164 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useContextStore } from '../../stores/context'
+import type { ContextNode } from '../../stores/context'
+import { useConversationsStore } from '../../stores/conversations'
+
+const props = defineProps<{ activeNodeId: string | null }>()
+const emit = defineEmits<{ 'update:activeNodeId': [id: string | null] }>()
+
+const contextStore = useContextStore()
+const conversationsStore = useConversationsStore()
+
+// Track expanded nodes
+const expandedNodes = ref<Set<string>>(new Set())
+// Track which node is being dragged over
+const dragOverNodeId = ref<string | null>(null)
+
+onMounted(() => {
+  contextStore.fetchRootNodes()
+})
+
+function selectAll() {
+  emit('update:activeNodeId', null)
+}
+
+function selectNode(nodeId: string) {
+  emit('update:activeNodeId', nodeId)
+}
+
+async function toggleExpand(node: ContextNode, evt: Event) {
+  evt.stopPropagation()
+  const id = node.id
+  if (expandedNodes.value.has(id)) {
+    expandedNodes.value = new Set([...expandedNodes.value].filter(x => x !== id))
+  } else {
+    expandedNodes.value = new Set([...expandedNodes.value, id])
+    await contextStore.fetchChildren(id)
+  }
+}
+
+function hasChildren(node: ContextNode): boolean {
+  // Show chevron if children_count is set and > 0, OR if undefined (unknown, optimistically show)
+  if (node.children_count === undefined) return false
+  return node.children_count > 0
+}
+
+function onDragOver(nodeId: string, evt: DragEvent) {
+  evt.preventDefault()
+  dragOverNodeId.value = nodeId
+}
+
+function onDragLeave(nodeId: string) {
+  if (dragOverNodeId.value === nodeId) {
+    dragOverNodeId.value = null
+  }
+}
+
+async function onDrop(nodeId: string, evt: DragEvent) {
+  evt.preventDefault()
+  dragOverNodeId.value = null
+  const raw = evt.dataTransfer?.getData('text/plain')
+  if (!raw) return
+  try {
+    const { conversationId } = JSON.parse(raw)
+    if (conversationId) {
+      await conversationsStore.assignNode(conversationId, nodeId)
+    }
+  } catch {
+    // ignore malformed data
+  }
+}
+</script>
+
+<template>
+  <div class="flex flex-col h-full bg-[--bg-1] text-sm">
+    <!-- Header -->
+    <div class="px-3 py-3 border-b border-[--border-1] flex-shrink-0">
+      <span class="font-semibold text-xs text-[--fg-3] uppercase tracking-wide">Context</span>
+    </div>
+
+    <!-- All item -->
+    <div
+      data-testid="all-item"
+      class="flex items-center px-3 py-2 cursor-pointer hover:bg-[--bg-2] transition-colors"
+      :class="activeNodeId === null ? 'bg-[--bg-elev-3] font-medium' : ''"
+      @click="selectAll"
+    >
+      <span class="text-[--fg-2] text-xs">All conversations</span>
+    </div>
+
+    <!-- Root nodes -->
+    <div class="flex-1 overflow-y-auto">
+      <template v-for="node in contextStore.rootNodes" :key="node.id">
+        <!-- Node row (also drop zone) -->
+        <div
+          :data-testid="`drop-zone-${node.id}`"
+          class="flex items-center gap-1 px-3 py-2 cursor-pointer hover:bg-[--bg-2] transition-colors"
+          :class="[
+            activeNodeId === node.id ? 'bg-[--bg-elev-3] font-medium' : '',
+            dragOverNodeId === node.id ? 'ring-2 ring-blue-400/50' : '',
+          ]"
+          @dragover="onDragOver(node.id, $event)"
+          @dragleave="onDragLeave(node.id)"
+          @drop="onDrop(node.id, $event)"
+        >
+          <!-- Expand chevron -->
+          <button
+            v-if="hasChildren(node)"
+            :data-testid="`expand-chevron-${node.id}`"
+            type="button"
+            class="w-4 h-4 flex items-center justify-center text-[--fg-4] hover:text-[--fg-1] flex-shrink-0"
+            @click.stop="toggleExpand(node, $event)"
+          >
+            <svg
+              class="w-3 h-3 transition-transform"
+              :class="expandedNodes.has(node.id) ? 'rotate-90' : ''"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+          <span v-else class="w-4 flex-shrink-0" />
+
+          <!-- Node name -->
+          <span
+            :data-testid="`node-row-${node.id}`"
+            class="text-[--fg-2] text-xs truncate flex-1"
+            @click="selectNode(node.id)"
+          >
+            {{ node.name }}
+          </span>
+        </div>
+
+        <!-- Children (indented) -->
+        <template v-if="expandedNodes.has(node.id)">
+          <div
+            v-for="child in contextStore.childrenOf(node.id)"
+            :key="child.id"
+            :data-testid="`drop-zone-${child.id}`"
+            class="flex items-center gap-1 pl-8 pr-3 py-2 cursor-pointer hover:bg-[--bg-2] transition-colors"
+            :class="[
+              activeNodeId === child.id ? 'bg-[--bg-elev-3] font-medium' : '',
+              dragOverNodeId === child.id ? 'ring-2 ring-blue-400/50' : '',
+            ]"
+            @dragover="onDragOver(child.id, $event)"
+            @dragleave="onDragLeave(child.id)"
+            @drop="onDrop(child.id, $event)"
+          >
+            <span
+              :data-testid="`node-row-${child.id}`"
+              class="text-[--fg-2] text-xs truncate flex-1"
+              @click="selectNode(child.id)"
+            >
+              {{ child.name }}
+            </span>
+          </div>
+        </template>
+      </template>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/chat/ContextNodeSidebar.vue
+++ b/frontend/src/components/chat/ContextNodeSidebar.vue
@@ -4,7 +4,7 @@ import { useContextStore } from '../../stores/context'
 import type { ContextNode } from '../../stores/context'
 import { useConversationsStore } from '../../stores/conversations'
 
-const props = defineProps<{ activeNodeId: string | null }>()
+defineProps<{ activeNodeId: string | null }>()
 const emit = defineEmits<{ 'update:activeNodeId': [id: string | null] }>()
 
 const contextStore = useContextStore()

--- a/frontend/src/components/chat/ContextNodeSidebar.vue
+++ b/frontend/src/components/chat/ContextNodeSidebar.vue
@@ -39,8 +39,9 @@ async function toggleExpand(node: ContextNode, evt: Event) {
 }
 
 function hasChildren(node: ContextNode): boolean {
-  // Show chevron if children_count is set and > 0, OR if undefined (unknown, optimistically show)
-  if (node.children_count === undefined) return false
+  // children_count is only set on single-node fetches, not list fetches.
+  // When undefined (list fetch), optimistically show chevron; fetchChildren returns [] if none.
+  if (node.children_count === undefined) return true
   return node.children_count > 0
 }
 

--- a/frontend/src/components/chat/ConversationList.vue
+++ b/frontend/src/components/chat/ConversationList.vue
@@ -1,8 +1,15 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, watch, onMounted } from 'vue'
 import { useConversationsStore } from '../../stores/conversations'
+import type { ConversationDetail } from '../../types/conversations'
 import PriorityPill from './PriorityPill.vue'
 import NewConversationModal from './NewConversationModal.vue'
+
+const props = withDefaults(defineProps<{
+  activeNodeId?: string | null
+}>(), {
+  activeNodeId: null,
+})
 
 const store = useConversationsStore()
 
@@ -20,6 +27,24 @@ async function setFilter(f: 'all' | 'open' | 'closed') {
   await store.refresh(f === 'all' ? undefined : { state: f })
 }
 
+function buildRefreshParams(): { state?: string; context_node_id?: string } | undefined {
+  const params: { state?: string; context_node_id?: string } = {}
+  if (activeFilter.value !== 'all') params.state = activeFilter.value
+  if (props.activeNodeId) params.context_node_id = props.activeNodeId
+  return Object.keys(params).length > 0 ? params : undefined
+}
+
+watch(
+  () => props.activeNodeId,
+  (nodeId) => {
+    if (nodeId) {
+      store.refresh({ context_node_id: nodeId })
+    } else {
+      store.refresh(undefined)
+    }
+  }
+)
+
 function formatRelativeTime(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime()
   const mins = Math.floor(diff / 60000)
@@ -30,8 +55,12 @@ function formatRelativeTime(iso: string): string {
   return `${Math.floor(hrs / 24)}d ago`
 }
 
+function onDragStart(conv: ConversationDetail, evt: DragEvent) {
+  evt.dataTransfer?.setData('text/plain', JSON.stringify({ conversationId: conv.id }))
+}
+
 onMounted(() => {
-  store.refresh()
+  store.refresh(buildRefreshParams())
 })
 </script>
 
@@ -75,9 +104,11 @@ onMounted(() => {
           v-for="conv in store.list"
           :key="conv.id"
           data-testid="conversation-row"
+          draggable="true"
           class="flex flex-col px-4 py-3 border-b border-[--border-1] cursor-pointer hover:bg-[--bg-2] transition-colors"
           :class="store.selectedId === conv.id ? 'bg-[--bg-2]' : ''"
           @click="store.select(conv.id)"
+          @dragstart="onDragStart(conv, $event)"
         >
           <div class="flex items-center gap-2 min-w-0">
             <span class="font-medium text-sm text-[--fg-1] truncate flex-1">{{ conv.name }}</span>
@@ -98,6 +129,7 @@ onMounted(() => {
     <NewConversationModal
       :open="showModal"
       :context-nodes="[]"
+      :default-node-id="activeNodeId"
       @close="showModal = false"
       @created="showModal = false"
     />

--- a/frontend/src/components/chat/ConversationList.vue
+++ b/frontend/src/components/chat/ConversationList.vue
@@ -24,7 +24,7 @@ const filters = [
 
 async function setFilter(f: 'all' | 'open' | 'closed') {
   activeFilter.value = f
-  await store.refresh(f === 'all' ? undefined : { state: f })
+  await store.refresh(buildRefreshParams())
 }
 
 function buildRefreshParams(): { state?: string; context_node_id?: string } | undefined {
@@ -36,12 +36,8 @@ function buildRefreshParams(): { state?: string; context_node_id?: string } | un
 
 watch(
   () => props.activeNodeId,
-  (nodeId) => {
-    if (nodeId) {
-      store.refresh({ context_node_id: nodeId })
-    } else {
-      store.refresh(undefined)
-    }
+  () => {
+    store.refresh(buildRefreshParams())
   }
 )
 

--- a/frontend/src/components/chat/NewConversationModal.vue
+++ b/frontend/src/components/chat/NewConversationModal.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { useConversationsStore } from '../../stores/conversations'
 import type { ConversationDetail } from '../../types/conversations'
 
-defineProps<{
+const props = defineProps<{
   open: boolean
   contextNodes: { id: string; name: string }[]
+  defaultNodeId?: string | null
 }>()
 
 const emit = defineEmits<{
@@ -18,8 +19,16 @@ const conversationsStore = useConversationsStore()
 const name = ref('')
 const type = ref<'interactive' | 'passive'>('interactive')
 const priority = ref<'low' | 'normal' | 'high' | 'urgent'>('normal')
-const contextNodeId = ref<string>('')
+const contextNodeId = ref<string>(props.defaultNodeId ?? '')
 const submitting = ref(false)
+
+// Keep contextNodeId in sync when defaultNodeId changes
+watch(
+  () => props.defaultNodeId,
+  (val) => {
+    contextNodeId.value = val ?? ''
+  }
+)
 
 async function onSubmit() {
   if (!name.value.trim() || submitting.value) return

--- a/frontend/src/components/chat/__tests__/ContextNodeSidebar.test.ts
+++ b/frontend/src/components/chat/__tests__/ContextNodeSidebar.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { setActivePinia, createPinia } from 'pinia'
-import { defineComponent, ref, computed, reactive } from 'vue'
+import { computed, reactive } from 'vue'
 
 // Mock both stores
 vi.mock('../../../stores/context', () => ({

--- a/frontend/src/components/chat/__tests__/ContextNodeSidebar.test.ts
+++ b/frontend/src/components/chat/__tests__/ContextNodeSidebar.test.ts
@@ -139,6 +139,34 @@ describe('ContextNodeSidebar', () => {
     expect(chevron.exists()).toBe(true)
   })
 
+  it('shows expand chevron for node with children_count undefined (list fetch)', () => {
+    // children_count is absent from list-fetch responses — show chevron optimistically
+    const node = makeNode({ id: 'node-1', name: 'Parent' })
+    delete (node as any).children_count
+    mockUseContextStore.mockReturnValue(makeContextStore([node]) as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, {
+      props: { activeNodeId: null },
+    })
+
+    const chevron = wrapper.find('[data-testid="expand-chevron-node-1"]')
+    expect(chevron.exists()).toBe(true)
+  })
+
+  it('does not show expand chevron for node with children_count === 0', () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Leaf', children_count: 0 })]
+    mockUseContextStore.mockReturnValue(makeContextStore(nodes) as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, {
+      props: { activeNodeId: null },
+    })
+
+    const chevron = wrapper.find('[data-testid="expand-chevron-node-1"]')
+    expect(chevron.exists()).toBe(false)
+  })
+
   it('clicking expand chevron calls contextStore.fetchChildren(nodeId)', async () => {
     const contextStore = makeContextStore([
       makeNode({ id: 'node-1', name: 'Parent', children_count: 2 }),

--- a/frontend/src/components/chat/__tests__/ContextNodeSidebar.test.ts
+++ b/frontend/src/components/chat/__tests__/ContextNodeSidebar.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import { defineComponent, ref, computed, reactive } from 'vue'
+
+// Mock both stores
+vi.mock('../../../stores/context', () => ({
+  useContextStore: vi.fn(),
+}))
+vi.mock('../../../stores/conversations', () => ({
+  useConversationsStore: vi.fn(),
+}))
+
+import { useContextStore } from '../../../stores/context'
+import { useConversationsStore } from '../../../stores/conversations'
+import ContextNodeSidebar from '../ContextNodeSidebar.vue'
+
+const mockUseContextStore = vi.mocked(useContextStore)
+const mockUseConversationsStore = vi.mocked(useConversationsStore)
+
+function makeNode(overrides = {}) {
+  return {
+    id: 'node-1',
+    parent_id: null,
+    name: 'Test Node',
+    description: null,
+    node_type: 'context' as const,
+    archived: false,
+    target_date: null,
+    status: null,
+    status_override: false,
+    color: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    children_count: 0,
+    ...overrides,
+  }
+}
+
+function makeContextStore(nodes: ReturnType<typeof makeNode>[] = []) {
+  // Use reactive so that computed refs are auto-unwrapped (mirroring Pinia store behavior)
+  return reactive({
+    nodes: {} as Record<string, ReturnType<typeof makeNode>>,
+    rootNodes: computed(() => nodes),
+    fetchRootNodes: vi.fn().mockResolvedValue(nodes),
+    fetchChildren: vi.fn().mockResolvedValue([]),
+    childrenOf: vi.fn().mockReturnValue([]),
+  })
+}
+
+function makeConversationsStore() {
+  return {
+    assignNode: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+describe('ContextNodeSidebar', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('mounts without error', () => {
+    mockUseContextStore.mockReturnValue(makeContextStore() as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, {
+      props: { activeNodeId: null },
+    })
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('shows "All conversations" option at top', () => {
+    mockUseContextStore.mockReturnValue(makeContextStore() as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, {
+      props: { activeNodeId: null },
+    })
+    expect(wrapper.text()).toContain('All')
+  })
+
+  it('clicking "All" emits update:activeNodeId with null', async () => {
+    mockUseContextStore.mockReturnValue(makeContextStore() as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, {
+      props: { activeNodeId: 'node-1' },
+    })
+
+    const allItem = wrapper.find('[data-testid="all-item"]')
+    await allItem.trigger('click')
+
+    expect(wrapper.emitted('update:activeNodeId')).toBeTruthy()
+    expect(wrapper.emitted('update:activeNodeId')![0]).toEqual([null])
+  })
+
+  it('shows root nodes from contextStore.rootNodes', () => {
+    const nodes = [
+      makeNode({ id: 'node-1', name: 'Alpha' }),
+      makeNode({ id: 'node-2', name: 'Beta' }),
+    ]
+    mockUseContextStore.mockReturnValue(makeContextStore(nodes) as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, {
+      props: { activeNodeId: null },
+    })
+    expect(wrapper.text()).toContain('Alpha')
+    expect(wrapper.text()).toContain('Beta')
+  })
+
+  it('clicking a node row emits update:activeNodeId with the node id', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha' })]
+    mockUseContextStore.mockReturnValue(makeContextStore(nodes) as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, {
+      props: { activeNodeId: null },
+    })
+
+    const nodeRow = wrapper.find('[data-testid="node-row-node-1"]')
+    await nodeRow.trigger('click')
+
+    expect(wrapper.emitted('update:activeNodeId')).toBeTruthy()
+    expect(wrapper.emitted('update:activeNodeId')![0]).toEqual(['node-1'])
+  })
+
+  it('shows expand chevron for node with children_count > 0', () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Parent', children_count: 3 })]
+    mockUseContextStore.mockReturnValue(makeContextStore(nodes) as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, {
+      props: { activeNodeId: null },
+    })
+
+    const chevron = wrapper.find('[data-testid="expand-chevron-node-1"]')
+    expect(chevron.exists()).toBe(true)
+  })
+
+  it('clicking expand chevron calls contextStore.fetchChildren(nodeId)', async () => {
+    const contextStore = makeContextStore([
+      makeNode({ id: 'node-1', name: 'Parent', children_count: 2 }),
+    ])
+    mockUseContextStore.mockReturnValue(contextStore as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, {
+      props: { activeNodeId: null },
+    })
+
+    const chevron = wrapper.find('[data-testid="expand-chevron-node-1"]')
+    await chevron.trigger('click')
+
+    expect(contextStore.fetchChildren).toHaveBeenCalledWith('node-1')
+  })
+
+  it('shows drag-over highlight when dragover event fires on a node row', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha' })]
+    mockUseContextStore.mockReturnValue(makeContextStore(nodes) as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, {
+      props: { activeNodeId: null },
+    })
+
+    const dropZone = wrapper.find('[data-testid="drop-zone-node-1"]')
+    await dropZone.trigger('dragover')
+
+    // Should have drag-over highlight class
+    expect(dropZone.classes()).toContain('ring-2')
+  })
+
+  it('calls conversationsStore.assignNode on drop with conversation id', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha' })]
+    const conversationsStore = makeConversationsStore()
+    mockUseContextStore.mockReturnValue(makeContextStore(nodes) as any)
+    mockUseConversationsStore.mockReturnValue(conversationsStore as any)
+
+    const wrapper = mount(ContextNodeSidebar, {
+      props: { activeNodeId: null },
+    })
+
+    const dropZone = wrapper.find('[data-testid="drop-zone-node-1"]')
+
+    // Simulate drop with dataTransfer
+    const dropEvent = new Event('drop') as any
+    dropEvent.preventDefault = vi.fn()
+    dropEvent.dataTransfer = {
+      getData: vi.fn().mockReturnValue(JSON.stringify({ conversationId: 'conv-123' })),
+    }
+    await dropZone.element.dispatchEvent(dropEvent)
+    await wrapper.vm.$nextTick()
+
+    expect(conversationsStore.assignNode).toHaveBeenCalledWith('conv-123', 'node-1')
+  })
+})

--- a/frontend/src/components/chat/__tests__/ConversationList.test.ts
+++ b/frontend/src/components/chat/__tests__/ConversationList.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import { reactive, ref } from 'vue'
+
+vi.mock('../../../stores/conversations', () => ({
+  useConversationsStore: vi.fn(),
+}))
+
+import { useConversationsStore } from '../../../stores/conversations'
+import ConversationList from '../ConversationList.vue'
+
+const mockUseConversationsStore = vi.mocked(useConversationsStore)
+
+function makeConv(overrides = {}) {
+  return {
+    id: 'conv-1',
+    name: 'Test Conv',
+    type: 'interactive' as const,
+    priority: 'normal' as const,
+    state: 'open' as const,
+    context_node_id: null,
+    thread_key: null,
+    is_system: false,
+    created_at: '2026-01-01T00:00:00Z',
+    last_message_at: '2026-01-01T00:01:00Z',
+    folder_name: null,
+    ...overrides,
+  }
+}
+
+function makeStore(convs: ReturnType<typeof makeConv>[] = []) {
+  return reactive({
+    list: convs,
+    selectedId: ref<string | null>(null),
+    loading: false,
+    error: null,
+    refresh: vi.fn().mockResolvedValue(undefined),
+    select: vi.fn(),
+    create: vi.fn().mockResolvedValue(null),
+  })
+}
+
+describe('ConversationList', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('accepts activeNodeId prop (string | null, default null)', () => {
+    const store = makeStore()
+    mockUseConversationsStore.mockReturnValue(store as any)
+
+    // Should mount with no prop (default null)
+    const wrapper = mount(ConversationList)
+    expect(wrapper.exists()).toBe(true)
+
+    // Should also accept a string
+    const wrapper2 = mount(ConversationList, {
+      props: { activeNodeId: 'node-1' },
+    })
+    expect(wrapper2.exists()).toBe(true)
+  })
+
+  it('calls store.refresh with context_node_id when activeNodeId prop is set on mount', async () => {
+    const store = makeStore()
+    mockUseConversationsStore.mockReturnValue(store as any)
+
+    mount(ConversationList, {
+      props: { activeNodeId: 'node-abc' },
+    })
+    await flushPromises()
+
+    // Called at least once with the node id
+    const calls = store.refresh.mock.calls
+    const nodeCall = calls.find((c: any[]) => c[0]?.context_node_id === 'node-abc')
+    expect(nodeCall).toBeTruthy()
+  })
+
+  it('calls store.refresh when activeNodeId prop changes', async () => {
+    const store = makeStore()
+    mockUseConversationsStore.mockReturnValue(store as any)
+
+    const wrapper = mount(ConversationList, {
+      props: { activeNodeId: null },
+    })
+    await flushPromises()
+    store.refresh.mockClear()
+
+    await wrapper.setProps({ activeNodeId: 'node-xyz' })
+    await flushPromises()
+
+    expect(store.refresh).toHaveBeenCalledWith({ context_node_id: 'node-xyz' })
+  })
+
+  it('calls store.refresh with no args when activeNodeId changes to null', async () => {
+    const store = makeStore()
+    mockUseConversationsStore.mockReturnValue(store as any)
+
+    const wrapper = mount(ConversationList, {
+      props: { activeNodeId: 'node-1' },
+    })
+    await flushPromises()
+    store.refresh.mockClear()
+
+    await wrapper.setProps({ activeNodeId: null })
+    await flushPromises()
+
+    expect(store.refresh).toHaveBeenCalledWith(undefined)
+  })
+
+  it('conversation rows have draggable="true"', () => {
+    const store = makeStore([makeConv(), makeConv({ id: 'conv-2', name: 'Conv 2' })])
+    mockUseConversationsStore.mockReturnValue(store as any)
+
+    const wrapper = mount(ConversationList)
+
+    const rows = wrapper.findAll('[data-testid="conversation-row"]')
+    expect(rows.length).toBeGreaterThan(0)
+    rows.forEach(row => {
+      expect(row.attributes('draggable')).toBe('true')
+    })
+  })
+
+  it('sets dataTransfer with conversationId on dragstart', async () => {
+    const convs = [makeConv({ id: 'conv-99', name: 'Draggable Conv' })]
+    const store = makeStore(convs)
+    mockUseConversationsStore.mockReturnValue(store as any)
+
+    const wrapper = mount(ConversationList)
+
+    const row = wrapper.find('[data-testid="conversation-row"]')
+    expect(row.exists()).toBe(true)
+
+    const setDataMock = vi.fn()
+    const dragEvent = new Event('dragstart') as any
+    dragEvent.dataTransfer = { setData: setDataMock }
+
+    await row.element.dispatchEvent(dragEvent)
+    await wrapper.vm.$nextTick()
+
+    expect(setDataMock).toHaveBeenCalledWith(
+      'text/plain',
+      JSON.stringify({ conversationId: 'conv-99' })
+    )
+  })
+})

--- a/frontend/src/components/chat/__tests__/ConversationList.test.ts
+++ b/frontend/src/components/chat/__tests__/ConversationList.test.ts
@@ -77,7 +77,7 @@ describe('ConversationList', () => {
     expect(nodeCall).toBeTruthy()
   })
 
-  it('calls store.refresh when activeNodeId prop changes', async () => {
+  it('calls store.refresh with context_node_id when activeNodeId prop changes to a node', async () => {
     const store = makeStore()
     mockUseConversationsStore.mockReturnValue(store as any)
 
@@ -90,10 +90,11 @@ describe('ConversationList', () => {
     await wrapper.setProps({ activeNodeId: 'node-xyz' })
     await flushPromises()
 
+    // buildRefreshParams composes both filters; with activeFilter='all', only context_node_id is set
     expect(store.refresh).toHaveBeenCalledWith({ context_node_id: 'node-xyz' })
   })
 
-  it('calls store.refresh with no args when activeNodeId changes to null', async () => {
+  it('calls store.refresh without context_node_id when activeNodeId changes back to null', async () => {
     const store = makeStore()
     mockUseConversationsStore.mockReturnValue(store as any)
 
@@ -106,6 +107,7 @@ describe('ConversationList', () => {
     await wrapper.setProps({ activeNodeId: null })
     await flushPromises()
 
+    // With no active state filter and no node filter, buildRefreshParams returns undefined
     expect(store.refresh).toHaveBeenCalledWith(undefined)
   })
 

--- a/frontend/src/stores/__tests__/conversations.assignNode.test.ts
+++ b/frontend/src/stores/__tests__/conversations.assignNode.test.ts
@@ -22,10 +22,7 @@ describe('useConversationsStore.assignNode()', () => {
   })
 
   it('calls PATCH /api/conversations/{id} with context_node_id', async () => {
-    // First call: PATCH, second call: refresh GET
-    mockApi
-      .mockResolvedValueOnce(mockResponse({ id: 'conv-1' }, true, 200))
-      .mockResolvedValueOnce(mockResponse([], true, 200))
+    mockApi.mockResolvedValueOnce(mockResponse({ id: 'conv-1' }, true, 200))
 
     const store = useConversationsStore()
     await store.assignNode('conv-1', 'node-abc')
@@ -39,9 +36,7 @@ describe('useConversationsStore.assignNode()', () => {
   })
 
   it('calls PATCH with context_node_id: null when nodeId is null', async () => {
-    mockApi
-      .mockResolvedValueOnce(mockResponse({ id: 'conv-1' }, true, 200))
-      .mockResolvedValueOnce(mockResponse([], true, 200))
+    mockApi.mockResolvedValueOnce(mockResponse({ id: 'conv-1' }, true, 200))
 
     const store = useConversationsStore()
     await store.assignNode('conv-1', null)
@@ -52,19 +47,24 @@ describe('useConversationsStore.assignNode()', () => {
     expect(body).toEqual({ context_node_id: null })
   })
 
-  it('calls refresh() after successful PATCH', async () => {
-    mockApi
-      .mockResolvedValueOnce(mockResponse({ id: 'conv-1' }, true, 200))
-      .mockResolvedValueOnce(mockResponse([{ id: 'conv-1', name: 'Test' }], true, 200))
+  it('updates context_node_id in-place on the list after successful PATCH', async () => {
+    mockApi.mockResolvedValueOnce(mockResponse({ id: 'conv-1' }, true, 200))
 
     const store = useConversationsStore()
+    // Seed the list with a conversation
+    store.list.push({
+      id: 'conv-1', name: 'Test', type: 'interactive', priority: 'normal',
+      state: 'open', context_node_id: null, thread_key: null, is_system: false,
+      created_at: '2026-01-01T00:00:00Z', last_message_at: '2026-01-01T00:01:00Z',
+      folder_name: null,
+    } as any)
+
     await store.assignNode('conv-1', 'node-abc')
 
-    // refresh() makes a GET call — should be the second api call
-    expect(mockApi).toHaveBeenCalledTimes(2)
-    const refreshCall = mockApi.mock.calls[1]
-    expect((refreshCall[0] as string)).toContain('/api/conversations')
-    expect(refreshCall[1]).toBeUndefined() // GET has no init options
+    // Only one API call (no refresh)
+    expect(mockApi).toHaveBeenCalledTimes(1)
+    // Local list updated in-place
+    expect(store.list[0].context_node_id).toBe('node-abc')
   })
 
   it('throws when API returns non-ok response', async () => {

--- a/frontend/src/stores/__tests__/conversations.assignNode.test.ts
+++ b/frontend/src/stores/__tests__/conversations.assignNode.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useConversationsStore } from '../conversations'
+
+vi.mock('../../lib/api', () => ({ api: vi.fn() }))
+
+import { api } from '../../lib/api'
+const mockApi = vi.mocked(api)
+
+function mockResponse(data: unknown, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    json: async () => data,
+  } as Response
+}
+
+describe('useConversationsStore.assignNode()', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockApi.mockReset()
+  })
+
+  it('calls PATCH /api/conversations/{id} with context_node_id', async () => {
+    // First call: PATCH, second call: refresh GET
+    mockApi
+      .mockResolvedValueOnce(mockResponse({ id: 'conv-1' }, true, 200))
+      .mockResolvedValueOnce(mockResponse([], true, 200))
+
+    const store = useConversationsStore()
+    await store.assignNode('conv-1', 'node-abc')
+
+    const patchCall = mockApi.mock.calls[0]
+    expect(patchCall[0]).toBe('/api/conversations/conv-1')
+    const init = patchCall[1] as RequestInit
+    expect(init.method).toBe('PATCH')
+    const body = JSON.parse(init.body as string)
+    expect(body).toEqual({ context_node_id: 'node-abc' })
+  })
+
+  it('calls PATCH with context_node_id: null when nodeId is null', async () => {
+    mockApi
+      .mockResolvedValueOnce(mockResponse({ id: 'conv-1' }, true, 200))
+      .mockResolvedValueOnce(mockResponse([], true, 200))
+
+    const store = useConversationsStore()
+    await store.assignNode('conv-1', null)
+
+    const patchCall = mockApi.mock.calls[0]
+    const init = patchCall[1] as RequestInit
+    const body = JSON.parse(init.body as string)
+    expect(body).toEqual({ context_node_id: null })
+  })
+
+  it('calls refresh() after successful PATCH', async () => {
+    mockApi
+      .mockResolvedValueOnce(mockResponse({ id: 'conv-1' }, true, 200))
+      .mockResolvedValueOnce(mockResponse([{ id: 'conv-1', name: 'Test' }], true, 200))
+
+    const store = useConversationsStore()
+    await store.assignNode('conv-1', 'node-abc')
+
+    // refresh() makes a GET call — should be the second api call
+    expect(mockApi).toHaveBeenCalledTimes(2)
+    const refreshCall = mockApi.mock.calls[1]
+    expect((refreshCall[0] as string)).toContain('/api/conversations')
+    expect(refreshCall[1]).toBeUndefined() // GET has no init options
+  })
+
+  it('throws when API returns non-ok response', async () => {
+    mockApi.mockResolvedValueOnce(mockResponse(null, false, 400))
+
+    const store = useConversationsStore()
+    await expect(store.assignNode('conv-1', 'node-abc')).rejects.toThrow()
+  })
+})

--- a/frontend/src/stores/conversations.ts
+++ b/frontend/src/stores/conversations.ts
@@ -100,5 +100,15 @@ export const useConversationsStore = defineStore('conversations', () => {
     setMessages(conversationId, [...msgs, msg])
   }
 
-  return { list, selectedId, selected, messagesById, hasMoreById, loading, error, refresh, create, patch, select, loadMessages, loadMessagesOlder, appendMessage }
+  async function assignNode(conversationId: string, nodeId: string | null): Promise<void> {
+    const res = await api(`/api/conversations/${conversationId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ context_node_id: nodeId }),
+    })
+    if (!res.ok) throw new Error(`assignNode: HTTP ${res.status}`)
+    await refresh()
+  }
+
+  return { list, selectedId, selected, messagesById, hasMoreById, loading, error, refresh, create, patch, select, loadMessages, loadMessagesOlder, appendMessage, assignNode }
 })

--- a/frontend/src/stores/conversations.ts
+++ b/frontend/src/stores/conversations.ts
@@ -107,7 +107,9 @@ export const useConversationsStore = defineStore('conversations', () => {
       body: JSON.stringify({ context_node_id: nodeId }),
     })
     if (!res.ok) throw new Error(`assignNode: HTTP ${res.status}`)
-    await refresh()
+    // Update local list in-place (avoids resetting active filter state)
+    const idx = list.value.findIndex(c => c.id === conversationId)
+    if (idx !== -1) list.value[idx].context_node_id = nodeId
   }
 
   return { list, selectedId, selected, messagesById, hasMoreById, loading, error, refresh, create, patch, select, loadMessages, loadMessagesOlder, appendMessage, assignNode }

--- a/frontend/src/views/ChatPageView.vue
+++ b/frontend/src/views/ChatPageView.vue
@@ -1,16 +1,23 @@
 <script setup lang="ts">
+import { ref } from 'vue'
+import ContextNodeSidebar from '../components/chat/ContextNodeSidebar.vue'
 import ConversationList from '../components/chat/ConversationList.vue'
 import ConversationView from '../components/chat/ConversationView.vue'
+
+const activeNodeId = ref<string | null>(null)
 </script>
 
 <template>
   <div class="flex h-screen bg-[--bg-1]">
-    <!-- Left pane: conversation list -->
-    <div class="w-80 flex-shrink-0 border-r border-[--border-1] overflow-hidden">
-      <ConversationList />
+    <!-- Context node sidebar -->
+    <div class="w-52 flex-shrink-0 border-r border-[--border-1] overflow-hidden">
+      <ContextNodeSidebar v-model:activeNodeId="activeNodeId" />
     </div>
-
-    <!-- Right pane: conversation view -->
+    <!-- Conversation list -->
+    <div class="w-72 flex-shrink-0 border-r border-[--border-1] overflow-hidden">
+      <ConversationList :activeNodeId="activeNodeId" />
+    </div>
+    <!-- Conversation view -->
     <div class="flex-1 min-w-0 overflow-hidden">
       <ConversationView />
     </div>


### PR DESCRIPTION
## Summary

- New `ContextNodeSidebar` component: compact tree of context nodes with expand/collapse, click-to-filter conversations, drag-and-drop conversation assignment
- `conversationsStore.assignNode`: PATCHes `/api/conversations/{id}` with `context_node_id`, updates list in-place (no filter reset)
- `ConversationList`: accepts `activeNodeId` prop, draggable rows, both state + node filters composed correctly via `buildRefreshParams()`
- `ChatPageView`: 3-column layout — context sidebar (208px) | conversation list (288px) | conversation view (flex)
- `NewConversationModal`: passes `defaultNodeId` so new conversations default to the active folder

## Implementation notes

- Reuses `contextStore` (stores/context.ts) — `fetchRootNodes`, `fetchChildren`, `childrenOf` already existed
- `ContextTreeNode.vue` deliberately not reused — it's a full-featured editing widget; the sidebar needs a compact read-only tree
- Children shown one level deep (root + immediate children); deeper nesting available via expand
- Drop on node row calls `conversationsStore.assignNode`, updating the conversation's `context_node_id` in-place

## Test plan

- [ ] All 793 Vitest tests pass
- [ ] `npm run build` — zero type errors
- [ ] Open `/chat`, context sidebar renders on the left with node tree
- [ ] Click a node — conversation list filters to that node's conversations
- [ ] Click "All conversations" — list resets to all
- [ ] Expand a node with children — children appear indented
- [ ] Drag a conversation row onto a node folder — conversation reassigns (folder_name updates on next filter change)
- [ ] Open/Closed filter chips still work alongside node filter
- [ ] "+ New" button with a node selected — new conversation modal defaults to that node