### PR TITLE
feat(frontend): Beacon wave 7 — pending/rejected conversation actions (D1) + SuppressionsView fill-in (D3)

### DIFF
--- a/frontend/src/components/__tests__/chat/ConversationStateActions.test.ts
+++ b/frontend/src/components/__tests__/chat/ConversationStateActions.test.ts
@@ -5,12 +5,12 @@
  *   pending  → "Approve" (→ open) + "Dismiss" (→ rejected)
  *   rejected → "Restore" (→ open)
  *   open     → overflow "Mark as rejected" option
- *   closed   → no actions (archive state)
+ *   closed   → overflow "Mark as rejected" option (spec §7.2: any conv)
  *
  * The component emits state-change events; the parent calls store.patch().
  * This keeps the component pure and testable without store mocking.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import ConversationStateActions from '../../chat/ConversationStateActions.vue'
@@ -168,13 +168,33 @@ describe('ConversationStateActions — closed state', () => {
     setActivePinia(createPinia())
   })
 
-  it('renders nothing meaningful for closed conversations (archive state)', () => {
+  it('renders overflow button for closed conversations (can still be rejected)', () => {
     const wrapper = mount(ConversationStateActions, {
       props: { state: 'closed', convId: 'conv-4' },
     })
-    // No action buttons for closed/archived convs
+    // No inline approve/dismiss/restore for closed convs
     expect(wrapper.find('[data-testid="btn-approve"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="btn-dismiss"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="btn-restore"]').exists()).toBe(false)
+    // But overflow menu should be present (spec §7.2: any conv can be marked rejected)
+    expect(wrapper.find('[data-testid="btn-overflow"]').exists()).toBe(true)
+  })
+
+  it('clicking overflow exposes Mark-as-rejected for closed conversations', async () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'closed', convId: 'conv-4' },
+    })
+    await wrapper.find('[data-testid="btn-overflow"]').trigger('click')
+    expect(wrapper.find('[data-testid="btn-mark-rejected"]').exists()).toBe(true)
+  })
+
+  it('clicking Mark-as-rejected emits dismiss event for closed conversations', async () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'closed', convId: 'conv-4' },
+    })
+    await wrapper.find('[data-testid="btn-overflow"]').trigger('click')
+    await wrapper.find('[data-testid="btn-mark-rejected"]').trigger('click')
+    expect(wrapper.emitted('dismiss')).toBeTruthy()
+    expect(wrapper.emitted('dismiss')![0]).toEqual(['conv-4'])
   })
 })

--- a/frontend/src/components/__tests__/chat/ConversationStateActions.test.ts
+++ b/frontend/src/components/__tests__/chat/ConversationStateActions.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for ConversationStateActions — Beacon wave 7, D1.
+ *
+ * This component renders appropriate action buttons based on conversation state:
+ *   pending  → "Approve" (→ open) + "Dismiss" (→ rejected)
+ *   rejected → "Restore" (→ open)
+ *   open     → overflow "Mark as rejected" option
+ *   closed   → no actions (archive state)
+ *
+ * The component emits state-change events; the parent calls store.patch().
+ * This keeps the component pure and testable without store mocking.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ConversationStateActions from '../../chat/ConversationStateActions.vue'
+
+describe('ConversationStateActions — pending state', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders Approve and Dismiss buttons for a pending conversation', () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'pending', convId: 'conv-1' },
+    })
+    const text = wrapper.text().toLowerCase()
+    expect(text).toContain('approve')
+    expect(text).toContain('dismiss')
+  })
+
+  it('Approve button has data-testid="btn-approve"', () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'pending', convId: 'conv-1' },
+    })
+    expect(wrapper.find('[data-testid="btn-approve"]').exists()).toBe(true)
+  })
+
+  it('Dismiss button has data-testid="btn-dismiss"', () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'pending', convId: 'conv-1' },
+    })
+    expect(wrapper.find('[data-testid="btn-dismiss"]').exists()).toBe(true)
+  })
+
+  it('clicking Approve emits approve event', async () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'pending', convId: 'conv-1' },
+    })
+    await wrapper.find('[data-testid="btn-approve"]').trigger('click')
+    expect(wrapper.emitted('approve')).toBeTruthy()
+    expect(wrapper.emitted('approve')![0]).toEqual(['conv-1'])
+  })
+
+  it('clicking Dismiss emits dismiss event', async () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'pending', convId: 'conv-1' },
+    })
+    await wrapper.find('[data-testid="btn-dismiss"]').trigger('click')
+    expect(wrapper.emitted('dismiss')).toBeTruthy()
+    expect(wrapper.emitted('dismiss')![0]).toEqual(['conv-1'])
+  })
+
+  it('Approve button is disabled when loading=true', async () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'pending', convId: 'conv-1', loading: true },
+    })
+    const approveBtn = wrapper.find('[data-testid="btn-approve"]')
+    expect(approveBtn.attributes('disabled')).toBeDefined()
+  })
+
+  it('Dismiss button is disabled when loading=true', async () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'pending', convId: 'conv-1', loading: true },
+    })
+    const dismissBtn = wrapper.find('[data-testid="btn-dismiss"]')
+    expect(dismissBtn.attributes('disabled')).toBeDefined()
+  })
+
+  it('does NOT render Restore button for pending', () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'pending', convId: 'conv-1' },
+    })
+    expect(wrapper.find('[data-testid="btn-restore"]').exists()).toBe(false)
+  })
+})
+
+describe('ConversationStateActions — rejected state', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders Restore button for a rejected conversation', () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'rejected', convId: 'conv-2' },
+    })
+    expect(wrapper.text().toLowerCase()).toContain('restore')
+  })
+
+  it('Restore button has data-testid="btn-restore"', () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'rejected', convId: 'conv-2' },
+    })
+    expect(wrapper.find('[data-testid="btn-restore"]').exists()).toBe(true)
+  })
+
+  it('clicking Restore emits restore event with convId', async () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'rejected', convId: 'conv-2' },
+    })
+    await wrapper.find('[data-testid="btn-restore"]').trigger('click')
+    expect(wrapper.emitted('restore')).toBeTruthy()
+    expect(wrapper.emitted('restore')![0]).toEqual(['conv-2'])
+  })
+
+  it('does NOT render Approve or Dismiss for rejected', () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'rejected', convId: 'conv-2' },
+    })
+    expect(wrapper.find('[data-testid="btn-approve"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="btn-dismiss"]').exists()).toBe(false)
+  })
+})
+
+describe('ConversationStateActions — open state', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders a "Mark as rejected" overflow option for open conversations', () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'open', convId: 'conv-3' },
+    })
+    // The overflow button should exist
+    expect(wrapper.find('[data-testid="btn-overflow"]').exists()).toBe(true)
+  })
+
+  it('clicking overflow exposes Mark-as-rejected option', async () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'open', convId: 'conv-3' },
+    })
+    await wrapper.find('[data-testid="btn-overflow"]').trigger('click')
+    expect(wrapper.find('[data-testid="btn-mark-rejected"]').exists()).toBe(true)
+  })
+
+  it('clicking Mark-as-rejected emits dismiss event', async () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'open', convId: 'conv-3' },
+    })
+    await wrapper.find('[data-testid="btn-overflow"]').trigger('click')
+    await wrapper.find('[data-testid="btn-mark-rejected"]').trigger('click')
+    expect(wrapper.emitted('dismiss')).toBeTruthy()
+    expect(wrapper.emitted('dismiss')![0]).toEqual(['conv-3'])
+  })
+
+  it('does NOT render Approve, Dismiss, or Restore inline for open', () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'open', convId: 'conv-3' },
+    })
+    expect(wrapper.find('[data-testid="btn-approve"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="btn-dismiss"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="btn-restore"]').exists()).toBe(false)
+  })
+})
+
+describe('ConversationStateActions — closed state', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders nothing meaningful for closed conversations (archive state)', () => {
+    const wrapper = mount(ConversationStateActions, {
+      props: { state: 'closed', convId: 'conv-4' },
+    })
+    // No action buttons for closed/archived convs
+    expect(wrapper.find('[data-testid="btn-approve"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="btn-dismiss"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="btn-restore"]').exists()).toBe(false)
+  })
+})

