### PR TITLE
fix: reject empty user_id at pool manager API boundary

### DIFF
--- a/agent_pool_manager/server.py
+++ b/agent_pool_manager/server.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 class AcquireRequest(BaseModel):
-    user_id: str
+    user_id: str = Field(..., min_length=1)
     options_hash: str
     options: dict[str, Any] = Field(default_factory=dict)
     timeout_seconds: float | None = None
@@ -45,7 +45,7 @@ class QueryRequest(BaseModel):
 
 
 class HintRequest(BaseModel):
-    user_id: str
+    user_id: str = Field(..., min_length=1)
     options_hash: str
     options: dict[str, Any] = Field(default_factory=dict)
 

--- a/agent_pool_manager/server.py
+++ b/agent_pool_manager/server.py
@@ -5,6 +5,11 @@ import asyncio
 import dataclasses
 import json
 import logging
+import os
+import re
+import time
+import urllib.parse
+import uuid
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator
 
@@ -18,6 +23,126 @@ from .pool import Pool, PoolExhausted
 from .refill import RefillLoop
 
 log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Setup-token pexpect helpers
+# ---------------------------------------------------------------------------
+
+_ANTHROPIC_URL_RE = re.compile(r"https://\S+")
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+_OAUTH_TOKEN_RE = re.compile(r"sk-ant-[A-Za-z0-9_-]+")
+_VALID_ANTHROPIC_NETLOCS = {"console.anthropic.com", "claude.com"}
+_SETUP_TTL = 600  # seconds
+
+# Pending setup-token sessions: session_id → {"child": ..., "created_at": float}
+_setup_token_sessions: dict[str, dict] = {}
+
+
+def _extract_anthropic_url(text: str) -> str | None:
+    joined = text.replace("\r", "").replace("\n", "")
+    for match in _ANTHROPIC_URL_RE.finditer(joined):
+        candidate = match.group(0).rstrip(".,;)")
+        parsed = urllib.parse.urlparse(candidate)
+        if parsed.scheme == "https" and parsed.netloc in _VALID_ANTHROPIC_NETLOCS:
+            return candidate
+    return None
+
+
+def _start_pexpect_sync(env: dict) -> tuple:
+    """Spawn ``claude setup-token`` in a PTY, wait for the auth URL.
+
+    Returns ``(child, url)`` on success or ``(None, None)`` on failure.
+    The child stays alive waiting for the OAuth code via :func:`_complete_pexpect_sync`.
+    """
+    import pexpect  # lazy import — keeps module importable when pexpect absent
+
+    log.info("setup_token/start: spawning claude setup-token")
+    try:
+        child = pexpect.spawn("claude", args=["setup-token"], env=env, dimensions=(24, 500))
+    except Exception:
+        log.exception("setup_token/start: pexpect.spawn failed")
+        return None, None
+
+    buf = ""
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        try:
+            chunk = child.read_nonblocking(4096, timeout=1)
+            buf += chunk.decode(errors="replace")
+            clean = _ANSI_ESCAPE_RE.sub("", buf)
+            url = _extract_anthropic_url(clean)
+            if url:
+                log.info("setup_token/start: auth URL extracted: %s", url)
+                return child, url
+        except pexpect.TIMEOUT:
+            continue
+        except pexpect.EOF:
+            log.warning("setup_token/start: EOF before URL found; output: %r", buf[-500:])
+            break
+        except Exception:
+            log.exception("setup_token/start: unexpected error reading child output")
+            break
+
+    log.error("setup_token/start: timed out waiting for auth URL")
+    try:
+        child.close(force=True)
+    except Exception:
+        pass
+    return None, None
+
+
+def _complete_pexpect_sync(child, code: str) -> tuple[str, str]:
+    """Send the OAuth code to the waiting child and capture the OAuth token.
+
+    Returns ``(result, token)`` where result is ``"ok"``, ``"failed"``,
+    ``"timeout"``, or ``"error"``.
+    """
+    import pexpect  # lazy import
+
+    log.info("setup_token/complete: sending code to pexpect child")
+    try:
+        child.send(code + "\r")
+    except Exception:
+        log.exception("setup_token/complete: pexpect send failed")
+        return "error", ""
+
+    buf = b""
+    token: str | None = None
+    sent_confirm = False
+    deadline = time.time() + 120
+
+    while time.time() < deadline:
+        try:
+            chunk = child.read_nonblocking(4096, timeout=1)
+            buf += chunk
+            clean = _ANSI_ESCAPE_RE.sub("", chunk.decode(errors="replace"))
+            match = _OAUTH_TOKEN_RE.search(clean)
+            if match:
+                token = match.group(0)
+                break
+            if not sent_confirm and b"\r\r\n\r\r\n" in buf:
+                child.send("\r")
+                sent_confirm = True
+        except pexpect.TIMEOUT:
+            continue
+        except pexpect.EOF:
+            full_clean = _ANSI_ESCAPE_RE.sub("", buf.decode(errors="replace"))
+            match = _OAUTH_TOKEN_RE.search(full_clean)
+            if match:
+                token = match.group(0)
+            break
+        except Exception:
+            log.exception("setup_token/complete: unexpected error")
+            return "error", ""
+    else:
+        return "timeout", ""
+
+    try:
+        child.close()
+    except Exception:
+        pass
+
+    return ("ok", token) if token else ("failed", "")
 
 
 # ---------------------------------------------------------------------------
@@ -55,6 +180,11 @@ class ControlResponseRequest(BaseModel):
     subtype: str
     decision: str  # "allow" | "deny"
     denial_message: str | None = None
+
+
+class SetupTokenCompleteRequest(BaseModel):
+    session_id: str
+    code: str
 
 
 # ---------------------------------------------------------------------------
