### PR TITLE
fix(deploy): add redis-server binary and redis Python package missing from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM python:3.11-slim
 # cron is needed for anchor trigger scheduling in the bot container.
 # curl is needed for the NodeSource setup script.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc libffi-dev cron git gosu curl \
+    gcc libffi-dev cron git gosu curl redis-server \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js 20 via NodeSource so npm has a properly self-contained

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ websockets>=12.0
 pexpect>=4.8
 icalendar>=5.0,<7.0
 claude-agent-sdk>=0.1.55
+redis>=5.0


### PR DESCRIPTION
## Summary

Hotfix for two deploy regressions introduced by PR #404 (Redis pub/sub cross-process events):

- **redis-server binary missing from image:** `supervisord.conf` added a `[program:redis]` stanza, but the Dockerfile's `apt-get install` line didn't include `redis-server`. Caused `spawnerr: can't find command 'redis-server'` on startup.
- **redis Python package not installed:** PR #404 added `redis>=5.0` to `pyproject.toml`, but the production image installs from `requirements.txt` (Dockerfile line 52). Added `redis>=5.0` to `requirements.txt` — the source of truth for the image build. `fakeredis>=2.20` stays in pyproject.toml dev deps only (not needed in production).

## Changes

- `Dockerfile` — add `redis-server` to apt-get install line
- `requirements.txt` — add `redis>=5.0`

## Test plan

- [ ] No new tests (pure packaging fix)
- [ ] Verify `grep "redis-server" Dockerfile` shows the binary in apt install
- [ ] Verify `grep "redis" requirements.txt` shows `redis>=5.0`
- [ ] Merge and trigger Fly redeploy to confirm crash loop resolved