### PR TITLE
fix(bot): prevent double-send when premium handler streams then raises

### DIFF
--- a/bot/agent_dispatch.py
+++ b/bot/agent_dispatch.py
@@ -41,6 +41,27 @@ from interactive_agent_layer.client import LayerClient
 logger = logging.getLogger(__name__)
 
 _DEFAULT_VERSION = "tether-agent-2.0"
+
+
+class _SendTracker:
+    """Wraps a send_fn callback to record whether it was ever called.
+
+    Used by _dispatch_v25 to detect whether the premium handler streamed
+    any output before raising an exception.  If it did, we skip the 1.0
+    fallback (handle_message) entirely to avoid double-send: the user has
+    already received premium output and calling handle_message would splice
+    a second, unrelated response on top of it.
+    """
+
+    def __init__(self, fn: Callable[[str], None]) -> None:
+        self._fn = fn
+        self.called: bool = False
+
+    def __call__(self, text: str) -> None:
+        self.called = True
+        self._fn(text)
+
+
 _KNOWN_VERSIONS: frozenset[str] = frozenset(
     {"tether-agent-1.0", "tether-agent-2.0", "tether-agent-2.5"}
 )
@@ -220,12 +241,22 @@ async def _dispatch_v25(
             async with pg.get_conn(pool, user_id) as conn:
                 is_paid = await get_user_is_paid(conn)
         except Exception:
+            # Intentional fail-closed policy: on transient DB errors, treat the user
+            # as free-tier rather than granting premium access.  Fail-open (granting
+            # access on error) was explicitly rejected as a security/billing risk.
+            # Sending a neutral "try again" message was also rejected because it
+            # gives users no actionable path.  The 1.0 fallback ensures a response.
             logger.warning(
                 "dispatch_v25: subscription check failed for user_id=%s — defaulting to free",
                 user_id,
             )
 
     if is_admin or is_paid:
+        # Wrap send_fn so we can detect whether the premium handler streamed
+        # any output before raising.  If it did, we must NOT run handle_message
+        # (1.0 fallback) — doing so would splice a second response on top of
+        # partial premium output the user has already received.
+        tracked_send = _SendTracker(send_fn)
         try:
             from tether_premium.register import get_premium_handler
             from db.pg_queries import get_anchors
@@ -237,10 +268,10 @@ async def _dispatch_v25(
 
             response = await get_premium_handler()(
                 text, pool, user_id, anchors, current_anchor,
-                send_fn=send_fn, status_fn=status_fn,
+                send_fn=tracked_send, status_fn=status_fn,
             )
             if response:
-                send_fn(response)
+                tracked_send(response)
             return
         except (ImportError, NotImplementedError):
             logger.warning(
@@ -252,6 +283,18 @@ async def _dispatch_v25(
                 "dispatch_v25: premium handler raised for user_id=%s — falling back to 1.0",
                 user_id,
             )
+
+        if tracked_send.called:
+            # Premium already streamed output to the user.  Skip handle_message to
+            # avoid double-send.  Running handle_message here would also risk DB
+            # side effects (task mutations etc.) on a message that premium already
+            # partially handled.
+            logger.warning(
+                "dispatch_v25: premium handler streamed then raised for user_id=%s"
+                " — suppressing 1.0 fallback to avoid double-send",
+                user_id,
+            )
+            return
     else:
         send_fn(
             "tether-agent-2.5 is available on the Pro plan — you're currently on "

--- a/tests/bot/test_agent_dispatch_v25.py
+++ b/tests/bot/test_agent_dispatch_v25.py
@@ -223,3 +223,98 @@ class TestDispatchMessageRouting:
         # Generic "not yet wired" stub must NOT appear
         assert not any("not yet wired" in s for s in sent)
 
+
+# ---------------------------------------------------------------------------
+# _SendTracker / double-send guard
+# ---------------------------------------------------------------------------
+
+class TestDoubleSendGuard:
+    """Tests for the _SendTracker double-send protection.
+
+    When a premium handler streams output via send_fn and then raises an
+    exception, the 1.0 fallback path must NOT run (no double-send).
+    When the premium handler raises without ever calling send_fn, the 1.0
+    fallback MUST run so the user always gets a response.
+    """
+
+    @pytest.mark.asyncio
+    async def test_premium_streams_then_raises_skips_fallback(self):
+        """Premium handler streams partial output then raises → exactly one message, no 1.0 fallback.
+
+        This is the core double-send regression: previously, the exception
+        handler fell through to handle_message even after premium had already
+        called send_fn, producing spliced output (premium partial + 1.0 response).
+        """
+        import sys
+        sent = []
+
+        async def _streaming_then_crashing(
+            text, pool, user_id, anchors, current_anchor, *, send_fn, status_fn=None
+        ):
+            send_fn("premium-partial")  # streams something first
+            raise RuntimeError("handler crashed mid-stream")
+
+        mock_register = MagicMock()
+        mock_register.get_premium_handler = MagicMock(return_value=_streaming_then_crashing)
+        mock_tether_premium = MagicMock()
+        fake_modules = {
+            "tether_premium": mock_tether_premium,
+            "tether_premium.register": mock_register,
+        }
+
+        with patch("bot.agent_dispatch.handle_message", new=_fake_handle_1_0), \
+             patch("db.postgres.get_conn", return_value=_make_conn_ctx()), \
+             patch("db.pg_queries.subscriptions.get_user_is_paid",
+                   new=AsyncMock(return_value=True)), \
+             patch("db.pg_queries.get_anchors", new=AsyncMock(return_value=[])), \
+             patch("bot.handler_utils.get_current_anchor", return_value={}), \
+             patch.dict(sys.modules, fake_modules):
+
+            from bot.agent_dispatch import _dispatch_v25
+            await _dispatch_v25("do a task", sent.append, None, TEST_USER_ID)
+
+        assert "premium-partial" in sent, f"Premium output must be delivered. Got: {sent}"
+        assert "1.0-response" not in sent, (
+            f"Double-send: handle_message ran after premium already streamed. Got: {sent}"
+        )
+        assert sent.count("premium-partial") == 1, \
+            f"Premium output must appear exactly once. Got: {sent}"
+
+    @pytest.mark.asyncio
+    async def test_premium_raises_without_streaming_still_runs_fallback(self):
+        """Premium handler raises before sending anything → 1.0 fallback runs normally.
+
+        This is the regression guard: the double-send fix must NOT suppress
+        the fallback when premium never actually sent any output.
+        """
+        import sys
+        sent = []
+
+        async def _crashing_immediately(
+            text, pool, user_id, anchors, current_anchor, *, send_fn, status_fn=None
+        ):
+            raise RuntimeError("handler failed before sending anything")
+
+        mock_register = MagicMock()
+        mock_register.get_premium_handler = MagicMock(return_value=_crashing_immediately)
+        mock_tether_premium = MagicMock()
+        fake_modules = {
+            "tether_premium": mock_tether_premium,
+            "tether_premium.register": mock_register,
+        }
+
+        with patch("bot.agent_dispatch.handle_message", new=_fake_handle_1_0), \
+             patch("db.postgres.get_conn", return_value=_make_conn_ctx()), \
+             patch("db.pg_queries.subscriptions.get_user_is_paid",
+                   new=AsyncMock(return_value=True)), \
+             patch("db.pg_queries.get_anchors", new=AsyncMock(return_value=[])), \
+             patch("bot.handler_utils.get_current_anchor", return_value={}), \
+             patch.dict(sys.modules, fake_modules):
+
+            from bot.agent_dispatch import _dispatch_v25
+            await _dispatch_v25("do a task", sent.append, None, TEST_USER_ID)
+
+        assert "1.0-response" in sent, \
+            f"Fallback must run when premium never sent output. Got: {sent}"
+        assert "premium-partial" not in sent
+


### PR DESCRIPTION
## Summary

- **Bug 2 (double-send):** When the premium handler in `_dispatch_v25` calls `send_fn` to stream partial output and then raises an exception, the `except Exception` block previously fell through to `handle_message` — producing spliced output (premium partial + 1.0 response). Fix: adds `_SendTracker` wrapper that records whether `send_fn` was called; if so, the 1.0 fallback is suppressed entirely after the exception to avoid double-send.
- **Bug 1 (documentation):** Adds an explanatory comment on the fail-closed policy at the `get_user_is_paid()` DB error path, documenting that fail-open and neutral-message alternatives were considered and explicitly rejected.

## Changed files

- `bot/agent_dispatch.py` — `_SendTracker` class, `_dispatch_v25` wraps `send_fn` in tracker, guard after try/except, fail-closed comment
- `tests/bot/test_agent_dispatch_v25.py` — `TestDoubleSendGuard` (2 tests): `test_premium_streams_then_raises_skips_fallback` (was RED, tests the fix) and `test_premium_raises_without_streaming_still_runs_fallback` (regression guard)

## Test plan

- [ ] `pytest tests/bot/test_agent_dispatch_v25.py -v` → 9 passed
- [ ] Full suite in worktree → 630 passed, 649 skipped, no failures
- [ ] Code review (pr-review-toolkit:code-reviewer) — no ≥80% findings