@@ -331,7 +461,69 @@ def build_app(
                 detail=f"request_id {req.request_id!r} not found or already resolved",
             )
 
+    # -----------------------------------------------------------------------
+    # POST /setup-token
+    #
+    # Spawns ``claude setup-token`` in a PTY, waits for the Anthropic auth
+    # URL, and returns it along with a session_id the caller uses to submit
+    # the OAuth code via POST /setup-token/complete.
+    # -----------------------------------------------------------------------
+    @app.post("/setup-token")
+    async def setup_token_start(request: Request) -> JSONResponse:
+        # Sweep expired sessions before starting a new one
+        now = time.time()
+        expired = [sid for sid, s in _setup_token_sessions.items()
+                   if now - s["created_at"] > _SETUP_TTL]
+        for sid in expired:
+            entry = _setup_token_sessions.pop(sid, None)
+            if entry:
+                loop = asyncio.get_running_loop()
+                loop.run_in_executor(None, lambda c=entry["child"]: _close_child(c))
+
+        env = {**os.environ}
+        loop = asyncio.get_running_loop()
+        child, url = await loop.run_in_executor(None, _start_pexpect_sync, env)
+
+        if child is None or url is None:
+            return JSONResponse(
+                status_code=503,
+                content={"error": "setup_token_failed", "detail": "claude setup-token did not produce an auth URL"},
+            )
+
+        session_id = str(uuid.uuid4())
+        _setup_token_sessions[session_id] = {"child": child, "created_at": now}
+        log.info("setup_token/start: session_id=%s url=%s", session_id, url)
+        return JSONResponse({"session_id": session_id, "url": url})
+
+    # -----------------------------------------------------------------------
+    # POST /setup-token/complete
+    #
+    # Sends the OAuth code to the waiting pexpect child identified by
+    # session_id and returns the resulting OAuth token.
+    # -----------------------------------------------------------------------
+    @app.post("/setup-token/complete")
+    async def setup_token_complete(req: SetupTokenCompleteRequest) -> JSONResponse:
+        entry = _setup_token_sessions.pop(req.session_id, None)
+        if entry is None:
+            raise HTTPException(status_code=404, detail="session not found or expired")
+
+        child = entry["child"]
+        loop = asyncio.get_running_loop()
+        result, token = await loop.run_in_executor(
+            None, _complete_pexpect_sync, child, req.code
+        )
+        log.info("setup_token/complete: session_id=%s result=%s", req.session_id, result)
+        return JSONResponse({"result": result, "token": token if token else None})
+
     return app
+
+
+def _close_child(child) -> None:
+    """Kill a pexpect child — used for TTL cleanup."""
+    try:
+        child.close(force=True)
+    except Exception:
+        pass
 
 
 # ---------------------------------------------------------------------------

--- a/agent_pool_manager/server.py
+++ b/agent_pool_manager/server.py
@@ -183,8 +183,8 @@ class ControlResponseRequest(BaseModel):
 
 
 class SetupTokenCompleteRequest(BaseModel):
-    session_id: str
-    code: str
+    session_id: str = Field(..., min_length=1)
+    code: str = Field(..., min_length=1)
 
 
 # ---------------------------------------------------------------------------
@@ -467,6 +467,11 @@ def build_app(
     # Spawns ``claude setup-token`` in a PTY, waits for the Anthropic auth
     # URL, and returns it along with a session_id the caller uses to submit
     # the OAuth code via POST /setup-token/complete.
+    #
+    # Security note: this endpoint is unauthenticated at the pool-manager
+    # layer (consistent with /acquire and /hint).  Access control is enforced
+    # by the API service that proxies here — callers must not expose the pool
+    # manager port (5002) to untrusted networks.
     # -----------------------------------------------------------------------
     @app.post("/setup-token")
     async def setup_token_start(request: Request) -> JSONResponse:
@@ -514,6 +519,23 @@ def build_app(
         )
         log.info("setup_token/complete: session_id=%s result=%s", req.session_id, result)
         return JSONResponse({"result": result, "token": token if token else None})
+
+    # -----------------------------------------------------------------------
+    # DELETE /setup-token/{session_id}
+    #
+    # Cancels a pending setup-token session, killing the pexpect child.
+    # Called by the API proxy when a user restarts /start to prevent
+    # orphaned subprocess accumulation.
+    # -----------------------------------------------------------------------
+    @app.delete("/setup-token/{session_id}", status_code=204)
+    async def setup_token_cancel(session_id: str, request: Request) -> None:
+        entry = _setup_token_sessions.pop(session_id, None)
+        if entry is None:
+            raise HTTPException(status_code=404, detail="session not found or expired")
+        child = entry["child"]
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, _close_child, child)
+        log.info("setup_token/cancel: session_id=%s child reaped", session_id)
 
     return app
 

--- a/api/routes/integrations.py
+++ b/api/routes/integrations.py
@@ -490,8 +490,22 @@ async def _anthropic_start_locked(request: Request, user_id: str) -> dict:
     logger.info("anthropic/start: request for user_id=%s", user_id)
 
     if user_id in _pending_setups:
-        logger.info("anthropic/start: discarding stale pending setup for user_id=%s", user_id)
-        _pending_setups.pop(user_id)
+        old_entry = _pending_setups.pop(user_id)
+        old_session_id = old_entry.get("session_id")
+        logger.info(
+            "anthropic/start: canceling stale pending setup for user_id=%s session_id=%s",
+            user_id, old_session_id,
+        )
+        if old_session_id:
+            try:
+                async with httpx.AsyncClient(timeout=5.0) as client:
+                    await client.delete(f"{_POOL_MANAGER_BASE_URL}/setup-token/{old_session_id}")
+            except Exception:
+                logger.warning(
+                    "anthropic/start: failed to cancel stale session_id=%s (continuing)",
+                    old_session_id,
+                    exc_info=True,
+                )
 
     try:
         async with httpx.AsyncClient(timeout=90.0) as client:

