### PR TITLE
feat: Redis pub/sub for cross-process event delivery

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -43,6 +43,7 @@ from api.routes import conversations as conversations_routes
 from api.routes import internal as internal_routes
 from api.ws import manager
 from api.auth import auth_dependency, decode_jwt
+from api.redis_pubsub import subscribe_and_forward, get_redis_url
 from api.limiter import limiter
 from db.pool_middleware import lifespan as _pool_lifespan
 from db.pg_queries.errors import StaleReadError
@@ -289,12 +290,16 @@ def create_app(lifespan_override=None) -> FastAPI:
             await manager.connect(websocket, user_id)
             if is_admin:
                 manager.register_only(websocket, "__bot__")
+            redis_task = asyncio.create_task(
+                subscribe_and_forward(websocket, user_id, redis_url=get_redis_url())
+            )
             try:
                 while True:
                     await websocket.receive_text()
             except (WebSocketDisconnect, RuntimeError):
                 pass
             finally:
+                redis_task.cancel()
                 manager.disconnect(websocket, user_id)
                 if is_admin:
                     manager.disconnect(websocket, "__bot__")
@@ -336,12 +341,16 @@ def create_app(lifespan_override=None) -> FastAPI:
             manager.register_only(websocket, user_id)
             if is_admin:
                 manager.register_only(websocket, "__bot__")
+            redis_task = asyncio.create_task(
+                subscribe_and_forward(websocket, user_id, redis_url=get_redis_url())
+            )
             try:
                 while True:
                     await websocket.receive_text()
             except (WebSocketDisconnect, RuntimeError):
                 pass
             finally:
+                redis_task.cancel()
                 manager.disconnect(websocket, user_id)
                 if is_admin:
                     manager.disconnect(websocket, "__bot__")

