### PR TITLE
feat: pool warm hint on chat page load

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -41,6 +41,7 @@ from api.routes import preferences as preferences_routes
 from api.routes import ical as ical_routes
 from api.routes import conversations as conversations_routes
 from api.routes import internal as internal_routes
+from api.routes import pool as pool_routes
 from api.ws import manager
 from api.auth import auth_dependency, decode_jwt
 from api.redis_pubsub import subscribe_and_forward, get_redis_url
@@ -220,6 +221,11 @@ def create_app(lifespan_override=None) -> FastAPI:
     app.include_router(
         internal_routes.router,
         prefix="/api/internal",
+        include_in_schema=False,
+    )
+    app.include_router(
+        pool_routes.router,
+        prefix="/api/internal/pool",
         include_in_schema=False,
     )
 

--- a/api/routes/pool.py
+++ b/api/routes/pool.py
@@ -1,0 +1,132 @@
+"""Pool warm endpoint — user-facing hint to pre-warm a subprocess for the caller.
+
+POST /api/internal/pool/warm
+  Auth: cookie JWT (user-session auth, NOT X-Internal-Token cron auth)
+  Body: { "agent_version": str }
+  Response: 202 { "hinted": bool, "options_hash": str }
+
+Always returns 202 — warming is best-effort and must never block the frontend.
+Pool failure is logged and reflected in hinted=false for observability.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from api.auth import auth_dependency
+
+log = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# ---------------------------------------------------------------------------
+# Canonical options per agent version.
+#
+# These MUST match what bot.agent_dispatch passes to the layer on session/start.
+# If _V2_0_OPTIONS changes in agent_dispatch, update this mapping too — and
+# the test test_warm_options_hash_matches_layer_algorithm will catch any drift.
+# ---------------------------------------------------------------------------
+
+def _get_agent_options() -> dict[str, dict[str, Any]]:
+    """Lazy import so agent_dispatch doesn't load at module import time."""
+    try:
+        from bot.agent_dispatch import _V2_0_OPTIONS
+        v2_options: dict[str, Any] = _V2_0_OPTIONS
+    except ImportError:
+        v2_options = {}
+
+    return {
+        "tether-agent-1.0": {},
+        "tether-agent-2.0": v2_options,
+        # 2.5 goes through the premium handler directly (not the layer),
+        # so pool warming via layer is not applicable. We still accept 2.5
+        # and warm with a minimal options set so the FE can fire unconditionally.
+        "tether-agent-2.5": v2_options,
+    }
+
+
+def _compute_options_hash(options: dict[str, Any]) -> str:
+    """SHA-256 canonical-JSON hash, truncated to 16 hex chars.
+
+    Algorithm is identical to interactive_agent_layer.session._stable_options_hash.
+    Both must stay in sync — the test test_warm_options_hash_matches_layer_algorithm
+    enforces this.
+    """
+    canonical = json.dumps(options, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()[:16]
+
+
+def _get_pool_client(request: Request):
+    """Return the pool client, falling back to a lazily-constructed default."""
+    client = getattr(request.app.state, "pool_client", None)
+    if client is not None:
+        return client
+
+    # Construct from config on first use. The pool client is stateless enough
+    # that creating one per-request is safe (no persistent connection held).
+    try:
+        from config.loader import config
+        base_url: str = config.get("agent_pool.base_url", "http://127.0.0.1:5002")
+    except Exception:
+        base_url = "http://127.0.0.1:5002"
+
+    from agent_pool_manager.client import PoolClient
+    return PoolClient(base_url=base_url)
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+class WarmRequest(BaseModel):
+    agent_version: str
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+@router.post("/warm", status_code=202)
+async def pool_warm(
+    body: WarmRequest,
+    request: Request,
+    _auth: dict = Depends(auth_dependency),
+) -> dict:
+    """Pre-warm a pool subprocess for the authenticated user.
+
+    Returns 202 always — warming is best-effort.  ``hinted=false`` signals
+    that the pool call failed (pool unreachable), but the FE should not retry
+    aggressively; the next real acquire will fall through to cold-start.
+    """
+    user_id: str = request.state.user_id
+
+    agent_options = _get_agent_options()
+    options = agent_options.get(body.agent_version)
+    if options is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown agent_version: {body.agent_version!r}. "
+                   f"Valid versions: {sorted(agent_options)}",
+        )
+
+    options_hash = _compute_options_hash(options)
+    pool_client = _get_pool_client(request)
+
+    hinted = False
+    try:
+        await pool_client.hint(user_id, options_hash, options)
+        hinted = True
+    except Exception as exc:
+        log.warning(
+            "pool_warm: pool hint failed user_id=%s agent_version=%s: %s",
+            user_id,
+            body.agent_version,
+            exc,
+        )
+
+    return {"hinted": hinted, "options_hash": options_hash}

