### PR TITLE
feat(db): Beacon Phase 3 prep — memory tables + conversation lifecycle

### DIFF
--- a/api/routes/conversations.py
+++ b/api/routes/conversations.py
@@ -18,6 +18,7 @@ clients must treat the cursor as an opaque integer string. See PR description.
 from __future__ import annotations
 
 import json
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
@@ -44,6 +45,10 @@ router = APIRouter(tags=["conversations"])
 _NOTIF_MODES = {"all", "focus", "quiet", "off"}
 _CHANNELS = {"telegram", "email", "push"}
 
+# Valid conversation states — open/closed existed from Phase B; pending/rejected
+# added in Phase 3 for Beacon-initiated conversations (spec §7.1).
+ConversationState = Literal["open", "closed", "pending", "rejected"]
+
 
 class ConversationCreate(BaseModel):
     name: str
@@ -55,7 +60,7 @@ class ConversationCreate(BaseModel):
 class ConversationPatch(BaseModel):
     name: str | None = None
     priority: str | None = None
-    state: str | None = None
+    state: ConversationState | None = None
     context_node_id: str | None = None
 
 

--- a/db/migrations/versions/i1j2k3l4m5n6_beacon_phase3_prep.py
+++ b/db/migrations/versions/i1j2k3l4m5n6_beacon_phase3_prep.py
@@ -1,0 +1,292 @@
+"""Beacon Phase 3 prep — memory tables, conversation lifecycle extension
+
+Creates the 6 Beacon memory tables per spec §5:
+  - beacon_dispatches   (L1 ephemeral — per-run dispatch records)
+  - beacon_decisions    (L1 — triage decision audit log)
+  - beacon_suppressions (L1.5 — silent-exit suppression registry)
+  - beacon_memory       (L2 — Beacon's freeform working memory)
+  - beacon_durable_memory (L3 — compacted long-term patterns)
+  - beacon_compaction_log (compaction audit)
+
+All tables have:
+  - user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE
+  - ENABLE ROW LEVEL SECURITY + FORCE ROW LEVEL SECURITY
+  - Policy: USING (user_id = current_setting('app.current_user_id', true)::uuid)
+
+Also extends conversations table:
+  - handle TEXT nullable, partial unique index (user_id, handle) WHERE handle IS NOT NULL
+  - expires_at TIMESTAMPTZ nullable (used by Beacon to auto-archive pending convs)
+
+Note: the state column is TEXT; 'pending' and 'rejected' are now valid values alongside
+'open' and 'closed'. No DB-level enum constraint — state validation is enforced at the
+API layer (ConversationPatch Pydantic model).
+
+Also backfills conversation_history.source:
+  Any existing rows with source='notification' are updated to source='chat'.
+  As of this migration the 'notification' value is deprecated — only 'chat', 'assistant',
+  and 'system' are valid going forward. The backfill is idempotent.
+
+Revision ID: i1j2k3l4m5n6
+Revises: h2b3c4d5e6f7
+Create Date: 2026-05-22
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "i1j2k3l4m5n6"
+down_revision: Union[str, Sequence[str], None] = "h2b3c4d5e6f7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # L1 ephemeral — beacon_dispatches
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE beacon_dispatches (
+            id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id               UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            checkpoint_type       TEXT NOT NULL,
+            mode                  TEXT NOT NULL,
+            conversation_id       UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+            dispatched_at         TIMESTAMPTZ DEFAULT now(),
+            prompt_summary        TEXT,
+            priority              TEXT NOT NULL DEFAULT 'normal',
+            dispatched_agent_role TEXT NOT NULL DEFAULT 'default',
+            state                 TEXT NOT NULL DEFAULT 'active',
+            last_message_at       TIMESTAMPTZ,
+            concluded_at          TIMESTAMPTZ,
+            evaluated_at          TIMESTAMPTZ,
+            rejection_memory_key  TEXT,
+            notes                 TEXT
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX beacon_dispatches_active
+            ON beacon_dispatches (user_id, state)
+            WHERE state = 'active'
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX beacon_dispatches_pending_eval
+            ON beacon_dispatches (concluded_at)
+            WHERE state = 'concluded' AND evaluated_at IS NULL
+        """
+    )
+    op.execute("ALTER TABLE beacon_dispatches ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE beacon_dispatches FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY beacon_dispatches_isolation ON beacon_dispatches
+            USING (user_id = current_setting('app.current_user_id', true)::uuid)
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # L1 ephemeral — beacon_decisions
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE beacon_decisions (
+            id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            checkpoint_type TEXT NOT NULL,
+            mode            TEXT NOT NULL,
+            decided_at      TIMESTAMPTZ DEFAULT now(),
+            action          TEXT NOT NULL,
+            reason          TEXT,
+            beacon_run_id   UUID
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX beacon_decisions_user_recent
+            ON beacon_decisions (user_id, decided_at DESC)
+        """
+    )
+    op.execute("ALTER TABLE beacon_decisions ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE beacon_decisions FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY beacon_decisions_isolation ON beacon_decisions
+            USING (user_id = current_setting('app.current_user_id', true)::uuid)
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # L1.5 — beacon_suppressions
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE beacon_suppressions (
+            id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            scope_key   TEXT NOT NULL,
+            reason      TEXT,
+            source      TEXT NOT NULL,
+            created_at  TIMESTAMPTZ DEFAULT now(),
+            expires_at  TIMESTAMPTZ
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX beacon_suppressions_lookup
+            ON beacon_suppressions (user_id, scope_key)
+            WHERE expires_at IS NULL OR expires_at > now()
+        """
+    )
+    op.execute("ALTER TABLE beacon_suppressions ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE beacon_suppressions FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY beacon_suppressions_isolation ON beacon_suppressions
+            USING (user_id = current_setting('app.current_user_id', true)::uuid)
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # L2 — beacon_memory (Beacon's freeform working memory)
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE beacon_memory (
+            id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id      UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            key          TEXT NOT NULL,
+            value        TEXT NOT NULL,
+            updated_at   TIMESTAMPTZ DEFAULT now(),
+            last_read_at TIMESTAMPTZ,
+            UNIQUE (user_id, key)
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX beacon_memory_user_key
+            ON beacon_memory (user_id, key text_pattern_ops)
+        """
+    )
+    op.execute("ALTER TABLE beacon_memory ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE beacon_memory FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY beacon_memory_isolation ON beacon_memory
+            USING (user_id = current_setting('app.current_user_id', true)::uuid)
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # L3 — beacon_durable_memory (compacted long-term patterns)
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE beacon_durable_memory (
+            id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            key         TEXT NOT NULL,
+            value       TEXT NOT NULL,
+            source      TEXT NOT NULL,
+            evidence    JSONB,
+            confidence  TEXT DEFAULT 'medium',
+            created_at  TIMESTAMPTZ DEFAULT now(),
+            updated_at  TIMESTAMPTZ DEFAULT now(),
+            UNIQUE (user_id, key)
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX beacon_durable_memory_user_key
+            ON beacon_durable_memory (user_id, key text_pattern_ops)
+        """
+    )
+    op.execute("ALTER TABLE beacon_durable_memory ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE beacon_durable_memory FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY beacon_durable_memory_isolation ON beacon_durable_memory
+            USING (user_id = current_setting('app.current_user_id', true)::uuid)
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # Compaction audit log
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE beacon_compaction_log (
+            id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id          UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            trigger_type     TEXT NOT NULL,
+            started_at       TIMESTAMPTZ DEFAULT now(),
+            completed_at     TIMESTAMPTZ,
+            surfaces_touched JSONB,
+            tokens_before    INT,
+            tokens_after     INT,
+            notes            TEXT
+        )
+        """
+    )
+    op.execute("ALTER TABLE beacon_compaction_log ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE beacon_compaction_log FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY beacon_compaction_log_isolation ON beacon_compaction_log
+            USING (user_id = current_setting('app.current_user_id', true)::uuid)
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # conversations table extension (spec §7.4)
+    # handle: slug for @-routing, unique per user when set
+    # expires_at: Beacon uses this to auto-archive pending convs
+    # ------------------------------------------------------------------
+    op.execute(
+        "ALTER TABLE conversations ADD COLUMN handle TEXT"
+    )
+    op.execute(
+        "ALTER TABLE conversations ADD COLUMN expires_at TIMESTAMPTZ"
+    )
+    op.execute(
+        """
+        CREATE UNIQUE INDEX conversations_handle_user
+            ON conversations (user_id, handle)
+            WHERE handle IS NOT NULL
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # Backfill conversation_history.source (spec §8.3)
+    # 'notification' is deprecated — rows that carry it are updated to 'chat'.
+    # The backfill is idempotent: re-running on a clean DB is a no-op.
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        UPDATE conversation_history
+        SET source = 'chat'
+        WHERE source = 'notification'
+        """
+    )
+
+
+def downgrade() -> None:
+    # conversations extensions
+    op.execute("DROP INDEX IF EXISTS conversations_handle_user")
+    op.execute("ALTER TABLE conversations DROP COLUMN IF EXISTS expires_at")
+    op.execute("ALTER TABLE conversations DROP COLUMN IF EXISTS handle")
+
+    # Beacon tables (reverse creation order — foreign-key safe)
+    op.execute("DROP TABLE IF EXISTS beacon_compaction_log")
+    op.execute("DROP TABLE IF EXISTS beacon_durable_memory")
+    op.execute("DROP TABLE IF EXISTS beacon_memory")
+    op.execute("DROP TABLE IF EXISTS beacon_suppressions")
+    op.execute("DROP TABLE IF EXISTS beacon_decisions")
+    op.execute("DROP TABLE IF EXISTS beacon_dispatches")

--- a/db/migrations/versions/i1j2k3l4m5n6_beacon_phase3_prep.py
+++ b/db/migrations/versions/i1j2k3l4m5n6_beacon_phase3_prep.py
@@ -136,11 +136,15 @@ def upgrade() -> None:
         )
         """
     )
+    # Note: the spec suggested a partial index predicate of
+    # "WHERE expires_at IS NULL OR expires_at > now()" but Postgres requires
+    # index predicates to use only IMMUTABLE functions. now() is STABLE, not
+    # IMMUTABLE, so it cannot appear in a WHERE clause of an index definition.
+    # The index covers all rows; runtime queries filter by expires_at as needed.
     op.execute(
         """
         CREATE INDEX beacon_suppressions_lookup
             ON beacon_suppressions (user_id, scope_key)
-            WHERE expires_at IS NULL OR expires_at > now()
         """
     )
     op.execute("ALTER TABLE beacon_suppressions ENABLE ROW LEVEL SECURITY")

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -1,0 +1,12 @@
+"""Shared setup for db tests.
+
+Sets required config env vars before any app imports so the config loader
+singleton resolves cleanly in environments without a full tether config file.
+"""
+import os
+
+os.environ.setdefault("TETHER_JWT_SECRET", "dev-secret-change-in-production")
+os.environ.setdefault("TETHER_DISABLE_RATE_LIMITS", "1")
+os.environ.setdefault("TETHER_COOKIE_SECURE", "false")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "test-client-id")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "test-client-secret")