--- a/api/routes/integrations.py
+++ b/api/routes/integrations.py
@@ -18,10 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
-import re
 import time
-import urllib.parse
 
 import asyncpg
 import httpx
@@ -64,36 +61,9 @@ _pending_setups: dict[str, dict] = {}
 _start_locks: dict[str, asyncio.Lock] = {}
 
 _SETUP_TTL = 600  # seconds
-_ANTHROPIC_URL_RE = re.compile(r"https://\S+")
-# Strip ANSI CSI escape sequences emitted by TUI programs on a PTY.
-# Note: does not strip OSC8 hyperlinks (\x1b]8;;URL\x07...\x1b]8;;\x07) — if
-# claude setup-token ever uses them, extend this regex or post-process the URL.
-_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+# Pool manager base URL — pexpect subprocess work is delegated to this service.
+_POOL_MANAGER_BASE_URL = "http://127.0.0.1:5002"
 
-# `claude setup-token` prints a long-lived OAuth token to stdout (sk-ant-oat-…)
-# rather than writing a credentials file. The trailing run is URL-safe base64
-# plus dashes/underscores; we capture the longest such run after the prefix.
-_ANTHROPIC_URL_SCHEME = "https"
-# claude setup-token may emit URLs on either domain depending on version.
-_VALID_ANTHROPIC_NETLOCS = {"console.anthropic.com", "claude.com"}
-_OAUTH_TOKEN_RE = re.compile(r"sk-ant-[A-Za-z0-9_-]+")
-
-
-def _extract_anthropic_url(text: str) -> str | None:
-    """Extract and strictly validate the Anthropic auth URL from subprocess output.
-
-    Strips CR/LF before matching so PTY line-wrapping doesn't split the URL.
-    Uses urlparse to check scheme and netloc exactly — prevents substring-match
-    bypasses where a valid domain appears at an arbitrary position in a crafted URL.
-    """
-    # PTY output uses CRLF; strip both so the URL regex can match across wrap points.
-    joined = text.replace("\r", "").replace("\n", "")
-    for match in _ANTHROPIC_URL_RE.finditer(joined):
-        candidate = match.group(0).rstrip(".,;)")  # strip trailing punctuation
-        parsed = urllib.parse.urlparse(candidate)
-        if parsed.scheme == _ANTHROPIC_URL_SCHEME and parsed.netloc in _VALID_ANTHROPIC_NETLOCS:
-            return candidate
-    return None
 
 
 # ---------------------------------------------------------------------------
@@ -108,173 +78,14 @@ class AnthropicCompleteBody(BaseModel):
     code: str
 
 
