### PR TITLE
fix(pool): auth propagation + zombie subprocess cleanup

### DIFF
--- a/agent_pool_manager/config.py
+++ b/agent_pool_manager/config.py
@@ -39,6 +39,11 @@ class AgentPoolConfig:
     control_response_timeout_seconds: float = 60.0
     """Seconds the pool waits for a control_response before denying the tool call."""
 
+    connect_timeout_seconds: float = 15.0
+    """Max seconds to wait for ClaudeSDKClient.connect() before treating the spawn
+    as failed.  Must be shorter than prime_timeout_seconds so a hung transport
+    is detected and killed before the priming phase would time out anyway."""
+
 
 _FIELD_NAMES = {f.name for f in fields(AgentPoolConfig)}
 

--- a/agent_pool_manager/pool.py
+++ b/agent_pool_manager/pool.py
@@ -312,7 +312,35 @@ class Pool:
             can_use_tool=self._make_forwarding_callback(ctx),
         )
         client = ClaudeSDKClient(options=sdk_options)
-        await client.connect()
+        try:
+            await asyncio.wait_for(
+                client.connect(),
+                timeout=self.config.connect_timeout_seconds,
+            )
+        except Exception:
+            # Kill the underlying subprocess so a failed spawn doesn't leave a
+            # zombie Claude CLI process holding memory until the OS cleans it up.
+            # This covers both auth failures (70 s timeout) and other errors.
+            try:
+                transport = getattr(client, "_transport", None)
+                proc = getattr(transport, "_process", None) if transport is not None else None
+                if proc is not None:
+                    proc.kill()
+                    # asyncio.subprocess.Process.wait() is a coroutine; a
+                    # synchronous subprocess.Popen.wait() is not.  Guard against
+                    # the sync case so a future SDK transport change doesn't
+                    # silently suppress the TypeError and leave zombies.
+                    if asyncio.iscoroutinefunction(getattr(proc, "wait", None)):
+                        await proc.wait()
+                    else:
+                        log.warning(
+                            "pool.cleanup: proc.wait() is not a coroutine for hash=%s"
+                            " — skipping await; subprocess may remain as zombie",
+                            options_hash,
+                        )
+            except Exception:
+                pass
+            raise
 
         # Prime: send a cheap prompt so the subprocess pays its init cost now
         try:

--- a/api/routes/pool.py
+++ b/api/routes/pool.py
@@ -120,27 +120,29 @@ async def pool_warm(
                    f"Valid versions: {sorted(agent_options)}",
         )
 
-    # Inject the user's OAuth token so the pool subprocess can authenticate.
-    # Vault is None in dev/Pi (subprocess uses disk credentials instead).
-    options_for_hint = dict(options)
-    vault = getattr(request.app.state, "vault", None)
-    if vault is not None:
-        try:
-            async with vault.materialize(user_id) as env_dict:
-                options_for_hint = {**options, "env": env_dict}
-        except ValueError:
-            log.warning(
-                "pool_warm: no vault credentials for user_id=%s agent_version=%s"
-                " — hint will fire without env (subprocess may fail to authenticate)",
-                user_id,
-                body.agent_version,
-            )
+    vault = request.app.state.vault
+    if vault is None:
+        log.error(
+            "pool_warm: vault is not configured — set VAULT_KEY in the environment. "
+            "Pool warming requires vault to inject OAuth credentials into subprocesses."
+        )
+        return {"hinted": False, "options_hash": _compute_options_hash(options)}
 
-    # Hash is computed from options_for_hint (after env injection) so the warm
-    # queue partition matches the acquire-side hash in interactive_agent_layer.
-    # When env contains a per-user OAuth token, warm partitions are per-user —
-    # this is intentional: a subprocess authenticated as user A must not serve
-    # user B's requests.
+    try:
+        async with vault.materialize(user_id) as env_dict:
+            options_for_hint = {**options, "env": env_dict}
+    except ValueError:
+        log.warning(
+            "pool_warm: no vault credentials for user_id=%s agent_version=%s"
+            " — user must connect their Anthropic account first",
+            user_id,
+            body.agent_version,
+        )
+        return {"hinted": False, "options_hash": _compute_options_hash(options)}
+
+    # Hash computed after env injection so the warm partition matches the
+    # acquire-side hash in interactive_agent_layer. Partitions are per-user —
+    # a subprocess authenticated as user A must not serve user B.
     options_hash = _compute_options_hash(options_for_hint)
 
     pool_client = _get_pool_client(request)

--- a/api/routes/pool.py
+++ b/api/routes/pool.py
@@ -120,12 +120,34 @@ async def pool_warm(
                    f"Valid versions: {sorted(agent_options)}",
         )
 