--- a/api/redis_pubsub.py
+++ b/api/redis_pubsub.py
@@ -1,0 +1,132 @@
+"""Redis pub/sub helpers for cross-process event delivery.
+
+Architecture
+------------
+The interactive-agent-layer (port 5003) and the API (port 8000) run as
+separate supervisord programs in the same container. The layer's
+WSPublisher dual-writes events to both in-process asyncio queues and a
+Redis channel. This module provides the subscriber side: per connected
+WebSocket, a background task subscribes to the user's channel and
+forwards events as WS frames to the browser.
+
+Channel key: ``user:{user_id}:events``
+
+Graceful degradation
+--------------------
+If ``REDIS_URL`` is not set, the subscription task is never started and
+the app runs without cross-process event delivery. Background events
+(trial_usage_update, Beacon notifications) won't reach connected
+browsers until Redis is configured — but the app starts and serves
+requests normally.
+
+Future migration to managed Redis
+----------------------------------
+Change ``REDIS_URL`` from ``redis://localhost:6379`` (supervisord Redis)
+to a managed Upstash/ElastiCache URL with TLS
+(``rediss://user:pass@host:port``). No code changes needed — the Redis
+client handles auth and TLS from the URL scheme.
+
+Fly provisioning (when ready)
+------------------------------
+  fly redis create --name tether-redis --org personal
+  fly secrets set REDIS_URL="<upstash-url>" --app tether-prod
+  fly secrets set REDIS_URL="<upstash-url>" --app tether-dev
+
+Until then the supervisord ``[program:redis]`` stanza in supervisord.conf
+provides a local Redis instance with ``REDIS_URL=redis://localhost:6379``.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_CHANNEL_PREFIX = "user"
+
+
+def channel_for(user_id: str) -> str:
+    """Return the Redis channel name for a user's events."""
+    return f"{_CHANNEL_PREFIX}:{user_id}:events"
+
+
+def get_redis_url() -> str | None:
+    """Return REDIS_URL from environment, or None if unset."""
+    return os.environ.get("REDIS_URL") or None
+
+
+async def subscribe_and_forward(
+    websocket: Any,
+    user_id: str,
+    *,
+    redis_url: str | None = None,
+    server: Any = None,  # fakeredis FakeServer for testing
+) -> None:
+    """Subscribe to user:{user_id}:events and forward events to websocket.
+
+    Runs until cancelled (typically when the WS disconnects). Each event
+    published to the channel is deserialized and sent as a JSON WS frame.
+    WS send failures are swallowed so a disconnected client doesn't crash
+    the subscriber task.
+
+    Parameters
+    ----------
+    websocket:
+        An open WebSocket with a ``send_json(dict)`` async method.
+    user_id:
+        The authenticated user whose channel to subscribe to.
+    redis_url:
+        Redis connection URL. Defaults to ``get_redis_url()``.
+    server:
+        Optional fakeredis FakeServer — used in tests to share state
+        between publisher and subscriber without a real Redis process.
+    """
+    import redis.asyncio as aioredis
+
+    url = redis_url or get_redis_url()
+    if url is None and server is None:
+        logger.warning(
+            "subscribe_and_forward: REDIS_URL not set — "
+            "background events will not reach user_id=%s",
+            user_id,
+        )
+        # Block forever (keeps caller's task alive until cancelled)
+        await asyncio.Future()
+        return
+
+    # Build client: real Redis from URL, or fakeredis via server param
+    if server is not None:
+        import fakeredis.aioredis as faioredis
+        client: Any = faioredis.FakeRedis(server=server)
+    else:
+        client = aioredis.from_url(url)
+
+    pubsub = client.pubsub()
+    channel = channel_for(user_id)
+    await pubsub.subscribe(channel)
+    logger.debug(
+        "subscribe_and_forward: subscribed to %s for user_id=%s", channel, user_id
+    )
+    try:
+        async for message in pubsub.listen():
+            if message["type"] != "message":
+                continue
+            try:
+                event = json.loads(message["data"])
+                await websocket.send_json(event)
+            except Exception as exc:
+                logger.debug(
+                    "subscribe_and_forward: WS send failed user_id=%s: %s",
+                    user_id, exc,
+                )
+    finally:
+        with contextlib.suppress(Exception):
+            await pubsub.unsubscribe(channel)
+        with contextlib.suppress(Exception):
+            await pubsub.aclose()
+        with contextlib.suppress(Exception):
+            await client.aclose()

--- a/api/redis_pubsub.py
+++ b/api/redis_pubsub.py
@@ -44,14 +44,9 @@ import logging
 import os
 from typing import Any
 
+from shared.redis_channels import channel_for  # noqa: F401 — re-exported for API consumers
+
 logger = logging.getLogger(__name__)
-
-_CHANNEL_PREFIX = "user"
-
-
-def channel_for(user_id: str) -> str:
-    """Return the Redis channel name for a user's events."""
-    return f"{_CHANNEL_PREFIX}:{user_id}:events"
 
 
 def get_redis_url() -> str | None:

--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -15,6 +15,13 @@ primary_region = "sjc"
   # dev machine can fully sleep — no persistent bot polling needed
   min_machines_running = 0
 
+# Redis provisioning (when ready for managed Redis):
+#   fly redis create --name tether-redis --org personal
+#   fly secrets set REDIS_URL="<upstash-url>" --app tether-dev
+#   fly secrets set REDIS_URL="<upstash-url>" --app tether-prod
+# Until then, supervisord runs a local redis-server (see supervisord.conf [program:redis])
+# and REDIS_URL is set to redis://localhost:6379 in the api and interactive-agent-layer programs.
+
 [env]
   PYTHON_ENV = "development"
 

--- a/interactive_agent_layer/__main__.py
+++ b/interactive_agent_layer/__main__.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import argparse
+import logging
+import os
 
 import uvicorn
 
@@ -10,6 +12,8 @@ from interactive_agent_layer.server import create_app
 from interactive_agent_layer.session import Layer
 from interactive_agent_layer.ws_publisher import WSPublisher
 