--- a/api/routes/pool.py
+++ b/api/routes/pool.py
@@ -62,13 +62,17 @@ def _compute_options_hash(options: dict[str, Any]) -> str:
 
 
 def _get_pool_client(request: Request):
-    """Return the pool client, falling back to a lazily-constructed default."""
+    """Return the pool client, lazily constructing and caching on app.state.
+
+    Tests inject a mock by setting ``app.state.pool_client`` before requests.
+    In production the client is constructed once from config and reused, so
+    httpx connection pooling applies across requests.
+    """
     client = getattr(request.app.state, "pool_client", None)
     if client is not None:
         return client
 
-    # Construct from config on first use. The pool client is stateless enough
-    # that creating one per-request is safe (no persistent connection held).
+    # Construct from config on first use and cache for the app's lifetime.
     try:
         from config.loader import config
         base_url: str = config.get("agent_pool.base_url", "http://127.0.0.1:5002")
@@ -76,7 +80,9 @@ def _get_pool_client(request: Request):
         base_url = "http://127.0.0.1:5002"
 
     from agent_pool_manager.client import PoolClient
-    return PoolClient(base_url=base_url)
+    pool_client = PoolClient(base_url=base_url)
+    request.app.state.pool_client = pool_client
+    return pool_client
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/composables/__tests__/usePoolWarm.test.ts
+++ b/frontend/src/composables/__tests__/usePoolWarm.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for usePoolWarm composable.
+ *
+ * Verifies:
+ * - Hint is fired when composable is called (mount)
+ * - Hint is debounced on rapid agent version changes
+ * - Hint fires when agent version changes (after debounce)
+ * - Failures are silently swallowed (best-effort)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+// Mock the api module
+vi.mock('../../lib/api', () => ({
+  api: vi.fn(() => Promise.resolve({ ok: true, status: 202, json: async () => ({ hinted: true, options_hash: 'abc123' }) })),
+}))
+
+describe('usePoolWarm', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('fires hint POST on initial call', async () => {
+    const { api } = await import('../../lib/api')
+    const { usePoolWarm } = await import('../usePoolWarm')
+
+    usePoolWarm()
+
+    // Advance debounce timer
+    await vi.runAllTimersAsync()
+
+    expect(vi.mocked(api)).toHaveBeenCalledWith(
+      '/api/internal/pool/warm',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('debounces rapid calls — only fires once for rapid agent changes', async () => {
+    const { api } = await import('../../lib/api')
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const store = useAgentPickerStore()
+    const { usePoolWarm } = await import('../usePoolWarm')
+
+    usePoolWarm()
+
+    // Simulate rapid agent version changes before debounce fires
+    store.selectedAgent = 'tether-agent-1.0'
+    store.selectedAgent = 'tether-agent-2.0'
+    store.selectedAgent = 'tether-agent-2.0'
+
+    // Run timer — debounce should coalesce into one call
+    await vi.runAllTimersAsync()
+
+    // Only 1 call total (initial mount hint, debounced)
+    expect(vi.mocked(api)).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires a new hint after debounce when agent version changes', async () => {
+    const { api } = await import('../../lib/api')
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const store = useAgentPickerStore()
+    const { usePoolWarm } = await import('../usePoolWarm')
+
+    usePoolWarm()
+
+    // First fire (mount)
+    await vi.runAllTimersAsync()
+    expect(vi.mocked(api)).toHaveBeenCalledTimes(1)
+
+    // Agent version changes → triggers another debounced hint
+    store.selectedAgent = 'tether-agent-1.0'
+    await vi.runAllTimersAsync()
+
+    expect(vi.mocked(api)).toHaveBeenCalledTimes(2)
+  })
+
+  it('swallows API errors silently', async () => {
+    const { api } = await import('../../lib/api')
+    vi.mocked(api).mockRejectedValueOnce(new Error('network failure'))
+
+    const { usePoolWarm } = await import('../usePoolWarm')
+
+    // Should not throw
+    expect(() => usePoolWarm()).not.toThrow()
+    await vi.runAllTimersAsync()
+    // No unhandled rejection
+  })
+
+  it('includes agent_version in POST body', async () => {
+    const { api } = await import('../../lib/api')
+    const { useAgentPickerStore } = await import('../../stores/agentPicker')
+    const store = useAgentPickerStore()
+    store.selectedAgent = 'tether-agent-1.0'
+
+    const { usePoolWarm } = await import('../usePoolWarm')
+    usePoolWarm()
+
+    await vi.runAllTimersAsync()
+
+    const [, init] = vi.mocked(api).mock.calls[0]
+    const body = JSON.parse((init as RequestInit).body as string)
+    expect(body.agent_version).toBe('tether-agent-1.0')
+  })
+})

--- a/frontend/src/composables/usePoolWarm.ts
+++ b/frontend/src/composables/usePoolWarm.ts
@@ -1,0 +1,65 @@
+/**
+ * usePoolWarm — fires a best-effort pool warm hint to pre-warm a subprocess
+ * for the authenticated user when they land on the chat surface.
+ *
+ * Call once from ChatPageView.vue (or any component that signals chat intent).
+ * Also watches the selected agent version and re-hints on change so the correct
+ * subprocess configuration is warmed.
+ *
+ * 500ms debounce prevents spamming the endpoint on rapid picker changes.
+ * Failures are silently swallowed — warming is best-effort and must never
+ * interfere with the user experience.
+ */
+import { watch, onMounted, onUnmounted } from 'vue'
+import { api } from '../lib/api'
+import { useAgentPickerStore } from '../stores/agentPicker'
+
+const DEBOUNCE_MS = 500
+
+export function usePoolWarm(): void {
+  const pickerStore = useAgentPickerStore()
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+  function scheduleHint(): void {
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer)
+    }
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null
+      _fireHint(pickerStore.selectedAgent)
+    }, DEBOUNCE_MS)
+  }
+
+  // Fire on mount (user arrived at the chat surface)
+  onMounted(() => {
+    scheduleHint()
+  })
+
+  // Re-fire when the user changes their agent version selection
+  const stopWatch = watch(
+    () => pickerStore.selectedAgent,
+    () => {
+      scheduleHint()
+    },
+  )
+
+  onUnmounted(() => {
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer)
+      debounceTimer = null
+    }
+    stopWatch()
+  })
+}
+
+async function _fireHint(agentVersion: string): Promise<void> {
+  try {
+    await api('/api/internal/pool/warm', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent_version: agentVersion }),
+    })
+  } catch {
+    // Best-effort — silently ignore network failures
+  }
+}