-# ---------------------------------------------------------------------------
-# Anthropic OAuth helpers
-# ---------------------------------------------------------------------------
-
-def _close_child_sync(child) -> None:
-    """Kill a pexpect child and close its PTY file descriptor."""
-    try:
-        child.close(force=True)
-    except Exception:
-        pass
-
-
-async def _reap_child(child) -> None:
-    """Async wrapper: close pexpect child in an executor to avoid blocking the event loop."""
-    loop = asyncio.get_running_loop()
-    try:
-        await loop.run_in_executor(None, _close_child_sync, child)
-    except Exception:
-        pass
-
-
-def _start_pexpect_sync(env: dict) -> tuple:
-    """Spawn ``claude setup-token`` in a PTY, wait for the auth URL, return ``(child, url)``.
-
-    The child process stays alive after this returns, waiting for the user to
-    paste the OAuth code via :func:`_complete_pexpect_sync`.
-
-    A wide PTY (220 cols) prevents the URL from line-wrapping, which would
-    break the URL regex. Returns ``(None, None)`` on any failure.
-    """
-    import pexpect  # lazy — keeps module importable when pexpect is not installed
-
-    logger.info("anthropic/start: spawning claude setup-token")
-    try:
-        child = pexpect.spawn(
-            "claude",
-            args=["setup-token"],
-            env=env,
-            dimensions=(24, 500),
-        )
-        logger.debug("anthropic/start: pexpect.spawn ok, pid=%s", child.pid)
-    except Exception:
-        logger.exception("pexpect.spawn failed for claude setup-token")
-        return None, None
-
-    buf = ""
-    deadline = time.time() + 60
-    while time.time() < deadline:
-        try:
-            chunk = child.read_nonblocking(4096, timeout=1)
-            # Accumulate raw bytes first, then strip ANSI from the full buffer
-            # so CSI sequences that straddle read boundaries are handled correctly.
-            buf += chunk.decode(errors="replace")
-            clean = _ANSI_ESCAPE_RE.sub("", buf)
-            logger.debug("anthropic/start: pexpect buffer so far (clean): %r", clean[-500:])
-            url = _extract_anthropic_url(clean)
-            if url:
-                logger.info("anthropic/start: auth URL extracted: %s", url)
-                return child, url
-        except pexpect.TIMEOUT:
-            continue
-        except pexpect.EOF:
-            logger.warning(
-                "anthropic/start: pexpect EOF before URL found; full output: %r",
-                _ANSI_ESCAPE_RE.sub("", buf),
-            )
-            break
-        except Exception:
-            logger.exception("Unexpected error reading pexpect child output")
-            break
-
-    logger.error(
-        "anthropic/start: gave up waiting for auth URL after 30s; "
-        "last buffer (clean, last 500 chars): %r",
-        _ANSI_ESCAPE_RE.sub("", buf)[-500:],
-    )
-    _close_child_sync(child)
-    return None, None
-
-
-def _complete_pexpect_sync(child, code: str) -> tuple[str, str]:
-    """Send the OAuth code to the waiting pexpect child and capture the OAuth token.
-
-    Streams child output live (one INFO log per chunk) so we can see exactly
-    what the CLI emits after the code is sent. Scans each chunk for the token
-    pattern so we catch it as soon as it appears rather than waiting for EOF.
-
-    Returns a (result, token) tuple where result is one of:
-      ``"ok"``      — token found; token string is non-empty
-      ``"failed"``  — child exited without printing a token
-      ``"timeout"`` — 120 seconds elapsed without token or EOF
-      ``"error"``   — unexpected error
-    """
-    import pexpect  # lazy — keeps module importable when pexpect is not installed
-
-    logger.info("anthropic/complete: sending code (length=%d) to pexpect child", len(code))
-    try:
-        child.send(code + '\r')  # \r alone = one Enter in PTY canonical mode
-    except Exception:
-        logger.exception("pexpect send failed — child likely already exited")
-        return "error", ""
-
-    buf = b""
-    token: str | None = None
-    sent_confirm = False
-    deadline = time.time() + 120
-
-    while time.time() < deadline:
-        try:
-            chunk = child.read_nonblocking(4096, timeout=1)
-            buf += chunk
-            clean = _ANSI_ESCAPE_RE.sub("", chunk.decode(errors="replace"))
-            safe = _OAUTH_TOKEN_RE.sub("sk-ant-***REDACTED***", clean)
-            logger.info("anthropic/complete: child output chunk: %r", safe)
-            match = _OAUTH_TOKEN_RE.search(clean)
-            if match:
-                token = match.group(0)
-                logger.info("anthropic/complete: token found in output stream")
-                break
-            # After the code echo the CLI may sit at a secondary "press Enter"
-            # prompt.  Detect the two-blank-line pattern that follows the
-            # asterisk echo and send a confirming \r once.
-            if not sent_confirm and b"\r\r\n\r\r\n" in buf:
-                logger.info("anthropic/complete: sending confirm \\r after code echo")
-                child.send('\r')
-                sent_confirm = True
-        except pexpect.TIMEOUT:
-            continue
-        except pexpect.EOF:
-            logger.info("anthropic/complete: child EOF")
-            # Token may have arrived in the same read as EOF — scan full buffer.
-            full_clean = _ANSI_ESCAPE_RE.sub("", buf.decode(errors="replace"))
-            match = _OAUTH_TOKEN_RE.search(full_clean)
-            if match:
-                token = match.group(0)
-                logger.info("anthropic/complete: token found at EOF")
-            break
-        except Exception:
-            logger.exception("pexpect read_nonblocking failed")
-            return "error", ""
-    else:
-        full_clean = _ANSI_ESCAPE_RE.sub("", buf.decode(errors="replace"))
-        logger.warning(
-            "anthropic/complete: timed out waiting for token; output so far: %r",
-            full_clean[-500:],
-        )
-        return "timeout", ""
-
-    try:
-        child.close()
-    except Exception:
-        pass
-
-    if token:
-        return "ok", token
-    logger.warning(
-        "anthropic/complete: child exited without printing token; full output: %r",
-        _ANSI_ESCAPE_RE.sub("", buf.decode(errors="replace"))[-500:],
-    )
-    return "failed", ""
 
 
 async def _sweep_expired_setups() -> None:
-    """Kill and remove any pending setups older than _SETUP_TTL seconds.
+    """Remove pending setup entries older than _SETUP_TTL seconds.
 
-    Each killed child is reaped via an asyncio task so PTY FDs are released
-    without blocking the current request.
+    Session cleanup on the pool manager side is handled by the pool manager
+    itself; this sweep only removes stale session_id references from our
+    local ``_pending_setups`` dict.
     """
     now = time.time()
     expired_users = [
@@ -282,10 +93,8 @@ async def _sweep_expired_setups() -> None:
         if now - entry["started_at"] > _SETUP_TTL
     ]
     for uid in expired_users:
-        entry = _pending_setups.pop(uid)
-        child = entry.get("child")
-        if child is not None:
-            asyncio.create_task(_reap_child(child))
+        _pending_setups.pop(uid, None)
+        logger.debug("anthropic/sweep: removed expired setup for user_id=%s", uid)
 
 
 # ---------------------------------------------------------------------------
@@ -673,37 +482,44 @@ async def anthropic_start(
 async def _anthropic_start_locked(request: Request, user_id: str) -> dict:
     """Inner /start logic — called while holding the per-user _start_locks entry.
 