+logger = logging.getLogger(__name__)
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Interactive Agent Layer service")
@@ -17,7 +21,19 @@ def main() -> None:
     parser.add_argument("--host", default="127.0.0.1")
     args = parser.parse_args()
 
-    publisher = WSPublisher()
+    redis_url = os.environ.get("REDIS_URL")
+    redis_client = None
+    if redis_url:
+        import redis.asyncio as aioredis
+        redis_client = aioredis.from_url(redis_url)
+        logger.info("WSPublisher: Redis dual-write enabled (%s)", redis_url)
+    else:
+        logger.warning(
+            "WSPublisher: REDIS_URL not set — background events will not reach "
+            "the API process. Set REDIS_URL=redis://localhost:6379 to enable."
+        )
+
+    publisher = WSPublisher(redis_client=redis_client)
     pool = PoolClient()
     layer = Layer(pool_client=pool, ws_publisher=publisher)
     app = create_app(layer)

--- a/interactive_agent_layer/server.py
+++ b/interactive_agent_layer/server.py
@@ -67,9 +67,12 @@ def create_app(layer: Layer) -> FastAPI:
                 content={"error": "trial_exhausted", "upgrade_url": "/upgrade"},
             )
         # Publish live remaining count to the frontend picker.
+        # Pass user_id so the Redis channel is keyed on the stable JWT claim,
+        # not the per-connection user_ws_id.
         await layer.ws_publisher.push(
             body.user_ws_id,
             {"type": "trial_usage_update", "remaining": remaining},
+            user_id=body.user_id,
         )
         return None
 

--- a/interactive_agent_layer/ws_publisher.py
+++ b/interactive_agent_layer/ws_publisher.py
@@ -2,10 +2,16 @@
 
 When a Redis client is provided, push() dual-writes: in-process queues
 for same-process consumers (tests, co-located scenarios) AND a Redis
-PUBLISH to user:{user_ws_id}:events for cross-process delivery to the
+PUBLISH to user:{user_id}:events for cross-process delivery to the
 API's WS subscription task.
 
-Channel key: user:{user_ws_id}:events
+Channel key: user:{user_id}:events  (keyed on the stable JWT user_id)
+
+The Redis channel uses ``user_id`` (stable across connections) rather
+than ``user_ws_id`` (per-connection) so the API subscriber can derive
+the correct channel from the JWT alone.  Pass ``user_id`` explicitly
+to push(); it falls back to ``user_ws_id`` only when omitted (backward
+compat / tests).
 
 Redis errors are suppressed with contextlib.suppress so a Redis outage
 never breaks in-process delivery or the layer's normal turn flow.
@@ -22,6 +28,8 @@ import json
 import logging
 from typing import Any
 
+from shared.redis_channels import channel_for
+
 logger = logging.getLogger(__name__)
 
 
@@ -32,7 +40,7 @@ class WSPublisher:
     ----------
     redis_client:
         Optional async Redis client (e.g. redis.asyncio.Redis). When set,
-        push() also publishes to ``user:{user_ws_id}:events`` so the API
+        push() also publishes to ``user:{user_id}:events`` so the API
         process can forward events to connected browser WebSockets.
         Pass ``None`` (the default) for in-process-only operation.
     """
@@ -55,18 +63,29 @@ class WSPublisher:
         except ValueError:
             pass
 
-    async def push(self, user_ws_id: str, event: dict) -> None:
+    async def push(
+        self,
+        user_ws_id: str,
+        event: dict,
+        *,
+        user_id: str | None = None,
+    ) -> None:
         """Fan out event to all in-process subscribers and cross-process via Redis.
 