--- a/frontend/src/views/ChatPageView.vue
+++ b/frontend/src/views/ChatPageView.vue
@@ -7,6 +7,10 @@ import ContextNodeSidebar from '../components/chat/ContextNodeSidebar.vue'
 import FolderCenterPanel  from '../components/chat/FolderCenterPanel.vue'
 import ConversationView   from '../components/chat/ConversationView.vue'
 import ProjectDetailsPanel from '../components/chat/ProjectDetailsPanel.vue'
+import { usePoolWarm } from '../composables/usePoolWarm'
+
+// Pre-warm a pool subprocess as soon as the user arrives at the chat surface.
+usePoolWarm()
 
 // ─── Collapse state ───────────────────────────────────────
 const leftOpen  = ref(true)

--- a/interactive_agent_layer/server.py
+++ b/interactive_agent_layer/server.py
@@ -1,13 +1,17 @@
 """FastAPI app for the interactive agent layer service."""
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 
-from interactive_agent_layer.session import Layer, Session
+from interactive_agent_layer.session import Layer, Session, _stable_options_hash
+
+log = logging.getLogger(__name__)
 
 
 class SessionStartRequest(BaseModel):
@@ -89,6 +93,23 @@ def create_app(layer: Layer) -> FastAPI:
             agent_version=body.agent_version,
             options=body.options,
         )
+
+        # Belt-and-suspenders pool hint: fire-and-forget so the pool has a
+        # warm subprocess ready before the first turn starts.  Failures are
+        # logged but never block the session response.
+        async def _fire_hint() -> None:
+            try:
+                options_hash = _stable_options_hash(body.options)
+                await layer.pool_client.hint(body.user_id, options_hash, body.options)
+            except Exception as exc:
+                log.debug(
+                    "session_start: pool hint failed user_id=%s: %s",
+                    body.user_id,
+                    exc,
+                )
+
+        asyncio.create_task(_fire_hint())
+
         return {"session_id": session.session_id}
 
     @app.post("/session/{session_id}/turn")

