### PR TITLE
fix(pool): defensive spawn guard — refuse spawns without CLAUDE_CODE_OAUTH_TOKEN

### DIFF
--- a/agent_pool_manager/metrics.py
+++ b/agent_pool_manager/metrics.py
@@ -146,6 +146,10 @@ class PoolMetrics:
             "pool_refill_total",
             "Total subprocess spawns triggered by refill loop",
         )
+        self.spawn_guard_rejection_total = Counter(
+            "pool_spawn_guard_rejection_total",
+            "Total spawn attempts rejected by the auth guard (missing CLAUDE_CODE_OAUTH_TOKEN)",
+        )
         self.acquire_latency_seconds = Histogram(
             "pool_acquire_latency_seconds",
             "Time from acquire() call to handle returned (seconds)",
@@ -163,6 +167,7 @@ class PoolMetrics:
             self.release_total.render_text(),
             self.expire_total.render_text(),
             self.refill_total.render_text(),
+            self.spawn_guard_rejection_total.render_text(),
             self.acquire_latency_seconds.render_text(),
         ]
 

--- a/agent_pool_manager/pool.py
+++ b/agent_pool_manager/pool.py
@@ -298,6 +298,8 @@ class Pool:
                 " — skipping spawn to prevent auth-timeout waste",
                 options_hash,
             )
+            if self._metrics:
+                self._metrics.spawn_guard_rejection_total.inc()
             return False
 
         async with self._lock:

--- a/agent_pool_manager/pool.py
+++ b/agent_pool_manager/pool.py
@@ -279,8 +279,27 @@ class Pool:
     async def _try_inject_warm(self, options_hash: str, options: dict[str, Any]) -> bool:
         """Attempt to spawn-and-prime one subprocess.
 
-        Returns True if spawned, False if at capacity.
+        Returns True if spawned, False if at capacity or if the spawn guard fires.
+
+        Spawn guard: if options['env'] does not contain CLAUDE_CODE_OAUTH_TOKEN,
+        the spawn is rejected with a WARNING.  Subprocesses launched without OAuth
+        credentials time out after connect_timeout_seconds (15 s) with no useful
+        output, waste pool capacity, and leave asyncio "Task exception was never
+        retrieved" errors in the logs.  The guard fires before the warming counter
+        is incremented, so rejected attempts do not count against capacity.
+
+        All known spawn paths (RefillLoop.hint, RefillLoop.run_once, _inject_warm)
+        converge here, so this single check covers the entire spawn surface.
         """
+        token = (options.get("env") or {}).get("CLAUDE_CODE_OAUTH_TOKEN")
+        if not token:
+            log.warning(
+                "pool.spawn_guard: options_hash=%s missing CLAUDE_CODE_OAUTH_TOKEN in env"
+                " — skipping spawn to prevent auth-timeout waste",
+                options_hash,
+            )
+            return False
+
         async with self._lock:
             if self.total_count() >= self.config.capacity_total:
                 return False

--- a/tests/agent_pool_manager/test_client.py
+++ b/tests/agent_pool_manager/test_client.py
@@ -14,7 +14,7 @@ from agent_pool_manager.client import PoolClient, PoolClientError
 
 
 HASH_A = "abc123"