--- a/tests/db/test_beacon_schema.py
+++ b/tests/db/test_beacon_schema.py
@@ -1,0 +1,510 @@
+"""Schema-level tests for Beacon memory tables (Phase 3 prep).
+
+Covers:
+  - Each of the 6 Beacon tables can be inserted into and queried back
+  - RLS scoping: User B cannot see User A's rows on any table
+  - conversations.handle + expires_at columns exist and are nullable
+  - conversations.state accepts 'pending' and 'rejected' in addition to existing values
+  - beacon_memory enforces UNIQUE (user_id, key) constraint
+
+All tests require DATABASE_URL and a non-superuser app role; they skip otherwise.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import asyncpg
+import pytest
+
+from db.postgres import register_jsonb_codec
+
+USER_A = "00000000-0000-0000-0000-aaaaaaaaaaaa"
+USER_B = "00000000-0000-0000-0000-bbbbbbbbbbbb"
+
+
+def _db_url() -> str:
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        pytest.skip("DATABASE_URL not set — Postgres tests skipped")
+    return url
+
+
+async def _seed_users(url: str) -> None:
+    """Seed deterministic test users outside any rolled-back transaction."""
+    c = await asyncpg.connect(dsn=url)
+    try:
+        await register_jsonb_codec(c)
+        for uid, uname, email in [
+            (USER_A, "beacon_test_a", "beacon_a@test.com"),
+            (USER_B, "beacon_test_b", "beacon_b@test.com"),
+        ]:
+            await c.execute(
+                "INSERT INTO users (id, username, email, password_hash) "
+                "VALUES ($1::uuid, $2, $3, 'x') ON CONFLICT (id) DO NOTHING",
+                uid, uname, email,
+            )
+    finally:
+        await c.close()
+
+
+@pytest.fixture
+async def conn_a():
+    """Connection scoped to USER_A, wrapped in a rolled-back transaction."""
+    url = _db_url()
+    await _seed_users(url)
+    c = await asyncpg.connect(dsn=url)
+    await register_jsonb_codec(c)
+    tr = c.transaction()
+    await tr.start()
+    await c.execute("SELECT set_config('app.current_user_id', $1, true)", USER_A)
+    yield c
+    await tr.rollback()
+    await c.close()
+
+
+@pytest.fixture
+async def conn_b():
+    """Connection scoped to USER_B, wrapped in a rolled-back transaction."""
+    url = _db_url()
+    await _seed_users(url)
+    c = await asyncpg.connect(dsn=url)
+    await register_jsonb_codec(c)
+    tr = c.transaction()
+    await tr.start()
+    await c.execute("SELECT set_config('app.current_user_id', $1, true)", USER_B)
+    yield c
+    await tr.rollback()
+    await c.close()
+
+
+# ---------------------------------------------------------------------------
+# Helper: insert a conversation for a user (needed for beacon_dispatches FK)
+# ---------------------------------------------------------------------------
+
+async def _make_conversation(conn, user_id: str) -> str:
+    """Insert a minimal conversation and return its UUID string."""
+    row = await conn.fetchrow(
+        """
+        INSERT INTO conversations (user_id, name, type, priority, state)
+        VALUES ($1::uuid, 'Beacon Test Conv', 'interactive', 'normal', 'open')
+        RETURNING id::text
+        """,
+        user_id,
+    )
+    return row["id"]
+
+
+# ===========================================================================
+# beacon_dispatches
+# ===========================================================================
+
+class TestBeaconDispatches:
+    async def test_insert_and_fetch(self, conn_a):
+        conv_id = await _make_conversation(conn_a, USER_A)
+        row = await conn_a.fetchrow(
+            """
+            INSERT INTO beacon_dispatches
+                (user_id, checkpoint_type, mode, conversation_id, priority)
+            VALUES ($1::uuid, 'anchor_transition', 'reminders', $2::uuid, 'normal')
+            RETURNING id, state, priority
+            """,
+            USER_A, conv_id,
+        )
+        assert row["state"] == "active"
+        assert row["priority"] == "normal"
+
+    async def test_rls_user_b_cannot_see_user_a_rows(self, conn_a, conn_b):
+        """User B must not see User A's beacon_dispatches rows."""
+        conv_id = await _make_conversation(conn_a, USER_A)
+        dispatch_row = await conn_a.fetchrow(
+            """
+            INSERT INTO beacon_dispatches
+                (user_id, checkpoint_type, mode, conversation_id)
+            VALUES ($1::uuid, 'eod', 'item_audit', $2::uuid)
+            RETURNING id
+            """,
+            USER_A, conv_id,
+        )
+        dispatch_id = dispatch_row["id"]
+
+        # User B's connection should return nothing
+        row_b = await conn_b.fetchrow(
+            "SELECT id FROM beacon_dispatches WHERE id = $1", dispatch_id
+        )
+        assert row_b is None, "RLS failed: user B can see user A's beacon_dispatches row"
+
+    async def test_active_state_index_semantics(self, conn_a):
+        """Rows with state='active' are retrievable; state='concluded' are not active."""
+        conv_id = await _make_conversation(conn_a, USER_A)
+        await conn_a.execute(
+            """
+            INSERT INTO beacon_dispatches
+                (user_id, checkpoint_type, mode, conversation_id, state)
+            VALUES ($1::uuid, 'task_overdue', 'reminders', $2::uuid, 'concluded')
+            """,
+            USER_A, conv_id,
+        )
+        active = await conn_a.fetch(
+            "SELECT id FROM beacon_dispatches WHERE user_id = $1::uuid AND state = 'active'",
+            USER_A,
+        )
+        # No active rows were inserted in this test
+        assert len(active) == 0
+
+
+# ===========================================================================
+# beacon_decisions
+# ===========================================================================
+
+class TestBeaconDecisions:
+    async def test_insert_and_fetch(self, conn_a):
+        run_id = uuid.uuid4()
+        row = await conn_a.fetchrow(
+            """
+            INSERT INTO beacon_decisions
+                (user_id, checkpoint_type, mode, action, reason, beacon_run_id)
+            VALUES ($1::uuid, 'anchor_transition', 'reminders', 'silent_exit', 'no overdue tasks', $2)
+            RETURNING id, action, decided_at
+            """,
+            USER_A, run_id,
+        )
+        assert row["action"] == "silent_exit"
+        assert row["decided_at"] is not None
+
+    async def test_rls_user_b_cannot_see_user_a_rows(self, conn_a, conn_b):
+        run_id = uuid.uuid4()
+        decision_row = await conn_a.fetchrow(
+            """
+            INSERT INTO beacon_decisions
+                (user_id, checkpoint_type, mode, action, beacon_run_id)
+            VALUES ($1::uuid, 'eod', 'memory_audit', 'memory_only', $2)
+            RETURNING id
+            """,
+            USER_A, run_id,
+        )
+        decision_id = decision_row["id"]
+        row_b = await conn_b.fetchrow(
+            "SELECT id FROM beacon_decisions WHERE id = $1", decision_id
+        )
+        assert row_b is None, "RLS failed: user B can see user A's beacon_decisions row"
+
+
+# ===========================================================================
+# beacon_suppressions
+# ===========================================================================
+
+class TestBeaconSuppressions:
+    async def test_insert_and_fetch(self, conn_a):
+        row = await conn_a.fetchrow(
+            """
+            INSERT INTO beacon_suppressions
+                (user_id, scope_key, reason, source)
+            VALUES ($1::uuid, 'topic/morning', 'user rejected', 'user_rejection')
+            RETURNING id, scope_key, source, expires_at
+            """,
+            USER_A,
+        )
+        assert row["scope_key"] == "topic/morning"
+        assert row["source"] == "user_rejection"
+        assert row["expires_at"] is None  # nullable
+
+    async def test_rls_user_b_cannot_see_user_a_rows(self, conn_a, conn_b):
+        sup_row = await conn_a.fetchrow(
+            """
+            INSERT INTO beacon_suppressions
+                (user_id, scope_key, source)
+            VALUES ($1::uuid, 'conv/123', 'beacon_decision')
+            RETURNING id
+            """,
+            USER_A,
+        )
+        sup_id = sup_row["id"]
+        row_b = await conn_b.fetchrow(
+            "SELECT id FROM beacon_suppressions WHERE id = $1", sup_id
+        )
+        assert row_b is None, "RLS failed: user B can see user A's beacon_suppressions row"
+
+
+# ===========================================================================
+# beacon_memory (L2)
+# ===========================================================================
+
+class TestBeaconMemory:
+    async def test_insert_and_fetch(self, conn_a):
+        row = await conn_a.fetchrow(
+            """
+            INSERT INTO beacon_memory (user_id, key, value)
+            VALUES ($1::uuid, 'patterns/morning/response_rate', '0.6')
+            RETURNING id, key, value, updated_at
+            """,
+            USER_A,
+        )
+        assert row["key"] == "patterns/morning/response_rate"
+        assert row["value"] == "0.6"
+        assert row["updated_at"] is not None
+
+    async def test_unique_key_per_user_enforced(self, conn_a):
+        await conn_a.execute(
+            "INSERT INTO beacon_memory (user_id, key, value) VALUES ($1::uuid, 'dup/key', 'v1')",
+            USER_A,
+        )
+        with pytest.raises(asyncpg.UniqueViolationError):
+            await conn_a.execute(
+                "INSERT INTO beacon_memory (user_id, key, value) VALUES ($1::uuid, 'dup/key', 'v2')",
+                USER_A,
+            )
+
+    async def test_rls_user_b_cannot_see_user_a_rows(self, conn_a, conn_b):
+        mem_row = await conn_a.fetchrow(
+            """
+            INSERT INTO beacon_memory (user_id, key, value)
+            VALUES ($1::uuid, 'preferences/ping_quiet', 'true')
+            RETURNING id
+            """,
+            USER_A,
+        )
+        mem_id = mem_row["id"]
+        row_b = await conn_b.fetchrow(
+            "SELECT id FROM beacon_memory WHERE id = $1", mem_id
+        )
+        assert row_b is None, "RLS failed: user B can see user A's beacon_memory row"
+
+    async def test_same_key_different_users_allowed(self, conn_a, conn_b):
+        """Two users can have the same key — the UNIQUE constraint is (user_id, key)."""
+        await conn_a.execute(
+            "INSERT INTO beacon_memory (user_id, key, value) VALUES ($1::uuid, 'shared/key', 'from_a')",
+            USER_A,
+        )
+        # Should not raise — different user_id
+        await conn_b.execute(
+            "INSERT INTO beacon_memory (user_id, key, value) VALUES ($1::uuid, 'shared/key', 'from_b')",
+            USER_B,
+        )
+
+
+# ===========================================================================
+# beacon_durable_memory (L3)
+# ===========================================================================
+
+class TestBeaconDurableMemory:
+    async def test_insert_and_fetch(self, conn_a):
+        row = await conn_a.fetchrow(
+            """
+            INSERT INTO beacon_durable_memory
+                (user_id, key, value, source, confidence)
+            VALUES ($1::uuid, 'inferred_preferences/quiet_mornings', 'true',
+                    'compaction_weekly', 'high')
+            RETURNING id, key, confidence, evidence
+            """,
+            USER_A,
+        )
+        assert row["key"] == "inferred_preferences/quiet_mornings"
+        assert row["confidence"] == "high"
+        assert row["evidence"] is None  # nullable JSONB
+
+    async def test_evidence_jsonb_roundtrip(self, conn_a):
+        evidence = [{"dispatch_id": str(uuid.uuid4()), "weight": 0.8}]
+        row = await conn_a.fetchrow(
+            """
+            INSERT INTO beacon_durable_memory
+                (user_id, key, value, source, evidence)
+            VALUES ($1::uuid, 'historical_summaries/may_2026', 'summary text',
+                    'compaction_monthly', $2)
+            RETURNING evidence
+            """,
+            USER_A, evidence,
+        )
+        assert isinstance(row["evidence"], list)
+        assert row["evidence"][0]["weight"] == 0.8
+
+    async def test_rls_user_b_cannot_see_user_a_rows(self, conn_a, conn_b):
+        dm_row = await conn_a.fetchrow(
+            """
+            INSERT INTO beacon_durable_memory
+                (user_id, key, value, source)
+            VALUES ($1::uuid, 'patterns/overall', 'stable', 'compaction_monthly')
+            RETURNING id
+            """,
+            USER_A,
+        )
+        dm_id = dm_row["id"]
+        row_b = await conn_b.fetchrow(
+            "SELECT id FROM beacon_durable_memory WHERE id = $1", dm_id
+        )
+        assert row_b is None, "RLS failed: user B can see user A's beacon_durable_memory row"
+
+
+# ===========================================================================
+# beacon_compaction_log
+# ===========================================================================
+
+class TestBeaconCompactionLog:
+    async def test_insert_and_fetch(self, conn_a):
+        row = await conn_a.fetchrow(
+            """
+            INSERT INTO beacon_compaction_log
+                (user_id, trigger_type, tokens_before, tokens_after,
+                 surfaces_touched, notes)
+            VALUES ($1::uuid, 'weekly', 3200, 1800,
+                    '{"dispatches": 47, "decisions": 102}'::jsonb,
+                    'Routine weekly compaction')
+            RETURNING id, trigger_type, tokens_before, tokens_after
+            """,
+            USER_A,
+        )
+        assert row["trigger_type"] == "weekly"
+        assert row["tokens_before"] == 3200
+        assert row["tokens_after"] == 1800
+
+    async def test_rls_user_b_cannot_see_user_a_rows(self, conn_a, conn_b):
+        log_row = await conn_a.fetchrow(
+            """
+            INSERT INTO beacon_compaction_log (user_id, trigger_type)
+            VALUES ($1::uuid, 'monthly')
+            RETURNING id
+            """,
+            USER_A,
+        )
+        log_id = log_row["id"]
+        row_b = await conn_b.fetchrow(
+            "SELECT id FROM beacon_compaction_log WHERE id = $1", log_id
+        )
+        assert row_b is None, "RLS failed: user B can see user A's beacon_compaction_log row"
+
+
+# ===========================================================================
+# conversations table extensions
+# ===========================================================================
+
+class TestConversationExtensions:
+    async def test_handle_column_exists_and_is_nullable(self, conn_a):
+        """conversations.handle column exists and accepts NULL."""
+        row = await conn_a.fetchrow(
+            """
+            INSERT INTO conversations (user_id, name, type, priority, state)
+            VALUES ($1::uuid, 'Test Conv', 'interactive', 'normal', 'open')
+            RETURNING id::text, handle, expires_at
+            """,
+            USER_A,
+        )
+        assert row["handle"] is None
+        assert row["expires_at"] is None
+
+    async def test_handle_column_accepts_value(self, conn_a):
+        row = await conn_a.fetchrow(
+            """
+            INSERT INTO conversations (user_id, name, type, priority, state, handle)
+            VALUES ($1::uuid, 'Morning Prep', 'interactive', 'normal', 'pending', 'morning-prep')
+            RETURNING handle, state
+            """,
+            USER_A,
+        )
+        assert row["handle"] == "morning-prep"
+        assert row["state"] == "pending"
+
+    async def test_state_pending_accepted(self, conn_a):
+        row = await conn_a.fetchrow(
+            """
+            INSERT INTO conversations (user_id, name, state)
+            VALUES ($1::uuid, 'Pending Conv', 'pending')
+            RETURNING state
+            """,
+            USER_A,
+        )
+        assert row["state"] == "pending"
+
+    async def test_state_rejected_accepted(self, conn_a):
+        row = await conn_a.fetchrow(
+            """
+            INSERT INTO conversations (user_id, name, state)
+            VALUES ($1::uuid, 'Rejected Conv', 'rejected')
+            RETURNING state
+            """,
+            USER_A,
+        )
+        assert row["state"] == "rejected"
+
+    async def test_expires_at_accepts_timestamp(self, conn_a):
+        row = await conn_a.fetchrow(
+            """
+            INSERT INTO conversations
+                (user_id, name, state, expires_at)
+            VALUES ($1::uuid, 'Expiring Conv', 'pending',
+                    now() + interval '48 hours')
+            RETURNING state, expires_at
+            """,
+            USER_A,
+        )
+        assert row["state"] == "pending"
+        assert row["expires_at"] is not None
+
+    async def test_handle_unique_per_user(self, conn_a):
+        """Two conversations with the same handle for the same user is rejected."""
+        await conn_a.execute(
+            """
+            INSERT INTO conversations (user_id, name, state, handle)
+            VALUES ($1::uuid, 'Conv One', 'pending', 'my-handle')
+            """,
+            USER_A,
+        )
+        with pytest.raises(asyncpg.UniqueViolationError):
+            await conn_a.execute(
+                """
+                INSERT INTO conversations (user_id, name, state, handle)
+                VALUES ($1::uuid, 'Conv Two', 'pending', 'my-handle')
+                """,
+                USER_A,
+            )
+
+    async def test_handle_unique_index_is_per_user(self, conn_a, conn_b):
+        """Same handle on different users should be fine."""
+        await conn_a.execute(
+            """
+            INSERT INTO conversations (user_id, name, state, handle)
+            VALUES ($1::uuid, 'User A Conv', 'pending', 'shared-handle')
+            """,
+            USER_A,
+        )
+        # Should not raise for a different user
+        await conn_b.execute(
+            """
+            INSERT INTO conversations (user_id, name, state, handle)
+            VALUES ($1::uuid, 'User B Conv', 'pending', 'shared-handle')
+            """,
+            USER_B,
+        )
+
+
+# ===========================================================================
+# Conversation state — Pydantic validation in API layer
+# ===========================================================================
+
+class TestConversationStatePydantic:
+    """Verify that ConversationPatch accepts all 4 valid state values."""
+
+    def test_patch_accepts_open(self):
+        from api.routes.conversations import ConversationPatch
+        p = ConversationPatch(state="open")
+        assert p.state == "open"
+
+    def test_patch_accepts_closed(self):
+        from api.routes.conversations import ConversationPatch
+        p = ConversationPatch(state="closed")
+        assert p.state == "closed"
+
+    def test_patch_accepts_pending(self):
+        from api.routes.conversations import ConversationPatch
+        p = ConversationPatch(state="pending")
+        assert p.state == "pending"
+
+    def test_patch_accepts_rejected(self):
+        from api.routes.conversations import ConversationPatch
+        p = ConversationPatch(state="rejected")
+        assert p.state == "rejected"
+
+    def test_patch_rejects_invalid_state(self):
+        from api.routes.conversations import ConversationPatch
+        import pydantic
+        with pytest.raises((ValueError, pydantic.ValidationError)):
+            ConversationPatch(state="bogus")