--- a/tests/api/test_pool_warm.py
+++ b/tests/api/test_pool_warm.py
@@ -1,0 +1,194 @@
+"""Tests for POST /api/internal/pool/warm endpoint.
+
+These tests don't require DATABASE_URL — they mock auth and the pool client.
+They verify:
+  - Happy path returns 202 with hinted=true and options_hash
+  - Pool failure still returns 202 (best-effort, never blocks FE)
+  - options_hash computed correctly (same algorithm as layer._stable_options_hash)
+  - Unauthenticated requests get 401
+  - Unknown agent_version returns 400
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+
+os.environ.setdefault("TETHER_DISABLE_RATE_LIMITS", "1")
+os.environ.setdefault("TETHER_COOKIE_SECURE", "false")
+os.environ.setdefault("TETHER_JWT_SECRET", "dev-secret-change-in-production")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "test-client-id")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "test-client-secret")
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from api.auth import auth_dependency, create_jwt
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+TEST_USER_ID = "00000000-0000-0000-0000-000000000042"
+TEST_USERNAME = "warmuser"
+
+
+def _stable_options_hash(options: dict) -> str:
+    """Mirror of interactive_agent_layer.session._stable_options_hash."""
+    canonical = json.dumps(options, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()[:16]
+
+
+class _MockPoolClient:
+    """Pool client that records hint() calls."""
+
+    def __init__(self, *, raise_on_hint: bool = False):
+        self.hint_calls: list[tuple] = []
+        self._raise = raise_on_hint
+
+    async def hint(self, user_id: str, options_hash: str, options: dict) -> None:
+        self.hint_calls.append((user_id, options_hash, options))
+        if self._raise:
+            from agent_pool_manager.client import PoolClientError
+            raise PoolClientError("pool unreachable")
+
+
+def _make_app(mock_pool_client: _MockPoolClient) -> FastAPI:
+    """Create a minimal FastAPI app with just the pool warm router."""
+    from api.main import create_app
+    from api.routes import pool as pool_routes
+
+    app = create_app()
+    # Inject mock pool client into app state
+    app.state.pool_client = mock_pool_client
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_pool():
+    return _MockPoolClient()
+
+
+@pytest.fixture
+def mock_pool_failing():
+    return _MockPoolClient(raise_on_hint=True)
+
+
+@pytest.fixture
+async def warm_client(mock_pool):
+    app = _make_app(mock_pool)
+    token = create_jwt(TEST_USER_ID, TEST_USERNAME, is_admin=False)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"tether_token": token},
+    ) as client:
+        yield client, mock_pool
+
+
+@pytest.fixture
+async def warm_client_failing(mock_pool_failing):
+    app = _make_app(mock_pool_failing)
+    token = create_jwt(TEST_USER_ID, TEST_USERNAME, is_admin=False)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"tether_token": token},
+    ) as client:
+        yield client, mock_pool_failing
+
+
+@pytest.fixture
+async def unauthed_client(mock_pool):
+    app = _make_app(mock_pool)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+async def test_warm_happy_path_returns_202(warm_client):
+    """POST /api/internal/pool/warm returns 202 with hinted=true and options_hash."""
+    client, pool = warm_client
+    resp = await client.post(
+        "/api/internal/pool/warm",
+        json={"agent_version": "tether-agent-2.0"},
+    )
+    assert resp.status_code == 202
+    data = resp.json()
+    assert data["hinted"] is True
+    assert "options_hash" in data
+    assert len(data["options_hash"]) == 16  # SHA-256 truncated to 16 hex chars
+
+
+async def test_warm_calls_pool_hint(warm_client):
+    """POST /api/internal/pool/warm calls pool_client.hint with correct args."""
+    client, pool = warm_client
+    await client.post(
+        "/api/internal/pool/warm",
+        json={"agent_version": "tether-agent-2.0"},
+    )
+    assert len(pool.hint_calls) == 1
+    user_id, options_hash, options = pool.hint_calls[0]
+    assert user_id == TEST_USER_ID
+    assert len(options_hash) == 16
+
+
+async def test_warm_options_hash_matches_layer_algorithm(warm_client):
+    """The returned options_hash must match the layer's _stable_options_hash algorithm."""
+    from bot.agent_dispatch import _V2_0_OPTIONS
+
+    client, pool = warm_client
+    resp = await client.post(
+        "/api/internal/pool/warm",
+        json={"agent_version": "tether-agent-2.0"},
+    )
+    assert resp.status_code == 202
+    returned_hash = resp.json()["options_hash"]
+
+    expected_hash = _stable_options_hash(_V2_0_OPTIONS)
+    assert returned_hash == expected_hash
+
+
+async def test_warm_pool_failure_still_returns_202(warm_client_failing):
+    """POST /api/internal/pool/warm returns 202 even when the pool client raises."""
+    client, pool = warm_client_failing
+    resp = await client.post(
+        "/api/internal/pool/warm",
+        json={"agent_version": "tether-agent-2.0"},
+    )
+    assert resp.status_code == 202
+    data = resp.json()
+    # hinted=false when pool call fails — for observability
+    assert data["hinted"] is False
+    assert "options_hash" in data
+
+
+async def test_warm_unauthenticated_returns_401(unauthed_client):
+    """POST /api/internal/pool/warm returns 401 when no auth cookie."""
+    resp = await unauthed_client.post(
+        "/api/internal/pool/warm",
+        json={"agent_version": "tether-agent-2.0"},
+    )
+    assert resp.status_code == 401
+
+
+async def test_warm_unknown_agent_version_returns_400(warm_client):
+    """POST /api/internal/pool/warm returns 400 for unknown agent version."""
+    client, pool = warm_client
+    resp = await client.post(
+        "/api/internal/pool/warm",
+        json={"agent_version": "tether-agent-99.0"},
+    )
+    assert resp.status_code == 400