--- a/frontend/src/components/chat/ConversationStateActions.vue
+++ b/frontend/src/components/chat/ConversationStateActions.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+/**
+ * ConversationStateActions — Beacon wave 7, D1.
+ *
+ * Renders context-appropriate action buttons based on conversation state:
+ *   pending  → "Approve" (→ open) + "Dismiss" (→ rejected)
+ *   rejected → "Restore" (→ open)
+ *   open     → overflow "⋮" button → "Mark as rejected" menu item
+ *   closed   → nothing (archive state)
+ *
+ * Emits events; parent is responsible for calling store.patch() / store.discard().
+ * This keeps the component store-free and easy to test.
+ */
+import { ref } from 'vue'
+import type { ConversationState } from '../../types/conversations'
+
+const props = withDefaults(defineProps<{
+  convId: string
+  state: ConversationState
+  loading?: boolean
+}>(), {
+  loading: false,
+})
+
+const emit = defineEmits<{
+  /** User approved a pending conversation — parent should PATCH state → 'open'. */
+  approve: [convId: string]
+  /**
+   * User dismissed/rejected a conversation — parent should call store.discard().
+   * Note: spec §7.2 requires a beacon_suppressions row on dismiss. When the
+   * /api/conversations/{id}/discard endpoint ships (Phase 5), the store.discard()
+   * method should call that instead of PATCH state=rejected.
+   */
+  dismiss: [convId: string]
+  /** User restored a rejected conversation — parent should PATCH state → 'open'. */
+  restore: [convId: string]
+}>()
+
+// Overflow menu open/closed (for open conversations)
+const overflowOpen = ref(false)
+
+function toggleOverflow() {
+  overflowOpen.value = !overflowOpen.value
+}
+
+function closeOverflow() {
+  overflowOpen.value = false
+}
+
+function onApprove() {
+  if (props.loading) return
+  emit('approve', props.convId)
+}
+
+function onDismiss() {
+  if (props.loading) return
+  closeOverflow()
+  emit('dismiss', props.convId)
+}
+
+function onRestore() {
+  if (props.loading) return
+  emit('restore', props.convId)
+}
+</script>
+
+<template>
+  <!-- Pending: Approve + Dismiss side-by-side -->
+  <template v-if="state === 'pending'">
+    <div class="flex items-center gap-1">
+      <button
+        type="button"
+        data-testid="btn-approve"
+        class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium transition-colors"
+        :class="loading
+          ? 'opacity-50 cursor-not-allowed bg-[--bg-3] text-[--fg-4]'
+          : 'bg-green-500 text-white hover:bg-green-600'"
+        :disabled="loading"
+        @click.stop="onApprove"
+      >
+        ✓ Approve
+      </button>
+      <button
+        type="button"
+        data-testid="btn-dismiss"
+        class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium transition-colors"
+        :class="loading
+          ? 'opacity-50 cursor-not-allowed bg-[--bg-3] text-[--fg-4]'
+          : 'bg-[--bg-3] text-[--fg-3] hover:bg-[--status-block-bg] hover:text-[--status-block-fg]'"
+        :disabled="loading"
+        @click.stop="onDismiss"
+      >
+        ✕ Dismiss
+      </button>
+    </div>
+  </template>
+
+  <!-- Rejected: Restore button -->
+  <template v-else-if="state === 'rejected'">
+    <button
+      type="button"
+      data-testid="btn-restore"
+      class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium transition-colors"
+      :class="loading
+        ? 'opacity-50 cursor-not-allowed bg-[--bg-3] text-[--fg-4]'
+        : 'bg-[--bg-3] text-[--fg-3] hover:bg-[--accent] hover:text-[--accent-fg]'"
+      :disabled="loading"
+      @click.stop="onRestore"
+    >
+      ↩ Restore
+    </button>
+  </template>
+
+  <!-- Open: overflow menu with "Mark as rejected" -->
+  <template v-else-if="state === 'open'">
+    <div class="relative">
+      <button
+        type="button"
+        data-testid="btn-overflow"
+        class="px-1.5 py-0.5 rounded text-xs text-[--fg-4] hover:text-[--fg-2] hover:bg-[--bg-3] transition-colors"
+        :aria-label="'Conversation options'"
+        @click.stop="toggleOverflow"
+      >
+        ⋮
+      </button>
+
+      <!-- Overflow dropdown -->
+      <div
+        v-if="overflowOpen"
+        class="absolute right-0 top-full mt-1 z-50 min-w-36 rounded-lg border border-[--border-1] bg-[--bg-elev-2] shadow-lg py-1"
+        @click.stop
+      >
+        <button
+          type="button"
+          data-testid="btn-mark-rejected"
+          class="w-full text-left px-3 py-1.5 text-xs text-[--fg-2] hover:bg-[--bg-elev-3] transition-colors"
+          @click="onDismiss"
+        >
+          Mark as rejected
+        </button>
+      </div>
+    </div>
+  </template>
+
+  <!-- Closed: no actions -->
+</template>

