### PR TITLE
fix: use get_conn for RLS-scoped api_keys operations in pool manager

### DIFF
--- a/agent_pool_manager/pool.py
+++ b/agent_pool_manager/pool.py
@@ -526,8 +526,9 @@ class Pool:
         mcp_key_id: str | None = None
         if self._pg_pool is not None and user_id:  # truthy: excludes None and ""
             try:
+                import db.postgres as pg
                 from db.pg_queries.api_keys import create_key as _create_key
-                async with self._pg_pool.acquire() as _conn:
+                async with pg.get_conn(self._pg_pool, user_id=user_id) as _conn:
                     _raw_key, _key_rec = await _create_key(
                         _conn, user_id=user_id, name=f"pool_mcp_{options_hash[:8]}"
                     )
@@ -655,8 +656,9 @@ class Pool:
             # Spawn failed after key was created — revoke key to prevent orphan rows.
             if mcp_key_id is not None and self._pg_pool is not None and user_id:
                 try:
+                    import db.postgres as pg
                     from db.pg_queries.api_keys import revoke_key as _revoke_key
-                    async with self._pg_pool.acquire() as _conn:
+                    async with pg.get_conn(self._pg_pool, user_id=user_id) as _conn:
                         await _revoke_key(_conn, mcp_key_id, user_id)
                     log.info(
                         "pool.mcp_key_revoked_on_spawn_failure options_hash=%s key_id=%s",
@@ -773,8 +775,9 @@ class Pool:
         # Failure must not propagate — log and continue.
         if sub.mcp_key_id is not None and self._pg_pool is not None and sub.mcp_user_id:
             try:
+                import db.postgres as pg
                 from db.pg_queries.api_keys import revoke_key as _revoke_key
-                async with self._pg_pool.acquire() as _conn:
+                async with pg.get_conn(self._pg_pool, user_id=sub.mcp_user_id) as _conn:
                     await _revoke_key(_conn, sub.mcp_key_id, sub.mcp_user_id)
                 log.info(
                     "pool.mcp_key_revoked options_hash=%s key_id=%s",

--- a/agent_pool_manager/refill.py
+++ b/agent_pool_manager/refill.py
@@ -76,7 +76,9 @@ class RefillLoop:
     async def run_once(self) -> None:
         """Run one full refill cycle across all registered hashes."""
         for options_hash, options in list(self._registry.items()):
-            user_id = self._user_ids.get(options_hash)
+            # Defensive: normalise "" → None so create_key never receives an
+            # empty UUID regardless of how the value entered _user_ids.
+            user_id = self._user_ids.get(options_hash) or None
             deficit = self._deficit(options_hash)
             if deficit > 0:
                 log.info(

--- a/tests/agent_pool_manager/test_pool_mcp_injection.py
+++ b/tests/agent_pool_manager/test_pool_mcp_injection.py
@@ -9,6 +9,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+from contextlib import asynccontextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -98,8 +99,10 @@ async def test_spawn_creates_mcp_key_and_expands_options():
 
     mock_pg_pool = MagicMock()
     mock_conn = AsyncMock()
-    mock_pg_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
-    mock_pg_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    @asynccontextmanager
+    async def _fake_get_conn(pool, *, user_id=None):
+        yield mock_conn
 
     pool = _make_pool(pg_pool=mock_pg_pool)
 
@@ -117,6 +120,7 @@ async def test_spawn_creates_mcp_key_and_expands_options():
         pass
 
     with (
+        patch("db.postgres.get_conn", side_effect=_fake_get_conn),
         patch(
             "db.pg_queries.api_keys.create_key",
             new=AsyncMock(return_value=(fake_raw_key, fake_key_record)),
@@ -219,8 +223,10 @@ async def test_terminate_revokes_mcp_key():
     """_terminate calls revoke_key when sub has mcp_key_id."""
     mock_pg_pool = MagicMock()
     mock_conn = AsyncMock()
-    mock_pg_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
-    mock_pg_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    @asynccontextmanager
+    async def _fake_get_conn(pool, *, user_id=None):
+        yield mock_conn
 
     pool = _make_pool(pg_pool=mock_pg_pool)
 
@@ -235,10 +241,13 @@ async def test_terminate_revokes_mcp_key():
         mcp_user_id="user-uuid-999",
     )
 
-    with patch(
-        "db.pg_queries.api_keys.revoke_key",
-        new=AsyncMock(),
-    ) as mock_revoke:
+    with (
+        patch("db.postgres.get_conn", side_effect=_fake_get_conn),
+        patch(
+            "db.pg_queries.api_keys.revoke_key",
+            new=AsyncMock(),
+        ) as mock_revoke,
+    ):
         await pool._terminate(sub)
 
     mock_revoke.assert_awaited_once()
@@ -277,8 +286,10 @@ async def test_terminate_revoke_failure_does_not_block_disconnect():
     """Revoke failure must not prevent subprocess disconnect (fire-and-forget safety)."""
     mock_pg_pool = MagicMock()
     mock_conn = AsyncMock()
-    mock_pg_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
-    mock_pg_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    @asynccontextmanager
+    async def _fake_get_conn(pool, *, user_id=None):
+        yield mock_conn
 
     pool = _make_pool(pg_pool=mock_pg_pool)
 
@@ -293,9 +304,12 @@ async def test_terminate_revoke_failure_does_not_block_disconnect():
         mcp_user_id="user-uuid-999",
     )
 
-    with patch(
-        "db.pg_queries.api_keys.revoke_key",
-        new=AsyncMock(side_effect=Exception("DB down")),
+    with (
+        patch("db.postgres.get_conn", side_effect=_fake_get_conn),
+        patch(
+            "db.pg_queries.api_keys.revoke_key",
+            new=AsyncMock(side_effect=Exception("DB down")),
+        ),
     ):
         # Must not raise
         await pool._terminate(sub)
@@ -311,8 +325,10 @@ async def test_terminate_disconnect_before_revoke():
 
     mock_pg_pool = MagicMock()
     mock_conn = AsyncMock()
-    mock_pg_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
-    mock_pg_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    @asynccontextmanager
+    async def _fake_get_conn(pool, *, user_id=None):
+        yield mock_conn
 
     pool = _make_pool(pg_pool=mock_pg_pool)
 
@@ -332,7 +348,10 @@ async def test_terminate_disconnect_before_revoke():
 
     async def _revoke(conn, key_id, user_id):
         call_order.append("revoke")
-    with patch("db.pg_queries.api_keys.revoke_key", new=_revoke):
+    with (
+        patch("db.postgres.get_conn", side_effect=_fake_get_conn),
+        patch("db.pg_queries.api_keys.revoke_key", new=_revoke),
+    ):
         await pool._terminate(sub)
 
     assert call_order == ["disconnect", "revoke"], (
@@ -403,8 +422,10 @@ async def test_spawn_failure_revokes_key():
 
     mock_pg_pool = MagicMock()
     mock_conn = AsyncMock()
-    mock_pg_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
-    mock_pg_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    @asynccontextmanager
+    async def _fake_get_conn(pool, *, user_id=None):
+        yield mock_conn
 
     pool = _make_pool(pg_pool=mock_pg_pool)
 
@@ -412,6 +433,7 @@ async def test_spawn_failure_revokes_key():
     mock_client.connect = AsyncMock(side_effect=Exception("connect failed"))
 
     with (
+        patch("db.postgres.get_conn", side_effect=_fake_get_conn),
         patch(
             "db.pg_queries.api_keys.create_key",
             new=AsyncMock(return_value=(fake_raw_key, fake_key_record)),
@@ -475,8 +497,10 @@ async def test_spawn_key_failure_strips_mcp_placeholder():
     """When key creation fails, mcp_servers must be replaced with {} so SDK doesn't hang."""
     mock_pg_pool = MagicMock()
     mock_conn = AsyncMock()
-    mock_pg_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
-    mock_pg_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    @asynccontextmanager
+    async def _fake_get_conn(pool, *, user_id=None):
+        yield mock_conn
 
     pool = _make_pool(pg_pool=mock_pg_pool)
     captured_sdk_options: list[dict] = []
@@ -492,6 +516,7 @@ async def test_spawn_key_failure_strips_mcp_placeholder():
         pass
 
     with (
+        patch("db.postgres.get_conn", side_effect=_fake_get_conn),
         patch(
             "db.pg_queries.api_keys.create_key",
             new=AsyncMock(side_effect=Exception("DB error")),
@@ -514,3 +539,86 @@ async def test_spawn_key_failure_strips_mcp_placeholder():
     )
     # Must be an empty dict (no MCP servers) so subprocess can start without MCP auth
     assert mcp == {}, f"Expected empty dict mcp_servers on fallback, got: {mcp!r}"
+
+
+@pytest.mark.asyncio
+async def test_spawn_uses_get_conn_for_rls():
+    """_spawn_and_prime must use db.postgres.get_conn (not raw pool.acquire) so that
+    app.current_user_id is set before the INSERT — required by the api_keys RLS policy."""
+    from contextlib import asynccontextmanager
+
+    fake_raw_key = "ttr_fakerawkey123"
+    fake_key_record = {"id": "key-uuid-rls", "name": "pool_mcp_abcdef01"}
+
+    mock_pg_pool = MagicMock()
+    mock_conn = AsyncMock()
+
+    get_conn_calls: list[dict] = []
+
+    @asynccontextmanager
+    async def fake_get_conn(pool, *, user_id=None):
+        get_conn_calls.append({"pool": pool, "user_id": user_id})
+        yield mock_conn
+
+    mock_client = MagicMock()
+    mock_client.connect = AsyncMock()
+
+    pool = _make_pool(pg_pool=mock_pg_pool)
+
+    with (
+        patch("db.postgres.get_conn", side_effect=fake_get_conn),
+        patch(
+            "db.pg_queries.api_keys.create_key",
+            new=AsyncMock(return_value=(fake_raw_key, fake_key_record)),
+        ),
+        patch.object(Pool, "_build_sdk_options", return_value=MagicMock()),
+        patch("agent_pool_manager.pool.ClaudeSDKClient", return_value=mock_client),
+        patch.object(Pool, "_do_prime", new=AsyncMock()),
+    ):
+        sub = await pool._spawn_and_prime(
+            options_hash="abcdef01abcdef01",
+            options=_base_options(),
+            user_id="user-uuid-rls",
+        )
+
+    # get_conn must have been called with the correct user_id
+    assert len(get_conn_calls) == 1, f"Expected 1 get_conn call, got {len(get_conn_calls)}"
+    assert get_conn_calls[0]["user_id"] == "user-uuid-rls"
+    assert sub.mcp_key_id == "key-uuid-rls"
+
+
+@pytest.mark.asyncio
+async def test_terminate_uses_get_conn_for_rls():
+    """_terminate must use db.postgres.get_conn (not raw pool.acquire) for revoke_key
+    so that app.current_user_id is set — required by the api_keys RLS policy."""
+    from contextlib import asynccontextmanager
+
+    mock_pg_pool = MagicMock()
+    mock_conn = AsyncMock()
+
+    get_conn_calls: list[dict] = []
+
+    @asynccontextmanager
+    async def fake_get_conn(pool, *, user_id=None):
+        get_conn_calls.append({"pool": pool, "user_id": user_id})
+        yield mock_conn
+
+    pool = _make_pool(pg_pool=mock_pg_pool)
+
+    sub = MagicMock()
+    sub.mcp_key_id = "key-uuid-revoke"
+    sub.mcp_user_id = "user-uuid-rls"
+    sub.options_hash = "abcdef01"
+    sub.proc = AsyncMock()
+
+    with (
+        patch("db.postgres.get_conn", side_effect=fake_get_conn),
+        patch(
+            "db.pg_queries.api_keys.revoke_key",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        await pool._terminate(sub)
+
+    assert len(get_conn_calls) == 1, f"Expected 1 get_conn call, got {len(get_conn_calls)}"
+    assert get_conn_calls[0]["user_id"] == "user-uuid-rls"

--- a/tests/agent_pool_manager/test_refill.py
+++ b/tests/agent_pool_manager/test_refill.py
@@ -90,3 +90,36 @@ async def test_hint_triggers_aggressive_refill():
         await asyncio.sleep(0.1)
 
     assert pool.warm_count(HASH_A) == 2
+
+
+@pytest.mark.asyncio
+async def test_run_once_skips_empty_string_user_id():
+    """run_once must not pass user_id="" to _try_inject_warm.
+
+    Regression test: if _user_ids registry contains "" for a hash (e.g. due
+    to a race or legacy write path bypassing the truthy guard in register()),
+    run_once must NOT forward it — doing so reaches create_key with an empty
+    UUID string and causes a PostgreSQL cast error.
+    """
+    pool = make_pool(target_depth_per_hash=1)
+    loop = RefillLoop(pool)
+
+    # Register hash normally, then inject "" directly to simulate the bug
+    loop._registry[HASH_A] = OPTIONS_A
+    loop._user_ids[HASH_A] = ""  # simulate stale/corrupt registry state
+
+    calls: list = []
+
+    async def _capture_inject(options_hash, options, *, user_id=None):
+        calls.append(user_id)
+        return False  # pretend capacity full so we don't actually spawn
+
+    pool._try_inject_warm = _capture_inject
+
+    await loop.run_once()
+
+    assert calls, "run_once should have attempted injection"
+    assert "" not in calls, f'user_id="" must not reach _try_inject_warm, got: {calls}'
+    # Should be normalized to None (or injection skipped)
+    for user_id in calls:
+        assert user_id != "", f'empty string user_id leaked to inject: {user_id!r}'


### PR DESCRIPTION
## Summary

Production bugfixes for `InsufficientPrivilegeError` on `api_keys` INSERT/UPDATE caused by pool manager using raw asyncpg connections that bypass RLS.

**Bug 1 (committed separately):** `refill.run_once` was forwarding `user_id=""` from `_user_ids` registry to `_try_inject_warm`, which eventually reached `create_key` and caused a PostgreSQL UUID cast error. Fixed with `or None` normalization at read time in `run_once`.

**Bug 2 (this PR):** Three sites in `_spawn_and_prime` (main create path + error cleanup path) and `_terminate` (revoke path) used `self._pg_pool.acquire()` directly. The `api_keys` table has an RLS policy requiring `app.current_user_id` to be set — raw `pool.acquire()` never sets this session variable, causing `InsufficientPrivilegeError` on any INSERT or UPDATE.

Fix: all three sites now use `pg.get_conn(self._pg_pool, user_id=...)` which wraps the connection in a transaction and runs `SELECT set_config('app.current_user_id', $1, true)` before any DML.

## Test plan

- [ ] 2 new regression tests: `test_spawn_uses_get_conn_for_rls`, `test_terminate_uses_get_conn_for_rls` — assert `get_conn` is called with correct `user_id` in both paths
- [ ] 6 existing tests updated: replaced dead `mock_pg_pool.acquire()` mocks with `patch("db.postgres.get_conn", side_effect=...)` 
- [ ] 756 tests pass, 0 failures (`python -m pytest`)