-OPTIONS_A = {"model": "claude-haiku-4-5"}
+OPTIONS_A = {"model": "claude-haiku-4-5", "env": {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-test-token"}}
 USER_ID = "user-test-1"
 
 

--- a/tests/agent_pool_manager/test_integration.py
+++ b/tests/agent_pool_manager/test_integration.py
@@ -29,7 +29,7 @@ async def test_real_subprocess_acquire_query_release():
     )
     pool = Pool(cfg)
     options_hash = "integration-test-hash"
-    options = {}
+    options = {"env": {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-integration-test-token"}}
 
     await pool._inject_warm(options_hash, options)
     handle_id, meta = await pool.acquire(options_hash, options, timeout=30.0)

--- a/tests/agent_pool_manager/test_metrics.py
+++ b/tests/agent_pool_manager/test_metrics.py
@@ -17,7 +17,7 @@ from agent_pool_manager.server import build_app
 
 
 HASH_A = "aaa111"
-OPTIONS_A = {"model": "claude-haiku-4-5"}
+OPTIONS_A = {"model": "claude-haiku-4-5", "env": {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-test-token"}}
 USER_ID = "user-uuid-1234"
 
 

--- a/tests/agent_pool_manager/test_pool.py
+++ b/tests/agent_pool_manager/test_pool.py
@@ -13,8 +13,8 @@ from agent_pool_manager.pool import Pool, PoolExhausted
 
 HASH_A = "aaa111"
 HASH_B = "bbb222"
-OPTIONS_A = {"model": "claude-haiku-4-5"}
-OPTIONS_B = {"model": "claude-sonnet-4-5"}
+OPTIONS_A = {"model": "claude-haiku-4-5", "env": {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-test-token"}}
+OPTIONS_B = {"model": "claude-sonnet-4-5", "env": {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-test-token-b"}}
 
 
 def make_pool(**overrides) -> Pool:

--- a/tests/agent_pool_manager/test_pool_control.py
+++ b/tests/agent_pool_manager/test_pool_control.py
@@ -13,7 +13,7 @@ from agent_pool_manager.pool import Pool
 
 
 HASH_A = "abc123"
-OPTIONS_A = {"model": "claude-haiku-4-5"}
+OPTIONS_A = {"model": "claude-haiku-4-5", "env": {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-test-token"}}
 
 
 @pytest.fixture

--- a/tests/agent_pool_manager/test_refill.py
+++ b/tests/agent_pool_manager/test_refill.py
@@ -26,7 +26,7 @@ def make_pool(**overrides) -> Pool:
 
 
 HASH_A = "aaa111"
-OPTIONS_A = {"model": "claude-haiku-4-5"}
+OPTIONS_A = {"model": "claude-haiku-4-5", "env": {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-test-token"}}
 
 
 @pytest.mark.asyncio

--- a/tests/agent_pool_manager/test_server.py
+++ b/tests/agent_pool_manager/test_server.py
@@ -13,7 +13,7 @@ from agent_pool_manager.server import build_app
 
 
 HASH_A = "aaa111"
-OPTIONS_A = {"model": "claude-haiku-4-5"}
+OPTIONS_A = {"model": "claude-haiku-4-5", "env": {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-test-token"}}
 
 
 def make_pool(**kwargs) -> Pool:

--- a/tests/agent_pool_manager/test_server_control.py
+++ b/tests/agent_pool_manager/test_server_control.py
@@ -16,7 +16,7 @@ from agent_pool_manager.client import PoolClient, PoolClientError
 
 
 HASH_A = "abc123"
-OPTIONS_A = {"model": "claude-haiku-4-5"}
+OPTIONS_A = {"model": "claude-haiku-4-5", "env": {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-test-token"}}
 USER_ID = "user-ctrl-1"
 
 

--- a/tests/agent_pool_manager/test_smoke.py
+++ b/tests/agent_pool_manager/test_smoke.py
@@ -22,7 +22,7 @@ from agent_pool_manager.metrics import PoolMetrics
 
 
 HASH_A = "aaa111"
-OPTIONS_A = {"model": "claude-haiku-4-5"}
+OPTIONS_A = {"model": "claude-haiku-4-5", "env": {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-test-token"}}
 USER_ID = "smoke-user-1"
 
 COLD_DELAY = 0.05   # simulate a 50ms subprocess start cost

--- a/tests/agent_pool_manager/test_spawn_cleanup.py
+++ b/tests/agent_pool_manager/test_spawn_cleanup.py
@@ -18,7 +18,7 @@ from .fake_client import FakeClient
 
 
 HASH_A = "aaa111"
-OPTIONS_A = {"model": "claude-haiku-4-5"}
+OPTIONS_A = {"model": "claude-haiku-4-5", "env": {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-test-token"}}
 
 
 def make_pool(**overrides) -> Pool:

--- a/tests/agent_pool_manager/test_spawn_guard.py
+++ b/tests/agent_pool_manager/test_spawn_guard.py
@@ -1,0 +1,157 @@
+"""Tests for the spawn guard in _try_inject_warm.
+
+Option C — defensive auth guard: _try_inject_warm refuses to spawn a subprocess
+when options['env'] is missing or does not contain CLAUDE_CODE_OAUTH_TOKEN.
+
+Rationale: pool subprocesses launched without OAuth credentials connect to the
+Claude API without authentication and time out after 15 s (connect_timeout_seconds).
+These wasted slots prevent legitimate warm subprocesses from filling the queue.
+The guard blocks all hypotheses for unauthenticated spawns regardless of which
+call path (RefillLoop.hint, RefillLoop.run_once, or direct _inject_warm) triggered
+the spawn.
+
+Tests:
+  - No env key → returns False, no spawn, warning logged
+  - env key present but CLAUDE_CODE_OAUTH_TOKEN absent → same
+  - CLAUDE_CODE_OAUTH_TOKEN is empty string → same
+  - CLAUDE_CODE_OAUTH_TOKEN is present and non-empty → spawn proceeds normally
+  - Guard fires BEFORE the capacity check (no warming count incremented)
+"""
+from __future__ import annotations
+
+import logging
+import pytest
+from unittest.mock import patch
+
+from agent_pool_manager.config import AgentPoolConfig
+from agent_pool_manager.pool import Pool
+from .fake_client import FakeClient
+
+
+HASH_A = "aaa111"
+OPTIONS_WITH_TOKEN = {
+    "model": "claude-haiku-4-5",
+    "env": {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-test-token-abc123"},
+}
+OPTIONS_NO_ENV = {"model": "claude-haiku-4-5"}
+OPTIONS_EMPTY_ENV = {"model": "claude-haiku-4-5", "env": {}}
+OPTIONS_EMPTY_TOKEN = {
+    "model": "claude-haiku-4-5",
+    "env": {"CLAUDE_CODE_OAUTH_TOKEN": ""},
+}
+
+
+def make_pool(**overrides) -> Pool:
+    defaults = dict(
+        target_depth_per_hash=2,
+        capacity_total=8,
+        max_age_seconds=600,
+        refill_poll_interval=0.05,
+        prime_timeout_seconds=5,
+        acquire_default_timeout=1,
+    )
+    defaults.update(overrides)
+    cfg = AgentPoolConfig(**defaults)
+    return Pool(cfg)
+
+
+# ---------------------------------------------------------------------------
+# Guard: reject spawns without CLAUDE_CODE_OAUTH_TOKEN
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_spawn_guard_rejects_no_env_key():
+    """_try_inject_warm returns False when options has no 'env' key."""
+    pool = make_pool()
+    spawned = []
+
+    def _tracking_factory(*args, **kwargs):
+        client = FakeClient()
+        spawned.append(client)
+        return client
+
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", side_effect=_tracking_factory):
+        result = await pool._try_inject_warm(HASH_A, OPTIONS_NO_ENV)
+
+    assert result is False, "must return False when env key absent"
+    assert len(spawned) == 0, "no ClaudeSDKClient must be constructed"
+
+
+@pytest.mark.asyncio
+async def test_spawn_guard_rejects_empty_env():
+    """_try_inject_warm returns False when env dict has no CLAUDE_CODE_OAUTH_TOKEN."""
+    pool = make_pool()
+    spawned = []
+
+    def _tracking_factory(*args, **kwargs):
+        client = FakeClient()
+        spawned.append(client)
+        return client
+
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", side_effect=_tracking_factory):
+        result = await pool._try_inject_warm(HASH_A, OPTIONS_EMPTY_ENV)
+
+    assert result is False
+    assert len(spawned) == 0
+
+
+@pytest.mark.asyncio
+async def test_spawn_guard_rejects_empty_string_token():
+    """_try_inject_warm returns False when CLAUDE_CODE_OAUTH_TOKEN is empty string."""
+    pool = make_pool()
+    spawned = []
+
+    def _tracking_factory(*args, **kwargs):
+        client = FakeClient()
+        spawned.append(client)
+        return client
+
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", side_effect=_tracking_factory):
+        result = await pool._try_inject_warm(HASH_A, OPTIONS_EMPTY_TOKEN)
+
+    assert result is False
+    assert len(spawned) == 0
+
+
+@pytest.mark.asyncio
+async def test_spawn_guard_allows_valid_token():
+    """_try_inject_warm returns True and spawns when CLAUDE_CODE_OAUTH_TOKEN is present."""
+    pool = make_pool()
+    spawned = []
+
+    def _tracking_factory(*args, **kwargs):
+        client = FakeClient()
+        spawned.append(client)
+        return client
+
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", side_effect=_tracking_factory):
+        result = await pool._try_inject_warm(HASH_A, OPTIONS_WITH_TOKEN)
+
+    assert result is True, "must return True when token is present"
+    assert len(spawned) == 1, "exactly one ClaudeSDKClient must be constructed"
+
+
+@pytest.mark.asyncio
+async def test_spawn_guard_logs_warning_on_missing_token(caplog):
+    """_try_inject_warm emits a WARNING when the spawn guard fires."""
+    pool = make_pool()
+    with caplog.at_level(logging.WARNING, logger="agent_pool_manager.pool"):
+        with patch("agent_pool_manager.pool.ClaudeSDKClient", FakeClient):
+            await pool._try_inject_warm(HASH_A, OPTIONS_NO_ENV)
+
+    assert any(
+        "spawn_guard" in record.message and HASH_A in record.message
+        for record in caplog.records
+    ), f"expected spawn_guard warning with hash, got: {[r.message for r in caplog.records]}"
+
+
+@pytest.mark.asyncio
+async def test_spawn_guard_does_not_increment_warming_count():
+    """Guard fires before the warming counter increment — warm count stays 0."""
+    pool = make_pool()
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", FakeClient):
+        await pool._try_inject_warm(HASH_A, OPTIONS_NO_ENV)
+
+    assert pool.warming_count(HASH_A) == 0, (
+        "warming count must not be incremented when guard rejects the spawn"
+    )

--- a/tests/agent_pool_manager/test_spawn_guard.py
+++ b/tests/agent_pool_manager/test_spawn_guard.py
@@ -155,3 +155,30 @@ async def test_spawn_guard_does_not_increment_warming_count():
     assert pool.warming_count(HASH_A) == 0, (
         "warming count must not be incremented when guard rejects the spawn"
     )
+
+
+@pytest.mark.asyncio
+async def test_spawn_guard_increments_metrics_counter():
+    """Each guard rejection increments PoolMetrics.spawn_guard_rejection_total.
+
+    Critical for ops visibility — without this counter, the guard is silent in
+    production and we cannot tell whether it's rejecting 1 spawn/day or 1000/min.
+    """
+    from agent_pool_manager.metrics import PoolMetrics
+
+    pool = make_pool()
+    metrics = PoolMetrics(pool)
+    pool._metrics = metrics
+
+    assert metrics.spawn_guard_rejection_total.value == 0
+
+    with patch("agent_pool_manager.pool.ClaudeSDKClient", FakeClient):
+        await pool._try_inject_warm(HASH_A, OPTIONS_NO_ENV)
+        await pool._try_inject_warm(HASH_A, OPTIONS_EMPTY_ENV)
+        await pool._try_inject_warm(HASH_A, OPTIONS_EMPTY_TOKEN)
+        # Valid token — should NOT increment
+        await pool._try_inject_warm(HASH_A, OPTIONS_WITH_TOKEN)
+
+    assert metrics.spawn_guard_rejection_total.value == 3, (
+        "counter must increment once per guard rejection, not for valid spawns"
+    )


### PR DESCRIPTION
## Context

Follow-up to PR #419 (pool auth + zombie cleanup). After #419 deployed, prod logs at 06:55:11 showed pool spawns happening at startup without going through `/api/internal/pool/warm` or `/hint` — resulting in `TimeoutError` from `_try_inject_warm` via `asyncio.create_task` (\"Task exception was never retrieved\").

The exact trigger could not be identified in code review: `RefillLoop._registry` is in-memory and starts empty on every restart, so `run_once()` should be a no-op at startup. The layer service has no startup hooks that fire hints. Yet spawns happened. This PR is **explicitly NOT a root-cause fix for the unknown trigger** — it's a defensive depth guard that catches **any** unauthenticated spawn path (current RefillLoop paths, future hooks, debug triggers, anything).

## What changed

Single chokepoint check in `agent_pool_manager/pool.py:_try_inject_warm()`, placed BEFORE the warming counter increment so rejected attempts don't consume capacity:

\`\`\`python
token = (options.get(\"env\") or {}).get(\"CLAUDE_CODE_OAUTH_TOKEN\")
if not token:
    log.warning(
        \"pool.spawn_guard: options_hash=%s missing CLAUDE_CODE_OAUTH_TOKEN in env\"
        \" — skipping spawn to prevent auth-timeout waste\",
        options_hash,
    )
    if self._metrics:
        self._metrics.spawn_guard_rejection_total.inc()
    return False
\`\`\`

Plus `pool_spawn_guard_rejection_total` Prometheus counter so we can see in `/metrics` whether the guard is firing in prod and at what rate (without grepping logs).

All 3 known spawn paths (`RefillLoop.hint`, `RefillLoop.run_once`, direct `_inject_warm`) funnel through `_try_inject_warm` — single audit point.

## Tests

7 new tests in `tests/agent_pool_manager/test_spawn_guard.py`:
- rejects: no-env key, empty env dict, empty-string token
- allows: valid non-empty token
- logs WARNING with `spawn_guard` and hash
- does NOT increment warming counter on rejection
- metrics counter increments per rejection, not per valid spawn

Updated `OPTIONS_A`/`OPTIONS_B`/inline-options across 10 existing test files to include a fake token so existing tests continue to exercise the normal warm path.

**686/686 tests passing** (excluding pre-existing-skipped integration/smoke). Code-reviewer pass: no findings.

## Deliberate non-scope

- Does not attempt to identify or fix the unknown startup spawn trigger
- Does not add token-freshness checking (existing token expiry handling unchanged)
- Does not touch hint/acquire paths — those remain best-effort, the guard is the safety net at the spawn boundary

## Operational note

After deploy, watch `pool_spawn_guard_rejection_total` on the `/metrics` endpoint. A non-zero value confirms the guard is firing in prod — that tells us the unknown trigger does exist and is being safely blocked. A zero value means either the trigger went away on its own (unlikely) or only goes through authenticated paths (good).