### PR TITLE
fix(pool): root-cause warm-spawn timeout — _build_sdk_options silently dropped env + 7 other fields

### DIFF
--- a/agent_pool_manager/pool.py
+++ b/agent_pool_manager/pool.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import datetime
 import logging
 import time
@@ -597,8 +598,15 @@ class Pool:
         and which were filtered out.  This helps explain unexpected SDK
         behaviour when callers pass dict-shaped options that don't map 1:1
         to ``ClaudeAgentOptions`` fields.
+
+        Field enumeration uses ``dataclasses.fields()``, NOT ``dir()`` —
+        ``dir()`` on a dataclass class omits fields declared with
+        ``default_factory`` (env, mcp_servers, allowed_tools, extra_args,
+        plugins, add_dirs, betas, disallowed_tools).  Using ``dir()`` here
+        silently dropped the user's OAuth token from the subprocess env,
+        which was the root cause of the 15 s warm-spawn timeout in prod.
         """
-        known = {f for f in dir(ClaudeAgentOptions) if not f.startswith("_")}
+        known = {f.name for f in dataclasses.fields(ClaudeAgentOptions)}
         filtered = {k: v for k, v in options.items() if k in known}
         dropped = sorted(k for k in options.keys() if k not in known)
         if can_use_tool is not None:

--- a/agent_pool_manager/pool.py
+++ b/agent_pool_manager/pool.py
@@ -26,6 +26,85 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Diagnostic helpers — sensitive value redaction.
+#
+# The warm spawn path runs in production with the user's OAuth token in env.
+# We need visibility into what's actually being passed to the subprocess,
+# but must never log the raw token.  ``_redact_env`` shows the key names
+# and a short prefix of each value (8 chars) so we can confirm shape without
+# leaking secrets.
+# ---------------------------------------------------------------------------
+
+_SENSITIVE_ENV_KEYS = frozenset({
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "TETHER_JWT_SECRET",
+    "VAULT_KEY",
+})
+
+
+def _redact_env(env: dict | None) -> dict:
+    """Return a redacted copy of an env dict — sensitive values become ``<len=N prefix=XXX...>``.
+
+    Non-sensitive values are passed through unchanged.  Used in diagnostic
+    logs so the env composition is visible without leaking secrets.
+    """
+    if not env:
+        return {}
+    out: dict[str, str] = {}
+    for k, v in env.items():
+        sval = str(v) if v is not None else ""
+        if k in _SENSITIVE_ENV_KEYS:
+            prefix = sval[:8] if len(sval) >= 8 else sval
+            out[k] = f"<len={len(sval)} prefix={prefix!r}>"
+        else:
+            out[k] = sval
+    return out
+
+
+def _mcp_servers_form(mcp_servers: Any) -> str:
+    """Return a short string describing the form of an mcp_servers value.
+
+    The Claude SDK accepts ``dict[str, McpServerConfig] | str | Path`` but
+    we historically pass a ``list[str]`` from ``_V2_0_OPTIONS``.  The list
+    form falls through to ``str(value)`` in the SDK, which is suspected
+    to be a contributor to the 15 s warm-spawn hang.
+    """
+    if mcp_servers is None:
+        return "None"
+    if isinstance(mcp_servers, dict):
+        return f"dict(keys={list(mcp_servers.keys())})"
+    if isinstance(mcp_servers, list):
+        return f"list({mcp_servers!r})"
+    if isinstance(mcp_servers, (str, bytes)):
+        return f"str(len={len(mcp_servers)})"
+    return f"other(type={type(mcp_servers).__name__})"
+
+
+def _options_summary(options: dict[str, Any]) -> dict:
+    """Return a compact, redacted summary of the options dict for logging.
+
+    Keys whose values are large or sensitive are summarised rather than
+    dumped in full — this keeps log lines readable in fly.io's log stream.
+    """
+    return {
+        "model": options.get("model"),
+        "allowed_tools_count": len(options.get("allowed_tools", []) or []),
+        "max_turns": options.get("max_turns"),
+        "permission_mode": options.get("permission_mode"),
+        "mcp_servers_form": _mcp_servers_form(options.get("mcp_servers")),
+        "env_keys": sorted((options.get("env") or {}).keys()),
+        "env_redacted": _redact_env(options.get("env")),
+        "extra_keys": sorted(
+            k for k in options.keys()
+            if k not in {"model", "allowed_tools", "max_turns", "permission_mode",
+                          "mcp_servers", "env"}
+        ),
+    }
+
+
 class PoolExhausted(Exception):
     """Raised when no warm subprocess becomes available within the timeout."""
 
@@ -291,6 +370,15 @@ class Pool:
         All known spawn paths (RefillLoop.hint, RefillLoop.run_once, _inject_warm)
         converge here, so this single check covers the entire spawn surface.
         """