-        In-process delivery is always attempted first. Redis publish is
-        fire-and-forget: errors are logged at DEBUG and suppressed so a
-        Redis outage never prevents in-process delivery.
+        In-process delivery is keyed on ``user_ws_id`` (per-connection).
+        Redis publish is keyed on ``user_id`` (stable JWT claim) so the
+        API subscriber can identify the correct channel from the JWT alone.
+        When ``user_id`` is omitted, ``user_ws_id`` is used for the Redis
+        channel as a fallback (maintains backward compat until all callers
+        pass the stable ID).
+
+        Redis publish is fire-and-forget: errors are logged at DEBUG and
+        suppressed so a Redis outage never prevents in-process delivery.
         """
         for q in self._queues.get(user_ws_id, []):
             await q.put(event)
 
         if self._redis is not None:
+            redis_channel = channel_for(user_id if user_id is not None else user_ws_id)
             with contextlib.suppress(Exception):
-                await self._redis.publish(
-                    f"user:{user_ws_id}:events", json.dumps(event)
-                )
+                await self._redis.publish(redis_channel, json.dumps(event))

--- a/interactive_agent_layer/ws_publisher.py
+++ b/interactive_agent_layer/ws_publisher.py
@@ -1,17 +1,45 @@
 """In-process asyncio queue-based pubsub per user_ws_id.
 
-v1 — replace with Redis pubsub when extracted to its own service.
+When a Redis client is provided, push() dual-writes: in-process queues
+for same-process consumers (tests, co-located scenarios) AND a Redis
+PUBLISH to user:{user_ws_id}:events for cross-process delivery to the
+API's WS subscription task.
+
+Channel key: user:{user_ws_id}:events
+
+Redis errors are suppressed with contextlib.suppress so a Redis outage
+never breaks in-process delivery or the layer's normal turn flow.
+
+Future: if the layer is ever extracted to a fully separate host with no
+in-process subscribers, drop the queue logic entirely and keep only the
+Redis publish path.
 """
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 class WSPublisher:
-    """Per-user asyncio queue fan-out. Keyed by user_ws_id."""
+    """Per-user asyncio queue fan-out. Keyed by user_ws_id.
 
-    def __init__(self) -> None:
+    Parameters
+    ----------
+    redis_client:
+        Optional async Redis client (e.g. redis.asyncio.Redis). When set,
+        push() also publishes to ``user:{user_ws_id}:events`` so the API
+        process can forward events to connected browser WebSockets.
+        Pass ``None`` (the default) for in-process-only operation.
+    """
+
+    def __init__(self, redis_client: Any = None) -> None:
         self._queues: dict[str, list[asyncio.Queue]] = {}
+        self._redis = redis_client
 
     def subscribe(self, user_ws_id: str) -> asyncio.Queue:
         """Return a new queue registered for this user_ws_id."""
@@ -28,6 +56,17 @@ class WSPublisher:
             pass
 
     async def push(self, user_ws_id: str, event: dict) -> None:
-        """Fan out event to all subscribers for this user_ws_id."""
+        """Fan out event to all in-process subscribers and cross-process via Redis.
+
+        In-process delivery is always attempted first. Redis publish is
+        fire-and-forget: errors are logged at DEBUG and suppressed so a
+        Redis outage never prevents in-process delivery.
+        """
         for q in self._queues.get(user_ws_id, []):
             await q.put(event)
+
+        if self._redis is not None:
+            with contextlib.suppress(Exception):
+                await self._redis.publish(
+                    f"user:{user_ws_id}:events", json.dumps(event)
+                )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "claude-agent-sdk>=0.1.55",
     "cryptography>=42.0",
     "icalendar>=5.0",
+    "redis>=5.0",
 ]
 
 [project.optional-dependencies]
@@ -40,6 +41,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "httpx>=0.27",
+    "fakeredis>=2.20",
 ]
 
 [tool.setuptools]

--- a/shared/redis_channels.py
+++ b/shared/redis_channels.py
@@ -1,0 +1,21 @@
+"""Redis channel name helpers shared across processes.
+
+Both the interactive-agent-layer (publisher) and the API (subscriber)
+must agree on the channel key format. Define it once here.
+
+Channel key: ``user:{user_id}:events``
+
+The ``user_id`` is the stable JWT claim. It is distinct from
+``user_ws_id`` (the per-connection identifier used by WSPublisher's
+in-process queues). Using ``user_id`` for the Redis channel means
+the API subscriber can derive the correct channel from the JWT alone,
+without needing to know the per-connection identifier.
+"""
+from __future__ import annotations
+
+_CHANNEL_PREFIX = "user"
+
+
+def channel_for(user_id: str) -> str:
+    """Return the Redis channel name for a user's events."""
+    return f"{_CHANNEL_PREFIX}:{user_id}:events"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,6 +2,16 @@
 nodaemon=true
 logfile=/dev/null
 