--- a/tests/interactive_agent_layer/test_session_start_hint.py
+++ b/tests/interactive_agent_layer/test_session_start_hint.py
@@ -1,0 +1,163 @@
+"""Tests that POST /session/start fires a best-effort pool hint.
+
+Belt-and-suspenders: even if the FE hint missed, session creation triggers
+a warm so the first turn is less likely to face a cold pool.
+"""
+from __future__ import annotations
+
+import asyncio
+import pathlib
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from interactive_agent_layer.ws_publisher import WSPublisher
+from interactive_agent_layer.session import Layer
+from interactive_agent_layer.translation import TranslationTable
+
+
+# ---------------------------------------------------------------------------
+# Mock pool client that records hint calls
+# ---------------------------------------------------------------------------
+
+class _HintCapturingPoolClient:
+    """Pool client that records hint() calls and optionally raises."""
+
+    def __init__(self, *, raise_on_hint: bool = False):
+        self.hint_calls: list[tuple] = []
+        self._raise = raise_on_hint
+
+    async def acquire(self, user_id, options_hash, options, timeout_seconds=None):
+        return "mock-handle"
+
+    async def query_stream(self, handle_id, prompt, session_id="default"):
+        yield {"type": "result", "final_text": "done", "tokens_used": 0}
+
+    async def release(self, handle_id, *, reusable=False):
+        pass
+
+    async def interrupt(self, handle_id):
+        pass
+
+    async def hint(self, user_id: str, options_hash: str, options: dict) -> None:
+        self.hint_calls.append((user_id, options_hash, options))
+        if self._raise:
+            raise RuntimeError("pool hint failed")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def patch_config_getters(monkeypatch):
+    monkeypatch.setattr(
+        "interactive_agent_layer.session.get_auto_approve_user_actions",
+        lambda: False,
+    )
+
+
+def _make_layer(pool_client) -> Layer:
+    yaml_path = pathlib.Path(__file__).parent.parent.parent / "config" / "agent_translations.yaml"
+    return Layer(
+        pool_client=pool_client,
+        ws_publisher=WSPublisher(),
+        translation_table=TranslationTable.from_yaml(yaml_path),
+    )
+
+
+@pytest.fixture
+async def hint_client():
+    """Layer app with a hint-capturing pool client."""
+    pool_client = _HintCapturingPoolClient()
+    layer = _make_layer(pool_client)
+    from interactive_agent_layer.server import create_app
+    app = create_app(layer)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        yield client, pool_client
+
+
+@pytest.fixture
+async def hint_failing_client():
+    """Layer app with a pool client whose hint() raises."""
+    pool_client = _HintCapturingPoolClient(raise_on_hint=True)
+    layer = _make_layer(pool_client)
+    from interactive_agent_layer.server import create_app
+    app = create_app(layer)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        yield client, pool_client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+async def test_session_start_fires_pool_hint(hint_client):
+    """POST /session/start fires pool_client.hint for the session's options."""
+    client, pool = hint_client
+
+    resp = await client.post(
+        "/session/start",
+        json={
+            "user_id": "user-hint-1",
+            "user_ws_id": "ws-1",
+            "agent_version": "tether-agent-2.0",
+            "options": {"model": "haiku-4.5"},
+            "user_message": "hello",
+        },
+    )
+    assert resp.status_code == 200
+    # Give the background task a moment to run
+    await asyncio.sleep(0.05)
+
+    assert len(pool.hint_calls) == 1
+    user_id, options_hash, options = pool.hint_calls[0]
+    assert user_id == "user-hint-1"
+    assert len(options_hash) == 16
+
+
+async def test_session_start_hint_failure_does_not_block_response(hint_failing_client):
+    """POST /session/start returns 200 even when pool hint raises."""
+    client, pool = hint_failing_client
+
+    resp = await client.post(
+        "/session/start",
+        json={
+            "user_id": "user-hint-fail",
+            "user_ws_id": "ws-fail",
+            "agent_version": "tether-agent-2.0",
+            "options": {},
+            "user_message": "hi",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "session_id" in data
+
+
+async def test_session_start_hint_uses_session_options(hint_client):
+    """Pool hint receives same options dict as passed in session start."""
+    client, pool = hint_client
+    test_options = {"model": "sonnet-4.5", "allowed_tools": ["get_anchors"]}
+
+    await client.post(
+        "/session/start",
+        json={
+            "user_id": "user-opts",
+            "user_ws_id": "ws-opts",
+            "agent_version": "tether-agent-2.0",
+            "options": test_options,
+            "user_message": "check options",
+        },
+    )
+    await asyncio.sleep(0.05)
+
+    assert len(pool.hint_calls) == 1
+    _, _, hinted_options = pool.hint_calls[0]
+    assert hinted_options == test_options


### PR DESCRIPTION
## Summary

- **Deliverable 1 — Backend warm endpoint** (`api/routes/pool.py`): `POST /api/internal/pool/warm` authenticated via JWT cookie. Accepts `agent_version`, resolves canonical `options` server-side (same static dict as `agent_dispatch._V2_0_OPTIONS`) to guarantee `options_hash` matches what the layer later uses for `acquire()`. Calls `PoolClient.hint()` best-effort, always returns 202. Returns `hinted=false` on pool failure for observability. PoolClient cached on `app.state` after first construction.

- **Deliverable 2 — Frontend composable** (`frontend/src/composables/usePoolWarm.ts`): Fires hint on mount and re-hints when `agentPickerStore.selectedAgent` changes, with 500ms debounce. Wired into `ChatPageView.vue` so hint fires as soon as user opens `/chat`. Failures silently swallowed.

- **Deliverable 3 — Layer pre-warm** (`interactive_agent_layer/server.py`): Belt-and-suspenders — `POST /session/start` fires `asyncio.create_task(_fire_hint())` after session creation. Never blocks the response.

## Key design decisions

- **Options-hash consistency**: FE sends only `agent_version`; backend resolves canonical options from a known version map. Hash computed with identical algorithm to `interactive_agent_layer/session._stable_options_hash` (SHA-256, canonical JSON, 16-char hex). Test `test_warm_options_hash_matches_layer_algorithm` enforces this against `_V2_0_OPTIONS`.
- **Auth**: `Depends(auth_dependency)` (cookie JWT). `user_id` read from `request.state.user_id`, never from request body.
- **Pool failures never block**: all pool calls wrapped in `try/except`, `hinted=false` returned for diagnostics.

## Test plan

- [x] 6 backend pytest tests: 202 happy path, hint called with correct args, options_hash matches layer algorithm, 202 on pool failure, 401 unauthenticated, 400 unknown agent version
- [x] 3 layer pytest tests: hint fires on session/start, hint failure doesn't block response, hint passes correct options
- [x] Frontend vitest tests written (`usePoolWarm.test.ts`) — blocked by Node 18/vitest 4 env constraint on local dev machine; CI will run them
- [x] Code reviewer pass: no HIGH/CRITICAL findings
- [x] `tests/interactive_agent_layer/` full suite: 124 tests green
- [x] `tests/agent_pool_manager/` full suite: 67 tests green

## "Folder's project page composer" hint
Per spec, this was conditional on the surface existing in ChatPageView. Post-PR #411 rewrite, no folder composer hint surface is present. Dropped from scope.