### PR TITLE
feat(frontend): Beacon notification system FE prep

### DIFF
--- a/frontend/src/components/MessageBubble.vue
+++ b/frontend/src/components/MessageBubble.vue
@@ -40,6 +40,8 @@ const priorityIcon = computed(() => PRIORITY_ICON[systemPriority.value])
       class="inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1 rounded-lg"
       :class="systemPriority === 'urgent' ? 'system-bubble-urgent' : 'system-bubble-important'"
     >
+      <!-- sr-only prefix conveys priority to screen readers without visual duplication -->
+      <span class="sr-only">{{ systemPriority === 'urgent' ? 'Urgent:' : 'Important:' }} </span>
       <span aria-hidden="true">{{ priorityIcon }}</span>
       {{ msg.content }}
     </span>

--- a/frontend/src/components/MessageBubble.vue
+++ b/frontend/src/components/MessageBubble.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
-import type { ChatMessage } from '../types/chat'
+import type { ChatMessage, SystemMessagePriority } from '../types/chat'
 
 const props = defineProps<{ msg: ChatMessage }>()
 
@@ -11,12 +11,38 @@ const renderedHtml = computed(() => {
   const raw = marked.parse(props.msg.content) as string
   return DOMPurify.sanitize(raw, { USE_PROFILES: { html: true } })
 })
+
+// Effective priority — only meaningful on system messages; absent = 'normal'.
+const systemPriority = computed<SystemMessagePriority>(() =>
+  props.msg.role === 'system' ? (props.msg.priority ?? 'normal') : 'normal'
+)
+
+// Icon prefix gives color-independent scanability (a11y requirement).
+const PRIORITY_ICON: Record<SystemMessagePriority, string> = {
+  normal: '',
+  important: '⏰',
+  urgent: '🚨',
+}
+const priorityIcon = computed(() => PRIORITY_ICON[systemPriority.value])
 </script>
 
 <template>
-  <!-- System message: centered, no bubble -->
+  <!-- System message — plain for normal; tinted box with icon for important/urgent -->
   <div v-if="msg.role === 'system'" class="flex justify-center text-center py-1">
-    <span class="text-xs italic text-[--fg-4]">{{ msg.content }}</span>
+    <!-- Normal: plain centered italic, no visual weight -->
+    <span v-if="systemPriority === 'normal'" class="text-xs italic text-[--fg-4]">
+      {{ msg.content }}
+    </span>
+    <!-- Important / Urgent: tinted rounded box with icon prefix -->
+    <span
+      v-else
+      :data-priority="systemPriority"
+      class="inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1 rounded-lg"
+      :class="systemPriority === 'urgent' ? 'system-bubble-urgent' : 'system-bubble-important'"
+    >
+      <span aria-hidden="true">{{ priorityIcon }}</span>
+      {{ msg.content }}
+    </span>
   </div>
 
   <!-- User message: right-aligned bubble, plain text -->