-    Spawns ``claude setup-token`` in a PTY via :func:`_start_pexpect_sync` (run
-    in a thread-pool executor so the event loop is not blocked). The pexpect child
-    stays alive waiting for the user to paste their OAuth code.
+    Proxies to the agent pool manager's POST /setup-token endpoint, which
+    spawns ``claude setup-token`` in a PTY and returns the auth URL and a
+    session_id.  The session_id is stored in ``_pending_setups`` so the
+    /complete handler can forward the OAuth code to the correct subprocess.
     """
     logger.info("anthropic/start: request for user_id=%s", user_id)
 
     if user_id in _pending_setups:
-        logger.info("anthropic/start: killing existing pending setup for user_id=%s", user_id)
-        old = _pending_setups.pop(user_id)
-        asyncio.create_task(_reap_child(old["child"]))
+        logger.info("anthropic/start: discarding stale pending setup for user_id=%s", user_id)
+        _pending_setups.pop(user_id)
 
-    env_override = dict(os.environ)
-
-    loop = asyncio.get_running_loop()
     try:
-        child, url = await loop.run_in_executor(
-            None, _start_pexpect_sync, env_override
-        )
+        async with httpx.AsyncClient(timeout=90.0) as client:
+            resp = await client.post(f"{_POOL_MANAGER_BASE_URL}/setup-token", json={})
     except Exception as exc:
-        logger.exception("Unexpected error from _start_pexpect_sync: %s", exc)
-        raise HTTPException(status_code=502, detail="Failed to spawn setup process")
+        logger.exception("anthropic/start: pool manager request failed: %s", exc)
+        raise HTTPException(status_code=502, detail="Failed to reach setup-token service")
 
-    if url is None:
-        logger.error("anthropic/start: failed to extract auth URL for user_id=%s", user_id)
+    if resp.status_code != 200:
+        logger.error(
+            "anthropic/start: pool manager returned %d for user_id=%s body=%r",
+            resp.status_code, user_id, resp.text,
+        )
         raise HTTPException(status_code=502, detail="Auth URL not found in claude output")
 
+    data = resp.json()
+    session_id = data.get("session_id")
+    url = data.get("url")
+
+    if not session_id or not url:
+        logger.error("anthropic/start: pool manager response missing fields: %r", data)
+        raise HTTPException(status_code=502, detail="Invalid response from setup-token service")
+
     _pending_setups[user_id] = {
-        "child": child,
+        "session_id": session_id,
         "started_at": time.time(),
     }
-    logger.info("anthropic/start: success, auth URL ready for user_id=%s", user_id)
+    logger.info("anthropic/start: success, auth URL ready for user_id=%s session_id=%s", user_id, session_id)
 
     return {"url": url, "expires_in": _SETUP_TTL}
 
@@ -718,40 +534,53 @@ async def anthropic_complete(
     body: AnthropicCompleteBody,
     _auth: dict = Depends(auth_dependency),
 ):
-    """Submit the OAuth code to the waiting pexpect child and persist credentials."""
+    """Forward the OAuth code to the pool manager and persist the returned token."""
     user_id = request.state.user_id
     logger.info("anthropic/complete: request for user_id=%s, code_length=%d", user_id, len(body.code))
 
-    # Pop atomically: prevents two concurrent /complete calls from racing on the
-    # same child process or temp dir.
     entry = _pending_setups.pop(user_id, None)
     if entry is None:
         logger.warning("anthropic/complete: no pending setup found for user_id=%s", user_id)
         raise HTTPException(status_code=404, detail="No pending Anthropic setup for this user")
 
-    child = entry["child"]
+    session_id = entry["session_id"]
     age = time.time() - entry["started_at"]
-    logger.debug("anthropic/complete: pending setup age=%.1fs", age)
+    logger.debug("anthropic/complete: pending setup age=%.1fs session_id=%s", age, session_id)
 
-    loop = asyncio.get_running_loop()
-    result, token = await loop.run_in_executor(None, _complete_pexpect_sync, child, body.code)
-    logger.info("anthropic/complete: pexpect result=%r for user_id=%s", result, user_id)
+    try:
+        async with httpx.AsyncClient(timeout=150.0) as client:
+            resp = await client.post(
+                f"{_POOL_MANAGER_BASE_URL}/setup-token/complete",
+                json={"session_id": session_id, "code": body.code},
+            )
+    except Exception as exc:
+        logger.exception("anthropic/complete: pool manager request failed: %s", exc)
+        raise HTTPException(status_code=502, detail="Failed to reach setup-token service")
+
+    if resp.status_code != 200:
+        logger.error(
+            "anthropic/complete: pool manager returned %d for user_id=%s body=%r",
+            resp.status_code, user_id, resp.text,
+        )
+        raise HTTPException(status_code=502, detail="Setup token completion failed")
+
+    data = resp.json()
+    result = data.get("result")
+    token = data.get("token") or ""
+    logger.info("anthropic/complete: pool manager result=%r for user_id=%s", result, user_id)
 
     if result == "error":
-        asyncio.create_task(_reap_child(child))
         raise HTTPException(status_code=502, detail="Setup process closed unexpectedly")
 
     if result == "timeout":
-        asyncio.create_task(_reap_child(child))
         raise HTTPException(status_code=504, detail="Setup process timed out")
 
-    # child already reaped by _complete_pexpect_sync.
     if result == "failed":
         logger.warning("anthropic/complete: setup process reported failure for user_id=%s", user_id)
         return {"ok": False, "error": "setup failed"}
 
-    # result == "ok": token was extracted from the output stream by _complete_pexpect_sync.
-    logger.debug("anthropic/complete: OAuth token extracted (len=%d)", len(token))
+    # result == "ok": token extracted by the pool manager's pexpect handler.
+    logger.debug("anthropic/complete: OAuth token received (len=%d)", len(token))
 
     vault = request.app.state.vault
     if vault is None:

--- a/tests/agent_pool_manager/test_server.py
+++ b/tests/agent_pool_manager/test_server.py
@@ -159,3 +159,28 @@ async def test_interrupt_unknown_handle_returns_404(client_and_pool):
     ac, pool, refill = client_and_pool
     resp = await ac.post("/handle/does-not-exist/interrupt")
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_hint_rejects_empty_user_id(client_and_pool):
+    """POST /hint with user_id='' returns 422 — prevents '' reaching create_key."""
+    ac, pool, refill = client_and_pool
+    resp = await ac.post("/hint", json={
+        "user_id": "",
+        "options_hash": HASH_A,
+        "options": OPTIONS_A,
+    })
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_acquire_rejects_empty_user_id(client_and_pool):
+    """POST /acquire with user_id='' returns 422 — prevents '' reaching pool."""
+    ac, pool, refill = client_and_pool
+    resp = await ac.post("/acquire", json={
+        "user_id": "",
+        "options_hash": HASH_A,
+        "options": OPTIONS_A,
+        "timeout_seconds": 0.1,
+    })
+    assert resp.status_code == 422

--- a/tests/agent_pool_manager/test_setup_token.py
+++ b/tests/agent_pool_manager/test_setup_token.py
@@ -98,3 +98,43 @@ async def test_setup_token_complete_unknown_session(client_and_pool):
         "code": "whatever",
     })
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_setup_token_cancel_reaps_session(client_and_pool):
+    """DELETE /setup-token/{session_id} removes the session and returns 204."""
+    ac, pool, refill = client_and_pool
+    fake_child = MagicMock()
+    fake_url = "https://console.anthropic.com/oauth/authorize?code=abc"
+
+    with patch("agent_pool_manager.server._start_pexpect_sync", return_value=(fake_child, fake_url)):
+        start_resp = await ac.post("/setup-token", json={})
+    session_id = start_resp.json()["session_id"]
+
+    resp = await ac.delete(f"/setup-token/{session_id}")
+    assert resp.status_code == 204
+
+    # Session should be gone — complete now 404s
+    complete_resp = await ac.post("/setup-token/complete", json={
+        "session_id": session_id,
+        "code": "code",
+    })
+    assert complete_resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_setup_token_cancel_unknown_session_returns_404(client_and_pool):
+    """DELETE /setup-token/{unknown} returns 404."""
+    ac, pool, refill = client_and_pool
+    resp = await ac.delete("/setup-token/does-not-exist")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_setup_token_complete_rejects_empty_fields(client_and_pool):
+    """POST /setup-token/complete with empty session_id or code returns 422."""
+    ac, pool, refill = client_and_pool
+    resp = await ac.post("/setup-token/complete", json={"session_id": "", "code": "code"})
+    assert resp.status_code == 422
+    resp2 = await ac.post("/setup-token/complete", json={"session_id": "sess", "code": ""})
+    assert resp2.status_code == 422

--- a/tests/agent_pool_manager/test_setup_token.py
+++ b/tests/agent_pool_manager/test_setup_token.py
@@ -1,0 +1,100 @@
+"""Tests for POST /setup-token in agent_pool_manager.server."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch, MagicMock
+from httpx import AsyncClient, ASGITransport
+
+from agent_pool_manager.config import AgentPoolConfig
+from agent_pool_manager.pool import Pool
+from agent_pool_manager.refill import RefillLoop
+from agent_pool_manager.server import build_app
+
+
+def make_pool(**kwargs) -> Pool:
+    cfg = AgentPoolConfig(
+        target_depth_per_hash=2,
+        capacity_total=8,
+        max_age_seconds=600,
+        refill_poll_interval=0.05,
+        prime_timeout_seconds=5,
+        acquire_default_timeout=1,
+        **kwargs,
+    )
+    return Pool(cfg)
+
+
+@pytest.fixture
+async def client_and_pool():
+    pool = make_pool()
+    refill = RefillLoop(pool)
+    app = build_app(pool=pool, refill=refill)
+    app.state.pool = pool
+    app.state.refill = refill
+    refill.start()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac, pool, refill
+    refill.stop()
+
+
+@pytest.mark.asyncio
+async def test_setup_token_returns_url_and_session(client_and_pool):
+    """POST /setup-token returns auth URL and session_id when pexpect succeeds."""
+    ac, pool, refill = client_and_pool
+    fake_child = MagicMock()
+    fake_url = "https://console.anthropic.com/oauth/authorize?code=abc"
+
+    with patch("agent_pool_manager.server._start_pexpect_sync", return_value=(fake_child, fake_url)):
+        resp = await ac.post("/setup-token", json={})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["url"] == fake_url
+    assert "session_id" in body
+
+
+@pytest.mark.asyncio
+async def test_setup_token_returns_503_when_pexpect_fails(client_and_pool):
+    """POST /setup-token returns 503 when pexpect fails to extract a URL."""
+    ac, pool, refill = client_and_pool
+
+    with patch("agent_pool_manager.server._start_pexpect_sync", return_value=(None, None)):
+        resp = await ac.post("/setup-token", json={})
+
+    assert resp.status_code == 503
+    assert "error" in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_setup_token_complete_sends_code(client_and_pool):
+    """POST /setup-token/complete sends the OAuth code and returns token."""
+    ac, pool, refill = client_and_pool
+    fake_child = MagicMock()
+    fake_url = "https://console.anthropic.com/oauth/authorize?code=abc"
+    fake_token = "sk-ant-oat-fake-token"
+
+    with patch("agent_pool_manager.server._start_pexpect_sync", return_value=(fake_child, fake_url)):
+        start_resp = await ac.post("/setup-token", json={})
+    session_id = start_resp.json()["session_id"]
+
+    with patch("agent_pool_manager.server._complete_pexpect_sync", return_value=("ok", fake_token)):
+        complete_resp = await ac.post("/setup-token/complete", json={
+            "session_id": session_id,
+            "code": "oauth-code-here",
+        })
+
+    assert complete_resp.status_code == 200
+    body = complete_resp.json()
+    assert body.get("result") == "ok"
+    assert body.get("token") == fake_token
+
+
+@pytest.mark.asyncio
+async def test_setup_token_complete_unknown_session(client_and_pool):
+    """POST /setup-token/complete with unknown session_id returns 404."""
+    ac, pool, refill = client_and_pool
+    resp = await ac.post("/setup-token/complete", json={
+        "session_id": "does-not-exist",
+        "code": "whatever",
+    })
+    assert resp.status_code == 404

