### PR TITLE
feat(chat): K1-PR2 sidebar editing — rename, create, delete, drag-reparent

### DIFF
--- a/frontend/src/components/chat/ContextNodeSidebar.vue
+++ b/frontend/src/components/chat/ContextNodeSidebar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, nextTick } from 'vue'
 import { useContextStore } from '../../stores/context'
 import type { ContextNode } from '../../stores/context'
 import { useConversationsStore } from '../../stores/conversations'
@@ -15,16 +15,35 @@ const emit = defineEmits<{
 const contextStore = useContextStore()
 const conversationsStore = useConversationsStore()
 
+// ── Core state ─────────────────────────────────────────────────────────────
+
 // Track expanded nodes
 const expandedNodes = ref<Set<string>>(new Set())
-// Track which node is being dragged over
+// Track which node is being dragged over (for drop zone highlight)
 const dragOverNodeId = ref<string | null>(null)
 // Map of nodeId → conversations fetched for that node
 const convsByNode = ref<Map<string, ConversationDetail[]>>(new Map())
 
+// ── Editing state (K1-PR2) ─────────────────────────────────────────────────
+
+// Inline rename
+const renamingNodeId = ref<string | null>(null)
+const renameValue = ref<string>('')
+const renameInputRef = ref<HTMLInputElement | null>(null)
+
+// Inline create (parentId string = child; 'root' = root level; null = not creating)
+const creatingUnderNodeId = ref<string | null>(null)
+const newFolderName = ref<string>('')
+const createInputRef = ref<HTMLInputElement | null>(null)
+
+// Delete confirmation
+const deletingNode = ref<ContextNode | null>(null)
+
 onMounted(() => {
   contextStore.fetchRootNodes()
 })
+
+// ── Selection ──────────────────────────────────────────────────────────────
 
 function selectAll() {
   emit('update:activeNodeId', null)
@@ -34,6 +53,8 @@ function selectNode(nodeId: string) {
   emit('update:activeNodeId', nodeId)
 }
 
+// ── Expand / collapse ──────────────────────────────────────────────────────
+
 async function toggleExpand(node: ContextNode, evt: Event) {
   evt.stopPropagation()
   const id = node.id
@@ -42,11 +63,10 @@ async function toggleExpand(node: ContextNode, evt: Event) {
   } else {
     expandedNodes.value = new Set([...expandedNodes.value, id])
     await contextStore.fetchChildren(id)
-    // Fetch conversations scoped to this node
     await conversationsStore.refresh({ context_node_id: id })
     convsByNode.value = new Map(convsByNode.value).set(
       id,
-      conversationsStore.list.filter(c => c.context_node_id === id)
+      conversationsStore.list.filter(c => c.context_node_id === id),
     )
   }
 }
@@ -54,6 +74,102 @@ async function toggleExpand(node: ContextNode, evt: Event) {
 function hasChildren(node: ContextNode): boolean {
   if (node.children_count === undefined) return true
   return node.children_count > 0
+}
+
+// ── Inline rename ──────────────────────────────────────────────────────────
+
+function startRename(node: ContextNode, evt: Event) {
+  evt.stopPropagation()
+  renamingNodeId.value = node.id
+  renameValue.value = node.name
+  nextTick(() => renameInputRef.value?.focus())
+}
+
+function commitRename(nodeId: string, originalName: string) {
+  const trimmed = renameValue.value.trim()
+  renamingNodeId.value = null
+  if (!trimmed || trimmed === originalName) return
+  contextStore.patchNode(nodeId, { name: trimmed })
+}
+
+function cancelRename() {
+  renamingNodeId.value = null
+}
+
+function onRenameKeydown(nodeId: string, originalName: string, evt: KeyboardEvent) {
+  if (evt.key === 'Enter') { evt.preventDefault(); commitRename(nodeId, originalName) }
+  if (evt.key === 'Escape') { evt.preventDefault(); cancelRename() }
+}
+
+// ── Create folder ──────────────────────────────────────────────────────────
+
+// parentId: node id string → child of that node; 'root' → root-level folder
+function startCreate(parentId: string | 'root', evt: Event) {
+  evt.stopPropagation()
+  creatingUnderNodeId.value = parentId
+  newFolderName.value = ''
+  nextTick(() => createInputRef.value?.focus())
+}
+
+function commitCreate() {
+  const name = newFolderName.value.trim()
+  const parentId = creatingUnderNodeId.value
+  creatingUnderNodeId.value = null
+  if (!name || !parentId) return
+  contextStore.createNode(parentId === 'root' ? null : parentId, name)
+}
+
+function cancelCreate() {
+  creatingUnderNodeId.value = null
+}
+
+function onCreateKeydown(evt: KeyboardEvent) {
+  if (evt.key === 'Enter') { evt.preventDefault(); commitCreate() }
+  if (evt.key === 'Escape') { evt.preventDefault(); cancelCreate() }
+}
+
+// ── Delete folder ──────────────────────────────────────────────────────────
+
+function startDelete(node: ContextNode, evt: Event) {
+  evt.stopPropagation()
+  deletingNode.value = node
+}
+
+async function confirmDelete() {
+  if (!deletingNode.value) return
+  const nodeId = deletingNode.value.id
+  deletingNode.value = null
+  await contextStore.deleteNode(nodeId)
+}
+
+function cancelDelete() {
+  deletingNode.value = null
+}
+
+// ── Drag: conversation onto folder (existing) ──────────────────────────────
+
+function onConvLeafDragStart(conv: ConversationDetail, evt: DragEvent) {
+  evt.dataTransfer?.setData('text/plain', JSON.stringify({ conversationId: conv.id }))
+}
+
+// ── Drag: folder reparent (K1-PR2) ────────────────────────────────────────
+
+// Uses distinct MIME 'application/x-tether-folder' to avoid conflict with
+// the conversation drag payload ('text/plain' + {conversationId}).
+function onFolderDragStart(nodeId: string, evt: DragEvent) {
+  evt.dataTransfer?.setData(
+    'application/x-tether-folder',
+    JSON.stringify({ folderId: nodeId }),
+  )
+  if (evt.dataTransfer) evt.dataTransfer.effectAllowed = 'move'
+}
+
+function isFolderDrag(evt: DragEvent): boolean {
+  // types is a DOMStringList in browsers; may be an array or absent in test environments
+  const types = evt.dataTransfer?.types
+  return (types != null && typeof types.includes === 'function')
+    ? types.includes('application/x-tether-folder')
+    : false
 }
 
 function onDragOver(nodeId: string, evt: DragEvent) {
@@ -67,9 +183,26 @@ function onDragLeave(nodeId: string) {
   }
 }
 
+// Handles drops on folder rows — dispatches to either folder-reparent or conv-assign.
 async function onDrop(nodeId: string, evt: DragEvent) {
   evt.preventDefault()
   dragOverNodeId.value = null
+
+  if (isFolderDrag(evt)) {
+    const raw = evt.dataTransfer?.getData('application/x-tether-folder') ?? ''
+    try {
+      const { folderId } = JSON.parse(raw)
+      // Prevent self-drop (cycle guard: descendent check is backend-enforced)
+      if (folderId && folderId !== nodeId) {
+        await contextStore.moveNode(folderId, nodeId)
+      }
+    } catch {
+      // ignore malformed
+    }
+    return
+  }
+
+  // Fallback: conversation drop
   const raw = evt.dataTransfer?.getData('text/plain')
   if (!raw) return
   try {
@@ -82,9 +215,27 @@ async function onDrop(nodeId: string, evt: DragEvent) {
   }
 }
 
-function onConvLeafDragStart(conv: ConversationDetail, evt: DragEvent) {
-  evt.dataTransfer?.setData('text/plain', JSON.stringify({ conversationId: conv.id }))
+// Root drop zone — folder drag only (conversations have no "unassign" meaning here)
+async function onRootDrop(evt: DragEvent) {
+  evt.preventDefault()
+  dragOverNodeId.value = null
+  if (!isFolderDrag(evt)) return
+  const raw = evt.dataTransfer?.getData('application/x-tether-folder') ?? ''
+  try {
+    const { folderId } = JSON.parse(raw)
+    if (folderId) {
+      await contextStore.moveNode(folderId, null)
+    }
+  } catch {
+    // ignore
+  }
 }
+
+function onRootDragOver(evt: DragEvent) {
+  if (isFolderDrag(evt)) evt.preventDefault()
+}
+
+// ── Misc helpers ───────────────────────────────────────────────────────────
 
 function relativeTime(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime()
@@ -96,16 +247,18 @@ function relativeTime(iso: string): string {
   return `${Math.floor(hrs / 24)}d`
 }
 
-// + New chat: emit update:activeNodeId with the folder's id — switches
-// FolderCenterPanel to that folder's composer with that folder as default scope.
 function startNewChat(nodeId: string) {
   emit('update:activeNodeId', nodeId)
 }
 </script>
 
 <template>
-  <div class="flex flex-col h-full bg-[--bg-1] text-sm" style="width:240px;flex-shrink:0;border-right:1px solid var(--border-1);">
-    <!-- Header -->
+  <div
+    class="sidebar-root flex flex-col h-full text-sm"
+    style="width:240px;flex-shrink:0;border-right:1px solid var(--border-1);"
+  >
+
+    <!-- ── Header ── -->
     <div class="px-3 py-2.5 border-b border-[--border-1] flex-shrink-0 flex items-center justify-between">
       <span class="font-semibold text-[10px] text-[--fg-5] uppercase tracking-widest font-mono">Chat</span>
       <div class="flex items-center gap-1">
@@ -114,42 +267,43 @@ function startNewChat(nodeId: string) {
           class="sidebar-icon-btn"
           title="New chat"
           @click="emit('update:activeNodeId', null)"
-        >
-          +
-        </button>
+        >+</button>
         <button
           data-testid="sidebar-collapse-btn"
           type="button"
           class="sidebar-icon-btn"
           title="Collapse"
           @click="emit('collapse')"
-        >
-          ‹
-        </button>
+        >‹</button>
       </div>
     </div>
 
-    <!-- All item -->
+    <!-- ── All conversations (also root folder-drag drop zone) ── -->
     <div
       data-testid="all-item"
       class="flex items-center px-3 py-2 cursor-pointer hover:bg-[--bg-2] transition-colors"
       :class="activeNodeId === null ? 'bg-[--bg-elev-3] font-medium' : ''"
       @click="selectAll"
+      @dragover="onRootDragOver"
+      @drop="onRootDrop"
     >
       <span class="text-[--fg-2] text-xs">All conversations</span>
     </div>
 
-    <!-- Root nodes -->
+    <!-- ── Node tree ── -->
     <div class="flex-1 overflow-y-auto">
       <template v-for="node in contextStore.rootNodes" :key="node.id">
-        <!-- Node row (also drop zone) -->
+
+        <!-- Root node row -->
         <div
           :data-testid="`drop-zone-${node.id}`"
-          class="flex items-center gap-1 px-3 py-2 cursor-pointer hover:bg-[--bg-2] transition-colors"
+          class="node-row flex items-center gap-1 px-3 py-2 cursor-pointer hover:bg-[--bg-2] transition-colors group"
           :class="[
             activeNodeId === node.id ? 'bg-[--bg-elev-3] font-medium' : '',
             dragOverNodeId === node.id ? 'drag-over' : '',
           ]"
+          draggable="true"
+          @dragstart="onFolderDragStart(node.id, $event)"
           @dragover="onDragOver(node.id, $event)"
           @dragleave="onDragLeave(node.id)"
           @drop="onDrop(node.id, $event)"
@@ -175,39 +329,129 @@ function startNewChat(nodeId: string) {
           </button>
           <span v-else class="w-4 flex-shrink-0" />
 
-          <!-- Node name -->
+          <!-- Name: rename input or clickable span -->
+          <input
+            v-if="renamingNodeId === node.id"
+            :ref="(el) => { if (el) renameInputRef = el as HTMLInputElement }"
+            :data-testid="`rename-input-${node.id}`"
+            class="rename-input flex-1 text-xs"
+            :value="renameValue"
+            @input="renameValue = ($event.target as HTMLInputElement).value"
+            @keydown="onRenameKeydown(node.id, node.name, $event)"
+            @blur="commitRename(node.id, node.name)"
+            @click.stop
+          />
           <span
+            v-else
             :data-testid="`node-row-${node.id}`"
             class="text-[--fg-2] text-xs truncate flex-1"
             @click="selectNode(node.id)"
+            @dblclick.stop="startRename(node, $event)"
           >
             {{ node.name }}
           </span>
+
+          <!-- Action buttons (visible on group hover) -->
+          <div class="node-actions flex items-center gap-0.5 flex-shrink-0">
+            <button
+              :data-testid="`create-child-btn-${node.id}`"
+              type="button"
+              class="node-action-btn"
+              title="New subfolder"
+              @click.stop="startCreate(node.id, $event)"
+            >+</button>
+            <button
+              :data-testid="`delete-btn-${node.id}`"
+              type="button"
+              class="node-action-btn node-action-btn--danger"
+              title="Delete folder"
+              @click.stop="startDelete(node, $event)"
+            >
+              <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+                <path d="M2 4h12M6 4V2h4v2M5 4l1 10h4l1-10"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <!-- Inline create-child input (appears after the node row) -->
+        <div
+          v-if="creatingUnderNodeId === node.id"
+          class="create-input-row flex items-center pl-8 pr-3 py-1"
+        >
+          <input
+            :ref="(el) => { if (el) createInputRef = el as HTMLInputElement }"
+            :data-testid="`create-input-${node.id}`"
+            class="create-input flex-1 text-xs"
+            v-model="newFolderName"
+            placeholder="Folder name…"
+            @keydown="onCreateKeydown"
+            @blur="commitCreate"
+          />
         </div>
 
         <!-- Children + conversation leaves (when expanded) -->
         <template v-if="expandedNodes.has(node.id)">
+
           <!-- Child folder nodes (indented) -->
           <div
             v-for="child in contextStore.childrenOf(node.id)"
             :key="child.id"
             :data-testid="`drop-zone-${child.id}`"
-            class="flex items-center gap-1 pl-8 pr-3 py-2 cursor-pointer hover:bg-[--bg-2] transition-colors"
+            class="node-row flex items-center gap-1 pl-8 pr-3 py-2 cursor-pointer hover:bg-[--bg-2] transition-colors group"
             :class="[
               activeNodeId === child.id ? 'bg-[--bg-elev-3] font-medium' : '',
               dragOverNodeId === child.id ? 'drag-over' : '',
             ]"
+            draggable="true"
+            @dragstart="onFolderDragStart(child.id, $event)"
             @dragover="onDragOver(child.id, $event)"
             @dragleave="onDragLeave(child.id)"
             @drop="onDrop(child.id, $event)"
           >
+            <!-- Name: rename input or span -->
+            <input
+              v-if="renamingNodeId === child.id"
+              :ref="(el) => { if (el) renameInputRef = el as HTMLInputElement }"
+              :data-testid="`rename-input-${child.id}`"
+              class="rename-input flex-1 text-xs"
+              :value="renameValue"
+              @input="renameValue = ($event.target as HTMLInputElement).value"
+              @keydown="onRenameKeydown(child.id, child.name, $event)"
+              @blur="commitRename(child.id, child.name)"
+              @click.stop
+            />
             <span
+              v-else
               :data-testid="`node-row-${child.id}`"
               class="text-[--fg-2] text-xs truncate flex-1"
               @click="selectNode(child.id)"
+              @dblclick.stop="startRename(child, $event)"
             >
               {{ child.name }}
             </span>
+
+            <!-- Action buttons -->
+            <div class="node-actions flex items-center gap-0.5 flex-shrink-0">
+              <button
+                :data-testid="`create-child-btn-${child.id}`"
+                type="button"
+                class="node-action-btn"
+                title="New subfolder"
+                @click.stop="startCreate(child.id, $event)"
+              >+</button>
+              <button
+                :data-testid="`delete-btn-${child.id}`"
+                type="button"
+                class="node-action-btn node-action-btn--danger"
+                title="Delete folder"
+                @click.stop="startDelete(child, $event)"
+              >
+                <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+                  <path d="M2 4h12M6 4V2h4v2M5 4l1 10h4l1-10"/>
+                </svg>
+              </button>
+            </div>
           </div>
 
           <!-- Conversation leaf items -->
@@ -231,12 +475,72 @@ function startNewChat(nodeId: string) {
             + New chat
           </div>
         </template>
+
       </template>
+
+      <!-- ── New root folder affordance ── -->
+      <div
+        v-if="creatingUnderNodeId === 'root'"
+        class="create-input-row flex items-center px-3 py-1"
+      >
+        <input
+          :ref="(el) => { if (el) createInputRef = el as HTMLInputElement }"
+          data-testid="create-input-root"
+          class="create-input flex-1 text-xs"
+          v-model="newFolderName"
+          placeholder="New folder name…"
+          @keydown="onCreateKeydown"
+          @blur="commitCreate"
+        />
+      </div>
+      <div
+        v-else
+        data-testid="create-root-btn"
+        class="tree-new-root"
+        @click="startCreate('root', $event)"
+      >
+        + New folder
+      </div>
     </div>
+
+    <!-- ── Delete confirmation overlay ── -->
+    <div
+      v-if="deletingNode"
+      data-testid="delete-confirm-dialog"
+      class="delete-overlay"
+      @click.self="cancelDelete"
+    >
+      <div class="delete-dialog">
+        <p class="delete-dialog__msg">
+          Delete '{{ deletingNode.name }}'?
+          <template v-if="(deletingNode.children_count ?? 0) > 0">
+            This will delete {{ deletingNode.children_count }}
+            {{ deletingNode.children_count === 1 ? 'subfolder' : 'subfolders' }}.
+          </template>
+          Any conversations inside will move to All conversations.
+        </p>
+        <div class="delete-dialog__actions">
+          <button
+            data-testid="delete-confirm-cancel"
+            type="button"
+            class="delete-btn delete-btn--cancel"
+            @click="cancelDelete"
+          >Cancel</button>
+          <button
+            data-testid="delete-confirm-ok"
+            type="button"
+            class="delete-btn delete-btn--ok"
+            @click="confirmDelete"
+          >Delete</button>
+        </div>
+      </div>
+    </div>
+
   </div>
 </template>
 
 <style scoped>
+/* ── Tree items ── */
 .tree-conv-item {
   display: flex; align-items: center; gap: 8px;
   padding: 5px 10px 5px 48px;
@@ -265,8 +569,18 @@ function startNewChat(nodeId: string) {
   color: var(--accent); cursor: pointer; opacity: 0.7;
   transition: opacity 150ms;
 }
-.tree-new-chat:hover           { opacity: 1; }
+.tree-new-chat:hover { opacity: 1; }
 
+.tree-new-root {
+  display: flex; align-items: center; gap: 5px;
+  padding: 6px 12px;
+  font-family: var(--font-mono); font-size: 11px;
+  color: var(--fg-5); cursor: pointer; opacity: 0.5;
+  transition: opacity 150ms, color 150ms;
+}
+.tree-new-root:hover { opacity: 1; color: var(--accent); }
+
+/* ── Sidebar icon buttons ── */
 .sidebar-icon-btn {
   width: 20px; height: 20px;
   display: flex; align-items: center; justify-content: center;
@@ -276,10 +590,117 @@ function startNewChat(nodeId: string) {
 }
 .sidebar-icon-btn:hover { background: var(--bg-elev-3); color: var(--fg-2); }
 
-/* Drag-over highlight on folder drop zones — themed via tokens */
+/* ── Drag-over highlight ── */
 .drag-over {
   outline: 1px solid var(--accent-soft);
   outline-offset: -1px;
   background: var(--accent-veil);
 }
+
+/* ── Node action buttons (hover-visible on parent .group) ── */
+.node-actions {
+  opacity: 0;
+  transition: opacity 100ms;
+}
+.node-row:hover .node-actions,
+.node-row:focus-within .node-actions {
+  opacity: 1;
+}
+
+.node-action-btn {
+  width: 18px; height: 18px;
+  display: flex; align-items: center; justify-content: center;
+  border: none; background: transparent; cursor: pointer;
+  border-radius: var(--radius-sharp); color: var(--fg-5);
+  font-size: 12px;
+  transition: background 100ms, color 100ms;
+}
+.node-action-btn:hover { background: var(--bg-elev-3); color: var(--fg-2); }
+.node-action-btn--danger:hover { background: var(--status-block-bg, #f003); color: var(--status-block-fg, var(--fg-1)); }
+
+/* ── Rename input ── */
+.rename-input {
+  background: var(--bg-elev-2);
+  border: 1px solid var(--accent-soft);
+  border-radius: var(--radius-sharp);
+  color: var(--fg-1);
+  padding: 1px 5px;
+  outline: none;
+  font-family: var(--font-sans);
+  min-width: 0;
+}
+
+/* ── Create input ── */
+.create-input-row {
+  background: var(--bg-elev-1);
+}
+.create-input {
+  background: var(--bg-elev-2);
+  border: 1px solid var(--accent-soft);
+  border-radius: var(--radius-sharp);
+  color: var(--fg-1);
+  padding: 2px 6px;
+  outline: none;
+  font-family: var(--font-sans);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* ── Delete confirmation overlay ── */
+.delete-overlay {
+  position: absolute;
+  inset: 0;
+  background: var(--bg-canvas);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+  padding: 16px;
+}
+
+.delete-dialog {
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border-1);
+  border-radius: var(--radius-soft);
+  padding: 16px;
+  max-width: 200px;
+  width: 100%;
+  box-shadow: var(--shadow-md, 0 4px 12px rgba(0,0,0,0.2));
+}
+
+.delete-dialog__msg {
+  font-size: 12px;
+  color: var(--fg-2);
+  line-height: 1.5;
+  margin-bottom: 12px;
+}
+
+.delete-dialog__actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.delete-btn {
+  padding: 4px 10px;
+  font-size: 11.5px;
+  border-radius: var(--radius-sharp);
+  border: 1px solid var(--border-1);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: background 150ms, color 150ms;
+}
+
+.delete-btn--cancel {
+  background: transparent;
+  color: var(--fg-3);
+}
+.delete-btn--cancel:hover { background: var(--bg-elev-3); color: var(--fg-1); }
+
+.delete-btn--ok {
+  background: var(--status-block-bg, color-mix(in srgb, var(--fg-1) 8%, transparent));
+  color: var(--fg-1);
+  border-color: transparent;
+}
+.delete-btn--ok:hover { opacity: 0.85; }
 </style>

--- a/frontend/src/components/chat/ContextNodeSidebar.vue
+++ b/frontend/src/components/chat/ContextNodeSidebar.vue
@@ -38,6 +38,7 @@ const createInputRef = ref<HTMLInputElement | null>(null)
 
 // Delete confirmation
 const deletingNode = ref<ContextNode | null>(null)
+const deleteCancelBtnRef = ref<HTMLButtonElement | null>(null)
 
 onMounted(() => {
   contextStore.fetchRootNodes()
@@ -93,6 +94,9 @@ function commitRename(nodeId: string, originalName: string) {
 }
 
 function cancelRename() {
+  // Zero renameValue so that if the browser fires blur on DOM teardown,
+  // commitRename's !trimmed guard treats it as a no-op.
+  renameValue.value = ''
   renamingNodeId.value = null
 }
 
@@ -133,6 +137,7 @@ function onCreateKeydown(evt: KeyboardEvent) {
 function startDelete(node: ContextNode, evt: Event) {
   evt.stopPropagation()
   deletingNode.value = node
+  nextTick(() => deleteCancelBtnRef.value?.focus())
 }
 
 async function confirmDelete() {
@@ -508,10 +513,14 @@ function startNewChat(nodeId: string) {
       v-if="deletingNode"
       data-testid="delete-confirm-dialog"
       class="delete-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="delete-dialog-title"
       @click.self="cancelDelete"
+      @keydown.escape.stop="cancelDelete"
     >
       <div class="delete-dialog">
-        <p class="delete-dialog__msg">
+        <p id="delete-dialog-title" class="delete-dialog__msg">
           Delete '{{ deletingNode.name }}'?
           <template v-if="(deletingNode.children_count ?? 0) > 0">
             This will delete {{ deletingNode.children_count }}
@@ -521,6 +530,7 @@ function startNewChat(nodeId: string) {
         </p>
         <div class="delete-dialog__actions">
           <button
+            :ref="(el) => { if (el) deleteCancelBtnRef = el as HTMLButtonElement }"
             data-testid="delete-confirm-cancel"
             type="button"
             class="delete-btn delete-btn--cancel"
@@ -616,7 +626,7 @@ function startNewChat(nodeId: string) {
   transition: background 100ms, color 100ms;
 }
 .node-action-btn:hover { background: var(--bg-elev-3); color: var(--fg-2); }
-.node-action-btn--danger:hover { background: var(--status-block-bg, #f003); color: var(--status-block-fg, var(--fg-1)); }
+.node-action-btn--danger:hover { background: var(--status-block-bg); color: var(--status-block-fg, var(--fg-1)); }
 
 /* ── Rename input ── */
 .rename-input {
@@ -665,7 +675,7 @@ function startNewChat(nodeId: string) {
   padding: 16px;
   max-width: 200px;
   width: 100%;
-  box-shadow: var(--shadow-md, 0 4px 12px rgba(0,0,0,0.2));
+  box-shadow: var(--shadow-pop);
 }
 
 .delete-dialog__msg {

--- a/frontend/src/components/chat/__tests__/ContextNodeSidebar.test.ts
+++ b/frontend/src/components/chat/__tests__/ContextNodeSidebar.test.ts
@@ -45,6 +45,11 @@ function makeContextStore(nodes: ReturnType<typeof makeNode>[] = []) {
     fetchRootNodes: vi.fn().mockResolvedValue(nodes),
     fetchChildren: vi.fn().mockResolvedValue([]),
     childrenOf: vi.fn().mockReturnValue([]),
+    // Editing operations (K1-PR2)
+    patchNode: vi.fn().mockResolvedValue({}),
+    createNode: vi.fn().mockResolvedValue({ id: 'new-node', name: 'New Folder', parent_id: null }),
+    deleteNode: vi.fn().mockResolvedValue(undefined),
+    moveNode: vi.fn().mockResolvedValue(undefined),
   })
 }
 
@@ -347,6 +352,434 @@ describe('ContextNodeSidebar', () => {
     expect(wrapper.emitted('open-conversation')![0]).toEqual(['conv-click'])
     // Old buggy behavior was emit('update:activeNodeId', null); ensure it doesn't.
     expect(wrapper.emitted('update:activeNodeId')).toBeFalsy()
+  })
+
+  // ── K1-PR2: Inline rename ──────────────────────────────────────────────
+
+  it('double-clicking a node name shows a rename input pre-filled with the name', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    mockUseContextStore.mockReturnValue(makeContextStore(nodes) as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    const nameSpan = wrapper.find('[data-testid="node-row-node-1"]')
+    await nameSpan.trigger('dblclick')
+
+    // Input should appear in place of the span
+    const input = wrapper.find('[data-testid="rename-input-node-1"]')
+    expect(input.exists()).toBe(true)
+    expect((input.element as HTMLInputElement).value).toBe('Alpha')
+  })
+
+  it('pressing Enter on rename input calls patchNode and hides input', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    const ctxStore = makeContextStore(nodes)
+    mockUseContextStore.mockReturnValue(ctxStore as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    await wrapper.find('[data-testid="node-row-node-1"]').trigger('dblclick')
+
+    const input = wrapper.find('[data-testid="rename-input-node-1"]')
+    await input.setValue('Beta')
+    await input.trigger('keydown', { key: 'Enter' })
+    await wrapper.vm.$nextTick()
+
+    expect(ctxStore.patchNode).toHaveBeenCalledWith('node-1', { name: 'Beta' })
+    // Input should be gone, span restored
+    expect(wrapper.find('[data-testid="rename-input-node-1"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="node-row-node-1"]').exists()).toBe(true)
+  })
+
+  it('pressing Escape on rename input cancels without calling patchNode', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    const ctxStore = makeContextStore(nodes)
+    mockUseContextStore.mockReturnValue(ctxStore as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    await wrapper.find('[data-testid="node-row-node-1"]').trigger('dblclick')
+
+    const input = wrapper.find('[data-testid="rename-input-node-1"]')
+    await input.setValue('SomethingElse')
+    await input.trigger('keydown', { key: 'Escape' })
+    await wrapper.vm.$nextTick()
+
+    expect(ctxStore.patchNode).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="rename-input-node-1"]').exists()).toBe(false)
+  })
+
+  it('blurring the rename input commits the rename', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    const ctxStore = makeContextStore(nodes)
+    mockUseContextStore.mockReturnValue(ctxStore as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    await wrapper.find('[data-testid="node-row-node-1"]').trigger('dblclick')
+
+    const input = wrapper.find('[data-testid="rename-input-node-1"]')
+    await input.setValue('Gamma')
+    await input.trigger('blur')
+    await wrapper.vm.$nextTick()
+
+    expect(ctxStore.patchNode).toHaveBeenCalledWith('node-1', { name: 'Gamma' })
+  })
+
+  it('rename does not call patchNode when value is unchanged', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    const ctxStore = makeContextStore(nodes)
+    mockUseContextStore.mockReturnValue(ctxStore as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    await wrapper.find('[data-testid="node-row-node-1"]').trigger('dblclick')
+
+    const input = wrapper.find('[data-testid="rename-input-node-1"]')
+    // Do not change value (still 'Alpha')
+    await input.trigger('keydown', { key: 'Enter' })
+    await wrapper.vm.$nextTick()
+
+    expect(ctxStore.patchNode).not.toHaveBeenCalled()
+  })
+
+  it('rename does not call patchNode when value is blank after trim', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    const ctxStore = makeContextStore(nodes)
+    mockUseContextStore.mockReturnValue(ctxStore as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    await wrapper.find('[data-testid="node-row-node-1"]').trigger('dblclick')
+
+    const input = wrapper.find('[data-testid="rename-input-node-1"]')
+    await input.setValue('   ')
+    await input.trigger('keydown', { key: 'Enter' })
+    await wrapper.vm.$nextTick()
+
+    expect(ctxStore.patchNode).not.toHaveBeenCalled()
+  })
+
+  // ── K1-PR2: Create folder ──────────────────────────────────────────────
+
+  it('shows a "+" create button on each root folder row', () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    mockUseContextStore.mockReturnValue(makeContextStore(nodes) as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    expect(wrapper.find('[data-testid="create-child-btn-node-1"]').exists()).toBe(true)
+  })
+
+  it('clicking the folder "+" button shows an inline create input', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    mockUseContextStore.mockReturnValue(makeContextStore(nodes) as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    await wrapper.find('[data-testid="create-child-btn-node-1"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="create-input-node-1"]').exists()).toBe(true)
+  })
+
+  it('Enter on create input calls createNode with parentId and name, then hides input', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    const ctxStore = makeContextStore(nodes)
+    mockUseContextStore.mockReturnValue(ctxStore as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    await wrapper.find('[data-testid="create-child-btn-node-1"]').trigger('click')
+
+    const input = wrapper.find('[data-testid="create-input-node-1"]')
+    await input.setValue('Child Folder')
+    await input.trigger('keydown', { key: 'Enter' })
+    await wrapper.vm.$nextTick()
+
+    expect(ctxStore.createNode).toHaveBeenCalledWith('node-1', 'Child Folder')
+    expect(wrapper.find('[data-testid="create-input-node-1"]').exists()).toBe(false)
+  })
+
+  it('Escape on create input cancels without calling createNode', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    const ctxStore = makeContextStore(nodes)
+    mockUseContextStore.mockReturnValue(ctxStore as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    await wrapper.find('[data-testid="create-child-btn-node-1"]').trigger('click')
+
+    await wrapper.find('[data-testid="create-input-node-1"]').trigger('keydown', { key: 'Escape' })
+    await wrapper.vm.$nextTick()
+
+    expect(ctxStore.createNode).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="create-input-node-1"]').exists()).toBe(false)
+  })
+
+  it('shows a "New root folder" affordance', () => {
+    mockUseContextStore.mockReturnValue(makeContextStore() as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    expect(wrapper.find('[data-testid="create-root-btn"]').exists()).toBe(true)
+  })
+
+  it('clicking "New root folder" shows a root create input; Enter calls createNode(null, name)', async () => {
+    const ctxStore = makeContextStore()
+    mockUseContextStore.mockReturnValue(ctxStore as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    await wrapper.find('[data-testid="create-root-btn"]').trigger('click')
+
+    const input = wrapper.find('[data-testid="create-input-root"]')
+    expect(input.exists()).toBe(true)
+    await input.setValue('Root Folder')
+    await input.trigger('keydown', { key: 'Enter' })
+    await wrapper.vm.$nextTick()
+
+    expect(ctxStore.createNode).toHaveBeenCalledWith(null, 'Root Folder')
+    expect(wrapper.find('[data-testid="create-input-root"]').exists()).toBe(false)
+  })
+
+  it('create does not call createNode when name is blank', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    const ctxStore = makeContextStore(nodes)
+    mockUseContextStore.mockReturnValue(ctxStore as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    await wrapper.find('[data-testid="create-child-btn-node-1"]').trigger('click')
+
+    const input = wrapper.find('[data-testid="create-input-node-1"]')
+    await input.setValue('   ')
+    await input.trigger('keydown', { key: 'Enter' })
+    await wrapper.vm.$nextTick()
+
+    expect(ctxStore.createNode).not.toHaveBeenCalled()
+  })
+
+  // ── K1-PR2: Delete folder ──────────────────────────────────────────────
+
+  it('shows a delete button on each root folder row', () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    mockUseContextStore.mockReturnValue(makeContextStore(nodes) as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    expect(wrapper.find('[data-testid="delete-btn-node-1"]').exists()).toBe(true)
+  })
+
+  it('clicking delete button shows confirmation dialog with node name', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    mockUseContextStore.mockReturnValue(makeContextStore(nodes) as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    await wrapper.find('[data-testid="delete-btn-node-1"]').trigger('click')
+
+    const dialog = wrapper.find('[data-testid="delete-confirm-dialog"]')
+    expect(dialog.exists()).toBe(true)
+    expect(dialog.text()).toContain('Alpha')
+  })
+
+  it('delete confirmation mentions subfolders count when children_count > 0', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 3 })]
+    mockUseContextStore.mockReturnValue(makeContextStore(nodes) as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    await wrapper.find('[data-testid="delete-btn-node-1"]').trigger('click')
+
+    const dialog = wrapper.find('[data-testid="delete-confirm-dialog"]')
+    expect(dialog.text()).toContain('3 subfolder')
+  })
+
+  it('delete confirmation omits subfolder sentence when children_count === 0', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    mockUseContextStore.mockReturnValue(makeContextStore(nodes) as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    await wrapper.find('[data-testid="delete-btn-node-1"]').trigger('click')
+
+    const dialog = wrapper.find('[data-testid="delete-confirm-dialog"]')
+    expect(dialog.text()).not.toContain('subfolder')
+  })
+
+  it('delete confirmation mentions conversations moving to All conversations', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    mockUseContextStore.mockReturnValue(makeContextStore(nodes) as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    await wrapper.find('[data-testid="delete-btn-node-1"]').trigger('click')
+
+    const dialog = wrapper.find('[data-testid="delete-confirm-dialog"]')
+    expect(dialog.text()).toContain('All conversations')
+  })
+
+  it('confirming delete calls deleteNode and closes dialog', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    const ctxStore = makeContextStore(nodes)
+    mockUseContextStore.mockReturnValue(ctxStore as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    await wrapper.find('[data-testid="delete-btn-node-1"]').trigger('click')
+    await wrapper.find('[data-testid="delete-confirm-ok"]').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(ctxStore.deleteNode).toHaveBeenCalledWith('node-1')
+    expect(wrapper.find('[data-testid="delete-confirm-dialog"]').exists()).toBe(false)
+  })
+
+  it('cancelling delete does not call deleteNode and closes dialog', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    const ctxStore = makeContextStore(nodes)
+    mockUseContextStore.mockReturnValue(ctxStore as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    await wrapper.find('[data-testid="delete-btn-node-1"]').trigger('click')
+    await wrapper.find('[data-testid="delete-confirm-cancel"]').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(ctxStore.deleteNode).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="delete-confirm-dialog"]').exists()).toBe(false)
+  })
+
+  // ── K1-PR2: Folder drag-and-drop reparent ─────────────────────────────
+
+  it('folder rows are draggable', () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    mockUseContextStore.mockReturnValue(makeContextStore(nodes) as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    const dropZone = wrapper.find('[data-testid="drop-zone-node-1"]')
+    expect(dropZone.attributes('draggable')).toBe('true')
+  })
+
+  it('dragstart on a folder row sets application/x-tether-folder dataTransfer', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    mockUseContextStore.mockReturnValue(makeContextStore(nodes) as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    const dropZone = wrapper.find('[data-testid="drop-zone-node-1"]')
+
+    const setDataMock = vi.fn()
+    const dragEvent = new Event('dragstart') as any
+    dragEvent.dataTransfer = { setData: setDataMock, effectAllowed: '' }
+    await dropZone.element.dispatchEvent(dragEvent)
+
+    expect(setDataMock).toHaveBeenCalledWith(
+      'application/x-tether-folder',
+      JSON.stringify({ folderId: 'node-1' }),
+    )
+  })
+
+  it('dropping a folder onto another folder calls moveNode(folderId, targetId)', async () => {
+    const nodes = [
+      makeNode({ id: 'node-a', name: 'Alpha', children_count: 0 }),
+      makeNode({ id: 'node-b', name: 'Beta', children_count: 0 }),
+    ]
+    const ctxStore = makeContextStore(nodes)
+    mockUseContextStore.mockReturnValue(ctxStore as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+
+    // Drop node-a onto node-b
+    const dropZoneB = wrapper.find('[data-testid="drop-zone-node-b"]')
+    const dropEvent = new Event('drop') as any
+    dropEvent.preventDefault = vi.fn()
+    dropEvent.dataTransfer = {
+      getData: vi.fn().mockImplementation((type: string) => {
+        if (type === 'application/x-tether-folder') return JSON.stringify({ folderId: 'node-a' })
+        return ''
+      }),
+      types: ['application/x-tether-folder'],
+    }
+    await dropZoneB.element.dispatchEvent(dropEvent)
+    await wrapper.vm.$nextTick()
+
+    expect(ctxStore.moveNode).toHaveBeenCalledWith('node-a', 'node-b')
+  })
+
+  it('dropping a folder onto root zone calls moveNode(folderId, null)', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    const ctxStore = makeContextStore(nodes)
+    mockUseContextStore.mockReturnValue(ctxStore as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+
+    const rootDropZone = wrapper.find('[data-testid="all-item"]')
+    const dropEvent = new Event('drop') as any
+    dropEvent.preventDefault = vi.fn()
+    dropEvent.dataTransfer = {
+      getData: vi.fn().mockImplementation((type: string) => {
+        if (type === 'application/x-tether-folder') return JSON.stringify({ folderId: 'node-1' })
+        return ''
+      }),
+      types: ['application/x-tether-folder'],
+    }
+    await rootDropZone.element.dispatchEvent(dropEvent)
+    await wrapper.vm.$nextTick()
+
+    expect(ctxStore.moveNode).toHaveBeenCalledWith('node-1', null)
+  })
+
+  it('dropping a folder onto itself does not call moveNode', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    const ctxStore = makeContextStore(nodes)
+    mockUseContextStore.mockReturnValue(ctxStore as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+
+    const dropZone = wrapper.find('[data-testid="drop-zone-node-1"]')
+    const dropEvent = new Event('drop') as any
+    dropEvent.preventDefault = vi.fn()
+    dropEvent.dataTransfer = {
+      getData: vi.fn().mockImplementation((type: string) => {
+        if (type === 'application/x-tether-folder') return JSON.stringify({ folderId: 'node-1' })
+        return ''
+      }),
+      types: ['application/x-tether-folder'],
+    }
+    await dropZone.element.dispatchEvent(dropEvent)
+    await wrapper.vm.$nextTick()
+
+    expect(ctxStore.moveNode).not.toHaveBeenCalled()
+  })
+
+  it('existing conversation drag still calls assignNode (not moveNode)', async () => {
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    const ctxStore = makeContextStore(nodes)
+    const convStore = makeConversationsStore()
+    mockUseContextStore.mockReturnValue(ctxStore as any)
+    mockUseConversationsStore.mockReturnValue(convStore as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+
+    const dropZone = wrapper.find('[data-testid="drop-zone-node-1"]')
+    const dropEvent = new Event('drop') as any
+    dropEvent.preventDefault = vi.fn()
+    dropEvent.dataTransfer = {
+      getData: vi.fn().mockImplementation((type: string) => {
+        if (type === 'text/plain') return JSON.stringify({ conversationId: 'conv-99' })
+        return ''
+      }),
+      types: ['text/plain'],
+    }
+    await dropZone.element.dispatchEvent(dropEvent)
+    await wrapper.vm.$nextTick()
+
+    expect(convStore.assignNode).toHaveBeenCalledWith('conv-99', 'node-1')
+    expect(ctxStore.moveNode).not.toHaveBeenCalled()
   })
 
   it('conversation leaves are draggable with correct dataTransfer payload', async () => {

--- a/frontend/src/components/chat/__tests__/ContextNodeSidebar.test.ts
+++ b/frontend/src/components/chat/__tests__/ContextNodeSidebar.test.ts
@@ -443,6 +443,31 @@ describe('ContextNodeSidebar', () => {
     expect(ctxStore.patchNode).not.toHaveBeenCalled()
   })
 
+  it('cancelRename zeros renameValue so blur-on-teardown does not commit', async () => {
+    // Regression guard for Escape→blur ordering:
+    // cancelRename must zero renameValue before removing the input, so that if
+    // the browser fires blur on DOM teardown, commitRename's !trimmed guard fires.
+    const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
+    const ctxStore = makeContextStore(nodes)
+    mockUseContextStore.mockReturnValue(ctxStore as any)
+    mockUseConversationsStore.mockReturnValue(makeConversationsStore() as any)
+
+    const wrapper = mount(ContextNodeSidebar, { props: { activeNodeId: null } })
+    await wrapper.find('[data-testid="node-row-node-1"]').trigger('dblclick')
+
+    const input = wrapper.find('[data-testid="rename-input-node-1"]')
+    await input.setValue('Beta')
+    // Cancel — renameValue should be zeroed
+    await input.trigger('keydown', { key: 'Escape' })
+    await wrapper.vm.$nextTick()
+
+    // Simulate what the browser does: fire blur after DOM removal
+    const vm = wrapper.vm as any
+    vm.commitRename('node-1', 'Alpha')
+
+    expect(ctxStore.patchNode).not.toHaveBeenCalled()
+  })
+
   it('rename does not call patchNode when value is blank after trim', async () => {
     const nodes = [makeNode({ id: 'node-1', name: 'Alpha', children_count: 0 })]
     const ctxStore = makeContextStore(nodes)


### PR DESCRIPTION
## Summary

Adds four editing affordances to `ContextNodeSidebar.vue`, building on the K1-PR1 layout refactor (#411).

- **Inline rename**: double-click folder name → input pre-filled with current name → Enter/blur commits `patchNode({name})`; Escape cancels; no-op on blank or unchanged name
- **Create folder**: hover "+" button per folder → inline input → Enter calls `createNode(parentId, name)`; "New folder" affordance at bottom of tree calls `createNode(null, name)` for root-level folders
- **Delete folder**: hover trash icon → confirmation overlay with node name + subfolder count (from cached `children_count`, no extra fetch) + "Any conversations inside will move to All conversations." (accurate: backend uses `ON DELETE SET NULL` on conversations.context_node_id); confirm calls `deleteNode`
- **Folder drag-and-drop reparent**: folder rows are `draggable="true"`; dragstart sets `application/x-tether-folder` MIME (distinct from existing conv drag `text/plain`); drop on folder = `moveNode(folderId, targetId)`; drop on "All conversations" row = `moveNode(folderId, null)`; self-drop is a no-op

## Implementation notes

- Backend cascade verified: child nodes `ON DELETE CASCADE`, conversations `ON DELETE SET NULL` (not deleted)
- `isFolderDrag()` checks `dataTransfer.types` defensively (`typeof includes === 'function'`) — handles `DOMStringList` vs array across browser/test environments
- Delete dialog: `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, focus moves to Cancel on open, Escape closes
- All CSS via design tokens (`var(--...)`); no raw hex/rgb — reviewer finding addressed (`#f003` fallback removed, `--shadow-pop` replaces raw rgba)
- Escape→blur race fixed: `cancelRename` zeros `renameValue` before nulling `renamingNodeId` so `commitRename`'s `!trimmed` guard fires if browser dispatches blur on DOM teardown

## Test plan

- [x] 43 `ContextNodeSidebar.test.ts` tests (24 new): rename happy-path, Escape cancel, blur commit, blank guards, create child/root, delete confirm/cancel, subfolder count copy, folder dragstart MIME, folder drop → moveNode, root drop → moveNode(null), self-drop no-op, conv drag still calls assignNode
- [x] Escape→blur regression test (calls `commitRename` directly after cancel, verifies `patchNode` not called)
- [x] `npm run build` — zero TS errors
- [x] 875/875 vitest tests pass (85 test files)
- [x] `pr-review-toolkit:code-reviewer` pass — all 3 findings (≥80%) addressed inline