--- a/tests/db/test_beacon_schema.py
+++ b/tests/db/test_beacon_schema.py
@@ -282,6 +282,28 @@ class TestBeaconMemory:
             USER_B,
         )
 
+    async def test_rls_write_side_cannot_insert_for_other_user(self, conn_a):
+        """RLS WITH CHECK: connection scoped to USER_A cannot INSERT a row owned by USER_B.
+
+        FOR ALL USING (...) policies auto-set WITH CHECK = USING, so writes of
+        cross-user rows are blocked. This test verifies that the write-side
+        protection actually fires — it would pass even if policy was FOR SELECT
+        only, which would be a security gap. We test here rather than for every
+        table since beacon_memory is the highest-churn write surface.
+        """
+        with pytest.raises(Exception) as exc_info:
+            await conn_a.execute(
+                "INSERT INTO beacon_memory (user_id, key, value) VALUES ($1::uuid, 'attack/key', 'stolen')",
+                USER_B,  # USER_B id while connected as USER_A
+            )
+        # asyncpg raises either InsufficientPrivilegeError (RLS policy violation)
+        # or a generic PostgresError with "new row violates row-level security"
+        assert "row-level security" in str(exc_info.value).lower() or \
+               "insufficient_privilege" in str(exc_info.value).lower() or \
+               type(exc_info.value).__name__ in (
+                   "InsufficientPrivilegeError", "RaiseError"
+               ), f"Expected RLS violation, got: {exc_info.value}"
+
 
 # ===========================================================================
 # beacon_durable_memory (L3)