--- a/tests/api/test_anthropic_integrations.py
+++ b/tests/api/test_anthropic_integrations.py
@@ -1,13 +1,11 @@
 """API tests for Anthropic OAuth vault endpoints.
 
-TDD: written before handlers existed and confirmed to fail for the right reason.
-All tests mock subprocess; no live claude binary required.
-These tests do NOT require DATABASE_URL -- they mock the vault and skip DB.
+All tests mock the pool manager HTTP call; no live claude binary or pool
+manager service required.  Pending setup entries now contain session_id
+(not child) since pexpect was moved to the pool manager service.
 """
 from __future__ import annotations
 
-import asyncio
-import json
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,6 +13,26 @@ import pytest
 from httpx import AsyncClient, ASGITransport
 
 from tests.api.conftest import TEST_USER_ID, TEST_USERNAME
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build fake httpx responses
+# ---------------------------------------------------------------------------
+
+def _mock_httpx_post(status_code: int, body: dict):
+    """Return a patched httpx.AsyncClient that yields one canned POST response."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.json.return_value = body
+    mock_resp.text = str(body)
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_resp)
+
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=mock_client)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx
 
 
 # ---------------------------------------------------------------------------
@@ -64,23 +82,18 @@ def clear_pending_setups():
 
 @pytest.mark.asyncio
 async def test_start_returns_url(auth_app_client):
-    """Mock _start_pexpect_sync returning a URL; response contains url + expires_in."""
+    """Pool manager returns session_id + url; response contains url + expires_in."""
     client, mock_vault, app = auth_app_client
 
-    mock_child = MagicMock()
     expected_url = "https://console.anthropic.com/oauth/authorize?code=abc123"
+    mock_ctx = _mock_httpx_post(200, {"session_id": "sess-abc", "url": expected_url})
 
-    with patch(
-        "api.routes.integrations._start_pexpect_sync",
-        return_value=(mock_child, expected_url),
-    ):
+    with patch("httpx.AsyncClient", return_value=mock_ctx):
         resp = await client.post("/api/integrations/anthropic/start")
 
     assert resp.status_code == 200
     data = resp.json()
     assert "url" in data
-    # Use startswith to validate exact scheme + netloc — substring 'in' check is
-    # insufficient (CodeQL: incomplete URL substring sanitization)
     assert data["url"].startswith("https://console.anthropic.com/"), (
         f"URL must start with exact scheme+netloc, got: {data['url']}"
     )
@@ -88,18 +101,17 @@ async def test_start_returns_url(auth_app_client):
 
 
 # ---------------------------------------------------------------------------
-# 2. POST /api/integrations/anthropic/start -- 502 when no URL found
+# 2. POST /api/integrations/anthropic/start -- 502 when pool manager fails
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
 async def test_start_no_url_returns_502(auth_app_client):
-    """When _start_pexpect_sync finds no URL, endpoint returns 502."""
+    """When pool manager returns 503, endpoint returns 502."""
     client, mock_vault, app = auth_app_client
 
-    with patch(
-        "api.routes.integrations._start_pexpect_sync",
-        return_value=(None, None),
-    ):
+    mock_ctx = _mock_httpx_post(503, {"error": "setup_token_failed"})
+
+    with patch("httpx.AsyncClient", return_value=mock_ctx):
         resp = await client.post("/api/integrations/anthropic/start")
 
     assert resp.status_code == 502
@@ -111,22 +123,20 @@ async def test_start_no_url_returns_502(auth_app_client):
 
 @pytest.mark.asyncio
 async def test_complete_success(auth_app_client):
-    """Stash a fake pending entry; complete receives token from _complete_pexpect_sync and persists it."""
+    """Pending session_id entry forwarded to pool; token returned and stored in vault."""
     import api.routes.integrations as ant_routes
     client, mock_vault, app = auth_app_client
 
     fake_token = "sk-ant-oat01-FAKETOKEN_abc123"
-    mock_child = MagicMock()
 
     ant_routes._pending_setups[TEST_USER_ID] = {
-        "child": mock_child,
+        "session_id": "sess-xyz",
         "started_at": time.time(),
     }
 
-    with patch(
-        "api.routes.integrations._complete_pexpect_sync",
-        return_value=("ok", fake_token),
-    ):
+    mock_ctx = _mock_httpx_post(200, {"result": "ok", "token": fake_token})
+
+    with patch("httpx.AsyncClient", return_value=mock_ctx):
         resp = await client.post(
             "/api/integrations/anthropic/complete",
             json={"code": "auth_code_123"},
@@ -142,21 +152,18 @@ async def test_complete_success(auth_app_client):
 
 @pytest.mark.asyncio
 async def test_complete_no_token_in_output_returns_error(auth_app_client):
-    """If _complete_pexpect_sync finds no token it returns 'failed'; endpoint surfaces an error."""
+    """Pool manager returns 'failed'; endpoint surfaces an error dict."""
     import api.routes.integrations as ant_routes
     client, mock_vault, app = auth_app_client
 
-    mock_child = MagicMock()
-
     ant_routes._pending_setups[TEST_USER_ID] = {
-        "child": mock_child,
+        "session_id": "sess-xyz",
         "started_at": time.time(),
     }
 
-    with patch(
-        "api.routes.integrations._complete_pexpect_sync",
-        return_value=("failed", ""),
-    ):
+    mock_ctx = _mock_httpx_post(200, {"result": "failed", "token": None})
+
+    with patch("httpx.AsyncClient", return_value=mock_ctx):
         resp = await client.post(
             "/api/integrations/anthropic/complete",
             json={"code": "auth_code_123"},
@@ -176,24 +183,16 @@ async def test_complete_success_does_not_log_token(auth_app_client, caplog):
     client, mock_vault, app = auth_app_client
 
     fake_token = "sk-ant-oat01-SECRET_TOKEN_value_xyz789"
-    mock_child = MagicMock()
-    mock_child.before = (
-        b"\x1b[2K\x1b[1Gpasted code\n"
-        b"OAuth token created!\n"
-        + fake_token.encode()
-        + b"\n"
-    )
 
     ant_routes._pending_setups[TEST_USER_ID] = {
-        "child": mock_child,
+        "session_id": "sess-secret",
         "started_at": time.time(),
     }
 
+    mock_ctx = _mock_httpx_post(200, {"result": "ok", "token": fake_token})
+
     caplog.set_level(logging.DEBUG, logger="api.routes.integrations")
-    with patch(
-        "api.routes.integrations._complete_pexpect_sync",
-        return_value=("ok", fake_token),
-    ):
+    with patch("httpx.AsyncClient", return_value=mock_ctx):
         resp = await client.post(
             "/api/integrations/anthropic/complete",
             json={"code": "auth_code_123"},
@@ -226,21 +225,18 @@ async def test_complete_no_pending_returns_404(auth_app_client):
 
 @pytest.mark.asyncio
 async def test_complete_process_timeout_returns_504(auth_app_client):
-    """If _complete_pexpect_sync returns 'timeout', endpoint returns 504."""
+    """Pool manager returns 'timeout'; endpoint returns 504."""
     import api.routes.integrations as ant_routes
     client, mock_vault, app = auth_app_client
 
-    mock_child = MagicMock()
-
     ant_routes._pending_setups[TEST_USER_ID] = {
-        "child": mock_child,
+        "session_id": "sess-timeout",
         "started_at": time.time(),
     }
 
-    with patch(
-        "api.routes.integrations._complete_pexpect_sync",
-        return_value=("timeout", ""),
-    ):
+    mock_ctx = _mock_httpx_post(200, {"result": "timeout", "token": None})
+
+    with patch("httpx.AsyncClient", return_value=mock_ctx):
         resp = await client.post(
             "/api/integrations/anthropic/complete",
             json={"code": "code"},
@@ -333,28 +329,24 @@ async def test_start_requires_auth():
 
 @pytest.mark.asyncio
 async def test_complete_broken_pipe_returns_502(auth_app_client):
-    """If _complete_pexpect_sync returns 'error' (e.g. sendline failed), return 502."""
+    """Pool manager returns 'error'; endpoint returns 502."""
     import api.routes.integrations as routes
     client, mock_vault, app = auth_app_client
 
-    mock_child = MagicMock()
-
     routes._pending_setups[TEST_USER_ID] = {
-        "child": mock_child,
+        "session_id": "sess-broken",
         "started_at": time.time(),
     }
 
-    with patch(
-        "api.routes.integrations._complete_pexpect_sync",
-        return_value=("error", ""),
-    ):
+    mock_ctx = _mock_httpx_post(200, {"result": "error", "token": None})
+
+    with patch("httpx.AsyncClient", return_value=mock_ctx):
         resp = await client.post(
             "/api/integrations/anthropic/complete",
             json={"code": "code"},
         )
 
     assert resp.status_code == 502
-    # Entry should be cleaned up
     assert TEST_USER_ID not in routes._pending_setups
 
 
@@ -367,6 +359,7 @@ async def test_cfg_vault_key_roundtrip(monkeypatch):
     """A key from Fernet.generate_key().decode() round-trips through cfg → CredentialsVault."""
     from cryptography.fernet import Fernet
     from contextlib import asynccontextmanager
+    from unittest.mock import AsyncMock
 
     raw_key = Fernet.generate_key()
     monkeypatch.setenv("TETHER_VAULT_KEY", raw_key.decode())
@@ -394,7 +387,6 @@ async def test_cfg_vault_key_roundtrip(monkeypatch):
 
     @asynccontextmanager
     async def fake_get_conn(pool, user_id=None):
-        from unittest.mock import AsyncMock
         yield AsyncMock()
 
     with patch("api.credentials_vault.store_credentials_blob", side_effect=fake_store), \
@@ -407,27 +399,25 @@ async def test_cfg_vault_key_roundtrip(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# 10. /start pending entry must NOT contain temp_dir
+# 10. /start pending entry must contain session_id (not child or temp_dir)
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_start_pending_entry_has_no_temp_dir(auth_app_client):
-    """After /start succeeds, the pending entry must not have a 'temp_dir' key.
-    claude setup-token writes only to stdout — no filesystem temp dir needed.
-    """
+async def test_start_pending_entry_has_session_id(auth_app_client):
+    """After /start succeeds, the pending entry must have session_id and no child/temp_dir."""
     import api.routes.integrations as ant_routes
     client, mock_vault, app = auth_app_client
 
-    mock_child = MagicMock()
     expected_url = "https://console.anthropic.com/oauth/authorize?code=abc"
+    mock_ctx = _mock_httpx_post(200, {"session_id": "sess-check", "url": expected_url})
 
-    with patch(
-        "api.routes.integrations._start_pexpect_sync",
-        return_value=(mock_child, expected_url),
-    ):
+    with patch("httpx.AsyncClient", return_value=mock_ctx):
         resp = await client.post("/api/integrations/anthropic/start")
 
     assert resp.status_code == 200
     entry = ant_routes._pending_setups.get(TEST_USER_ID)
     assert entry is not None
-    assert "temp_dir" not in entry, "pending entry must not contain temp_dir after OAuth migration"
+    assert "session_id" in entry
+    assert entry["session_id"] == "sess-check"
+    assert "child" not in entry, "pending entry must not contain pexpect child"
+    assert "temp_dir" not in entry, "pending entry must not contain temp_dir"


### PR DESCRIPTION
## Summary
- `AcquireRequest.user_id` and `HintRequest.user_id` now have `min_length=1`, returning 422 on empty string before any handler logic runs
- Prevents `user_id=""` from propagating through refill → pool → `create_key`, which caused `invalid input syntax for type uuid: ""` in Postgres
- Regression tests added for both `/acquire` and `/hint` endpoints

## Test plan
- [x] `test_hint_rejects_empty_user_id` — 422 on `user_id=""`
- [x] `test_acquire_rejects_empty_user_id` — 422 on `user_id=""`
- [x] All existing server tests pass (10/10)