### PR TITLE
feat: configurable initialize timeout + home directory pool for subprocess isolation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,19 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
 ARG CLAUDE_CODE_VERSION=2.1.116
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 
+# Home directory template for the agent pool manager.
+# Running `claude --version` once causes the CLI to write its initial config
+# (~/.claude.json, ~/.claude/) into the temp home.  We snapshot that state so
+# each warm subprocess gets a pre-seeded home dir, eliminating first-run setup
+# time and ~/.claude.json lock contention on concurrent spawns.
+# If the CLI produces no files (e.g. newer version skips auto-init), the
+# template dir is left empty — the isolation benefit still applies.
+RUN HOME=/tmp/claude-template \
+      claude --version 2>/dev/null || true \
+    && mkdir -p /etc/claude-home-template \
+    && cp -r /tmp/claude-template/. /etc/claude-home-template/ 2>/dev/null || true \
+    && chmod -R a+rX /etc/claude-home-template
+
 # Non-root user for running services. UID 1000 matches the default Pi user
 # so bind-mounted /data files are accessible without permission issues.
 RUN useradd -m -u 1000 -s /bin/bash tether

--- a/agent_pool_manager/config.py
+++ b/agent_pool_manager/config.py
@@ -44,6 +44,18 @@ class AgentPoolConfig:
     as failed.  Must be shorter than prime_timeout_seconds so a hung transport
     is detected and killed before the priming phase would time out anyway."""
 
+    initialize_timeout_ms: int = 120000
+    """Value injected as CLAUDE_CODE_STREAM_CLOSE_TIMEOUT (ms) in subprocess env.
+    The SDK uses this as its internal initialize timeout (floor: 60 000 ms).
+    Default: 120 000 ms (2 min)."""
+
+    home_dir_base: str = "/var/lib/tether/claude-homes"
+    """Directory where isolated per-subprocess home dirs are created."""
+
+    home_dir_template: str = "/etc/claude-home-template"
+    """Directory copied into each home dir at initialization.
+    If it does not exist, home dirs start empty (lock-contention fix still applies)."""
+
 
 _FIELD_NAMES = {f.name for f in fields(AgentPoolConfig)}
 

--- a/agent_pool_manager/homes.py
+++ b/agent_pool_manager/homes.py
@@ -1,0 +1,139 @@
+"""Isolated per-subprocess home directory pool.
+
+Each subprocess gets its own ``$HOME`` to eliminate ``~/.claude.json`` lock
+contention when two subprocesses spawn simultaneously.  Dirs are pre-created
+at pool startup and reset to a template state before each assignment so stale
+CLI state from a previous subprocess never bleeds into the next one.
+
+Design notes:
+- Dirs are never deleted during normal operation — only reset.
+- Reset (``shutil.rmtree`` + ``shutil.copytree``) runs in a thread-pool
+  executor so it does not block the asyncio event loop during spawn.
+- TTL sweep evicts stale assignments (e.g. a subprocess that was lost
+  without going through ``_terminate``).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent_pool_manager.config import AgentPoolConfig
+
+log = logging.getLogger(__name__)
+
+
+def _reset_home(home: Path, template: Path | None) -> None:
+    """Synchronous reset called from a thread executor.
+
+    Removes all content in *home* then either copies *template* in (if it
+    exists) or leaves *home* as an empty directory.
+    """
+    # Wipe and recreate so the dir is empty/fresh regardless of template.
+    shutil.rmtree(home, ignore_errors=True)
+    home.mkdir(parents=True, exist_ok=True)
+    if template is not None and template.is_dir():
+        # copytree requires the destination not to exist; use dirs_exist_ok
+        # (Python 3.8+) so we can copy *into* the already-created home dir.
+        shutil.copytree(str(template), str(home), dirs_exist_ok=True)
+
+
+class HomeDirPool:
+    """Pool of isolated home directories for agent subprocesses.
+
+    Call ``await initialize()`` once before first use.
+    Call ``await acquire()`` to obtain a home dir for a new subprocess.
+    Call ``release(path)`` when the subprocess terminates.
+    Call ``await sweep()`` periodically (from RefillLoop.run_once) to evict
+    stale assignments that were never released.
+    """
+
+    def __init__(self, config: AgentPoolConfig) -> None:
+        self._config = config
+        self._base = Path(config.home_dir_base)
+        template_path = Path(config.home_dir_template)
+        self._template: Path | None = template_path if template_path.is_dir() else None
+        self._dirs: list[Path] = []
+        self._available: asyncio.Queue[Path] = asyncio.Queue()
+        # str(path) → expiry timestamp (time.monotonic)
+        self._checked_out: dict[str, float] = {}
+
+    async def initialize(self) -> None:
+        """Create home dirs and seed from template.  Idempotent on re-call."""
+        count = self._config.capacity_total
+        self._base.mkdir(parents=True, exist_ok=True)
+
+        # Re-discover template now (it may have been created since __init__)
+        template_path = Path(self._config.home_dir_template)
+        self._template = template_path if template_path.is_dir() else None
+
+        loop = asyncio.get_event_loop()
+        for i in range(count):
+            home = self._base / f"home-{i}"
+            home.mkdir(parents=True, exist_ok=True)
+            # Seed from template in executor to avoid blocking the loop.
+            await loop.run_in_executor(None, _reset_home, home, self._template)
+            if home not in self._dirs:
+                self._dirs.append(home)
+            # Populate the available queue; clear first to avoid duplication on re-init.
+
+        # Rebuild _available from dirs not currently checked out.
+        while not self._available.empty():
+            try:
+                self._available.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+        checked_out_paths = set(self._checked_out.keys())
+        for home in self._dirs:
+            if str(home) not in checked_out_paths:
+                self._available.put_nowait(home)
+
+        log.info(
+            "home_pool.initialized count=%d template=%s available=%d",
+            count,
+            self._template,
+            self._available.qsize(),
+        )
+
+    async def acquire(self) -> Path:
+        """Return a home dir, reset to template state.
+
+        Blocks (up to the caller's timeout) if the pool is exhausted.
+        Raises ``asyncio.QueueEmpty`` if called with nowait and no dirs are
+        available — callers should use ``asyncio.wait_for`` for timeouts.
+        """
+        home = await self._available.get()
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, _reset_home, home, self._template)
+        expiry = time.monotonic() + self._config.max_age_seconds
+        self._checked_out[str(home)] = expiry
+        log.debug("home_pool.acquired path=%s", home)
+        return home
+
+    def release(self, home: Path) -> None:
+        """Return *home* to the available queue.  Idempotent."""
+        key = str(home)
+        if key not in self._checked_out:
+            # Already released or never acquired — silently ignore.
+            return
+        self._checked_out.pop(key)
+        self._available.put_nowait(home)
+        log.debug("home_pool.released path=%s", home)
+
+    async def sweep(self) -> None:
+        """Evict stale assignments that were never released (TTL-based safety net)."""
+        now = time.monotonic()
+        evicted = [k for k, expiry in list(self._checked_out.items()) if now > expiry]
+        for key in evicted:
+            self._checked_out.pop(key, None)
+            path = Path(key)
+            self._available.put_nowait(path)
+            log.warning("home_pool.sweep_evict path=%s", path)
+
+    def available_count(self) -> int:
+        """Number of home dirs currently available (not checked out)."""
+        return self._available.qsize()