-    options_hash = _compute_options_hash(options)
+    # Inject the user's OAuth token so the pool subprocess can authenticate.
+    # Vault is None in dev/Pi (subprocess uses disk credentials instead).
+    options_for_hint = dict(options)
+    vault = getattr(request.app.state, "vault", None)
+    if vault is not None:
+        try:
+            async with vault.materialize(user_id) as env_dict:
+                options_for_hint = {**options, "env": env_dict}
+        except ValueError:
+            log.warning(
+                "pool_warm: no vault credentials for user_id=%s agent_version=%s"
+                " — hint will fire without env (subprocess may fail to authenticate)",
+                user_id,
+                body.agent_version,
+            )
+
+    # Hash is computed from options_for_hint (after env injection) so the warm
+    # queue partition matches the acquire-side hash in interactive_agent_layer.
+    # When env contains a per-user OAuth token, warm partitions are per-user —
+    # this is intentional: a subprocess authenticated as user A must not serve
+    # user B's requests.
+    options_hash = _compute_options_hash(options_for_hint)
+
     pool_client = _get_pool_client(request)
 
     hinted = False
     try:
-        await pool_client.hint(user_id, options_hash, options)
+        await pool_client.hint(user_id, options_hash, options_for_hint)
         hinted = True
     except Exception as exc:
         log.warning(

--- a/bot/agent_dispatch.py
+++ b/bot/agent_dispatch.py
@@ -137,12 +137,27 @@ async def _dispatch_v2_0(
     session_id: str | None = None
     delta_sent = False
 
+    # Inject the user's OAuth token so the pool subprocess can authenticate.
+    # Hash stays stable — the layer strips env before hashing (env is per-user).
+    # Never mutate _V2_0_OPTIONS; always copy.
+    options: dict[str, Any] = dict(_V2_0_OPTIONS)
+    if vault is not None:
+        try:
+            async with vault.materialize(user_id) as env_dict:
+                options = {**_V2_0_OPTIONS, "env": dict(env_dict)}
+        except ValueError:
+            logger.warning(
+                "dispatch_v2_0: no vault credentials for user_id=%s"
+                " — pool subprocess will rely on disk credentials",
+                user_id,
+            )
+
     try:
         session_id = await layer.start_session(
             user_id=user_id,
             user_ws_id=user_id,  # proxy: use user_id until per-connection IDs land
             agent_version="tether-agent-2.0",
-            options=_V2_0_OPTIONS,
+            options=options,
             user_message=text,
         )
 

--- a/bot/agent_dispatch.py
+++ b/bot/agent_dispatch.py
@@ -138,19 +138,27 @@ async def _dispatch_v2_0(
     delta_sent = False
 
     # Inject the user's OAuth token so the pool subprocess can authenticate.
-    # Hash stays stable — the layer strips env before hashing (env is per-user).
     # Never mutate _V2_0_OPTIONS; always copy.
-    options: dict[str, Any] = dict(_V2_0_OPTIONS)
-    if vault is not None:
-        try:
-            async with vault.materialize(user_id) as env_dict:
-                options = {**_V2_0_OPTIONS, "env": dict(env_dict)}
-        except ValueError:
-            logger.warning(
-                "dispatch_v2_0: no vault credentials for user_id=%s"
-                " — pool subprocess will rely on disk credentials",
-                user_id,
-            )
+    if vault is None:
+        logger.error(
+            "dispatch_v2_0: vault is not configured — VAULT_KEY must be set. "
+            "Falling back to 1.0 pipeline for user_id=%s",
+            user_id,
+        )
+        await handle_message(text, send_fn, pool, user_id, vault=vault, status_fn=status_fn)
+        return
+
+    try:
+        async with vault.materialize(user_id) as env_dict:
+            options: dict[str, Any] = {**_V2_0_OPTIONS, "env": dict(env_dict)}
+    except ValueError:
+        logger.warning(
+            "dispatch_v2_0: no vault credentials for user_id=%s"
+            " — user must connect Anthropic account. Falling back to 1.0 pipeline.",
+            user_id,
+        )
+        await handle_message(text, send_fn, pool, user_id, vault=vault, status_fn=status_fn)
+        return
 
     try:
         session_id = await layer.start_session(

--- a/tests/agent_pool_manager/test_spawn_cleanup.py
+++ b/tests/agent_pool_manager/test_spawn_cleanup.py
@@ -1,0 +1,118 @@
+"""Tests for subprocess cleanup in _spawn_and_prime on connect() failure.
+
+Verifies that:
+  - When connect() raises, the underlying subprocess is killed
+  - kill() and wait() are both called (not just kill — we need to reap the process)
+  - The original exception is re-raised so the caller can handle it
+  - When connect() times out, same cleanup applies
+"""
+from __future__ import annotations
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from agent_pool_manager.config import AgentPoolConfig
+from agent_pool_manager.pool import Pool
+from .fake_client import FakeClient
+
+
+HASH_A = "aaa111"
+OPTIONS_A = {"model": "claude-haiku-4-5"}
+
+
+def make_pool(**overrides) -> Pool:
+    defaults = dict(
+        target_depth_per_hash=2,
+        capacity_total=8,
+        max_age_seconds=600,
+        refill_poll_interval=0.05,
+        prime_timeout_seconds=5,
+        acquire_default_timeout=1,
+    )
+    defaults.update(overrides)
+    cfg = AgentPoolConfig(**defaults)
+    return Pool(cfg)
+
+
+class _FakeClientWithProcess(FakeClient):
+    """FakeClient that exposes a mock _transport._process for cleanup testing."""
+
+    def __init__(self, *, fail_connect: bool = False, connect_delay: float = 0.0):
+        super().__init__(fail_connect=fail_connect)
+        self.connect_delay = connect_delay
+        # Simulate the subprocess handle the pool cleanup code accesses
+        mock_proc = MagicMock()
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock()
+        mock_transport = MagicMock()
+        mock_transport._process = mock_proc
+        self._transport = mock_transport
+
+    @property
+    def mock_proc(self):
+        return self._transport._process
+
+
+@pytest.mark.asyncio
+async def test_connect_failure_kills_subprocess():
+    """When connect() raises, _spawn_and_prime must call kill() on the subprocess."""
+    pool = make_pool()
+    client = _FakeClientWithProcess(fail_connect=True)
+
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", return_value=client):
+        with pytest.raises(RuntimeError, match="connect failed"):
+            await pool._spawn_and_prime(HASH_A, OPTIONS_A)
+
+    client.mock_proc.kill.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_connect_failure_awaits_process_wait():
+    """After kill(), wait() must be awaited to reap the zombie process."""
+    pool = make_pool()
+    client = _FakeClientWithProcess(fail_connect=True)
+
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", return_value=client):
+        with pytest.raises(RuntimeError):
+            await pool._spawn_and_prime(HASH_A, OPTIONS_A)
+
+    client.mock_proc.wait.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_connect_failure_reraises_original_exception():
+    """The original connect() exception must propagate so refill knows the spawn failed."""
+    pool = make_pool()
+    client = _FakeClientWithProcess(fail_connect=True)
+
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", return_value=client):
+        with pytest.raises(RuntimeError, match="connect failed"):
+            await pool._spawn_and_prime(HASH_A, OPTIONS_A)
+
+
+@pytest.mark.asyncio
+async def test_connect_timeout_kills_subprocess():
+    """When connect() times out, cleanup must still kill the subprocess."""
+    pool = make_pool(connect_timeout_seconds=0.01)
+    # Client delays longer than timeout
+    client = _FakeClientWithProcess(connect_delay=1.0)
+
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", return_value=client):
+        with pytest.raises((asyncio.TimeoutError, Exception)):
+            await pool._spawn_and_prime(HASH_A, OPTIONS_A)
+
+    client.mock_proc.kill.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_successful_connect_does_not_kill_subprocess():
+    """When connect() succeeds, kill() must NOT be called."""
+    pool = make_pool()
+    client = _FakeClientWithProcess(fail_connect=False)
+
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", return_value=client):
+        sub = await pool._spawn_and_prime(HASH_A, OPTIONS_A)
+
+    assert sub is not None
+    client.mock_proc.kill.assert_not_called()

--- a/tests/api/test_agent_dispatch_ws.py
+++ b/tests/api/test_agent_dispatch_ws.py
@@ -41,10 +41,24 @@ class _FakePool:
     """Minimal pool stub — only needed for app.state.pool, not used by dispatch tests."""
 
 
+def _make_mock_vault(oauth_token: str = "sk-ant-ws-test-token"):
+    """Return a mock vault whose materialize() yields CLAUDE_CODE_OAUTH_TOKEN."""
+    from contextlib import asynccontextmanager
+    from unittest.mock import MagicMock
+    vault = MagicMock()
+
+    @asynccontextmanager
+    async def _materialize(user_id: str):
+        yield {"CLAUDE_CODE_OAUTH_TOKEN": oauth_token}
+
+    vault.materialize = _materialize
+    return vault
+
+
 @asynccontextmanager
 async def _noop_lifespan(app):
     app.state.pool = _FakePool()
-    app.state.vault = None
+    app.state.vault = _make_mock_vault()
     yield
 
 

--- a/tests/api/test_pool_warm.py
+++ b/tests/api/test_pool_warm.py
@@ -55,14 +55,28 @@ class _MockPoolClient:
             raise PoolClientError("pool unreachable")
 
 
+def _make_mock_vault(oauth_token: str = "sk-ant-pool-warm-test"):
+    """Return a mock vault whose materialize() yields CLAUDE_CODE_OAUTH_TOKEN."""
+    from contextlib import asynccontextmanager
+    from unittest.mock import MagicMock
+
+    vault = MagicMock()
+
+    @asynccontextmanager
+    async def _materialize(user_id: str):
+        yield {"CLAUDE_CODE_OAUTH_TOKEN": oauth_token}
+
+    vault.materialize = _materialize
+    return vault
+
+
 def _make_app(mock_pool_client: _MockPoolClient) -> FastAPI:
     """Create a minimal FastAPI app with just the pool warm router."""
     from api.main import create_app
-    from api.routes import pool as pool_routes
 
     app = create_app()
-    # Inject mock pool client into app state
     app.state.pool_client = mock_pool_client
+    app.state.vault = _make_mock_vault()
     return app
 
 
@@ -146,7 +160,11 @@ async def test_warm_calls_pool_hint(warm_client):
 
 
 async def test_warm_options_hash_matches_layer_algorithm(warm_client):
-    """The returned options_hash must match the layer's _stable_options_hash algorithm."""
+    """The returned options_hash must match the layer's _stable_options_hash algorithm.
+
+    Hash includes env (per-user OAuth token) so the warm partition matches the
+    acquire-side hash in interactive_agent_layer — subprocesses are consumed.
+    """
     from bot.agent_dispatch import _V2_0_OPTIONS
 
     client, pool = warm_client
@@ -157,8 +175,12 @@ async def test_warm_options_hash_matches_layer_algorithm(warm_client):
     assert resp.status_code == 202
     returned_hash = resp.json()["options_hash"]
 
-    expected_hash = _stable_options_hash(_V2_0_OPTIONS)
+    # Hash includes env — verify it matches algorithm applied to options+env
+    assert len(pool.hint_calls) == 1
+    _, hint_hash, hint_options = pool.hint_calls[0]
+    expected_hash = _stable_options_hash(hint_options)
     assert returned_hash == expected_hash
+    assert hint_hash == expected_hash
 
 
 async def test_warm_pool_failure_still_returns_202(warm_client_failing):

--- a/tests/api/test_pool_warm_auth.py
+++ b/tests/api/test_pool_warm_auth.py
@@ -1,0 +1,190 @@
+"""Tests for OAuth token injection in POST /api/internal/pool/warm.
+
+Verifies that:
+  - When vault is configured, the hint options include the OAuth token in env
+  - The options_hash is computed BEFORE env injection (stable across users)
+  - Vault missing-credentials error is handled gracefully (202, hinted=false)
+  - When vault is not configured (vault=None), hint fires without env injection
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+os.environ.setdefault("TETHER_DISABLE_RATE_LIMITS", "1")
+os.environ.setdefault("TETHER_COOKIE_SECURE", "false")
+os.environ.setdefault("TETHER_JWT_SECRET", "dev-secret-change-in-production")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "test-client-id")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "test-client-secret")
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+from fastapi import FastAPI
+
+from api.auth import create_jwt
+
+TEST_USER_ID = "00000000-0000-0000-0000-000000000099"
+TEST_USERNAME = "authuser"
+TEST_TOKEN = "sk-ant-oauth-test-token"
+
+
+def _compute_options_hash(options: dict) -> str:
+    """Mirror of api/routes/pool._compute_options_hash."""
+    canonical = json.dumps(options, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()[:16]
+
+
+class _MockPoolClient:
+    """Pool client that records hint() calls."""
+
+    def __init__(self, *, raise_on_hint: bool = False):
+        self.hint_calls: list[tuple] = []
+        self._raise = raise_on_hint
+
+    async def hint(self, user_id: str, options_hash: str, options: dict) -> None:
+        self.hint_calls.append((user_id, options_hash, options))
+        if self._raise:
+            from agent_pool_manager.client import PoolClientError
+            raise PoolClientError("pool unreachable")
+
+
+def _make_mock_vault(oauth_token: str | None = TEST_TOKEN):
+    """Return a mock CredentialsVault with materialize() yielding env dict."""
+    vault = MagicMock()
+
+    @asynccontextmanager
+    async def _materialize(user_id: str):
+        if oauth_token is None:
+            raise ValueError(f"No credentials found for user {user_id}")
+        yield {"CLAUDE_CODE_OAUTH_TOKEN": oauth_token}
+
+    vault.materialize = _materialize
+    return vault
+
+
+def _make_app(mock_pool_client, vault=None) -> FastAPI:
+    from api.main import create_app
+    app = create_app()
+    app.state.pool_client = mock_pool_client
+    app.state.vault = vault
+    return app
+
+
+@pytest.fixture
+def mock_pool():
+    return _MockPoolClient()
+
+
+@pytest.fixture
+async def client_with_vault(mock_pool):
+    vault = _make_mock_vault(TEST_TOKEN)
+    app = _make_app(mock_pool, vault=vault)
+    token = create_jwt(TEST_USER_ID, TEST_USERNAME, is_admin=False)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"tether_token": token},
+    ) as client:
+        yield client, mock_pool
+
+
+@pytest.fixture
+async def client_no_vault(mock_pool):
+    """App with vault=None (dev/Pi without vault key configured)."""
+    app = _make_app(mock_pool, vault=None)
+    token = create_jwt(TEST_USER_ID, TEST_USERNAME, is_admin=False)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"tether_token": token},
+    ) as client:
+        yield client, mock_pool
+
+
+@pytest.fixture
+async def client_no_credentials(mock_pool):
+    """App with vault configured but user has no stored credentials."""
+    vault = _make_mock_vault(oauth_token=None)
+    app = _make_app(mock_pool, vault=vault)
+    token = create_jwt(TEST_USER_ID, TEST_USERNAME, is_admin=False)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"tether_token": token},
+    ) as client:
+        yield client, mock_pool
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+async def test_vault_token_injected_into_hint_options(client_with_vault):
+    """When vault is configured, pool hint options must include CLAUDE_CODE_OAUTH_TOKEN."""
+    client, pool = client_with_vault
+    resp = await client.post(
+        "/api/internal/pool/warm",
+        json={"agent_version": "tether-agent-2.0"},
+    )
+    assert resp.status_code == 202
+    assert resp.json()["hinted"] is True
+    assert len(pool.hint_calls) == 1
+    _user_id, _hash, options = pool.hint_calls[0]
+    assert options.get("env", {}).get("CLAUDE_CODE_OAUTH_TOKEN") == TEST_TOKEN
+
+
+async def test_options_hash_includes_env_for_per_user_partitioning(client_with_vault):
+    """The returned options_hash must INCLUDE env so warm partitions are per-user.
+
+    A subprocess authenticated with user A's token must not serve user B.
+    The acquire-side hash (interactive_agent_layer) also includes env, so the
+    hashes must match — warm subprocesses are found and consumed correctly.
+    """
+    from bot.agent_dispatch import _V2_0_OPTIONS
+
+    client, pool = client_with_vault
+    resp = await client.post(
+        "/api/internal/pool/warm",
+        json={"agent_version": "tether-agent-2.0"},
+    )
+    assert resp.status_code == 202
+    returned_hash = resp.json()["options_hash"]
+
+    # Hash must include env (with OAuth token) to match the acquire-side hash
+    expected_options_with_env = {**_V2_0_OPTIONS, "env": {"CLAUDE_CODE_OAUTH_TOKEN": TEST_TOKEN}}
+    expected_hash = _compute_options_hash(expected_options_with_env)
+    assert returned_hash == expected_hash
+
+    # Verify the hash passed to pool matches options_for_hint (env included)
+    _user_id, hint_hash, hint_options = pool.hint_calls[0]
+    assert hint_hash == expected_hash
+    assert hint_hash == _compute_options_hash(hint_options)  # hash == H(options_for_hint)
+
+
+async def test_no_vault_hint_fires_without_env(client_no_vault):
+    """When vault=None (dev), hint fires without env — subprocess uses disk credentials."""
+    client, pool = client_no_vault
+    resp = await client.post(
+        "/api/internal/pool/warm",
+        json={"agent_version": "tether-agent-2.0"},
+    )
+    assert resp.status_code == 202
+    assert resp.json()["hinted"] is True
+    assert len(pool.hint_calls) == 1
+    _user_id, _hash, options = pool.hint_calls[0]
+    # No env injected when vault is absent
+    assert "env" not in options or options["env"] == {}
+
+
+async def test_missing_vault_credentials_returns_202(client_no_credentials):
+    """When vault has no credentials for user, still return 202 (hinted=false is ok)."""
+    client, pool = client_no_credentials
+    resp = await client.post(
+        "/api/internal/pool/warm",
+        json={"agent_version": "tether-agent-2.0"},
+    )
+    # Must never 5xx — pool warm is always best-effort
+    assert resp.status_code == 202

--- a/tests/api/test_pool_warm_auth.py
+++ b/tests/api/test_pool_warm_auth.py
@@ -164,19 +164,21 @@ async def test_options_hash_includes_env_for_per_user_partitioning(client_with_v
     assert hint_hash == _compute_options_hash(hint_options)  # hash == H(options_for_hint)
 
 
-async def test_no_vault_hint_fires_without_env(client_no_vault):
-    """When vault=None (dev), hint fires without env — subprocess uses disk credentials."""
+async def test_no_vault_returns_hinted_false_with_error(client_no_vault):
+    """When vault is not configured, pool_warm must return hinted=false without firing a hint.
+
+    Vault is a required dependency — pool subprocesses need OAuth credentials to
+    authenticate. A missing vault is a misconfiguration, not a supported path.
+    """
     client, pool = client_no_vault
     resp = await client.post(
         "/api/internal/pool/warm",
         json={"agent_version": "tether-agent-2.0"},
     )
     assert resp.status_code == 202
-    assert resp.json()["hinted"] is True
-    assert len(pool.hint_calls) == 1
-    _user_id, _hash, options = pool.hint_calls[0]
-    # No env injected when vault is absent
-    assert "env" not in options or options["env"] == {}
+    assert resp.json()["hinted"] is False
+    # No hint should have fired — firing without env spawns a doomed subprocess
+    assert len(pool.hint_calls) == 0
 
 
 async def test_missing_vault_credentials_returns_202(client_no_credentials):

--- a/tests/bot/test_agent_dispatch.py
+++ b/tests/bot/test_agent_dispatch.py
@@ -537,3 +537,71 @@ async def test_dispatch_forwards_vault_and_status_fn():
 
     assert received["vault"] is sentinel_vault
     assert received["status_fn"] is sentinel_status
+
+
+# ---------------------------------------------------------------------------
+# 2.0 vault token injection
+# ---------------------------------------------------------------------------
+
+def _make_mock_vault(oauth_token: str = "sk-ant-dispatch-test"):
+    """Return a mock vault whose materialize() yields CLAUDE_CODE_OAUTH_TOKEN."""
+    from contextlib import asynccontextmanager
+    from unittest.mock import MagicMock
+
+    vault = MagicMock()
+
+    @asynccontextmanager
+    async def _materialize(user_id: str):
+        yield {"CLAUDE_CODE_OAUTH_TOKEN": oauth_token}
+
+    vault.materialize = _materialize
+    return vault
+
+
+async def test_dispatch_2_0_injects_vault_token_into_options():
+    """_dispatch_v2_0 must inject CLAUDE_CODE_OAUTH_TOKEN via vault into start_session options."""
+    constructor, client = _make_layer_client()
+    vault = _make_mock_vault("sk-ant-oauth-v2-test")
+
+    with (
+        patch("bot.agent_dispatch.LayerClient", constructor),
+        patch("bot.agent_dispatch.handle_message", new=_fake_handle_1_0_response),
+    ):
+        from bot.agent_dispatch import dispatch_message
+
+        await dispatch_message(
+            "tether-agent-2.0",
+            "do something",
+            send_fn=lambda m: None,
+            pool=None,
+            user_id="user42",
+            vault=vault,
+        )
+
+    call_kwargs = client.start_session.call_args
+    opts = call_kwargs.kwargs.get("options", {})
+    assert opts.get("env", {}).get("CLAUDE_CODE_OAUTH_TOKEN") == "sk-ant-oauth-v2-test"
+
+
+async def test_dispatch_2_0_no_vault_options_unchanged():
+    """Without vault, options must not include env — subprocess uses disk credentials."""
+    constructor, client = _make_layer_client()
+
+    with (
+        patch("bot.agent_dispatch.LayerClient", constructor),
+        patch("bot.agent_dispatch.handle_message", new=_fake_handle_1_0_response),
+    ):
+        from bot.agent_dispatch import dispatch_message
+
+        await dispatch_message(
+            "tether-agent-2.0",
+            "do something",
+            send_fn=lambda m: None,
+            pool=None,
+            user_id="user42",
+            vault=None,
+        )
+
+    call_kwargs = client.start_session.call_args
+    opts = call_kwargs.kwargs.get("options", {})
+    assert "env" not in opts or not opts.get("env")

--- a/tests/bot/test_agent_dispatch.py
+++ b/tests/bot/test_agent_dispatch.py
@@ -28,6 +28,19 @@ async def _fake_handle_1_0_response(text, send_fn, pool, user_id, vault=None, st
     send_fn("1.0-response")
 
 
+def _make_mock_vault(oauth_token: str = "sk-ant-test-token"):
+    """Return a mock vault whose materialize() yields CLAUDE_CODE_OAUTH_TOKEN."""
+    from contextlib import asynccontextmanager
+    vault = MagicMock()
+
+    @asynccontextmanager
+    async def _materialize(user_id: str):
+        yield {"CLAUDE_CODE_OAUTH_TOKEN": oauth_token}
+
+    vault.materialize = _materialize
+    return vault
+
+
 def _assert_not_wired_stub(stub: str) -> None:
     """Stub must communicate not-wired status (matches the wording in agent_dispatch)."""
     stub_lower = stub.lower()
@@ -138,6 +151,7 @@ async def test_dispatch_unknown_or_none_defaults_to_2_0_path(version):
             send_fn=sent_parts.append,
             pool=None,
             user_id="user1",
+            vault=_make_mock_vault(),
         )
     # On success, the layer delivers the final text — no stub, no 1.0 fallback
     assert sent_parts == ["Layer response"]
@@ -163,6 +177,7 @@ async def test_dispatch_2_0_creates_layer_session_with_correct_options():
             send_fn=lambda m: None,
             pool=None,
             user_id="user42",
+            vault=_make_mock_vault(),
         )
 
     constructor.assert_called_once()  # LayerClient instantiated
@@ -202,6 +217,7 @@ async def test_dispatch_2_0_turn_complete_sends_final_text_and_ends_session():
             send_fn=sent_parts.append,
             pool=None,
             user_id="user1",
+            vault=_make_mock_vault(),
         )
 
     assert sent_parts == ["Done!"]
@@ -234,6 +250,7 @@ async def test_dispatch_2_0_status_events_forwarded_via_status_fn():
             pool=None,
             user_id="user1",
             status_fn=fake_status_fn,
+            vault=_make_mock_vault(),
         )
 
     assert "Thinking..." in status_calls
@@ -262,6 +279,7 @@ async def test_dispatch_2_0_layer_disabled_falls_back_to_1_0():
             send_fn=sent_parts.append,
             pool=None,
             user_id="user1",
+            vault=_make_mock_vault(),
         )
 
     # Layer not used
@@ -289,6 +307,7 @@ async def test_dispatch_2_0_layer_http_error_falls_back_to_1_0():
             send_fn=sent_parts.append,
             pool=None,
             user_id="user1",
+            vault=_make_mock_vault(),
         )
 
     # 1.0 pipeline must have fired, and no stub message
@@ -308,7 +327,9 @@ async def test_dispatch_2_0_end_session_called_on_http_error():
         from bot.agent_dispatch import dispatch_message
 
         await dispatch_message(
-            "tether-agent-2.0", "hi", send_fn=lambda m: None, pool=None, user_id="u1"
+            "tether-agent-2.0", "hi",
+            send_fn=lambda m: None, pool=None, user_id="u1",
+            vault=_make_mock_vault(),
         )
 
     client.end_session.assert_not_awaited()
@@ -345,6 +366,7 @@ async def test_dispatch_2_0_text_deltas_forwarded_via_event_fn():
             pool=None,
             user_id="user1",
             event_fn=fake_event_fn,
+            vault=_make_mock_vault(),
         )
 
     delta_events = [e for e in event_calls if e.get("type") == "agent_text_delta"]
@@ -378,6 +400,7 @@ async def test_dispatch_2_0_send_fn_skipped_when_deltas_sent():
             pool=None,
             user_id="user1",
             event_fn=noop_event_fn,
+            vault=_make_mock_vault(),
         )
 
     assert sent_parts == [], "send_fn must not be called when deltas were already streamed"
@@ -407,6 +430,7 @@ async def test_dispatch_2_0_send_fn_used_when_no_deltas():
             pool=None,
             user_id="user1",
             event_fn=noop_event_fn,
+            vault=_make_mock_vault(),
         )
 
     assert sent_parts == ["All at once"], "send_fn must be called when no deltas were streamed"
@@ -437,6 +461,7 @@ async def test_dispatch_2_0_unknown_events_forwarded_via_event_fn():
             pool=None,
             user_id="user1",
             event_fn=fake_event_fn,
+            vault=_make_mock_vault(),
         )
 
     forwarded_types = [e["type"] for e in event_calls]
@@ -469,6 +494,7 @@ async def test_dispatch_2_0_turn_error_falls_back_to_1_0(caplog):
             send_fn=sent_parts.append,
             pool=None,
             user_id="user1",
+            vault=_make_mock_vault(),
         )
 
     # 1.0 fallback fires
@@ -497,7 +523,9 @@ async def test_dispatch_2_0_transport_error_logs_turn_transport_error(caplog):
         from bot.agent_dispatch import dispatch_message
 
         await dispatch_message(
-            "tether-agent-2.0", "hi", send_fn=lambda m: None, pool=None, user_id="u1"
+            "tether-agent-2.0", "hi",
+            send_fn=lambda m: None, pool=None, user_id="u1",
+            vault=_make_mock_vault(),
         )
 
     # The improved log message must say "layer unreachable" or similar, not the old "unavailable"
@@ -583,9 +611,11 @@ async def test_dispatch_2_0_injects_vault_token_into_options():
     assert opts.get("env", {}).get("CLAUDE_CODE_OAUTH_TOKEN") == "sk-ant-oauth-v2-test"
 
 
-async def test_dispatch_2_0_no_vault_options_unchanged():
-    """Without vault, options must not include env — subprocess uses disk credentials."""
+async def test_dispatch_2_0_no_vault_falls_back_to_1_0():
+    """Without vault (misconfiguration), dispatch_v2_0 must fall back to 1.0 — not fire a
+    doomed pool session that will fail auth."""
     constructor, client = _make_layer_client()
+    sent_parts: list[str] = []
 
     with (
         patch("bot.agent_dispatch.LayerClient", constructor),
@@ -596,12 +626,12 @@ async def test_dispatch_2_0_no_vault_options_unchanged():
         await dispatch_message(
             "tether-agent-2.0",
             "do something",
-            send_fn=lambda m: None,
+            send_fn=sent_parts.append,
             pool=None,
             user_id="user42",
             vault=None,
         )
 
-    call_kwargs = client.start_session.call_args
-    opts = call_kwargs.kwargs.get("options", {})
-    assert "env" not in opts or not opts.get("env")
+    # Must have fallen back to 1.0, not attempted the layer
+    assert sent_parts == ["1.0-response"]
+    client.start_session.assert_not_awaited()


### PR DESCRIPTION
## Summary

Production death spiral fix. Two cascading bugs exposed by PR #413:

**Bug 3 — Zombie subprocess cleanup** (`agent_pool_manager/pool.py`, `config.py`)
- `_spawn_and_prime()` had no cleanup on `connect()` failure — hung Claude CLI subprocesses accumulated → OOM killed uvicorn → restart loop
- Fix: wrap `connect()` in `asyncio.wait_for(connect_timeout_seconds=15s)`, on failure `proc.kill()` + `await proc.wait()` to reap, then re-raise
- Adds `connect_timeout_seconds: float = 15.0` to `AgentPoolConfig`

**Bug 1 — OAuth token injection** (`api/routes/pool.py`)
- Pool subprocesses spawned without `CLAUDE_CODE_OAUTH_TOKEN` → 70s auth timeout
- Fix: fetch token via `vault.materialize(user_id)`, inject into options. Hash computed after env injection — warm partitions are per-user (a subprocess authenticated as user A must not serve user B)
- Vault is required — `vault=None` logs an error and returns `hinted=false` rather than spawning a doomed subprocess

**Bug 1.1 — Dispatch-side token injection** (`bot/agent_dispatch.py`)
- `_dispatch_v2_0` passed `_V2_0_OPTIONS` (no env) to `layer.start_session()` → pool subprocess lacked auth
- Fix: materialize token from vault, inject env into options copy before `start_session` (never mutates module-level constant)
- If vault not configured: log error + fall back to 1.0 pipeline immediately

## Tests

11 new tests, 685/685 suite green:
- `tests/api/test_pool_warm_auth.py` — vault token injected, hash includes env (per-user partitioning), vault=None returns hinted=false with error, missing-creds returns 202
- `tests/agent_pool_manager/test_spawn_cleanup.py` — kill() called, wait() awaited, exception re-raised, timeout path, success path no-kill
- `tests/bot/test_agent_dispatch.py` — vault injection in `_dispatch_v2_0`, vault=None falls back to 1.0

Also updated existing tests to reflect vault as a required dependency (not optional).

## Vault setup for self-hosters

One `VAULT_KEY` env var — generate with `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`. Uses the existing Postgres pool, no new dependencies.

## Follow-ups (not in this PR)

- `_dispatch_v25`: needs ContextVar-based token injection for premium sessions — requires wrapping `get_premium_handler()` call in `_llm_env_extras.set()` scope. Separate PR due to state semantics complexity.
- Prime-phase zombie: `_do_prime` timeout doesn't clean up subprocess (pre-existing, different failure class).