@@ -39,6 +65,20 @@ const renderedHtml = computed(() => {
 </template>
 
 <style scoped>
+/* Priority tints for Beacon-driven system messages.
+   Uses semantic status tokens defined in themes.css — works across all themes. */
+.system-bubble-important {
+  background-color: var(--status-important-bg);
+  color: var(--status-important-fg);
+  border: 1px solid var(--status-important);
+}
+
+.system-bubble-urgent {
+  background-color: var(--status-urgent-bg);
+  color: var(--status-urgent-fg);
+  border: 1px solid var(--status-urgent);
+}
+
 /* Tailwind's `prose` hard-codes color via --tw-prose-* variables. Re-point
    them at theme tokens so bot replies stay readable in every theme/mode. */
 .bot-bubble {

--- a/frontend/src/components/__tests__/MessageBubble.test.ts
+++ b/frontend/src/components/__tests__/MessageBubble.test.ts
@@ -7,6 +7,70 @@ function msg(overrides: Partial<ChatMessage> & Pick<ChatMessage, 'role' | 'conte
   return { id: 'test-id', ts: Date.now(), ...overrides }
 }
 
+// ── Priority styling for system messages (Beacon D1) ─────────────────────────
+describe('MessageBubble — system message priority', () => {
+  it('normal priority (absent): renders as plain centered italic with no priority tint', () => {
+    const wrapper = mount(MessageBubble, {
+      props: { msg: msg({ role: 'system', content: 'Session started' }) },
+    })
+    // No priority tint classes
+    expect(wrapper.html()).not.toContain('data-priority')
+    // Still renders centered
+    expect(wrapper.html()).toContain('text-center')
+  })
+
+  it('normal priority (explicit): same as absent — no tint', () => {
+    const wrapper = mount(MessageBubble, {
+      props: { msg: msg({ role: 'system', content: 'Info', priority: 'normal' }) },
+    })
+    expect(wrapper.html()).not.toContain('data-priority="important"')
+    expect(wrapper.html()).not.toContain('data-priority="urgent"')
+    expect(wrapper.html()).toContain('text-center')
+  })
+
+  it('important priority: renders tinted box with data-priority="important"', () => {
+    const wrapper = mount(MessageBubble, {
+      props: { msg: msg({ role: 'system', content: 'Anchor ping', priority: 'important' }) },
+    })
+    expect(wrapper.html()).toContain('data-priority="important"')
+    expect(wrapper.text()).toContain('Anchor ping')
+  })
+
+  it('urgent priority: renders tinted box with data-priority="urgent"', () => {
+    const wrapper = mount(MessageBubble, {
+      props: { msg: msg({ role: 'system', content: 'Critical alert', priority: 'urgent' }) },
+    })
+    expect(wrapper.html()).toContain('data-priority="urgent"')
+    expect(wrapper.text()).toContain('Critical alert')
+  })
+
+  it('important priority: renders ⏰ icon prefix (a11y: differentiable without color)', () => {
+    const wrapper = mount(MessageBubble, {
+      props: { msg: msg({ role: 'system', content: 'Time sensitive', priority: 'important' }) },
+    })
+    expect(wrapper.text()).toContain('⏰')
+  })
+
+  it('urgent priority: renders 🚨 icon prefix (a11y: differentiable without color)', () => {
+    const wrapper = mount(MessageBubble, {
+      props: { msg: msg({ role: 'system', content: 'Stop and look', priority: 'urgent' }) },
+    })
+    expect(wrapper.text()).toContain('🚨')
+  })
+
+  it('priority field on non-system message is ignored (no tint on user/bot)', () => {
+    const userWrapper = mount(MessageBubble, {
+      props: { msg: msg({ role: 'user', content: 'hello', priority: 'urgent' }) },
+    })
+    expect(userWrapper.html()).not.toContain('data-priority')
+
+    const botWrapper = mount(MessageBubble, {
+      props: { msg: msg({ role: 'bot', content: 'hi', priority: 'urgent' }) },
+    })
+    expect(botWrapper.html()).not.toContain('data-priority')
+  })
+})
+
 describe('MessageBubble', () => {
   it('renders user message with right-align class', () => {
     const wrapper = mount(MessageBubble, { props: { msg: msg({ role: 'user', content: 'hello' }) } })

--- a/frontend/src/components/__tests__/chat/ConversationList.test.ts
+++ b/frontend/src/components/__tests__/chat/ConversationList.test.ts
@@ -102,3 +102,85 @@ describe('ConversationList', () => {
     expect(wrapper.text().toLowerCase()).toContain('no conversation')
   })
 })
+
+// ── Pending / Rejected state UI (Beacon D2) ───────────────────────────────────
+describe('ConversationList — pending and rejected states', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders a pending conversation with data-state="pending"', () => {
+    const store = makeStore({ list: [makeConv({ id: 'p-1', name: 'Pending Conv', state: 'pending' })] })
+    vi.mocked(useConversationsStore).mockReturnValue(store as unknown as ReturnType<typeof useConversationsStore>)
+    const wrapper = mount(ConversationList, { global: { stubs: { NewConversationModal: true } } })
+    const row = wrapper.find('[data-testid="conversation-row"][data-state="pending"]')
+    expect(row.exists()).toBe(true)
+    expect(row.text()).toContain('Pending Conv')
+  })
+
+  it('renders a rejected conversation with data-state="rejected"', () => {
+    const store = makeStore({ list: [makeConv({ id: 'r-1', name: 'Rejected Conv', state: 'rejected' })] })
+    vi.mocked(useConversationsStore).mockReturnValue(store as unknown as ReturnType<typeof useConversationsStore>)
+    const wrapper = mount(ConversationList, { global: { stubs: { NewConversationModal: true } } })
+    const row = wrapper.find('[data-testid="conversation-row"][data-state="rejected"]')
+    expect(row.exists()).toBe(true)
+  })
+
+  it('filter chip "Pending" calls refresh with state=pending', async () => {
+    const store = makeStore()
+    vi.mocked(useConversationsStore).mockReturnValue(store as unknown as ReturnType<typeof useConversationsStore>)
+    const wrapper = mount(ConversationList, { global: { stubs: { NewConversationModal: true } } })
+    const chips = wrapper.findAll('button')
+    const pendingChip = chips.find(c => c.text().toLowerCase() === 'pending')
+    expect(pendingChip).toBeTruthy()
+    await pendingChip!.trigger('click')
+    expect(store.refresh).toHaveBeenCalledWith(expect.objectContaining({ state: 'pending' }))
+  })
+
+  it('filter chip "Rejected" calls refresh with state=rejected', async () => {
+    const store = makeStore()
+    vi.mocked(useConversationsStore).mockReturnValue(store as unknown as ReturnType<typeof useConversationsStore>)
+    const wrapper = mount(ConversationList, { global: { stubs: { NewConversationModal: true } } })
+    const chips = wrapper.findAll('button')
+    const rejectedChip = chips.find(c => c.text().toLowerCase() === 'rejected')
+    expect(rejectedChip).toBeTruthy()
+    await rejectedChip!.trigger('click')
+    expect(store.refresh).toHaveBeenCalledWith(expect.objectContaining({ state: 'rejected' }))
+  })
+
+  it('all four states render in "all" filter view', () => {
+    const store = makeStore({
+      list: [
+        makeConv({ id: '1', name: 'Open', state: 'open' }),
+        makeConv({ id: '2', name: 'Closed', state: 'closed' }),
+        makeConv({ id: '3', name: 'Pending', state: 'pending' }),
+        makeConv({ id: '4', name: 'Rejected', state: 'rejected' }),
+      ],
+    })
+    vi.mocked(useConversationsStore).mockReturnValue(store as unknown as ReturnType<typeof useConversationsStore>)
+    const wrapper = mount(ConversationList, { global: { stubs: { NewConversationModal: true } } })
+    const text = wrapper.text()
+    expect(text).toContain('Open')
+    expect(text).toContain('Closed')
+    expect(text).toContain('Pending')
+    expect(text).toContain('Rejected')
+  })
+
+  it('pending row has a visible "awaiting reply" indicator', () => {
+    const store = makeStore({ list: [makeConv({ id: 'p-2', name: 'Awaiting', state: 'pending' })] })
+    vi.mocked(useConversationsStore).mockReturnValue(store as unknown as ReturnType<typeof useConversationsStore>)
+    const wrapper = mount(ConversationList, { global: { stubs: { NewConversationModal: true } } })
+    // The pending badge text is rendered in the row
+    expect(wrapper.html()).toContain('data-pending-badge')
+  })
+
+  it('rejected row is visually greyed (has data-rejected class marker)', () => {
+    const store = makeStore({ list: [makeConv({ id: 'r-2', name: 'Discarded', state: 'rejected' })] })
+    vi.mocked(useConversationsStore).mockReturnValue(store as unknown as ReturnType<typeof useConversationsStore>)
+    const wrapper = mount(ConversationList, { global: { stubs: { NewConversationModal: true } } })
+    const row = wrapper.find('[data-testid="conversation-row"][data-state="rejected"]')
+    expect(row.exists()).toBe(true)
+    // Rejected rows carry opacity-muted class for greyout
+    expect(row.html()).toContain('rejected')
+  })
+})

--- a/frontend/src/components/chat/ConversationList.vue
+++ b/frontend/src/components/chat/ConversationList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, watch, onMounted } from 'vue'
 import { useConversationsStore } from '../../stores/conversations'
-import type { ConversationDetail } from '../../types/conversations'
+import type { ConversationDetail, ConversationState } from '../../types/conversations'
 import PriorityPill from './PriorityPill.vue'
 import NewConversationModal from './NewConversationModal.vue'
 
@@ -13,16 +13,18 @@ const props = withDefaults(defineProps<{
 
 const store = useConversationsStore()
 
-const activeFilter = ref<'all' | 'open' | 'closed'>('all')
+const activeFilter = ref<'all' | ConversationState>('all')
 const showModal = ref(false)
 
-const filters = [
-  { label: 'All', value: 'all' as const },
-  { label: 'Open', value: 'open' as const },
-  { label: 'Closed', value: 'closed' as const },
+const filters: Array<{ label: string; value: 'all' | ConversationState }> = [
+  { label: 'All',      value: 'all' },
+  { label: 'Open',     value: 'open' },
+  { label: 'Closed',   value: 'closed' },
+  { label: 'Pending',  value: 'pending' },
+  { label: 'Rejected', value: 'rejected' },
 ]
 
-async function setFilter(f: 'all' | 'open' | 'closed') {
+async function setFilter(f: 'all' | ConversationState) {
   activeFilter.value = f
   await store.refresh(buildRefreshParams())
 }
@@ -75,7 +77,7 @@ onMounted(() => {
     </div>
 
     <!-- Filter chips -->
-    <div class="flex gap-1 px-4 py-2 border-b border-[--border-1] flex-shrink-0">
+    <div class="flex flex-wrap gap-1 px-4 py-2 border-b border-[--border-1] flex-shrink-0">
       <button
         v-for="f in filters"
         :key="f.value"
@@ -101,14 +103,31 @@ onMounted(() => {
           :key="conv.id"
           data-testid="conversation-row"
           draggable="true"
+          :data-state="conv.state"
           class="flex flex-col px-4 py-3 border-b border-[--border-1] cursor-pointer hover:bg-[--bg-2] transition-colors"
-          :class="store.selectedId === conv.id ? 'bg-[--bg-2]' : ''"
+          :class="[
+            store.selectedId === conv.id ? 'bg-[--bg-2]' : '',
+            conv.state === 'rejected' ? 'opacity-50' : '',
+          ]"
           @click="store.select(conv.id)"
           @dragstart="onDragStart(conv, $event)"
         >
           <div class="flex items-center gap-2 min-w-0">
-            <span class="font-medium text-sm text-[--fg-1] truncate flex-1">{{ conv.name }}</span>
-            <PriorityPill :priority="conv.priority" />
+            <span
+              class="font-medium text-sm truncate flex-1"
+              :class="conv.state === 'rejected' ? 'text-[--fg-4]' : 'text-[--fg-1]'"
+            >
+              {{ conv.name }}
+            </span>
+            <!-- Pending badge: "awaiting reply" indicator -->
+            <span
+              v-if="conv.state === 'pending'"
+              data-pending-badge
+              class="inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 rounded-full bg-[--status-important-bg] text-[--status-important-fg] font-medium flex-shrink-0"
+            >
+              ⏳ Awaiting
+            </span>
+            <PriorityPill v-else :priority="conv.priority" />
           </div>
           <div class="flex items-center gap-2 mt-0.5">
             <span v-if="conv.folder_name" class="text-xs text-[--fg-4] truncate">

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -37,6 +37,7 @@ const router = createRouter({
     { path: '/anchors', name: 'anchors', component: () => import('./views/AnchorsView.vue') },
     { path: '/kanban', name: 'kanban', component: () => import('./views/KanbanView.vue') },
     { path: '/chat', name: 'chat', component: () => import('./views/ChatPageView.vue') },
+    { path: '/beacon/suppressions', name: 'beacon-suppressions', component: () => import('./views/SuppressionsView.vue') },
     { path: '/', redirect: '/dashboard' },
     { path: '/:pathMatch(.*)*', redirect: '/dashboard' },
   ],

--- a/frontend/src/stores/__tests__/suppressions.test.ts
+++ b/frontend/src/stores/__tests__/suppressions.test.ts
@@ -1,0 +1,51 @@
+// Isolated store test — no vi.mock on the suppressions store itself so we exercise real code.
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('../../lib/api', () => ({ api: vi.fn() }))
+
+import { api } from '../../lib/api'
+import { useSuppressionsStore } from '../suppressions'
+
+describe('useSuppressionsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.resetAllMocks()
+  })
+
+  it('returns empty array and no error on 404 (endpoint not yet implemented)', async () => {
+    vi.mocked(api).mockResolvedValue(new Response('Not Found', { status: 404 }) as Response)
+    const store = useSuppressionsStore()
+    await store.fetch()
+    expect(store.suppressions).toEqual([])
+    expect(store.error).toBeNull()
+    expect(store.loading).toBe(false)
+  })
+
+  it('returns suppressions array on 200', async () => {
+    const fixture = [
+      { id: 's-1', scope_key: 'topic/morning', reason: 'quiet hours', source: 'beacon_decision', created_at: '2026-05-22T00:00:00Z', expires_at: null },
+    ]
+    vi.mocked(api).mockResolvedValue(new Response(JSON.stringify(fixture), { status: 200, headers: { 'Content-Type': 'application/json' } }) as Response)
+    const store = useSuppressionsStore()
+    await store.fetch()
+    expect(store.suppressions).toEqual(fixture)
+    expect(store.error).toBeNull()
+  })
+
+  it('sets error string on non-200 non-404 response', async () => {
+    vi.mocked(api).mockResolvedValue(new Response('Server Error', { status: 500 }) as Response)
+    const store = useSuppressionsStore()
+    await store.fetch()
+    expect(store.suppressions).toEqual([])
+    expect(store.error).toContain('500')
+  })
+
+  it('sets error on network failure', async () => {
+    vi.mocked(api).mockRejectedValue(new Error('Network error'))
+    const store = useSuppressionsStore()
+    await store.fetch()
+    expect(store.suppressions).toEqual([])
+    expect(store.error).toContain('Network error')
+  })
+})

--- a/frontend/src/stores/suppressions.ts
+++ b/frontend/src/stores/suppressions.ts
@@ -1,0 +1,43 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { api } from '../lib/api'
+
+export interface BeaconSuppression {
+  id: string
+  scope_key: string
+  reason: string | null
+  source: 'user_rejection' | 'beacon_decision' | 'system'
+  created_at: string
+  expires_at: string | null
+}
+
+// Store for Beacon suppression history (GET /api/beacon/suppressions).
+// Endpoint is not yet implemented — handles 404 gracefully by returning empty array.
+// This store is premium-only; caller is responsible for not mounting if is_paid=false.
+export const useSuppressionsStore = defineStore('suppressions', () => {
+  const suppressions = ref<BeaconSuppression[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetch(): Promise<void> {
+    loading.value = true
+    error.value = null
+    try {
+      const res = await api('/api/beacon/suppressions')
+      if (res.status === 404) {
+        // Backend endpoint not yet implemented — return empty array gracefully.
+        suppressions.value = []
+        return
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      suppressions.value = await res.json()
+    } catch (e) {
+      error.value = String(e)
+      suppressions.value = []
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { suppressions, loading, error, fetch }
+})

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -1,11 +1,18 @@
 export type ChatRole = 'user' | 'bot' | 'system'
 
+// Beacon-driven priority for system messages (§3.2 of beacon-notification-system spec).
+// Distinct from ConversationDetail.priority (4-level conversation ranking).
+// Only rendered on system role messages — ignored on user/bot.
+export type SystemMessagePriority = 'normal' | 'important' | 'urgent'
+
 export interface ChatMessage {
   id: string
   role: ChatRole
   content: string
   ts: number     // epoch ms
   actions?: Array<{ action: string; tool?: string }>
+  // Optional: Beacon-assigned priority for system messages. Absent = 'normal'.
+  priority?: SystemMessagePriority
 }
 
 export interface PermissionDetail {

--- a/frontend/src/types/conversations.ts
+++ b/frontend/src/types/conversations.ts
@@ -3,7 +3,10 @@ export interface ConversationDetail {
   name: string
   type: 'interactive' | 'passive' | 'system'
   priority: 'low' | 'normal' | 'high' | 'urgent'
-  state: 'open' | 'closed'
+  // Beacon extends state with 'pending' and 'rejected' (beacon-notification-system §7).
+  // pending: Beacon-initiated, awaiting first user reply (shown in pending bin, not main list)
+  // rejected: user clicked Discard on a pending conv (hidden by default behind filter toggle)
+  state: 'open' | 'closed' | 'pending' | 'rejected'
   context_node_id: string | null
   thread_key: string | null
   is_system: boolean

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -510,6 +510,24 @@ async function linkTelegram() {
           </p>
         </div>
       </section>
+
+      <!-- Beacon (premium) -->
+      <section class="mb-8" data-section="beacon">
+        <h2 class="text-sm font-semibold text-[--fg-3] uppercase tracking-wider mb-3">Beacon</h2>
+        <div class="bg-[--bg-elev-1] rounded-xl p-4 space-y-3">
+          <p class="text-sm text-[--fg-3]">
+            Beacon is Tether's intelligent notification system. It decides when to ping you —
+            and when to stay quiet.
+          </p>
+          <router-link
+            to="/beacon/suppressions"
+            class="flex items-center justify-between text-sm text-[--fg-2] hover:text-[--fg-1] transition-colors py-1"
+          >
+            <span>Suppression history</span>
+            <span class="text-[--fg-5]">→</span>
+          </router-link>
+        </div>
+      </section>
     </div>
   </div>
 </template>

--- a/frontend/src/views/SuppressionsView.vue
+++ b/frontend/src/views/SuppressionsView.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useAuthStore } from '../stores/auth'
+import { useSuppressionsStore } from '../stores/suppressions'
+
+const auth = useAuthStore()
+const store = useSuppressionsStore()
+
+// Beacon is premium-only. Treat absent is_paid as free.
+const isPaid = computed(() => auth.user?.is_paid === true)
+
+onMounted(() => {
+  if (isPaid.value) {
+    store.fetch()
+  }
+})
+</script>
+
+<template>
+  <div class="max-w-2xl mx-auto px-4 py-8">
+    <h1 class="text-xl font-semibold text-[--fg-1] mb-1">Suppression History</h1>
+    <p class="text-sm text-[--fg-3] mb-6">
+      Events Beacon chose not to notify you about.
+    </p>
+
+    <!-- Upgrade nudge: shown to free users -->
+    <div
+      v-if="!isPaid"
+      class="rounded-xl border border-[--border-1] bg-[--bg-elev-1] px-6 py-8 text-center"
+    >
+      <p class="text-2xl mb-3">🔒</p>
+      <h2 class="font-semibold text-[--fg-1] mb-2">Beacon is a premium feature</h2>
+      <p class="text-sm text-[--fg-3] mb-4">
+        Upgrade to a paid plan to unlock Beacon's intelligent notification system and
+        see its suppression history.
+      </p>
+      <a
+        href="/settings"
+        class="inline-flex items-center px-4 py-2 rounded-lg bg-[--accent] text-[--accent-fg] text-sm font-medium hover:opacity-90 transition-opacity"
+      >
+        View upgrade options
+      </a>
+    </div>
+
+    <!-- Paid user content -->
+    <template v-else>
+      <!-- Loading -->
+      <div v-if="store.loading" class="text-sm text-[--fg-4] py-8 text-center">
+        Loading…
+      </div>
+
+      <!-- Error -->
+      <div
+        v-else-if="store.error"
+        class="rounded-lg border border-[--border-1] bg-[--bg-elev-1] px-4 py-4 text-sm text-[--fg-3]"
+      >
+        Could not load suppression history. {{ store.error }}
+      </div>
+
+      <!-- Empty state -->
+      <div
+        v-else-if="store.suppressions.length === 0"
+        class="rounded-xl border border-dashed border-[--border-2] bg-[--bg-elev-1] px-6 py-12 text-center"
+      >
+        <p class="text-3xl mb-3">🔕</p>
+        <h2 class="font-medium text-[--fg-2] mb-1">No suppressed events yet</h2>
+        <p class="text-sm text-[--fg-4]">
+          When Beacon decides not to notify you about something, it will appear here
+          so you can see what it filtered out.
+        </p>
+      </div>
+
+      <!-- Suppression list (shown once backend ships) -->
+      <ul v-else class="space-y-2">
+        <li
+          v-for="s in store.suppressions"
+          :key="s.id"
+          class="rounded-lg border border-[--border-1] bg-[--bg-elev-1] px-4 py-3 text-sm"
+        >
+          <div class="flex items-start justify-between gap-2">
+            <span class="text-[--fg-2] font-mono text-xs">{{ s.scope_key }}</span>
+            <span class="text-[--fg-5] text-xs flex-shrink-0">{{ s.source }}</span>
+          </div>
+          <p v-if="s.reason" class="text-[--fg-3] mt-1">{{ s.reason }}</p>
+        </li>
+      </ul>
+    </template>
+  </div>
+</template>

--- a/frontend/src/views/__tests__/SuppressionsView.test.ts
+++ b/frontend/src/views/__tests__/SuppressionsView.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('../../lib/api', () => ({ api: vi.fn() }))
+vi.mock('../../stores/auth', () => ({ useAuthStore: vi.fn() }))
+vi.mock('../../stores/suppressions', () => ({ useSuppressionsStore: vi.fn() }))
+
+import { useAuthStore } from '../../stores/auth'
+import { useSuppressionsStore } from '../../stores/suppressions'
+import SuppressionsView from '../SuppressionsView.vue'
+
+function makeAuthStore(isPaid?: boolean) {
+  return {
+    user: { user_id: 'u1', username: 'jason', is_admin: false, is_paid: isPaid },
+    isAuthenticated: true,
+    checked: true,
+    checkAuth: vi.fn(),
+  }
+}
+
+function makeSuppressionsStore(overrides = {}) {
+  return {
+    suppressions: [],
+    loading: false,
+    error: null,
+    fetch: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+describe('SuppressionsView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders the suppression history heading', () => {
+    vi.mocked(useAuthStore).mockReturnValue(makeAuthStore(true) as unknown as ReturnType<typeof useAuthStore>)
+    vi.mocked(useSuppressionsStore).mockReturnValue(makeSuppressionsStore() as unknown as ReturnType<typeof useSuppressionsStore>)
+    const wrapper = mount(SuppressionsView)
+    expect(wrapper.text().toLowerCase()).toContain('suppress')
+  })
+
+  it('paid user: shows empty state when no suppressions', () => {
+    vi.mocked(useAuthStore).mockReturnValue(makeAuthStore(true) as unknown as ReturnType<typeof useAuthStore>)
+    vi.mocked(useSuppressionsStore).mockReturnValue(makeSuppressionsStore() as unknown as ReturnType<typeof useSuppressionsStore>)
+    const wrapper = mount(SuppressionsView)
+    expect(wrapper.text().toLowerCase()).toContain('no suppressed')
+  })
+
+  it('free user (is_paid=false): shows upgrade nudge instead of content', () => {
+    vi.mocked(useAuthStore).mockReturnValue(makeAuthStore(false) as unknown as ReturnType<typeof useAuthStore>)
+    vi.mocked(useSuppressionsStore).mockReturnValue(makeSuppressionsStore() as unknown as ReturnType<typeof useSuppressionsStore>)
+    const wrapper = mount(SuppressionsView)
+    expect(wrapper.text().toLowerCase()).toMatch(/upgrade|premium|beacon/)
+    expect(wrapper.text().toLowerCase()).not.toContain('no suppressed')
+  })
+
+  it('free user (is_paid absent/undefined): shows upgrade nudge', () => {
+    vi.mocked(useAuthStore).mockReturnValue(makeAuthStore(undefined) as unknown as ReturnType<typeof useAuthStore>)
+    vi.mocked(useSuppressionsStore).mockReturnValue(makeSuppressionsStore() as unknown as ReturnType<typeof useSuppressionsStore>)
+    const wrapper = mount(SuppressionsView)
+    expect(wrapper.text().toLowerCase()).toMatch(/upgrade|premium|beacon/)
+  })
+
+  it('calls suppressions store fetch on mount (paid user)', () => {
+    vi.mocked(useAuthStore).mockReturnValue(makeAuthStore(true) as unknown as ReturnType<typeof useAuthStore>)
+    const store = makeSuppressionsStore()
+    vi.mocked(useSuppressionsStore).mockReturnValue(store as unknown as ReturnType<typeof useSuppressionsStore>)
+    mount(SuppressionsView)
+    expect(store.fetch).toHaveBeenCalled()
+  })
+
+  it('does NOT call suppressions store fetch for free user', () => {
+    vi.mocked(useAuthStore).mockReturnValue(makeAuthStore(false) as unknown as ReturnType<typeof useAuthStore>)
+    const store = makeSuppressionsStore()
+    vi.mocked(useSuppressionsStore).mockReturnValue(store as unknown as ReturnType<typeof useSuppressionsStore>)
+    mount(SuppressionsView)
+    expect(store.fetch).not.toHaveBeenCalled()
+  })
+})
+
+// ── Suppressions store 404 handling ──────────────────────────────────────────
+describe('useSuppressionsStore — 404 graceful handling', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.resetModules()
+  })
+
+  it('returns empty array and no error on 404', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockResolvedValue(new Response('Not Found', { status: 404 }) as Response)
+
+    // Import real (non-mocked) store for this test
+    const { useSuppressionsStore: realStore } = await import('../../stores/suppressions')
+    setActivePinia(createPinia())
+    const store = realStore()
+    await store.fetch()
+    expect(store.suppressions).toEqual([])
+    expect(store.error).toBeNull()
+  })
+})

--- a/frontend/src/views/__tests__/SuppressionsView.test.ts
+++ b/frontend/src/views/__tests__/SuppressionsView.test.ts
@@ -80,23 +80,5 @@ describe('SuppressionsView', () => {
   })
 })
 
-// ── Suppressions store 404 handling ──────────────────────────────────────────
-describe('useSuppressionsStore — 404 graceful handling', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-    vi.resetModules()
-  })
-
-  it('returns empty array and no error on 404', async () => {
-    const { api } = await import('../../lib/api')
-    vi.mocked(api).mockResolvedValue(new Response('Not Found', { status: 404 }) as Response)
-
-    // Import real (non-mocked) store for this test
-    const { useSuppressionsStore: realStore } = await import('../../stores/suppressions')
-    setActivePinia(createPinia())
-    const store = realStore()
-    await store.fetch()
-    expect(store.suppressions).toEqual([])
-    expect(store.error).toBeNull()
-  })
-})
+// Store-level tests (404 handling, 200, network error) are in:
+// stores/__tests__/suppressions.test.ts — isolated to avoid vi.mock hoisting interference.


### PR DESCRIPTION
## Summary

Frontend foundation work for the Beacon notification system (Wave 5). Backend Beacon is in-flight separately; this PR ships the FE types, components, and views so they're ready when the backend produces real Beacon events.

Three deliverables:

**D1 — Priority styling for system messages**
- Extended `ChatMessage` with optional `priority?: 'normal' | 'important' | 'urgent'` (3-level, per Beacon spec §3.2) — distinct from the existing 4-level `ConversationDetail.priority`
- `MessageBubble.vue`: normal = unchanged centered italic; important/urgent = tinted box + icon prefix (⏰/🚨) using existing `--status-{important,urgent}-{bg,fg}` tokens from `themes.css` (already defined across all 4 themes)
- Screen-reader `sr-only` prefix so priority is announced without color dependence
- Priority on user/bot messages is typed but ignored in rendering

**D2 — Pending/rejected conversation state UI**
- Extended `ConversationDetail.state` to `'open' | 'closed' | 'pending' | 'rejected'` (Beacon spec §7)
- `ConversationList.vue`: added Pending + Rejected filter chips; `data-state` attribute on rows; pending badge (⏳ Awaiting, using `--status-important-*` tokens); rejected rows greyed (opacity-50)
- `ConversationState` type alias updates automatically via index-access type — no separate update needed

**D3 — Suppression history view skeleton**
- `useSuppressionsStore` — calls `GET /api/beacon/suppressions`, handles 404 gracefully (empty array, no error) since endpoint is not yet implemented
- `SuppressionsView.vue` — gated on `is_paid`: free users see upgrade nudge; paid users see empty-state skeleton
- Route `/beacon/suppressions` added to router
- Beacon section added to `SettingsView.vue` with link to suppression history

## Test plan

- [ ] 78 test files, 797 tests passing (`npx vitest run`)
- [ ] `npm run build` — zero TypeScript errors
- [ ] D1: MessageBubble renders priority tint + icon for important/urgent; normal stays as-is; non-system messages unaffected
- [ ] D2: ConversationList Pending/Rejected filter chips trigger `store.refresh({ state })` correctly
- [ ] D3: SuppressionsView shows upgrade nudge for `is_paid=false/undefined`; shows empty state for paid; store returns `[]` on 404
- [ ] No regressions in existing 780+ tests

## Coordination note

`pool-builder` is adding `pending`/`rejected` to `conversations.state` on the backend. If their PR lands after this one, the type definition here is the source of truth that backend should match.