--- a/agent_pool_manager/homes.py
+++ b/agent_pool_manager/homes.py
@@ -71,12 +71,14 @@ class HomeDirPool:
         template_path = Path(self._config.home_dir_template)
         self._template = template_path if template_path.is_dir() else None
 
-        loop = asyncio.get_event_loop()
         for i in range(count):
             home = self._base / f"home-{i}"
             home.mkdir(parents=True, exist_ok=True)
-            # Seed from template in executor to avoid blocking the loop.
-            await loop.run_in_executor(None, _reset_home, home, self._template)
+            # Skip reset for dirs currently checked out by a live subprocess —
+            # wiping them would corrupt the running CLI process's HOME.
+            if str(home) not in self._checked_out:
+                # Seed from template in executor to avoid blocking the loop.
+                await asyncio.to_thread(_reset_home, home, self._template)
             if home not in self._dirs:
                 self._dirs.append(home)
             # Populate the available queue; clear first to avoid duplication on re-init.
@@ -107,9 +109,11 @@ class HomeDirPool:
         available — callers should use ``asyncio.wait_for`` for timeouts.
         """
         home = await self._available.get()
-        loop = asyncio.get_event_loop()
-        await loop.run_in_executor(None, _reset_home, home, self._template)
-        expiry = time.monotonic() + self._config.max_age_seconds
+        await asyncio.to_thread(_reset_home, home, self._template)
+        # Use 2× subprocess max_age as home TTL so sweep never evicts a home
+        # whose subprocess might still be running (drain-on-touch retirement
+        # means a subprocess can live past its nominal max_age).
+        expiry = time.monotonic() + self._config.max_age_seconds * 2
         self._checked_out[str(home)] = expiry
         log.debug("home_pool.acquired path=%s", home)
         return home

--- a/agent_pool_manager/pool.py
+++ b/agent_pool_manager/pool.py
@@ -551,6 +551,17 @@ class Pool:
                 options = dict(options)
                 options["mcp_servers"] = {}
 
+        # Inject initialize timeout — tells the SDK how long to wait before
+        # treating a connect() call as failed.  Use setdefault so a caller-
+        # supplied value is not overridden.
+        env = dict(options.get("env") or {})
+        env.setdefault(
+            "CLAUDE_CODE_STREAM_CLOSE_TIMEOUT",
+            str(self.config.initialize_timeout_ms),
+        )
+        options = dict(options)
+        options["env"] = env
+
         # Wire subprocess stderr to our logger so CLI errors surface in
         # fly.io's log stream.  Without this, stderr is dropped on the floor.
         def _stderr_cb(line: str) -> None:

--- a/agent_pool_manager/pool.py
+++ b/agent_pool_manager/pool.py
@@ -20,8 +20,10 @@ from claude_agent_sdk.types import (
 
 from .config import AgentPoolConfig
 from .control import ControlBridge, ControlTimeout
+from .homes import HomeDirPool
 
 if TYPE_CHECKING:
+    from pathlib import Path
     from .metrics import PoolMetrics
 
 log = logging.getLogger(__name__)
@@ -182,6 +184,9 @@ class Subprocess:
     # None when pool has no DB access or no user_id was available at spawn.
     mcp_key_id: str | None = None
     mcp_user_id: str | None = None
+    # Isolated home directory assigned at spawn time; released on _terminate.
+    # None when home pool is not configured.
+    home_path: "Path | None" = None
 
     def is_expired(self, max_age_seconds: int) -> bool:
         return (time.monotonic() - self.spawned_at) > max_age_seconds
@@ -213,6 +218,18 @@ class Pool:
         self._metrics: "PoolMetrics | None" = None
         # optional asyncpg pool for ephemeral MCP key creation/revocation
         self._pg_pool: Any = pg_pool
+        # optional home directory pool — set via initialize_home_pool()
+        self._home_pool: HomeDirPool | None = None
+
+    async def initialize_home_pool(self) -> None:
+        """Create and seed the home directory pool.
+
+        Must be called once before _spawn_and_prime if home isolation is
+        desired.  Safe to call multiple times (idempotent).
+        """
+        if self._home_pool is None:
+            self._home_pool = HomeDirPool(self.config)
+        await self._home_pool.initialize()
 
     # ------------------------------------------------------------------
     # Public API
@@ -562,6 +579,16 @@ class Pool:
         options = dict(options)
         options["env"] = env
 
+        # Assign an isolated home directory if the home pool is available.
+        # This eliminates ~/.claude.json file-lock contention when multiple
+        # subprocesses spawn simultaneously.
+        home_path: "Path | None" = None
+        if self._home_pool is not None:
+            home_path = await self._home_pool.acquire()
+            env = dict(options["env"])
+            env["HOME"] = str(home_path)
+            options["env"] = env
+
         # Wire subprocess stderr to our logger so CLI errors surface in
         # fly.io's log stream.  Without this, stderr is dropped on the floor.
         def _stderr_cb(line: str) -> None:
@@ -681,6 +708,8 @@ class Pool:
                         mcp_key_id,
                         exc_info=True,
                     )
+            if home_path is not None and self._home_pool is not None:
+                self._home_pool.release(home_path)
             raise
 
         now = time.monotonic()
@@ -693,6 +722,7 @@ class Pool:
             callback_ctx=ctx,
             mcp_key_id=mcp_key_id,
             mcp_user_id=user_id,
+            home_path=home_path,
         )
 
     @staticmethod
@@ -800,3 +830,7 @@ class Pool:
                     sub.mcp_key_id,
                     exc_info=True,
                 )
+
+        # Return the isolated home directory to the pool.
+        if sub.home_path is not None and self._home_pool is not None:
+            self._home_pool.release(sub.home_path)

--- a/agent_pool_manager/pool.py
+++ b/agent_pool_manager/pool.py
@@ -584,10 +584,22 @@ class Pool:
         # subprocesses spawn simultaneously.
         home_path: "Path | None" = None
         if self._home_pool is not None:
-            home_path = await self._home_pool.acquire()
-            env = dict(options["env"])
-            env["HOME"] = str(home_path)
-            options["env"] = env
+            try:
+                home_path = await asyncio.wait_for(
+                    self._home_pool.acquire(),
+                    timeout=self.config.connect_timeout_seconds,
+                )
+            except asyncio.TimeoutError:
+                log.warning(
+                    "pool.home_acquire_timeout options_hash=%s timeout_s=%.1f"
+                    " — spawning without isolated home dir",
+                    options_hash,
+                    self.config.connect_timeout_seconds,
+                )
+            if home_path is not None:
+                env = dict(options["env"])
+                env["HOME"] = str(home_path)
+                options["env"] = env
 
         # Wire subprocess stderr to our logger so CLI errors surface in
         # fly.io's log stream.  Without this, stderr is dropped on the floor.

--- a/agent_pool_manager/refill.py
+++ b/agent_pool_manager/refill.py
@@ -98,6 +98,10 @@ class RefillLoop:
                     )
                     break
 
+        # TTL sweep — evict any stale home dir assignments each cycle.
+        if self._pool._home_pool is not None:
+            await self._pool._home_pool.sweep()
+
     async def run(self) -> None:
         """Continuous refill loop — run as an asyncio task."""
         self._running = True

--- a/config/app_config.yaml
+++ b/config/app_config.yaml
@@ -30,6 +30,9 @@ agent_pool:
   base_url: "http://127.0.0.1:5002"  # override for remote pool deployments
   enabled: true                 # false = callers fall back to direct spawn (local dev)
   control_response_timeout_seconds: 60  # seconds pool waits for control_response before denying
+  initialize_timeout_ms: 120000         # CLAUDE_CODE_STREAM_CLOSE_TIMEOUT injected into subprocess env (ms)
+  home_dir_base: /var/lib/tether/claude-homes    # isolated home dirs for subprocesses
+  home_dir_template: /etc/claude-home-template   # seed state copied into each home dir at init
 
 llm:
   use_v3: false

--- a/tests/agent_pool_manager/test_home_dirs.py
+++ b/tests/agent_pool_manager/test_home_dirs.py
@@ -1,0 +1,350 @@
+"""Tests for HomeDirPool — isolated per-subprocess home directory management."""
+from __future__ import annotations
+
+import asyncio
+import shutil
+import tempfile
+import time
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent_pool_manager.config import AgentPoolConfig
+from agent_pool_manager.homes import HomeDirPool
+from agent_pool_manager.pool import Pool, Subprocess
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_home_pool(base_dir: str, template_dir: str, count: int = 3,
+                    max_age_seconds: int = 600) -> HomeDirPool:
+    cfg = AgentPoolConfig(
+        capacity_total=count,
+        max_age_seconds=max_age_seconds,
+        target_depth_per_hash=1,
+        prime_timeout_seconds=5,
+        acquire_default_timeout=1,
+        home_dir_base=base_dir,
+        home_dir_template=template_dir,
+    )
+    return HomeDirPool(cfg)
+
+
+def _make_pool(base_dir: str, template_dir: str, **overrides) -> Pool:
+    defaults = dict(
+        target_depth_per_hash=1,
+        capacity_total=3,
+        max_age_seconds=600,
+        refill_poll_interval=2.0,
+        prime_timeout_seconds=5,
+        acquire_default_timeout=1,
+        connect_timeout_seconds=5.0,
+        home_dir_base=base_dir,
+        home_dir_template=template_dir,
+    )
+    defaults.update(overrides)
+    return Pool(AgentPoolConfig(**defaults))
+
+
+# ---------------------------------------------------------------------------
+# HomeDirPool unit tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_initialize_creates_dirs():
+    """initialize() creates capacity_total subdirs under base_dir."""
+    with tempfile.TemporaryDirectory() as base:
+        pool = _make_home_pool(base, "/nonexistent-template", count=3)
+        await pool.initialize()
+
+        created = sorted(Path(base).iterdir())
+        assert len(created) == 3
+        for d in created:
+            assert d.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_initialize_seeds_from_template():
+    """initialize() copies template_dir content into each home dir."""
+    with (
+        tempfile.TemporaryDirectory() as base,
+        tempfile.TemporaryDirectory() as template,
+    ):
+        # Create a sentinel file in template
+        (Path(template) / "sentinel.txt").write_text("hello")
+        (Path(template) / "subdir").mkdir()
+        (Path(template) / "subdir" / "nested.txt").write_text("nested")
+
+        pool = _make_home_pool(base, template, count=2)
+        await pool.initialize()
+
+        for home in Path(base).iterdir():
+            assert (home / "sentinel.txt").exists(), f"sentinel missing in {home}"
+            assert (home / "subdir" / "nested.txt").exists(), f"nested missing in {home}"
+
+
+@pytest.mark.asyncio
+async def test_initialize_without_template_dir():
+    """initialize() succeeds when template_dir does not exist — homes start empty."""
+    with tempfile.TemporaryDirectory() as base:
+        pool = _make_home_pool(base, "/nonexistent-no-template", count=2)
+        # Must not raise even though template_dir doesn't exist
+        await pool.initialize()
+        assert pool.available_count() == 2
+
+
+@pytest.mark.asyncio
+async def test_acquire_returns_path():
+    """acquire() returns a Path from the available pool."""
+    with tempfile.TemporaryDirectory() as base:
+        pool = _make_home_pool(base, "/nonexistent-template", count=2)
+        await pool.initialize()
+
+        path = await pool.acquire()
+        assert isinstance(path, Path)
+        assert path.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_acquire_decrements_available():
+    """acquire() reduces available count by 1."""
+    with tempfile.TemporaryDirectory() as base:
+        pool = _make_home_pool(base, "/nonexistent-template", count=3)
+        await pool.initialize()
+
+        assert pool.available_count() == 3
+        await pool.acquire()
+        assert pool.available_count() == 2
+        await pool.acquire()
+        assert pool.available_count() == 1
+
+
+@pytest.mark.asyncio
+async def test_release_returns_dir_to_pool():
+    """release() puts the path back in the available queue."""
+    with tempfile.TemporaryDirectory() as base:
+        pool = _make_home_pool(base, "/nonexistent-template", count=2)
+        await pool.initialize()
+
+        path = await pool.acquire()
+        assert pool.available_count() == 1
+
+        pool.release(path)
+        assert pool.available_count() == 2
+
+
+@pytest.mark.asyncio
+async def test_acquire_resets_dir_from_template():
+    """acquire() resets the dir to template state before returning it."""
+    with (
+        tempfile.TemporaryDirectory() as base,
+        tempfile.TemporaryDirectory() as template,
+    ):
+        (Path(template) / "config.json").write_text("{}")
+
+        pool = _make_home_pool(base, template, count=1)
+        await pool.initialize()
+
+        path = await pool.acquire()
+        # Simulate subprocess leaving state
+        (path / "dirty_file.txt").write_text("leftover")
+        pool.release(path)
+
+        # Re-acquire — should be reset to template state
+        path2 = await pool.acquire()
+        assert path2 == path  # same dir was reused
+        assert not (path2 / "dirty_file.txt").exists(), "Dir must be reset at acquire time"
+        assert (path2 / "config.json").exists(), "Template file must be present after reset"
+
+
+@pytest.mark.asyncio
+async def test_ttl_sweep_evicts_stale_homes():
+    """TTL sweep evicts homes held longer than max_age_seconds."""
+    with tempfile.TemporaryDirectory() as base:
+        pool = _make_home_pool(base, "/nonexistent-template", count=2, max_age_seconds=1)
+        await pool.initialize()
+
+        path = await pool.acquire()
+        assert pool.available_count() == 1
+
+        # Force expiry by manipulating internal TTL
+        pool._checked_out[str(path)] = time.monotonic() - 2  # 2s in the past
+
+        await pool.sweep()
+        assert pool.available_count() == 2, "Expired home must be returned to pool after sweep"
+
+
+@pytest.mark.asyncio
+async def test_sweep_does_not_evict_fresh_homes():
+    """Sweep must not evict homes within TTL."""
+    with tempfile.TemporaryDirectory() as base:
+        pool = _make_home_pool(base, "/nonexistent-template", count=2, max_age_seconds=600)
+        await pool.initialize()
+
+        await pool.acquire()
+        assert pool.available_count() == 1
+
+        await pool.sweep()
+        assert pool.available_count() == 1, "Non-expired home must not be evicted"
+
+
+@pytest.mark.asyncio
+async def test_release_idempotent():
+    """release() called twice on the same path does not double-add to queue."""
+    with tempfile.TemporaryDirectory() as base:
+        pool = _make_home_pool(base, "/nonexistent-template", count=2)
+        await pool.initialize()
+
+        path = await pool.acquire()
+        pool.release(path)
+        pool.release(path)  # second call must be a no-op
+        # Queue should not exceed capacity_total
+        assert pool.available_count() <= 2
+
+
+# ---------------------------------------------------------------------------
+# Pool integration tests — HOME env var + release on _terminate
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_spawn_sets_home_env_var():
+    """_spawn_and_prime sets HOME to the assigned home dir in subprocess env."""
+    with (
+        tempfile.TemporaryDirectory() as base,
+        tempfile.TemporaryDirectory() as template,
+    ):
+        pool = _make_pool(base, template)
+        await pool.initialize_home_pool()
+
+        captured_options: list[dict] = []
+
+        def fake_build_sdk_options(options, can_use_tool=None):
+            captured_options.append(dict(options))
+            return MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock()
+
+        @asynccontextmanager
+        async def _fake_get_conn(p, *, user_id=None):
+            yield AsyncMock()
+
+        with (
+            patch("db.postgres.get_conn", side_effect=_fake_get_conn),
+            patch(
+                "db.pg_queries.api_keys.create_key",
+                new=AsyncMock(return_value=("ttr_fake", {"id": "k1"})),
+            ),
+            patch.object(Pool, "_build_sdk_options", side_effect=fake_build_sdk_options),
+            patch("agent_pool_manager.pool.ClaudeSDKClient", return_value=mock_client),
+            patch.object(Pool, "_do_prime", new=AsyncMock()),
+        ):
+            sub = await pool._spawn_and_prime(
+                options_hash="aabbccdd",
+                options={
+                    "model": "claude-haiku-4-5",
+                    "env": {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-test"},
+                    "mcp_servers": ["tether"],
+                },
+                user_id="user-uuid-123",
+            )
+
+        assert captured_options, "Expected _build_sdk_options to be called"
+        env = captured_options[0].get("env") or {}
+        assert "HOME" in env, f"HOME missing from subprocess env; got keys: {list(env.keys())}"
+        home_path = Path(env["HOME"])
+        assert home_path.is_dir(), f"HOME path must be an existing directory: {home_path}"
+
+        # Subprocess struct stores the home path
+        assert sub.home_path is not None
+        assert sub.home_path == home_path
+
+
+@pytest.mark.asyncio
+async def test_terminate_releases_home_dir():
+    """_terminate returns the home dir to the home pool."""
+    with (
+        tempfile.TemporaryDirectory() as base,
+        tempfile.TemporaryDirectory() as template,
+    ):
+        pool = _make_pool(base, template)
+        await pool.initialize_home_pool()
+
+        initial_available = pool._home_pool.available_count()
+
+        # Acquire directly
+        home_path = await pool._home_pool.acquire()
+        assert pool._home_pool.available_count() == initial_available - 1
+
+        mock_proc = MagicMock()
+        mock_proc.disconnect = AsyncMock()
+
+        sub = Subprocess(
+            proc=mock_proc,
+            options_hash="aabbccdd",
+            options={},
+            mcp_key_id=None,
+            mcp_user_id=None,
+            home_path=home_path,
+        )
+
+        await pool._terminate(sub)
+        assert pool._home_pool.available_count() == initial_available, (
+            "_terminate must release home_path back to home pool"
+        )
+
+
+@pytest.mark.asyncio
+async def test_terminate_without_home_path_does_not_fail():
+    """_terminate handles sub.home_path=None gracefully (no home pool configured)."""
+    pool = Pool(AgentPoolConfig())  # no home dir config
+    mock_proc = MagicMock()
+    mock_proc.disconnect = AsyncMock()
+
+    sub = Subprocess(
+        proc=mock_proc,
+        options_hash="aabbccdd",
+        options={},
+        home_path=None,
+    )
+    # Must not raise
+    await pool._terminate(sub)
+    mock_proc.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_spawn_without_home_pool_no_home_env():
+    """When home pool is not initialized, HOME is not injected into env."""
+    pool = Pool(AgentPoolConfig())  # no home dir config
+    pool._home_pool = None
+
+    captured_options: list[dict] = []
+
+    def fake_build_sdk_options(options, can_use_tool=None):
+        captured_options.append(dict(options))
+        return MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.connect = AsyncMock()
+
+    with (
+        patch.object(Pool, "_build_sdk_options", side_effect=fake_build_sdk_options),
+        patch("agent_pool_manager.pool.ClaudeSDKClient", return_value=mock_client),
+        patch.object(Pool, "_do_prime", new=AsyncMock()),
+    ):
+        sub = await pool._spawn_and_prime(
+            options_hash="aabbccdd",
+            options={
+                "model": "claude-haiku-4-5",
+                "env": {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-test"},
+            },
+            user_id=None,
+        )
+
+    env = (captured_options[0].get("env") or {}) if captured_options else {}
+    assert "HOME" not in env, "HOME must not be injected when home pool is absent"
+    assert sub.home_path is None

--- a/tests/agent_pool_manager/test_initialize_timeout.py
+++ b/tests/agent_pool_manager/test_initialize_timeout.py
@@ -1,0 +1,176 @@
+"""Tests for configurable initialize_timeout_ms — CLAUDE_CODE_STREAM_CLOSE_TIMEOUT injection."""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent_pool_manager.config import AgentPoolConfig
+from agent_pool_manager.pool import Pool
+
+
+def _make_pool(**overrides) -> Pool:
+    defaults = dict(
+        target_depth_per_hash=1,
+        capacity_total=4,
+        max_age_seconds=600,
+        refill_poll_interval=2.0,
+        prime_timeout_seconds=5,
+        acquire_default_timeout=1,
+        connect_timeout_seconds=5.0,
+    )
+    defaults.update(overrides)
+    cfg = AgentPoolConfig(**defaults)
+    return Pool(cfg)
+
+
+def _base_options() -> dict:
+    return {
+        "model": "claude-haiku-4-5",
+        "env": {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-test-token"},
+        "mcp_servers": ["tether"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_initialize_timeout_injected_into_env():
+    """CLAUDE_CODE_STREAM_CLOSE_TIMEOUT must be set in subprocess env from config."""
+    pool = _make_pool(initialize_timeout_ms=180000)
+
+    captured_options: list[dict] = []
+
+    def fake_build_sdk_options(options, can_use_tool=None):
+        captured_options.append(dict(options))
+        return MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.connect = AsyncMock()
+
+    @asynccontextmanager
+    async def _fake_get_conn(p, *, user_id=None):
+        yield AsyncMock()
+
+    with (
+        patch("db.postgres.get_conn", side_effect=_fake_get_conn),
+        patch(
+            "db.pg_queries.api_keys.create_key",
+            new=AsyncMock(return_value=("ttr_fake", {"id": "k1"})),
+        ),
+        patch.object(Pool, "_build_sdk_options", side_effect=fake_build_sdk_options),
+        patch("agent_pool_manager.pool.ClaudeSDKClient", return_value=mock_client),
+        patch.object(Pool, "_do_prime", new=AsyncMock()),
+    ):
+        await pool._spawn_and_prime(
+            options_hash="aabbccdd",
+            options=_base_options(),
+            user_id="user-uuid-123",
+        )
+
+    assert captured_options, "Expected _build_sdk_options to be called"
+    env = captured_options[0].get("env") or {}
+    assert "CLAUDE_CODE_STREAM_CLOSE_TIMEOUT" in env, (
+        f"CLAUDE_CODE_STREAM_CLOSE_TIMEOUT missing from env; got keys: {list(env.keys())}"
+    )
+    assert env["CLAUDE_CODE_STREAM_CLOSE_TIMEOUT"] == "180000", (
+        f"Expected '180000', got {env['CLAUDE_CODE_STREAM_CLOSE_TIMEOUT']!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_initialize_timeout_uses_default():
+    """Default initialize_timeout_ms=120000 is injected when not overridden."""
+    pool = _make_pool()  # default: 120000
+
+    captured_options: list[dict] = []
+
+    def fake_build_sdk_options(options, can_use_tool=None):
+        captured_options.append(dict(options))
+        return MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.connect = AsyncMock()
+
+    @asynccontextmanager
+    async def _fake_get_conn(p, *, user_id=None):
+        yield AsyncMock()
+
+    with (
+        patch("db.postgres.get_conn", side_effect=_fake_get_conn),
+        patch(
+            "db.pg_queries.api_keys.create_key",
+            new=AsyncMock(return_value=("ttr_fake", {"id": "k1"})),
+        ),
+        patch.object(Pool, "_build_sdk_options", side_effect=fake_build_sdk_options),
+        patch("agent_pool_manager.pool.ClaudeSDKClient", return_value=mock_client),
+        patch.object(Pool, "_do_prime", new=AsyncMock()),
+    ):
+        await pool._spawn_and_prime(
+            options_hash="aabbccdd",
+            options=_base_options(),
+            user_id="user-uuid-123",
+        )
+
+    env = (captured_options[0].get("env") or {}) if captured_options else {}
+    assert env.get("CLAUDE_CODE_STREAM_CLOSE_TIMEOUT") == "120000", (
+        f"Expected default '120000', got {env.get('CLAUDE_CODE_STREAM_CLOSE_TIMEOUT')!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_initialize_timeout_does_not_override_caller_value():
+    """If the caller already set CLAUDE_CODE_STREAM_CLOSE_TIMEOUT, we must not clobber it."""
+    pool = _make_pool(initialize_timeout_ms=120000)
+
+    options = dict(_base_options())
+    options["env"] = dict(options["env"])
+    options["env"]["CLAUDE_CODE_STREAM_CLOSE_TIMEOUT"] = "999999"
+
+    captured_options: list[dict] = []
+
+    def fake_build_sdk_options(o, can_use_tool=None):
+        captured_options.append(dict(o))
+        return MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.connect = AsyncMock()
+
+    @asynccontextmanager
+    async def _fake_get_conn(p, *, user_id=None):
+        yield AsyncMock()
+
+    with (
+        patch("db.postgres.get_conn", side_effect=_fake_get_conn),
+        patch(
+            "db.pg_queries.api_keys.create_key",
+            new=AsyncMock(return_value=("ttr_fake", {"id": "k1"})),
+        ),
+        patch.object(Pool, "_build_sdk_options", side_effect=fake_build_sdk_options),
+        patch("agent_pool_manager.pool.ClaudeSDKClient", return_value=mock_client),
+        patch.object(Pool, "_do_prime", new=AsyncMock()),
+    ):
+        await pool._spawn_and_prime(
+            options_hash="aabbccdd",
+            options=options,
+            user_id="user-uuid-123",
+        )
+
+    env = (captured_options[0].get("env") or {}) if captured_options else {}
+    assert env.get("CLAUDE_CODE_STREAM_CLOSE_TIMEOUT") == "999999", (
+        "Caller-supplied CLAUDE_CODE_STREAM_CLOSE_TIMEOUT must not be overridden"
+    )
+
+
+def test_initialize_timeout_ms_field_exists():
+    """AgentPoolConfig must have initialize_timeout_ms field with default 120000."""
+    cfg = AgentPoolConfig()
+    assert hasattr(cfg, "initialize_timeout_ms"), "Field initialize_timeout_ms missing from AgentPoolConfig"
+    assert cfg.initialize_timeout_ms == 120000, (
+        f"Default should be 120000, got {cfg.initialize_timeout_ms}"
+    )
+
+
+def test_initialize_timeout_ms_configurable():
+    """AgentPoolConfig accepts initialize_timeout_ms override."""
+    cfg = AgentPoolConfig(initialize_timeout_ms=60000)
+    assert cfg.initialize_timeout_ms == 60000


### PR DESCRIPTION
## Summary

Two improvements to the agent pool manager:

**Task 1 — Configurable initialize timeout:**
- `AgentPoolConfig.initialize_timeout_ms: int = 120000` (new field)
- `_spawn_and_prime` injects `CLAUDE_CODE_STREAM_CLOSE_TIMEOUT` into subprocess env via `setdefault` — caller-supplied value is not overridden
- `app_config.yaml` updated

**Task 2 — Home directory pool (`HomeDirPool`):**
- New `agent_pool_manager/homes.py` — `HomeDirPool` class
  - Creates `capacity_total` isolated dirs under `home_dir_base` at startup
  - Seeds each from `home_dir_template` (if it exists)
  - `acquire()` resets dir to template via `shutil.copytree` in **thread executor** (non-blocking)
  - `release(path)` returns dir to pool; idempotent
  - `sweep()` TTL-evicts stale assignments (runs each `RefillLoop.run_once` cycle)
- `Subprocess.home_path: Path | None` field
- `Pool.initialize_home_pool()` creates and initializes the pool
- `_spawn_and_prime` sets `HOME=str(home_path)` in subprocess env
- `_terminate` calls `release(sub.home_path)`
- Dockerfile build step seeds `/etc/claude-home-template` from `claude --version` run

**Why:** Multiple subprocesses spawning simultaneously contend on `~/.claude.json` file lock, adding startup time. Each subprocess now gets its own `$HOME` → zero lock contention.

## Test plan

- [ ] 5 tests: `test_initialize_timeout.py` — config field, env injection, setdefault, default value
- [ ] 14 tests: `test_home_dirs.py` — init, seed, acquire/release, TTL sweep, HOME env injection, terminate release, no-pool graceful handling
- [ ] 775 tests pass, 0 failures (`python -m pytest`)