### PR TITLE
fix(bot,db): tc.created_at column error + premium handler exc_info logging

### DIFF
--- a/bot/agent_dispatch.py
+++ b/bot/agent_dispatch.py
@@ -273,10 +273,18 @@ async def _dispatch_v25(
             if response:
                 tracked_send(response)
             return
-        except (ImportError, NotImplementedError):
+        except (ImportError, NotImplementedError) as exc:
+            # Log exc_info so the actual missing symbol or not-implemented site
+            # appears in the log — without this, the error is silent and the
+            # "premium not available" message is misleading (implies the package
+            # is absent when it may be an import symbol mismatch inside the handler).
             logger.warning(
-                "dispatch_v25: premium not available for user_id=%s — falling back to 1.0",
+                "dispatch_v25: premium handler raised %s for user_id=%s"
+                " — falling back to 1.0: %s",
+                type(exc).__name__,
                 user_id,
+                exc,
+                exc_info=True,
             )
         except Exception:
             logger.exception(

--- a/db/pg_auth_queries.py
+++ b/db/pg_auth_queries.py
@@ -371,10 +371,10 @@ async def clear_telegram_bot_token(
 
 
 async def get_most_recent_telegram_user(conn: asyncpg.Connection) -> dict | None:
-    """Return the user with the most recent telegram link or message turn.
+    """Return the user with the most recent telegram link.
 
-    'Most recent' = latest created_at in telegram_connections (for users who have a telegram_chat_id set).
-    Falls back to users ordered by conversation_history recency if available.
+    Orders by u.created_at (users table) — telegram_connections has no
+    created_at column (only user_id and telegram_chat_id).
 
     Returns dict with 'id' (str UUID) and 'telegram_chat_id' (str), or None.
     """
@@ -385,7 +385,7 @@ async def get_most_recent_telegram_user(conn: asyncpg.Connection) -> dict | None
         JOIN telegram_connections tc ON tc.user_id = u.id
         WHERE tc.telegram_chat_id IS NOT NULL
           AND tc.telegram_chat_id != ''
-        ORDER BY tc.created_at DESC NULLS LAST
+        ORDER BY u.created_at DESC NULLS LAST
         LIMIT 1
         """
     )

--- a/tests/db/test_telegram_user_query.py
+++ b/tests/db/test_telegram_user_query.py
@@ -1,0 +1,85 @@
+"""Unit test for get_most_recent_telegram_user SQL correctness.
+
+Wave 6 / Bug 2: the query used `ORDER BY tc.created_at` but the
+telegram_connections table has no created_at column (only user_id and
+telegram_chat_id). Postgres errors: "column tc.created_at does not exist".
+
+Fix: order by u.created_at (users table, which does have the column).
+
+This test does not require a live DATABASE_URL — it mocks conn.fetchrow
+and captures the SQL string to verify the column reference is correct.
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock
+
+
+class TestGetMostRecentTelegramUserQuery:
+    @pytest.mark.asyncio
+    async def test_query_does_not_reference_tc_created_at(self):
+        """The SQL must NOT reference tc.created_at (column doesn't exist on telegram_connections)."""
+        captured_sql: list[str] = []
+
+        mock_conn = AsyncMock()
+        async def _capture_fetchrow(sql, *args, **kwargs):
+            captured_sql.append(sql)
+            return None
+        mock_conn.fetchrow = _capture_fetchrow
+
+        from db.pg_auth_queries import get_most_recent_telegram_user
+        await get_most_recent_telegram_user(mock_conn)
+
+        assert captured_sql, "fetchrow was never called"
+        sql = captured_sql[0]
+        assert "tc.created_at" not in sql, (
+            f"Query must not reference tc.created_at (column doesn't exist on telegram_connections). "
+            f"Full SQL:\n{sql}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_query_orders_by_u_created_at(self):
+        """The SQL must order by u.created_at (users table has this column)."""
+        captured_sql: list[str] = []
+
+        mock_conn = AsyncMock()
+        async def _capture_fetchrow(sql, *args, **kwargs):
+            captured_sql.append(sql)
+            return None
+        mock_conn.fetchrow = _capture_fetchrow
+
+        from db.pg_auth_queries import get_most_recent_telegram_user
+        await get_most_recent_telegram_user(mock_conn)
+
+        assert captured_sql, "fetchrow was never called"
+        sql = captured_sql[0]
+        assert "u.created_at" in sql, (
+            f"Query must order by u.created_at. Full SQL:\n{sql}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_row(self):
+        """Returns None when fetchrow returns no match."""
+        mock_conn = AsyncMock()
+        mock_conn.fetchrow = AsyncMock(return_value=None)
+
+        from db.pg_auth_queries import get_most_recent_telegram_user
+        result = await get_most_recent_telegram_user(mock_conn)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_user_dict_when_row_found(self):
+        """Returns dict with id and telegram_chat_id when a user row is found."""
+        import uuid
+        fake_id = uuid.UUID("00000000-0000-0000-0000-000000000042")
+        mock_row = {"id": fake_id, "telegram_chat_id": "chat-999"}
+
+        mock_conn = AsyncMock()
+        mock_conn.fetchrow = AsyncMock(return_value=mock_row)
+
+        from db.pg_auth_queries import get_most_recent_telegram_user
+        result = await get_most_recent_telegram_user(mock_conn)
+
+        assert result is not None
+        assert result["id"] == "00000000-0000-0000-0000-000000000042"
+        assert result["telegram_chat_id"] == "chat-999"


### PR DESCRIPTION
## Summary

Two silent-degradation regressions surfaced after the post-#404 deploy.

**Bug 1 (tether side — improved logging):** `_dispatch_v25`'s `except (ImportError, NotImplementedError)` logged only "premium not available" with no exception details. The actual cause (e.g. a missing symbol in bot.message_handler) was invisible. Changed to log exception type, message, and full traceback via \`exc_info=True\`. The root import fix is in tether-premium PR (see companion PR).

**Bug 2:** \`get_most_recent_telegram_user()\` ordered by \`tc.created_at\` which doesn't exist on \`telegram_connections\` (table only has \`user_id\` and \`telegram_chat_id\`). Postgres error: *"column tc.created_at does not exist — perhaps you meant u.created_at"*. Fix: order by \`u.created_at\`.

## Changed files

- \`bot/agent_dispatch.py\` — \`except (ImportError, NotImplementedError) as exc\` + \`exc_info=True\` + exception type/msg in warning
- \`db/pg_auth_queries.py\` — \`ORDER BY tc.created_at\` → \`ORDER BY u.created_at\`
- \`tests/db/test_telegram_user_query.py\` (new) — 4 SQL-level unit tests (no DATABASE_URL needed)

## Test plan

- [ ] \`pytest tests/db/test_telegram_user_query.py tests/bot/test_agent_dispatch_v25.py -v\` → 13 passed
- [ ] Full suite → 660 passed, no failures
- [ ] Companion tether-premium PR: jlunder00/tether-premium fix/wave6-register-load-config