### PR TITLE
fix: pool MCP fallback and empty user_id production bugs

### DIFF
--- a/agent_pool_manager/pool.py
+++ b/agent_pool_manager/pool.py
@@ -524,7 +524,7 @@ class Pool:
         # computed from the placeholder stays stable across warm-endpoint and
         # dispatch_v2_0 callers.
         mcp_key_id: str | None = None
-        if self._pg_pool is not None and user_id is not None:
+        if self._pg_pool is not None and user_id:  # truthy: excludes None and ""
             try:
                 from db.pg_queries.api_keys import create_key as _create_key
                 async with self._pg_pool.acquire() as _conn:
@@ -544,6 +544,11 @@ class Pool:
                     options_hash,
                     exc_info=True,
                 )
+                # Strip the ['tether'] placeholder so the subprocess doesn't hang
+                # waiting for a tether MCP server it cannot authenticate with.
+                # An empty dict tells the SDK "no MCP servers" — clean start.
+                options = dict(options)
+                options["mcp_servers"] = {}
 
         # Wire subprocess stderr to our logger so CLI errors surface in
         # fly.io's log stream.  Without this, stderr is dropped on the floor.

--- a/agent_pool_manager/refill.py
+++ b/agent_pool_manager/refill.py
@@ -37,7 +37,7 @@ class RefillLoop:
         """Register a hash for periodic refill.  Idempotent."""
         already_known = options_hash in self._registry
         self._registry[options_hash] = options
-        if user_id is not None:
+        if user_id:  # truthy: excludes None and "" to prevent UUID parse errors
             self._user_ids[options_hash] = user_id
         log.info(
             "refill.register options_hash=%s already_known=%s registry_size=%d",

--- a/tests/agent_pool_manager/test_pool_mcp_injection.py
+++ b/tests/agent_pool_manager/test_pool_mcp_injection.py
@@ -432,3 +432,85 @@ async def test_spawn_failure_revokes_key():
     mock_revoke.assert_awaited_once()
     args = mock_revoke.await_args.args
     assert "key-uuid-leak" in args
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: empty-string user_id must be treated same as None (no key creation)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_spawn_with_empty_string_user_id_skips_key_creation():
+    """user_id='' must not trigger create_key — would cause UUID parse error in DB."""
+    mock_pg_pool = MagicMock()
+    pool = _make_pool(pg_pool=mock_pg_pool)
+
+    mock_client = MagicMock()
+    mock_client.connect = AsyncMock()
+
+    async def fake_do_prime(_client):
+        pass
+
+    with (
+        patch.object(Pool, "_build_sdk_options", return_value=MagicMock()),
+        patch("agent_pool_manager.pool.ClaudeSDKClient", return_value=mock_client),
+        patch.object(Pool, "_do_prime", new=staticmethod(fake_do_prime)),
+        patch("db.pg_queries.api_keys.create_key") as mock_create_key,
+    ):
+        sub = await pool._spawn_and_prime(
+            options_hash="abcdef01abcdef01",
+            options=_base_options(),
+            user_id="",  # empty string — must be treated as absent
+        )
+
+    mock_create_key.assert_not_called()
+    assert sub.mcp_key_id is None
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: key creation failure must strip ['tether'] placeholder before spawn
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_spawn_key_failure_strips_mcp_placeholder():
+    """When key creation fails, mcp_servers must be replaced with {} so SDK doesn't hang."""
+    mock_pg_pool = MagicMock()
+    mock_conn = AsyncMock()
+    mock_pg_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_pg_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    pool = _make_pool(pg_pool=mock_pg_pool)
+    captured_sdk_options: list[dict] = []
+
+    def fake_build_sdk_options(options, can_use_tool=None):
+        captured_sdk_options.append(dict(options))
+        return MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.connect = AsyncMock()
+
+    async def fake_do_prime(_client):
+        pass
+
+    with (
+        patch(
+            "db.pg_queries.api_keys.create_key",
+            new=AsyncMock(side_effect=Exception("DB error")),
+        ),
+        patch.object(Pool, "_build_sdk_options", side_effect=fake_build_sdk_options),
+        patch("agent_pool_manager.pool.ClaudeSDKClient", return_value=mock_client),
+        patch.object(Pool, "_do_prime", new=staticmethod(fake_do_prime)),
+    ):
+        sub = await pool._spawn_and_prime(
+            options_hash="abcdef01abcdef01",
+            options=_base_options(),
+            user_id="user-uuid-999",
+        )
+
+    assert len(captured_sdk_options) == 1
+    mcp = captured_sdk_options[0].get("mcp_servers")
+    # Must NOT be the list placeholder — that would cause SDK to hang
+    assert not isinstance(mcp, list), (
+        f"mcp_servers must not be a list after key creation failure, got: {mcp!r}"
+    )
+    # Must be an empty dict (no MCP servers) so subprocess can start without MCP auth
+    assert mcp == {}, f"Expected empty dict mcp_servers on fallback, got: {mcp!r}"


### PR DESCRIPTION
## Summary

- **Bug 1**: `user_id=""` passed `is not None` but caused `asyncpg.exceptions.InvalidTextRepresentationError: invalid input syntax for type uuid: ""` at `create_key`. Changed guard to truthy `if user_id:` in both `_spawn_and_prime` and `refill.register()` so empty strings are treated the same as `None`.
- **Bug 2**: When key creation fails, the `['tether']` list placeholder was left in `options` — SDK received an unparseable list, hung 15s, then TimeoutError. Fixed by setting `options["mcp_servers"] = {}` in the except block so the subprocess starts without MCP auth rather than hanging.

## Test plan

- [ ] `test_spawn_with_empty_string_user_id_skips_key_creation` — `user_id=""` → `create_key` not called
- [ ] `test_spawn_key_failure_strips_mcp_placeholder` — DB error → `mcp_servers={}` on fallback path
- [ ] 726/726 full suite passing