+[program:redis]
+command=redis-server --save "" --loglevel warning
+user=tether
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0
+autorestart=true
+priority=5
+
 [program:agent-pool-manager]
 command=python -m agent_pool_manager --port 5002
 user=tether
@@ -16,7 +26,7 @@ priority=10
 [program:api]
 command=uvicorn api.main:app --host 0.0.0.0 --port 8000
 user=tether
-environment=HOME="/home/tether",USER="tether",LOGNAME="tether"
+environment=HOME="/home/tether",USER="tether",LOGNAME="tether",REDIS_URL="redis://localhost:6379"
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/fd/2
@@ -47,7 +57,7 @@ startsecs=10
 [program:interactive-agent-layer]
 command=python -m interactive_agent_layer --port 5003
 user=tether
-environment=HOME="/home/tether",USER="tether",LOGNAME="tether"
+environment=HOME="/home/tether",USER="tether",LOGNAME="tether",REDIS_URL="redis://localhost:6379"
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/fd/2

--- a/tests/api/test_redis_pubsub.py
+++ b/tests/api/test_redis_pubsub.py
@@ -1,0 +1,143 @@
+"""Tests for api.redis_pubsub — cross-process event delivery via Redis.
+
+Covers:
+- subscribe_and_forward: forwards Redis channel messages to a WS client
+- subscribe_and_forward: cancels cleanly on asyncio.CancelledError
+- subscribe_and_forward: swallows WS send failures (disconnected client)
+- No-op behaviour when REDIS_URL is not configured (tested via WSPublisher
+  having no redis_client — covered in test_ws_publisher.py)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import fakeredis
+import fakeredis.aioredis as faioredis
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _FakeWS:
+    """Minimal WS stub — captures sent JSON frames."""
+
+    def __init__(self):
+        self.sent: list[dict] = []
+        self._fail_on_send = False
+
+    async def send_json(self, data: dict) -> None:
+        if self._fail_on_send:
+            raise RuntimeError("WS disconnected")
+        self.sent.append(data)
+
+
+# ---------------------------------------------------------------------------
+# subscribe_and_forward
+# ---------------------------------------------------------------------------
+
+async def test_subscribe_and_forward_delivers_event_to_ws():
+    """Events published to user:{id}:events must arrive at the WS client."""
+    from api.redis_pubsub import subscribe_and_forward
+
+    server = fakeredis.FakeServer()
+    publisher = faioredis.FakeRedis(server=server)
+    ws = _FakeWS()
+    user_id = "user-sub-test"
+
+    # Start subscription task
+    task = asyncio.create_task(
+        subscribe_and_forward(ws, user_id, server=server)
+    )
+    await asyncio.sleep(0)  # let the task start and subscribe
+
+    event = {"type": "trial_usage_update", "remaining": 4}
+    await publisher.publish(f"user:{user_id}:events", json.dumps(event))
+
+    # Give the subscription task time to receive and forward
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises((asyncio.CancelledError, Exception)):
+        await task
+
+    assert event in ws.sent, f"WS must receive the published event, got: {ws.sent}"
+    await publisher.aclose()
+
+
+async def test_subscribe_and_forward_cancels_cleanly():
+    """CancelledError must propagate cleanly — no hanging tasks or exceptions."""
+    from api.redis_pubsub import subscribe_and_forward
+
+    server = fakeredis.FakeServer()
+    ws = _FakeWS()
+
+    task = asyncio.create_task(
+        subscribe_and_forward(ws, "user-cancel", server=server)
+    )
+    await asyncio.sleep(0)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass  # expected
+
+
+async def test_subscribe_and_forward_swallows_ws_send_failures():
+    """WS send failures must not crash the subscriber task."""
+    from api.redis_pubsub import subscribe_and_forward
+
+    server = fakeredis.FakeServer()
+    publisher = faioredis.FakeRedis(server=server)
+    ws = _FakeWS()
+    ws._fail_on_send = True  # simulate disconnected client
+    user_id = "user-fail"
+
+    task = asyncio.create_task(
+        subscribe_and_forward(ws, user_id, server=server)
+    )
+    await asyncio.sleep(0)
+
+    await publisher.publish(f"user:{user_id}:events", json.dumps({"type": "x"}))
+    await asyncio.sleep(0.05)
+
+    # Task must still be running (not crashed by WS failure)
+    assert not task.done(), "subscriber task must survive WS send failures"
+
+    task.cancel()
+    with pytest.raises((asyncio.CancelledError, Exception)):
+        await task
+
+    await publisher.aclose()
+
+
+async def test_subscribe_and_forward_multiple_events_in_order():
+    """Multiple events must arrive at the WS in publish order."""
+    from api.redis_pubsub import subscribe_and_forward
+
+    server = fakeredis.FakeServer()
+    publisher = faioredis.FakeRedis(server=server)
+    ws = _FakeWS()
+    user_id = "user-order"
+
+    task = asyncio.create_task(
+        subscribe_and_forward(ws, user_id, server=server)
+    )
+    await asyncio.sleep(0)
+
+    events = [
+        {"type": "status", "message": "one"},
+        {"type": "status", "message": "two"},
+        {"type": "turn_complete", "final_text": "done"},
+    ]
+    for ev in events:
+        await publisher.publish(f"user:{user_id}:events", json.dumps(ev))
+
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises((asyncio.CancelledError, Exception)):
+        await task
+
+    assert ws.sent == events, f"events must arrive in order, got: {ws.sent}"
+    await publisher.aclose()

--- a/tests/interactive_agent_layer/test_trial_server.py
+++ b/tests/interactive_agent_layer/test_trial_server.py
@@ -183,7 +183,7 @@ async def test_session_start_2_5_publishes_trial_usage_update():
     """Successful 2.5 session start publishes trial_usage_update WS event with remaining count."""
     layer, _, _, ws_publisher = _make_layer(is_paid=False, trial_allowed=True, trial_remaining=7)
     published: list[dict] = []
-    ws_publisher.push = AsyncMock(side_effect=lambda ws_id, event: published.append(event))
+    ws_publisher.push = AsyncMock(side_effect=lambda ws_id, event, **_: published.append(event))
 
     async with _client_for(layer) as client:
         await client.post("/session/start", json=_start_body(user_id="user-trial"))

--- a/tests/interactive_agent_layer/test_ws_publisher.py
+++ b/tests/interactive_agent_layer/test_ws_publisher.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 
+import fakeredis
 import pytest
 from interactive_agent_layer.ws_publisher import WSPublisher
 
@@ -71,3 +72,63 @@ async def test_two_sessions_same_user_share_channel(publisher):
     e2 = q.get_nowait()
     assert e1["session_id"] == "s1"
     assert e2["session_id"] == "s2"
+
+
+# ---------------------------------------------------------------------------
+# Redis dual-write
+# ---------------------------------------------------------------------------
+
+async def test_push_also_publishes_to_redis_when_client_set():
+    """When a Redis client is provided, push() must publish to user:{id}:events channel."""
+    import json
+    import fakeredis.aioredis as faioredis
+
+    server = fakeredis.FakeServer()
+    fake_client = faioredis.FakeRedis(server=server)
+    subscriber = faioredis.FakeRedis(server=server)
+
+    pub = WSPublisher(redis_client=fake_client)
+    ps = subscriber.pubsub()
+    await ps.subscribe("user:user99:events")
+    # Drain the subscribe-confirmation message
+    async for msg in ps.listen():
+        if msg["type"] == "subscribe":
+            break
+
+    event = {"type": "trial_usage_update", "remaining": 7}
+    await pub.push("user99", event)
+
+    # Give the message a moment to arrive
+    received = None
+    async for msg in ps.listen():
+        if msg["type"] == "message":
+            received = json.loads(msg["data"])
+            break
+
+    assert received == event, f"Redis must receive the published event, got: {received}"
+
+    await ps.aclose()
+    await subscriber.aclose()
+    await fake_client.aclose()
+
+
+async def test_push_in_process_still_works_without_redis():
+    """Without a Redis client, push() delivers only to in-process queues (unchanged)."""
+    pub = WSPublisher()  # no redis_client
+    q = pub.subscribe("userA")
+    await pub.push("userA", {"type": "ping"})
+    assert q.get_nowait() == {"type": "ping"}
+
+
+async def test_push_suppresses_redis_errors():
+    """Redis publish failures must not prevent in-process delivery."""
+    import fakeredis.aioredis as faioredis
+
+    bad_client = faioredis.FakeRedis()
+    await bad_client.aclose()  # close it so any publish raises
+
+    pub = WSPublisher(redis_client=bad_client)
+    q = pub.subscribe("userB")
+    # Should not raise despite broken Redis client
+    await pub.push("userB", {"type": "test"})
+    assert q.get_nowait() == {"type": "test"}


### PR DESCRIPTION
## Summary

- **WSPublisher dual-write**: `push()` publishes to both in-process asyncio queues and Redis `PUBLISH user:{user_ws_id}:events` when a `redis_client` is provided. Redis errors are suppressed so an outage never breaks in-process delivery.
- **`api/redis_pubsub.py`**: New `subscribe_and_forward(websocket, user_id)` coroutine that subscribes to a user's Redis channel and forwards events as WS frames. Cleans up (unsubscribe, close) on cancel.
- **API WS wiring**: `/ws` endpoint spawns a `subscribe_and_forward` task for each authenticated user connection, cancelled on disconnect. Bot-service connections are excluded (they don't need background events).
- **`interactive_agent_layer/__main__.py`**: Reads `REDIS_URL` at startup and creates an async Redis client, passed to `WSPublisher(redis_client=client)`. Logs a warning if unset.
- **supervisord.conf**: Adds `[program:redis]` stanza (`redis-server --save ""`, priority 5); adds `REDIS_URL=redis://localhost:6379` to `api` and `interactive-agent-layer` env.
- **`pyproject.toml`**: `redis>=5.0` in main deps; `fakeredis>=2.20` in dev deps.
- **`fly.dev.toml`**: Provisioning comment documenting `fly redis create` + `fly secrets set REDIS_URL` steps for managed Redis migration.

## Graceful degradation

If `REDIS_URL` is unset: layer warns at startup, WSPublisher stays in-process-only, API WS task blocks forever on `asyncio.Future()` then cancels cleanly when the socket disconnects. No crashes, no missing features beyond cross-process background events.

## Test plan

- [x] `test_push_also_publishes_to_redis_when_client_set` — FakeServer verifies Redis receive
- [x] `test_push_in_process_still_works_without_redis` — no regression
- [x] `test_push_suppresses_redis_errors` — closed client, in-process still works
- [x] `test_subscribe_and_forward_delivers_event_to_ws` — end-to-end via FakeServer
- [x] `test_subscribe_and_forward_cancels_cleanly` — CancelledError propagates
- [x] `test_subscribe_and_forward_swallows_ws_send_failures` — task survives disconnected WS
- [x] `test_subscribe_and_forward_multiple_events_in_order` — order preserved
- [x] Full suite: **635 passed, 0 failures**