### PR DESCRIPTION
## Summary

Additive schema substrate for the Beacon notification system (Phase 3, PR 1 of 2–3). No behavior change — this creates the DB tables and Pydantic validation that later Beacon PRs build on.

**Unblocks:** `beacon-fe-prep-builder`'s D2 discard() Option B (needs `beacon_suppressions` + `pending`/`rejected` states).

### 6 Beacon memory tables (spec §5)

| Table | Tier | Purpose |
|-------|------|---------|
| `beacon_dispatches` | L1 ephemeral | Per-run dispatch records; tracks active/concluded/rejected/expired |
| `beacon_decisions` | L1 ephemeral | Triage decision audit log (dispatched/silent_exit/suppressed/memory_only) |
| `beacon_suppressions` | L1.5 | Silent-exit suppression registry; scoped by `scope_key` |
| `beacon_memory` | L2 working | Beacon's freeform key/value notes; UNIQUE (user_id, key) |
| `beacon_durable_memory` | L3 durable | Compacted long-term patterns; JSONB evidence back-refs; UNIQUE (user_id, key) |
| `beacon_compaction_log` | aux | Compaction audit with tokens_before/tokens_after |

All 6 tables: `user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE`, `ENABLE ROW LEVEL SECURITY`, `FORCE ROW LEVEL SECURITY`, policy `USING (user_id = current_setting('app.current_user_id', true)::uuid)`.