--- a/frontend/src/components/chat/ConversationStateActions.vue
+++ b/frontend/src/components/chat/ConversationStateActions.vue
@@ -6,7 +6,7 @@
  *   pending  → "Approve" (→ open) + "Dismiss" (→ rejected)
  *   rejected → "Restore" (→ open)
  *   open     → overflow "⋮" button → "Mark as rejected" menu item
- *   closed   → nothing (archive state)
+ *   closed   → overflow "⋮" button → "Mark as rejected" (spec §7.2: any conv)
  *
  * Emits events; parent is responsible for calling store.patch() / store.discard().
  * This keeps the component store-free and easy to test.
@@ -111,8 +111,8 @@ function onRestore() {
     </button>
   </template>
 
-  <!-- Open: overflow menu with "Mark as rejected" -->
-  <template v-else-if="state === 'open'">
+  <!-- Open / closed: overflow menu with "Mark as rejected" (spec §7.2) -->
+  <template v-else-if="state === 'open' || state === 'closed'">
     <div class="relative">
       <button
         type="button"
@@ -142,5 +142,5 @@ function onRestore() {
     </div>
   </template>
 
-  <!-- Closed: no actions -->
+
 </template>

--- a/frontend/src/components/chat/ConversationView.vue
+++ b/frontend/src/components/chat/ConversationView.vue
@@ -7,6 +7,7 @@ import { useConnectionsStore } from '../../stores/connections'
 import AgentPicker from '../AgentPicker.vue'
 import PriorityPill from './PriorityPill.vue'
 import StateToggle from './StateToggle.vue'
+import ConversationStateActions from './ConversationStateActions.vue'
 import type { ConversationMessage, ConversationPriority, ConversationState } from '../../types/conversations'
 
 const store = useConversationsStore()
@@ -238,6 +239,40 @@ async function onStateChange(s: ConversationState) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Pending / rejected state actions (D1)
+// ---------------------------------------------------------------------------
+
+async function onApprove(convId: string) {
+  if (patchingState.value) return
+  patchingState.value = true
+  try {
+    await store.patch(convId, { state: 'open' })
+  } finally {
+    patchingState.value = false
+  }
+}
+
+async function onDismiss(convId: string) {
+  if (patchingState.value) return
+  patchingState.value = true
+  try {
+    await store.discard(convId)
+  } finally {
+    patchingState.value = false
+  }
+}
+
+async function onRestore(convId: string) {
+  if (patchingState.value) return
+  patchingState.value = true
+  try {
+    await store.patch(convId, { state: 'open' })
+  } finally {
+    patchingState.value = false
+  }
+}
+
 async function loadOlder() {
   if (!selectedId.value || !scrollEl.value) return
   const firstMsgId = messages.value[0]?.id
@@ -308,10 +343,23 @@ function renderBody(body: string): string {
           {{ selected.folder_name }}
         </span>
 
+        <!-- Open/closed toggle — only shown for open & closed states.
+             Pending/rejected use ConversationStateActions instead. -->
         <StateToggle
+          v-if="selected.state === 'open' || selected.state === 'closed'"
           :state="selected.state"
           :loading="patchingState"
           @change="onStateChange"
+        />
+
+        <!-- Pending / rejected actions + open overflow (D1) -->
+        <ConversationStateActions
+          :conv-id="selected.id"
+          :state="selected.state"
+          :loading="patchingState"
+          @approve="onApprove"
+          @dismiss="onDismiss"
+          @restore="onRestore"
         />
       </div>
 

--- a/frontend/src/components/chat/FolderCenterPanel.vue
+++ b/frontend/src/components/chat/FolderCenterPanel.vue
@@ -4,6 +4,7 @@ import { useConversationsStore } from '../../stores/conversations'
 import { useContextStore } from '../../stores/context'
 import type { ContextNode } from '../../stores/context'
 import type { ConversationDetail } from '../../types/conversations'
+import ConversationStateActions from './ConversationStateActions.vue'
 
 const props = defineProps<{ nodeId: string | null }>()
 const emit  = defineEmits<{ 'open-conversation': [id: string] }>()
@@ -56,6 +57,43 @@ async function startChat() {
 
 function onDragStart(conv: ConversationDetail, evt: DragEvent) {
   evt.dataTransfer?.setData('text/plain', JSON.stringify({ conversationId: conv.id }))
+}
+
+// ---------------------------------------------------------------------------
+// State actions (D1) — approve/dismiss/restore pending & rejected convs
+// ---------------------------------------------------------------------------
+
+const actionLoading = ref<string | null>(null) // convId currently being patched
+
+async function onApprove(convId: string) {
+  if (actionLoading.value) return
+  actionLoading.value = convId
+  try {
+    await convStore.patch(convId, { state: 'open' })
+    emit('open-conversation', convId)
+  } finally {
+    actionLoading.value = null
+  }
+}
+
+async function onDismiss(convId: string) {
+  if (actionLoading.value) return
+  actionLoading.value = convId
+  try {
+    await convStore.discard(convId)
+  } finally {
+    actionLoading.value = null
+  }
+}
+
+async function onRestore(convId: string) {
+  if (actionLoading.value) return
+  actionLoading.value = convId
+  try {
+    await convStore.patch(convId, { state: 'open' })
+  } finally {
+    actionLoading.value = null
+  }
 }
 
 function formatTime(iso: string): string {
@@ -132,19 +170,51 @@ function formatTime(iso: string): string {
         v-for="conv in conversations"
         :key="conv.id"
         :data-testid="`conv-row-${conv.id}`"
+        :data-state="conv.state"
         class="convitem"
+        :class="{
+          'convitem--pending': conv.state === 'pending',
+          'convitem--rejected': conv.state === 'rejected',
+        }"
         draggable="true"
         @click="emit('open-conversation', conv.id)"
         @dragstart="onDragStart(conv, $event)"
       >
-        <span class="convitem__dot" :class="{ 'convitem__dot--on': conv.priority === 'urgent' || conv.priority === 'high' }" />
+        <!-- State dot: pending = amber, urgent/high = accent, else hidden -->
+        <span
+          class="convitem__dot"
+          :class="{
+            'convitem__dot--on': conv.priority === 'urgent' || conv.priority === 'high',
+            'convitem__dot--pending': conv.state === 'pending',
+          }"
+        />
         <div class="convitem__body">
-          <div class="convitem__title">{{ conv.name }}</div>
+          <div class="convitem__title" :class="{ 'convitem__title--muted': conv.state === 'rejected' }">
+            {{ conv.name }}
+            <!-- "Awaiting reply" badge for pending convs -->
+            <span
+              v-if="conv.state === 'pending'"
+              data-pending-badge
+              class="convitem__pending-badge"
+            >
+              ⏳ Awaiting
+            </span>
+          </div>
           <div class="convitem__meta">
             <span class="convitem__ts">{{ formatTime(conv.last_message_at) }}</span>
             <span class="convitem__path">{{ pathSegs.join(' › ') }}</span>
           </div>
         </div>
+
+        <!-- State actions: approve/dismiss for pending, restore for rejected, overflow for open -->
+        <ConversationStateActions
+          :conv-id="conv.id"
+          :state="conv.state"
+          :loading="actionLoading === conv.id"
+          @approve="onApprove"
+          @dismiss="onDismiss"
+          @restore="onRestore"
+        />
       </div>
     </div>
 
@@ -255,4 +325,22 @@ function formatTime(iso: string): string {
   font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-5);
 }
 .convitem__path { color: var(--fg-6); }
+
+/* Pending / rejected state variants */
+.convitem--pending { background: var(--status-important-bg, hsl(45 100% 97%)); }
+.convitem--pending:hover { background: var(--status-important-bg, hsl(45 100% 95%)); }
+.convitem--rejected { opacity: 0.55; }
+.convitem__dot--pending {
+  visibility: visible;
+  background: var(--status-important, hsl(38 92% 50%));
+}
+.convitem__title--muted { color: var(--fg-4); }
+.convitem__pending-badge {
+  display: inline-flex; align-items: center;
+  margin-left: 6px;
+  font-size: 10px; font-weight: 500;
+  padding: 1px 5px; border-radius: 9999px;
+  background: var(--status-important-bg); color: var(--status-important-fg);
+  vertical-align: middle;
+}
 </style>

--- a/frontend/src/stores/__tests__/conversations.test.ts
+++ b/frontend/src/stores/__tests__/conversations.test.ts
@@ -255,6 +255,37 @@ describe('useConversationsStore', () => {
     })
   })
 
+  describe('discard()', () => {
+    it('PATCHes state=rejected and updates list in place', async () => {
+      mockApi.mockResolvedValue({ ok: true } as Response)
+      const store = useConversationsStore()
+      store.list = [makeConv({ id: 'conv-9', state: 'pending' })]
+
+      const ok = await store.discard('conv-9')
+
+      expect(ok).toBe(true)
+      expect(mockApi).toHaveBeenCalledWith(
+        '/api/conversations/conv-9',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ state: 'rejected' }),
+        }),
+      )
+      expect(store.list[0].state).toBe('rejected')
+    })
+
+    it('returns false on API failure', async () => {
+      mockApi.mockResolvedValue({ ok: false } as Response)
+      const store = useConversationsStore()
+      store.list = [makeConv({ id: 'conv-9', state: 'pending' })]
+
+      const ok = await store.discard('conv-9')
+      expect(ok).toBe(false)
+      // List should not be mutated on failure
+      expect(store.list[0].state).toBe('pending')
+    })
+  })
+
   describe('appendMessage()', () => {
     it('appends to existing messages', () => {
       const store = useConversationsStore()

--- a/frontend/src/stores/conversations.ts
+++ b/frontend/src/stores/conversations.ts
@@ -100,6 +100,18 @@ export const useConversationsStore = defineStore('conversations', () => {
     setMessages(conversationId, [...msgs, msg])
   }
 
+  /**
+   * Discard a conversation: transitions state → 'rejected'.
+   *
+   * Phase 5 TODO: when POST /api/conversations/{id}/discard ships, call that
+   * endpoint instead of PATCH so that a beacon_suppressions row is also written
+   * (preventing Beacon from re-dispatching immediately). Until then this is
+   * Option A — state change only, no suppression write.
+   */
+  async function discard(conversationId: string): Promise<boolean> {
+    return patch(conversationId, { state: 'rejected' })
+  }
+
   async function assignNode(conversationId: string, nodeId: string | null): Promise<void> {
     const res = await api(`/api/conversations/${conversationId}`, {
       method: 'PATCH',
@@ -125,5 +137,5 @@ export const useConversationsStore = defineStore('conversations', () => {
     return conv
   }
 
-  return { list, selectedId, selected, messagesById, hasMoreById, loading, error, refresh, create, patch, select, loadMessages, loadMessagesOlder, appendMessage, assignNode, fetchOne }
+  return { list, selectedId, selected, messagesById, hasMoreById, loading, error, refresh, create, patch, discard, select, loadMessages, loadMessagesOlder, appendMessage, assignNode, fetchOne }
 })

--- a/frontend/src/stores/conversations.ts
+++ b/frontend/src/stores/conversations.ts
@@ -103,10 +103,21 @@ export const useConversationsStore = defineStore('conversations', () => {
   /**
    * Discard a conversation: transitions state → 'rejected'.
    *
-   * Phase 5 TODO: when POST /api/conversations/{id}/discard ships, call that
-   * endpoint instead of PATCH so that a beacon_suppressions row is also written
-   * (preventing Beacon from re-dispatching immediately). Until then this is
-   * Option A — state change only, no suppression write.
+   * ⚠️  KNOWN DEBT — Option A implementation:
+   * This call transitions conversation state to `rejected` but does NOT write a
+   * `beacon_suppressions` row (the table doesn't exist yet — landing in
+   * pool-builder's Beacon Phase 3 PR 1). When that PR merges, a follow-up PR
+   * will upgrade this to call `POST /api/conversations/{id}/discard`, which
+   * atomically writes state + suppression row. Until then, dismissals from this
+   * period will not be recorded as suppressions; Beacon (when Phase 5 ships)
+   * may re-dispatch the same checkpoint patterns the user already dismissed.
+   *
+   * TODO (Phase 5): replace with:
+   *   const res = await api(`/api/conversations/${conversationId}/discard`, { method: 'POST' })
+   *   if (!res.ok) return false
+   *   const idx = list.value.findIndex(c => c.id === conversationId)
+   *   if (idx !== -1) list.value[idx].state = 'rejected'
+   *   return true
    */
   async function discard(conversationId: string): Promise<boolean> {
     return patch(conversationId, { state: 'rejected' })

--- a/frontend/src/stores/suppressions.ts
+++ b/frontend/src/stores/suppressions.ts
@@ -7,6 +7,13 @@ export interface BeaconSuppression {
   scope_key: string
   reason: string | null
   source: 'user_rejection' | 'beacon_decision' | 'system'
+  /**
+   * Checkpoint type that triggered this suppression (e.g. 'anchor_transition',
+   * 'task_overdue'). Added to the type in wave 7 to support client-side
+   * filter chips in SuppressionsView. Backend will echo this field when
+   * Phase 5 suppression endpoint ships.
+   */
+  checkpoint_type?: string | null
   created_at: string
   expires_at: string | null
 }

--- a/frontend/src/views/SuppressionsView.vue
+++ b/frontend/src/views/SuppressionsView.vue
@@ -1,13 +1,52 @@
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useAuthStore } from '../stores/auth'
 import { useSuppressionsStore } from '../stores/suppressions'
+import type { BeaconSuppression } from '../stores/suppressions'
 
 const auth = useAuthStore()
 const store = useSuppressionsStore()
 
 // Beacon is premium-only. Treat absent is_paid as free.
 const isPaid = computed(() => auth.user?.is_paid === true)
+
+// ---------------------------------------------------------------------------
+// Filter state (client-side; ready for backend filter params in Phase 5)
+// ---------------------------------------------------------------------------
+
+const CHECKPOINT_TYPES = [
+  { label: 'All',               value: 'all' },
+  { label: 'Anchor transition', value: 'anchor_transition' },
+  { label: 'Task overdue',      value: 'task_overdue' },
+  { label: 'Post-conversation', value: 'post_conversation' },
+  { label: 'EOD',               value: 'eod' },
+  { label: 'Other',             value: 'other' },
+] as const
+
+type CheckpointFilter = typeof CHECKPOINT_TYPES[number]['value']
+
+const activeFilter = ref<CheckpointFilter>('all')
+
+const filtered = computed<BeaconSuppression[]>(() => {
+  if (activeFilter.value === 'all') return store.suppressions
+  if (activeFilter.value === 'other') {
+    const known = CHECKPOINT_TYPES
+      .filter(t => t.value !== 'all' && t.value !== 'other')
+      .map(t => t.value as string)
+    return store.suppressions.filter(s => !known.includes(s.checkpoint_type ?? ''))
+  }
+  return store.suppressions.filter(s => s.checkpoint_type === activeFilter.value)
+})
+
+function formatRelative(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  return `${Math.floor(hrs / 24)}d ago`
+}
 
 onMounted(() => {
   if (isPaid.value) {
@@ -44,10 +83,45 @@ onMounted(() => {
 
     <!-- Paid user content -->
     <template v-else>
-      <!-- Loading -->
-      <div v-if="store.loading" class="text-sm text-[--fg-4] py-8 text-center">
-        Loading…
+
+      <!-- Filter chips by checkpoint type -->
+      <div class="flex flex-wrap gap-1.5 mb-5" aria-label="Filter by checkpoint type">
+        <button
+          v-for="chip in CHECKPOINT_TYPES"
+          :key="chip.value"
+          type="button"
+          :data-testid="`filter-chip-${chip.value}`"
+          :aria-pressed="activeFilter === chip.value ? 'true' : 'false'"
+          class="text-xs px-3 py-1 rounded-full border transition-colors"
+          :class="activeFilter === chip.value
+            ? 'bg-[--accent] text-[--accent-fg] border-[--accent]'
+            : 'bg-[--bg-2] text-[--fg-3] border-[--border-1] hover:bg-[--bg-3]'"
+          @click="activeFilter = chip.value"
+        >
+          {{ chip.label }}
+        </button>
       </div>
+
+      <!-- Loading — skeleton items -->
+      <ul
+        v-if="store.loading"
+        class="space-y-2"
+        aria-busy="true"
+        aria-label="Loading suppressions"
+      >
+        <li
+          v-for="n in 4"
+          :key="n"
+          :data-testid="`skeleton-item-${n}`"
+          class="rounded-lg border border-[--border-1] bg-[--bg-elev-1] px-4 py-3 animate-pulse"
+        >
+          <div class="flex items-start justify-between gap-2">
+            <div class="h-3 w-40 rounded bg-[--bg-3]" />
+            <div class="h-3 w-16 rounded bg-[--bg-3] flex-shrink-0" />
+          </div>
+          <div class="h-2.5 w-60 rounded bg-[--bg-3] mt-2" />
+        </li>
+      </ul>
 
       <!-- Error -->
       <div
@@ -57,31 +131,57 @@ onMounted(() => {
         Could not load suppression history. {{ store.error }}
       </div>
 
-      <!-- Empty state -->
+      <!-- Empty state (no suppressions at all) -->
       <div
         v-else-if="store.suppressions.length === 0"
+        data-testid="empty-state"
         class="rounded-xl border border-dashed border-[--border-2] bg-[--bg-elev-1] px-6 py-12 text-center"
       >
         <p class="text-3xl mb-3">🔕</p>
-        <h2 class="font-medium text-[--fg-2] mb-1">No suppressed events yet</h2>
-        <p class="text-sm text-[--fg-4]">
-          When Beacon decides not to notify you about something, it will appear here
-          so you can see what it filtered out.
+        <h2 class="font-medium text-[--fg-2] mb-2">No suppressed events yet</h2>
+        <p class="text-sm text-[--fg-4] max-w-sm mx-auto leading-relaxed">
+          When Beacon decides not to send you a notification — because you're
+          already active, because you posted recently, or because it applied a
+          cooldown — it logs the decision here so you can see what it filtered
+          out and why.
         </p>
       </div>
 
-      <!-- Suppression list (shown once backend ships) -->
+      <!-- Filtered empty state (suppressions exist but current filter hides them all) -->
+      <div
+        v-else-if="filtered.length === 0"
+        class="rounded-lg border border-[--border-1] bg-[--bg-elev-1] px-4 py-6 text-center text-sm text-[--fg-4]"
+      >
+        No suppressions match this filter.
+        <button
+          type="button"
+          class="ml-1 text-[--accent] hover:underline"
+          @click="activeFilter = 'all'"
+        >
+          Clear filter
+        </button>
+      </div>
+
+      <!-- Suppression list (shown when backend ships data) -->
       <ul v-else class="space-y-2">
         <li
-          v-for="s in store.suppressions"
+          v-for="s in filtered"
           :key="s.id"
           class="rounded-lg border border-[--border-1] bg-[--bg-elev-1] px-4 py-3 text-sm"
         >
           <div class="flex items-start justify-between gap-2">
-            <span class="text-[--fg-2] font-mono text-xs">{{ s.scope_key }}</span>
-            <span class="text-[--fg-5] text-xs flex-shrink-0">{{ s.source }}</span>
+            <!-- scope_key — monospaced for readability -->
+            <span class="text-[--fg-2] font-mono text-xs truncate">{{ s.scope_key }}</span>
+            <div class="flex items-center gap-2 flex-shrink-0">
+              <span class="text-[--fg-5] text-xs">{{ s.source }}</span>
+              <span class="text-[--fg-6] text-xs">{{ formatRelative(s.created_at) }}</span>
+            </div>
           </div>
-          <p v-if="s.reason" class="text-[--fg-3] mt-1">{{ s.reason }}</p>
+          <p v-if="s.reason" class="text-[--fg-3] mt-1 text-xs">{{ s.reason }}</p>
+          <!-- Expiry note if set -->
+          <p v-if="s.expires_at" class="text-[--fg-5] mt-0.5 text-xs italic">
+            Expires {{ formatRelative(s.expires_at) }}
+          </p>
         </li>
       </ul>
     </template>

--- a/frontend/src/views/__tests__/SuppressionsView.test.ts
+++ b/frontend/src/views/__tests__/SuppressionsView.test.ts
@@ -82,3 +82,131 @@ describe('SuppressionsView', () => {
 
 // Store-level tests (404 handling, 200, network error) are in:
 // stores/__tests__/suppressions.test.ts — isolated to avoid vi.mock hoisting interference.
+
+// ── D3: Suppression view fill-in ─────────────────────────────────────────────
+
+function makeSuppression(overrides = {}) {
+  return {
+    id: 's-1',
+    scope_key: 'anchor_transition:grind_am',
+    reason: 'User posted recently',
+    source: 'beacon_decision' as const,
+    created_at: '2026-05-21T08:00:00Z',
+    expires_at: null,
+    checkpoint_type: 'anchor_transition',
+    ...overrides,
+  }
+}
+
+describe('SuppressionsView — filter chips (D3)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders checkpoint-type filter chips for paid users', () => {
+    vi.mocked(useAuthStore).mockReturnValue(makeAuthStore(true) as unknown as ReturnType<typeof useAuthStore>)
+    vi.mocked(useSuppressionsStore).mockReturnValue(
+      makeSuppressionsStore({ suppressions: [makeSuppression()] }) as unknown as ReturnType<typeof useSuppressionsStore>
+    )
+    const wrapper = mount(SuppressionsView)
+    // Should render some filter chips — at minimum an "All" chip
+    const chips = wrapper.findAll('[data-testid^="filter-chip"]')
+    expect(chips.length).toBeGreaterThan(0)
+  })
+
+  it('has an "All" filter chip that is active by default', () => {
+    vi.mocked(useAuthStore).mockReturnValue(makeAuthStore(true) as unknown as ReturnType<typeof useAuthStore>)
+    vi.mocked(useSuppressionsStore).mockReturnValue(
+      makeSuppressionsStore({ suppressions: [makeSuppression()] }) as unknown as ReturnType<typeof useSuppressionsStore>
+    )
+    const wrapper = mount(SuppressionsView)
+    const allChip = wrapper.find('[data-testid="filter-chip-all"]')
+    expect(allChip.exists()).toBe(true)
+    expect(allChip.attributes('aria-pressed')).toBe('true')
+  })
+
+  it('filter chips do not render for free users', () => {
+    vi.mocked(useAuthStore).mockReturnValue(makeAuthStore(false) as unknown as ReturnType<typeof useAuthStore>)
+    vi.mocked(useSuppressionsStore).mockReturnValue(makeSuppressionsStore() as unknown as ReturnType<typeof useSuppressionsStore>)
+    const wrapper = mount(SuppressionsView)
+    expect(wrapper.find('[data-testid="filter-chip-all"]').exists()).toBe(false)
+  })
+})
+
+describe('SuppressionsView — enriched empty state (D3)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('empty state explains what suppressions are', () => {
+    vi.mocked(useAuthStore).mockReturnValue(makeAuthStore(true) as unknown as ReturnType<typeof useAuthStore>)
+    vi.mocked(useSuppressionsStore).mockReturnValue(makeSuppressionsStore() as unknown as ReturnType<typeof useSuppressionsStore>)
+    const wrapper = mount(SuppressionsView)
+    const text = wrapper.text().toLowerCase()
+    // Should explain that Beacon suppressed notifications
+    expect(text).toMatch(/beacon|notif/)
+    // Should give user a reason why this is useful
+    expect(text).toMatch(/filter|skip|suppress|decid/)
+  })
+
+  it('empty state has a meaningful headline (not just "No suppressed events yet")', () => {
+    vi.mocked(useAuthStore).mockReturnValue(makeAuthStore(true) as unknown as ReturnType<typeof useAuthStore>)
+    vi.mocked(useSuppressionsStore).mockReturnValue(makeSuppressionsStore() as unknown as ReturnType<typeof useSuppressionsStore>)
+    const wrapper = mount(SuppressionsView)
+    const emptyBlock = wrapper.find('[data-testid="empty-state"]')
+    expect(emptyBlock.exists()).toBe(true)
+  })
+})
+
+describe('SuppressionsView — skeleton loading (D3)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('shows skeleton items while loading instead of a plain "Loading…" text', () => {
+    vi.mocked(useAuthStore).mockReturnValue(makeAuthStore(true) as unknown as ReturnType<typeof useAuthStore>)
+    vi.mocked(useSuppressionsStore).mockReturnValue(
+      makeSuppressionsStore({ loading: true }) as unknown as ReturnType<typeof useSuppressionsStore>
+    )
+    const wrapper = mount(SuppressionsView)
+    const skeletons = wrapper.findAll('[data-testid^="skeleton-item"]')
+    expect(skeletons.length).toBeGreaterThan(0)
+  })
+
+  it('does not show skeleton items when not loading', () => {
+    vi.mocked(useAuthStore).mockReturnValue(makeAuthStore(true) as unknown as ReturnType<typeof useAuthStore>)
+    vi.mocked(useSuppressionsStore).mockReturnValue(makeSuppressionsStore() as unknown as ReturnType<typeof useSuppressionsStore>)
+    const wrapper = mount(SuppressionsView)
+    expect(wrapper.find('[data-testid^="skeleton-item"]').exists()).toBe(false)
+  })
+})
+
+describe('SuppressionsView — data items (D3)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders suppression items with scope_key, source, and creation date', () => {
+    vi.mocked(useAuthStore).mockReturnValue(makeAuthStore(true) as unknown as ReturnType<typeof useAuthStore>)
+    vi.mocked(useSuppressionsStore).mockReturnValue(
+      makeSuppressionsStore({
+        suppressions: [makeSuppression({ id: 's-10', scope_key: 'task_overdue:task-42', source: 'user_rejection', reason: 'Dismissed by user' })],
+      }) as unknown as ReturnType<typeof useSuppressionsStore>
+    )
+    const wrapper = mount(SuppressionsView)
+    const text = wrapper.text()
+    expect(text).toContain('task_overdue')
+    expect(text).toContain('user_rejection')
+  })
+
+  it('renders suppression reason when present', () => {
+    vi.mocked(useAuthStore).mockReturnValue(makeAuthStore(true) as unknown as ReturnType<typeof useAuthStore>)
+    vi.mocked(useSuppressionsStore).mockReturnValue(
+      makeSuppressionsStore({
+        suppressions: [makeSuppression({ reason: 'Active cooldown in effect' })],
+      }) as unknown as ReturnType<typeof useSuppressionsStore>
+    )
+    const wrapper = mount(SuppressionsView)
+    expect(wrapper.text()).toContain('Active cooldown in effect')
+  })
+})


### PR DESCRIPTION
## Summary

Beacon FE wave 7. Two deliverables bundled into one PR:

### D1 — Pending/rejected conversation state actions

**New component: `ConversationStateActions.vue`** (emits-based, store-free)
- `pending` → **Approve** (patch → open) + **Dismiss** (discard → rejected)
- `rejected` → **Restore** (patch → open)
- `open` / `closed` → overflow ⋮ → **Mark as rejected** (spec §7.2: any conv can be rejected)
- Props: `convId`, `state`, `loading`; emits: `approve`, `dismiss`, `restore`

**Store: `conversations.ts`**
- New `discard(conversationId)` action — transitions state → `rejected`

**Wired into:**
- `ConversationView.vue` — header bar; `StateToggle` now conditional on open/closed only
- `FolderCenterPanel.vue` — conv list cards with per-conv loading guard, pending badge (⏳), state-driven CSS classes (`convitem--pending`, `convitem--rejected`)

### D3 — SuppressionsView fill-in

- **Filter chips** — 6 checkpoint types (All / anchor_transition / task_overdue / post_conversation / eod / other); client-side filter; `data-testid="filter-chip-{value}"` + `aria-pressed`
- **Skeleton loading** — 4 animated skeleton items while `store.loading`; `data-testid="skeleton-item-{n}"`
- **Enriched empty state** — explanatory copy: when Beacon decides not to notify, the decision is logged here so users understand what filtered out and why
- **Filtered empty state** — "No suppressions match this filter. Clear filter" link
- **Relative timestamps** — `formatRelative()` helper for `created_at` and `expires_at`
- **`BeaconSuppression.checkpoint_type`** — added optional field to store interface (wave 7 type prep)
- 404 graceful pattern preserved — backend endpoint not yet implemented

---

## Known limitation — `discard()` uses Option A

The dismiss/reject action transitions conversation state to `rejected` but does **NOT** write a `beacon_suppressions` row (the table doesn't exist yet — landing in `pool-builder`'s Beacon Phase 3 PR 1). When that PR merges, a follow-up PR will upgrade `discard()` to call a `POST /api/conversations/{id}/discard` endpoint that atomically writes state + suppression row. Until then, dismissals from this period will not be recorded as suppressions; Beacon (when Phase 5 ships) may re-dispatch the same checkpoint patterns the user already dismissed during the Option A window.

The inline `discard()` comment in `conversations.ts` documents this fully with the Phase 5 upgrade path.

---

## Test plan

- [ ] 878 Vitest tests pass (86 test files) — `npm run build` clean (zero vue-tsc errors)
- [ ] `ConversationStateActions.test.ts` — 19 tests cover all 4 states: pending (Approve+Dismiss), rejected (Restore), open (overflow+mark-rejected), closed (overflow+mark-rejected)
- [ ] `conversations.test.ts` — `discard()` tests: PATCH state=rejected on success; returns false + no list mutation on failure
- [ ] `SuppressionsView.test.ts` — filter chips, skeleton items, empty state, data items
- [ ] `pr-review-toolkit:code-reviewer` pass — no findings ≥80% confidence