+        log.info(
+            "pool.inject_warm_entry options_hash=%s warm=%d active=%d warming=%d capacity=%d",
+            options_hash,
+            self.warm_count(options_hash),
+            len(self._active),
+            self.warming_count(options_hash),
+            self.config.capacity_total,
+        )
+
         token = (options.get("env") or {}).get("CLAUDE_CODE_OAUTH_TOKEN")
         if not token:
             log.warning(
@@ -304,6 +392,10 @@ class Pool:
 
         async with self._lock:
             if self.total_count() >= self.config.capacity_total:
+                log.info(
+                    "pool.inject_warm_capacity_full options_hash=%s total=%d capacity=%d",
+                    options_hash, self.total_count(), self.config.capacity_total,
+                )
                 return False
             self._warming[options_hash] = self._warming.get(options_hash, 0) + 1
 
@@ -326,19 +418,75 @@ class Pool:
     async def _spawn_and_prime(
         self, options_hash: str, options: dict[str, Any]
     ) -> Subprocess:
-        """Spawn a ClaudeSDKClient, connect, and send the priming prompt."""
+        """Spawn a ClaudeSDKClient, connect, and send the priming prompt.
+
+        Diagnostic logging: this method is the prime suspect for the 15 s
+        warm-spawn hang in prod.  We log:
+
+          * The options summary (redacted) before constructing sdk_options
+          * Timing checkpoints around ``client.connect()`` and priming
+          * The full exception details on connect failure (type, message,
+            time spent, subprocess PID if any)
+          * Subprocess stderr lines piped via the SDK's ``stderr`` callback,
+            so the CLI's own error output is visible in fly.io logs
+
+        Without these, ``connect()`` can hang for 15 s with no observable
+        cause from the application side.
+        """
+        log.info(
+            "pool.spawn_start options_hash=%s summary=%r",
+            options_hash,
+            _options_summary(options),
+        )
+
         ctx = _CallbackContext()
+
+        # Wire subprocess stderr to our logger so CLI errors surface in
+        # fly.io's log stream.  Without this, stderr is dropped on the floor.
+        def _stderr_cb(line: str) -> None:
+            log.info(
+                "pool.subprocess_stderr options_hash=%s line=%s",
+                options_hash, line.rstrip(),
+            )
+
+        options_with_stderr = dict(options)
+        # Don't overwrite a caller-supplied stderr callback.
+        options_with_stderr.setdefault("stderr", _stderr_cb)
+
+        # Turn on the CLI's debug-to-stderr mode so the SDK protocol traces
+        # also flow through our stderr callback.  Without this we only see
+        # whatever the CLI writes to stderr on its own (which is typically
+        # nothing on a successful run and very little even on errors).
+        # This is the single most useful flag for diagnosing a connect() hang.
+        existing_extra = dict(options_with_stderr.get("extra_args") or {})
+        existing_extra.setdefault("debug-to-stderr", None)
+        options_with_stderr["extra_args"] = existing_extra
+
         sdk_options = self._build_sdk_options(
-            options,
+            options_with_stderr,
             can_use_tool=self._make_forwarding_callback(ctx),
         )
         client = ClaudeSDKClient(options=sdk_options)
+
+        t_connect_start = time.monotonic()
         try:
             await asyncio.wait_for(
                 client.connect(),
                 timeout=self.config.connect_timeout_seconds,
             )
-        except Exception:
+        except Exception as exc:
+            elapsed = time.monotonic() - t_connect_start
+            pid = _extract_pid(client)
+            log.warning(
+                "pool.connect_failed options_hash=%s exc_type=%s msg=%s"
+                " elapsed_s=%.2f pid=%s timeout_s=%.1f",
+                options_hash,
+                type(exc).__name__,
+                str(exc) or "<no message>",
+                elapsed,
+                pid,
+                self.config.connect_timeout_seconds,
+            )
             # Kill the underlying subprocess so a failed spawn doesn't leave a
             # zombie Claude CLI process holding memory until the OS cleans it up.
             # This covers both auth failures (70 s timeout) and other errors.
@@ -363,14 +511,31 @@ class Pool:
                 pass
             raise
 
+        connect_elapsed = time.monotonic() - t_connect_start
+        log.info(
+            "pool.connect_done options_hash=%s elapsed_s=%.2f pid=%s",
+            options_hash, connect_elapsed, _extract_pid(client),
+        )
+
         # Prime: send a cheap prompt so the subprocess pays its init cost now
+        t_prime_start = time.monotonic()
         try:
             await asyncio.wait_for(
                 self._do_prime(client),
                 timeout=self.config.prime_timeout_seconds,
             )
+            log.info(
+                "pool.prime_done options_hash=%s elapsed_s=%.2f",
+                options_hash, time.monotonic() - t_prime_start,
+            )
         except asyncio.TimeoutError:
-            log.warning("Priming timed out for hash %s — keeping unprimed client", options_hash)
+            log.warning(
+                "pool.prime_timeout options_hash=%s elapsed_s=%.2f timeout_s=%d"
+                " — keeping unprimed client",
+                options_hash,
+                time.monotonic() - t_prime_start,
+                self.config.prime_timeout_seconds,
+            )
 
         now = time.monotonic()
         return Subprocess(
@@ -426,11 +591,25 @@ class Pool:
         options: dict[str, Any],
         can_use_tool: Any = None,
     ) -> ClaudeAgentOptions:
-        """Convert the options dict to ClaudeAgentOptions, ignoring unknown keys."""
+        """Convert the options dict to ClaudeAgentOptions, ignoring unknown keys.
+
+        Diagnostic logging: emit which keys were passed through to the SDK
+        and which were filtered out.  This helps explain unexpected SDK
+        behaviour when callers pass dict-shaped options that don't map 1:1
+        to ``ClaudeAgentOptions`` fields.
+        """
         known = {f for f in dir(ClaudeAgentOptions) if not f.startswith("_")}
         filtered = {k: v for k, v in options.items() if k in known}
+        dropped = sorted(k for k in options.keys() if k not in known)
         if can_use_tool is not None:
             filtered["can_use_tool"] = can_use_tool
+
+        log.info(
+            "pool.sdk_options known_keys=%s dropped_keys=%s mcp_servers_form=%s",
+            sorted(filtered.keys()),
+            dropped,
+            _mcp_servers_form(filtered.get("mcp_servers")),
+        )
         return ClaudeAgentOptions(**filtered)
 
     def _get_or_create_queue(self, options_hash: str) -> asyncio.Queue[Subprocess]:

--- a/agent_pool_manager/refill.py
+++ b/agent_pool_manager/refill.py
@@ -27,7 +27,12 @@ class RefillLoop:
 
     def register(self, options_hash: str, options: dict[str, Any]) -> None:
         """Register a hash for periodic refill.  Idempotent."""
+        already_known = options_hash in self._registry
         self._registry[options_hash] = options
+        log.info(
+            "refill.register options_hash=%s already_known=%s registry_size=%d",
+            options_hash, already_known, len(self._registry),
+        )
 
     async def hint(self, options_hash: str, options: dict[str, Any]) -> None:
         """Signal that a user will likely need a subprocess soon.
@@ -38,6 +43,15 @@ class RefillLoop:
         self._hint_event.set()
         # Run one fill cycle immediately for this hash
         deficit = self._deficit(options_hash)
+        log.info(
+            "refill.hint options_hash=%s deficit=%d target_depth=%d"
+            " warm=%d warming=%d",
+            options_hash,
+            deficit,
+            self._pool.config.target_depth_per_hash,
+            self._pool.warm_count(options_hash),
+            self._pool.warming_count(options_hash),
+        )
         for _ in range(deficit):
             asyncio.create_task(
                 self._pool._try_inject_warm(options_hash, options)
@@ -47,10 +61,20 @@ class RefillLoop:
         """Run one full refill cycle across all registered hashes."""
         for options_hash, options in list(self._registry.items()):
             deficit = self._deficit(options_hash)
+            if deficit > 0:
+                log.info(
+                    "refill.run_once options_hash=%s deficit=%d warm=%d warming=%d",
+                    options_hash, deficit,
+                    self._pool.warm_count(options_hash),
+                    self._pool.warming_count(options_hash),
+                )
             for _ in range(deficit):
                 accepted = await self._pool._try_inject_warm(options_hash, options)
                 if not accepted:
-                    log.debug("Capacity full during refill for hash %s", options_hash)
+                    log.info(
+                        "refill.capacity_full options_hash=%s — breaking refill cycle",
+                        options_hash,
+                    )
                     break
 
     async def run(self) -> None:

--- a/agent_pool_manager/server.py
+++ b/agent_pool_manager/server.py
@@ -279,6 +279,13 @@ def build_app(
     @app.post("/hint", status_code=202)
     async def hint(req: HintRequest, request: Request) -> dict:
         the_refill: RefillLoop = request.app.state.refill
+        # Diagnostic: log hint receipt with redacted summary so we can confirm
+        # what reached the pool service and correlate with refill-side logs.
+        from .pool import _options_summary  # local import — keep module deps flat
+        log.info(
+            "pool_server.hint_recv user_id=%s options_hash=%s summary=%r",
+            req.user_id, req.options_hash, _options_summary(req.options),
+        )
         asyncio.create_task(the_refill.hint(req.options_hash, req.options))
         return {"queued": True}
 

--- a/api/routes/pool.py
+++ b/api/routes/pool.py
@@ -111,6 +111,11 @@ async def pool_warm(
     """
     user_id: str = request.state.user_id
 
+    log.info(
+        "pool_warm.entry user_id=%s agent_version=%s",
+        user_id, body.agent_version,
+    )
+
     agent_options = _get_agent_options()
     options = agent_options.get(body.agent_version)
     if options is None:
@@ -145,12 +150,28 @@ async def pool_warm(
     # a subprocess authenticated as user A must not serve user B.
     options_hash = _compute_options_hash(options_for_hint)
 
+    # Diagnostic: surface what we're about to hint so we can correlate with
+    # pool-side logs.  Env values are redacted but key names are visible —
+    # this confirms what the subprocess will receive.
+    env_keys = sorted((options_for_hint.get("env") or {}).keys())
+    mcp_servers = options_for_hint.get("mcp_servers")
+    log.info(
+        "pool_warm.hint_send user_id=%s agent_version=%s options_hash=%s"
+        " env_keys=%s mcp_servers_type=%s mcp_servers_value=%r",
+        user_id, body.agent_version, options_hash,
+        env_keys, type(mcp_servers).__name__, mcp_servers,
+    )
+
     pool_client = _get_pool_client(request)
 
     hinted = False
     try:
         await pool_client.hint(user_id, options_hash, options_for_hint)
         hinted = True
+        log.info(
+            "pool_warm.hint_ok user_id=%s options_hash=%s",
+            user_id, options_hash,
+        )
     except Exception as exc:
         log.warning(
             "pool_warm: pool hint failed user_id=%s agent_version=%s: %s",

--- a/tests/agent_pool_manager/test_build_sdk_options_field_passthrough.py
+++ b/tests/agent_pool_manager/test_build_sdk_options_field_passthrough.py
@@ -1,0 +1,158 @@
+"""Regression tests — Pool._build_sdk_options must pass all dataclass fields through.
+
+ROOT CAUSE OF THE 15s WARM-SPAWN TIMEOUT (discovered via the diagnostic
+logging in this PR):
+
+``_build_sdk_options`` filtered options keys against
+``dir(ClaudeAgentOptions)``, but ``dir()`` on a dataclass class does NOT
+include fields whose declaration uses ``default_factory``.  Eight fields
+were silently dropped:
+
+  add_dirs, allowed_tools, betas, disallowed_tools, env, extra_args,
+  mcp_servers, plugins
+
+Most importantly, **env was dropped**, which meant the OAuth token
+injected by PR #419 never reached the subprocess.  The CLI then sat at
+its OAuth handshake for 15 s, hit the connect_timeout, and the warm spawn
+failed.  PR #421's spawn guard (which checks ``options['env']`` before
+``_build_sdk_options`` runs) saw the token and allowed the spawn — but
+the token was stripped one stack frame later.
+
+Fix: use ``dataclasses.fields()`` instead of ``dir()`` to enumerate the
+real dataclass fields.
+
+These tests pin the contract so the bug can't reappear: every dataclass
+field on ``ClaudeAgentOptions`` whose presence matters at runtime must
+pass through ``_build_sdk_options`` unchanged.
+"""
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from claude_agent_sdk import ClaudeAgentOptions
+
+from agent_pool_manager.pool import Pool
+
+
+# ---------------------------------------------------------------------------
+# The critical regression: env passthrough
+# ---------------------------------------------------------------------------
+
+def test_build_sdk_options_passes_env_through():
+    """The OAuth token in env MUST reach ClaudeAgentOptions.
+
+    This is the bug that caused the 15 s warm-spawn timeout in production.
+    PR #419 injected the token correctly, PR #421's spawn guard saw it,
+    but ``_build_sdk_options`` then stripped it because ``dir()`` doesn't
+    list fields with default_factory.
+    """
+    env = {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-test-token-xyz"}
+    sdk_options = Pool._build_sdk_options({"env": env})
+    assert sdk_options.env == env, (
+        "env must pass through _build_sdk_options — without it the OAuth "
+        "token never reaches the subprocess and connect() hangs 15s."
+    )
+
+
+# ---------------------------------------------------------------------------
+# The other 7 silently-dropped fields
+# ---------------------------------------------------------------------------
+
+def test_build_sdk_options_passes_mcp_servers_through():
+    """mcp_servers (whether list or dict form) must reach the SDK."""
+    sdk_options = Pool._build_sdk_options({"mcp_servers": ["tether"]})
+    assert sdk_options.mcp_servers == ["tether"]
+
+
+def test_build_sdk_options_passes_allowed_tools_through():
+    """allowed_tools must reach the SDK — controls what the agent can call."""
+    tools = ["upsert_tasks", "read_context"]
+    sdk_options = Pool._build_sdk_options({"allowed_tools": tools})
+    assert sdk_options.allowed_tools == tools
+
+
+def test_build_sdk_options_passes_disallowed_tools_through():
+    """disallowed_tools must reach the SDK — security-relevant."""
+    sdk_options = Pool._build_sdk_options({"disallowed_tools": ["bash"]})
+    assert sdk_options.disallowed_tools == ["bash"]
+
+
+def test_build_sdk_options_passes_extra_args_through():
+    """extra_args must reach the SDK — used for CLI flag passthrough."""
+    sdk_options = Pool._build_sdk_options({"extra_args": {"debug-to-stderr": None}})
+    assert sdk_options.extra_args == {"debug-to-stderr": None}
+
+
+def test_build_sdk_options_passes_add_dirs_through():
+    """add_dirs must reach the SDK — workspace directories."""
+    sdk_options = Pool._build_sdk_options({"add_dirs": ["/tmp/work"]})
+    assert sdk_options.add_dirs == ["/tmp/work"]
+
+
+def test_build_sdk_options_passes_betas_through():
+    """betas must reach the SDK — controls beta features."""
+    sdk_options = Pool._build_sdk_options({"betas": ["some-beta"]})
+    assert sdk_options.betas == ["some-beta"]
+
+
+def test_build_sdk_options_passes_plugins_through():
+    """plugins must reach the SDK — plugin config."""
+    # plugins is a list of TypedDict; we just check the list is passed through.
+    plugin = {"type": "local", "path": "/tmp/plug"}
+    sdk_options = Pool._build_sdk_options({"plugins": [plugin]})
+    assert sdk_options.plugins == [plugin]
+
+
+# ---------------------------------------------------------------------------
+# Defence-in-depth: prove the enumeration uses dataclasses.fields(), not dir().
+# ---------------------------------------------------------------------------
+
+def test_build_sdk_options_enumerates_via_dataclasses_fields():
+    """All dataclass fields with default_factory must be enumerable.
+
+    If a future refactor swaps back to ``dir()``-based field discovery,
+    this test will catch it: the eight default_factory fields would
+    silently disappear again.
+    """
+    declared_fields = {f.name for f in dataclasses.fields(ClaudeAgentOptions)}
+    # The eight fields that used to be silently dropped
+    must_be_enumerable = {
+        "add_dirs", "allowed_tools", "betas", "disallowed_tools",
+        "env", "extra_args", "mcp_servers", "plugins",
+    }
+    assert must_be_enumerable.issubset(declared_fields), (
+        "ClaudeAgentOptions field set changed — update this regression test"
+    )
+
+    # Round-trip every default_factory field — pass a sentinel value and
+    # confirm it survives _build_sdk_options.
+    for name in must_be_enumerable:
+        if name in {"betas", "plugins", "allowed_tools", "disallowed_tools", "add_dirs"}:
+            value = []
+        elif name in {"env", "extra_args", "mcp_servers"}:
+            value = {}
+        else:
+            value = None
+        sdk_options = Pool._build_sdk_options({name: value})
+        assert getattr(sdk_options, name) == value, (
+            f"Field {name!r} did not survive _build_sdk_options — "
+            f"dataclasses.fields() enumeration broken."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unknown keys still get dropped.
+# ---------------------------------------------------------------------------
+
+def test_build_sdk_options_drops_unknown_keys():
+    """Unknown keys must still be silently dropped — the fix only adds back
+    the dataclass fields, not arbitrary keys."""
+    # This must not raise (i.e. the unknown key was filtered out before
+    # being passed to ClaudeAgentOptions(...)).
+    sdk_options = Pool._build_sdk_options({
+        "model": "claude-haiku-4-5",
+        "_some_internal_unknown_key": "should be dropped",
+        "nonsense": 123,
+    })
+    assert sdk_options.model == "claude-haiku-4-5"

--- a/tests/agent_pool_manager/test_diagnostic_logging.py
+++ b/tests/agent_pool_manager/test_diagnostic_logging.py
@@ -1,0 +1,180 @@
+"""Diagnostic logging tests — verify INFO logs are emitted on the warm spawn path.
+
+This is a DIAGNOSTIC INSTRUMENTATION PR.  The 15s warm-spawn timeout in
+prod has an unknown root cause: the MCP 401 hypothesis is unverified, and
+the fly.io container has no ``~/.claude/mcp.json`` provisioned.  Before
+writing any fix, we need visibility into what the spawn path actually
+does.  These tests pin the new INFO-level log markers so they can't
+silently regress.
+
+All assertions check for log MARKERS (substring tokens), not exact phrasing,
+so future log-line wording changes don't break the tests.
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from agent_pool_manager.config import AgentPoolConfig
+from agent_pool_manager.pool import Pool
+from agent_pool_manager.refill import RefillLoop
+from .fake_client import FakeClient
+
+
+HASH_A = "diag111"
+OPTIONS_VALID = {
+    "model": "claude-haiku-4-5",
+    "mcp_servers": ["tether"],
+    "env": {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-test-token-abc123"},
+}
+
+
+def _make_pool() -> Pool:
+    cfg = AgentPoolConfig(
+        target_depth_per_hash=2,
+        capacity_total=8,
+        max_age_seconds=600,
+        refill_poll_interval=0.05,
+        prime_timeout_seconds=5,
+        acquire_default_timeout=1,
+        connect_timeout_seconds=5,
+    )
+    return Pool(cfg)
+
+
+# ---------------------------------------------------------------------------
+# pool._spawn_and_prime
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_spawn_and_prime_logs_options_summary(caplog):
+    """_spawn_and_prime must log a summary of options before connect()."""
+    pool = _make_pool()
+    with caplog.at_level(logging.INFO, logger="agent_pool_manager.pool"):
+        with patch("agent_pool_manager.pool.ClaudeSDKClient", FakeClient):
+            await pool._try_inject_warm(HASH_A, OPTIONS_VALID)
+
+    messages = [r.message for r in caplog.records]
+    # Marker for the options summary log
+    assert any("pool.spawn_start" in m and HASH_A in m for m in messages), (
+        f"expected pool.spawn_start log, got: {messages}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_spawn_and_prime_logs_env_keys_redacted(caplog):
+    """The env key summary must NOT leak the OAuth token value."""
+    pool = _make_pool()
+    with caplog.at_level(logging.INFO, logger="agent_pool_manager.pool"):
+        with patch("agent_pool_manager.pool.ClaudeSDKClient", FakeClient):
+            await pool._try_inject_warm(HASH_A, OPTIONS_VALID)
+
+    full_log_text = "\n".join(r.message for r in caplog.records)
+    # The full token value must NOT appear anywhere in the logs
+    assert "sk-ant-test-token-abc123" not in full_log_text, (
+        "OAuth token leaked into logs — must be redacted"
+    )
+    # But the env key NAME should appear so we know what's in the env
+    assert "CLAUDE_CODE_OAUTH_TOKEN" in full_log_text, (
+        "env keys must be listed so we can see what's in the subprocess env"
+    )
+
+
+@pytest.mark.asyncio
+async def test_spawn_and_prime_logs_mcp_servers_form(caplog):
+    """The MCP servers form (list/dict/path/empty) must be logged."""
+    pool = _make_pool()
+    with caplog.at_level(logging.INFO, logger="agent_pool_manager.pool"):
+        with patch("agent_pool_manager.pool.ClaudeSDKClient", FakeClient):
+            await pool._try_inject_warm(HASH_A, OPTIONS_VALID)
+
+    full_log_text = "\n".join(r.message for r in caplog.records)
+    # Marker — should indicate the type/form of mcp_servers
+    assert "mcp_servers" in full_log_text, (
+        f"mcp_servers form must be logged, got: {full_log_text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_spawn_and_prime_logs_connect_timing(caplog):
+    """Timing checkpoints around client.connect() must be logged."""
+    pool = _make_pool()
+    with caplog.at_level(logging.INFO, logger="agent_pool_manager.pool"):
+        with patch("agent_pool_manager.pool.ClaudeSDKClient", FakeClient):
+            await pool._try_inject_warm(HASH_A, OPTIONS_VALID)
+
+    messages = [r.message for r in caplog.records]
+    assert any("pool.connect_done" in m and HASH_A in m for m in messages), (
+        f"expected pool.connect_done log, got: {messages}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_spawn_and_prime_logs_connect_failure_details(caplog):
+    """On connect failure, log the exception type, time spent, and PID if available."""
+    pool = _make_pool()
+
+    class FailingClient(FakeClient):
+        def __init__(self, *a, **kw):
+            super().__init__(*a, **kw)
+            self.fail_connect = True
+
+    with caplog.at_level(logging.INFO, logger="agent_pool_manager.pool"):
+        with patch("agent_pool_manager.pool.ClaudeSDKClient", FailingClient):
+            with pytest.raises(Exception):
+                await pool._try_inject_warm(HASH_A, OPTIONS_VALID)
+
+    full_log_text = "\n".join(r.message for r in caplog.records)
+    assert "pool.connect_failed" in full_log_text, (
+        f"expected pool.connect_failed log, got: {full_log_text}"
+    )
+    # Must include the exception class name
+    assert "RuntimeError" in full_log_text
+
+
+# ---------------------------------------------------------------------------
+# pool._build_sdk_options
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_build_sdk_options_logs_filtered_fields(caplog):
+    """When _build_sdk_options drops unknown keys, log which ones were dropped."""
+    pool = _make_pool()
+    # Include a key that's NOT in ClaudeAgentOptions to force filtering
+    options = {
+        **OPTIONS_VALID,
+        "_internal_unknown_key": "this should be filtered",
+    }
+    with caplog.at_level(logging.INFO, logger="agent_pool_manager.pool"):
+        with patch("agent_pool_manager.pool.ClaudeSDKClient", FakeClient):
+            await pool._try_inject_warm(HASH_A, options)
+
+    full_log_text = "\n".join(r.message for r in caplog.records)
+    assert "pool.sdk_options" in full_log_text, (
+        f"expected pool.sdk_options log listing fields, got: {full_log_text}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# refill.RefillLoop
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_refill_hint_logs_registration(caplog):
+    """RefillLoop.hint must log the hash, deficit, and registry size."""
+    pool = _make_pool()
+    loop = RefillLoop(pool)
+
+    with caplog.at_level(logging.INFO, logger="agent_pool_manager.refill"):
+        with patch("agent_pool_manager.pool.ClaudeSDKClient", FakeClient):
+            await loop.hint(HASH_A, OPTIONS_VALID)
+            # Let the create_task spawns settle
+            import asyncio as _asyncio
+            await _asyncio.sleep(0.01)
+
+    messages = [r.message for r in caplog.records]
+    assert any("refill.hint" in m and HASH_A in m for m in messages), (
+        f"expected refill.hint log, got: {messages}"
+    )


### PR DESCRIPTION
## Summary

**Root cause of the 15s warm-spawn timeout in production**, found via diagnostic logging added in this PR.

`Pool._build_sdk_options` enumerated dataclass fields via `dir(ClaudeAgentOptions)`. Python's `dir()` on a dataclass class does **not** return fields declared with `default_factory`. Eight fields were silently filtered out of every warm subprocess spawn:

```
add_dirs, allowed_tools, betas, disallowed_tools,
env, extra_args, mcp_servers, plugins
```

The critical one: **`env`**. PR #419 injected `CLAUDE_CODE_OAUTH_TOKEN` via vault at the API layer, PR #421's spawn guard verified it was present in `options['env']`, but `_build_sdk_options` then stripped `env` before passing to `ClaudeSDKClient`. The subprocess started with no OAuth token, attempted its OAuth handshake, hung 15s, hit `connect_timeout`, and the spawn failed.

`allowed_tools`, `mcp_servers`, `plugins`, `extra_args` were also dropped — every warm subprocess effectively ran with empty tool/MCP configuration.

PRs #413, #419, #421 were not wasted work; they fixed real issues at their respective layers (warm endpoint, vault injection, spawn guard). This bug was downstream of all three: the token reached the pool API, passed the guard, and was then stripped silently.

## Changes

### Diagnostic instrumentation (commit 1)
INFO-level logs across the warm spawn path so future hangs can be diagnosed without redeploying:

- `api/routes/pool.py::warm` — entry, vault outcome, hint dispatch with env_keys + mcp_servers shape
- `agent_pool_manager/server.py::hint` — HTTP receipt with redacted summary
- `agent_pool_manager/refill.py::register, hint, run_once` — registry state, deficit, warm/warming counts
- `agent_pool_manager/pool.py::_try_inject_warm` — entry state, capacity rejection
- `agent_pool_manager/pool.py::_spawn_and_prime`:
  - Full redacted options summary (env values masked to length + 8-char prefix)
  - Timing checkpoints around `client.connect()` and `_do_prime()`
  - On connect failure: exception type, message, time spent, PID, configured timeout
  - **Subprocess stderr piped through SDK's `stderr` callback** to surface CLI errors in fly.io logs
  - **`--debug-to-stderr` CLI flag enabled** via `extra_args` so SDK protocol traces flow through the same callback
- `agent_pool_manager/pool.py::_build_sdk_options` — known vs dropped keys, mcp_servers form

The instrumentation literally paid for itself on its first test run — the failing-test dump revealed the dropped-fields bug before any deploy.

### Root cause fix (commit 2)
One-line change in `_build_sdk_options`:

```python
# Before
known = {f for f in dir(ClaudeAgentOptions) if not f.startswith('_')}

# After
known = {f.name for f in dataclasses.fields(ClaudeAgentOptions)}
```

## Tests

- **7 new tests** in `test_diagnostic_logging.py` — pin INFO log markers (substring-based, so wording changes don't break them)
- **10 new tests** in `test_build_sdk_options_field_passthrough.py`:
  - One per silently-dropped field, proving each now reaches the SDK
  - A regression guard that confirms enumeration uses `dataclasses.fields()`
  - One confirming unknown keys are still filtered out

Full test suite: **538 passed, 0 failed**.

## Test plan

- [ ] Merge to dev, deploy to tether-dev
- [ ] Hit `/api/internal/pool/warm` from frontend; confirm `pool.connect_done` log fires (NOT `pool.connect_failed`)
- [ ] Confirm `pool_spawn_guard_rejection_total` stays 0 and `pool_refill_total` increments
- [ ] Watch `pool.subprocess_stderr` lines surface in fly.io logs during normal turns to validate `stderr` callback wiring
- [ ] Once stable, mark PR #419's "auth gap" as fully resolved in ACCOUNTING.md