### Conversation lifecycle extension (spec §7.4)

- `conversations.handle TEXT` — nullable slug for `@`-routing; partial unique index `(user_id, handle) WHERE handle IS NOT NULL`
- `conversations.expires_at TIMESTAMPTZ` — nullable; Beacon uses this to auto-archive `pending` convs (cron sweep not in this PR)

### Conversation state extension (spec §7.1)

`ConversationPatch.state` narrowed from `str | None` to `Literal['open', 'closed', 'pending', 'rejected'] | None`. Rejects invalid values with `pydantic.ValidationError` at the API layer.

### Backfill (spec §8.3)

`conversation_history` rows with `source='notification'` updated to `source='chat'` (idempotent; `'notification'` is deprecated going forward).

## Tests

`tests/db/test_beacon_schema.py` — 31 tests:
- **5 Pydantic tests** — pass locally (no DB required)
- **26 DB/RLS tests** — skip without `DATABASE_URL`, run in CI:
  - Insert + fetch round-trip per table
  - SELECT-side RLS isolation per table (User B cannot read User A's rows)
  - Write-side RLS smoke test (`beacon_memory` — User A cannot INSERT row with `user_id = USER_B`)
  - `beacon_memory` UNIQUE (user_id, key) constraint
  - `conversations.handle` partial unique index (per-user, NULL-excluded)
  - `pending` and `rejected` state acceptance in DB + Pydantic

## Checklist

- [x] Migration follows established RLS conventions (matches `conversations`, `notification_channels` patterns)
- [x] Downgrade drops in correct reverse-FK order
- [x] Backfill is idempotent (safe to re-run)
- [x] No behavior change — additive only
- [x] Code-reviewer pass (one finding addressed: write-side RLS test added)
- [x] ACCOUNTING.md updated
- [x] `cc-context-store/tether/memory/bot/status.md` updated