### PR TITLE
fix(pool): create homes dir, seed template .claude.json at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,17 @@ RUN mkdir -p /run/tether/creds \
     && chown tether:tether /run/tether/creds \
     && chmod 0700 /run/tether/creds
 
+# Agent pool manager home directory base.
+# /var/lib/ is root-owned — the tether user cannot mkdir here at runtime,
+# so the pool base dir must be pre-created and handed off in the image.
+# Also hand ownership of the Claude home template to tether so that
+# initialize() can write .claude.json into it at first boot (auth seeding).
+RUN mkdir -p /var/lib/tether/claude-homes \
+    && chown tether:tether /var/lib/tether/claude-homes \
+    && chmod 755 /var/lib/tether/claude-homes \
+    && chown tether:tether /etc/claude-home-template \
+    && chmod 755 /etc/claude-home-template
+
 WORKDIR /app
 
 # External dependencies (cached layer — only reruns when requirements.txt changes)

--- a/agent_pool_manager/homes.py
+++ b/agent_pool_manager/homes.py
@@ -26,6 +26,10 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+# Path to the running container user's .claude.json.  Isolated to a constant
+# so tests can monkeypatch without touching the filesystem at /home/tether.
+_AUTH_SOURCE_PATH: Path = Path("/home/tether/.claude.json")
+
 
 def _reset_home(home: Path, template: Path | None) -> None:
     """Synchronous reset called from a thread executor.
@@ -70,6 +74,31 @@ class HomeDirPool:
         # Re-discover template now (it may have been created since __init__)
         template_path = Path(self._config.home_dir_template)
         self._template = template_path if template_path.is_dir() else None
+
+        # Seed template with auth credentials at runtime if not already present.
+        # /home/tether/.claude.json is written by `claude setup-token` after
+        # the container first boots — it is never baked into the image (Fly
+        # secret).  Copying it into the template here means every warm
+        # subprocess starts with valid credentials without an extra setup step.
+        # Skips gracefully when: template dir absent, source absent, or
+        # template already has its own .claude.json.
+        if self._template is not None:
+            template_claude_json = self._template / ".claude.json"
+            if not template_claude_json.exists() and _AUTH_SOURCE_PATH.exists():
+                try:
+                    shutil.copy2(_AUTH_SOURCE_PATH, template_claude_json)
+                    log.info(
+                        "home_pool.seeded_template source=%s dest=%s",
+                        _AUTH_SOURCE_PATH,
+                        template_claude_json,
+                    )
+                except OSError:
+                    log.warning(
+                        "home_pool.seed_failed source=%s dest=%s",
+                        _AUTH_SOURCE_PATH,
+                        template_claude_json,
+                        exc_info=True,
+                    )
 
         for i in range(count):
             home = self._base / f"home-{i}"

--- a/config/app_config.yaml
+++ b/config/app_config.yaml
@@ -30,7 +30,7 @@ agent_pool:
   base_url: "http://127.0.0.1:5002"  # override for remote pool deployments
   enabled: true                 # false = callers fall back to direct spawn (local dev)
   control_response_timeout_seconds: 60  # seconds pool waits for control_response before denying
-  initialize_timeout_ms: 120000         # CLAUDE_CODE_STREAM_CLOSE_TIMEOUT injected into subprocess env (ms)
+  initialize_timeout_ms: 240000         # CLAUDE_CODE_STREAM_CLOSE_TIMEOUT injected into subprocess env (ms)
   home_dir_base: /var/lib/tether/claude-homes    # isolated home dirs for subprocesses
   home_dir_template: /etc/claude-home-template   # seed state copied into each home dir at init
 

--- a/tests/agent_pool_manager/test_template_seeding.py
+++ b/tests/agent_pool_manager/test_template_seeding.py
@@ -1,0 +1,134 @@
+"""Regression tests — HomeDirPool.initialize() runtime template seeding.
+
+Scenario: /home/tether/.claude.json holds OAuth credentials injected by
+`claude setup-token`.  The home-dir template (/etc/claude-home-template)
+is baked into the image without credentials (they're Fly secrets, not
+image layers).  initialize() must seed the template .claude.json from the
+running user's home dir so every warm subprocess inherits valid credentials.
+
+Three cases:
+  1. Source present, template missing  → seed (copy occurs)
+  2. Source present, template present  → do NOT overwrite (idempotent)
+  3. Source absent, template missing   → skip gracefully (no crash)
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import agent_pool_manager.homes as homes_module
+from agent_pool_manager.config import AgentPoolConfig
+from agent_pool_manager.homes import HomeDirPool
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _make_pool(base: str, template: str) -> HomeDirPool:
+    cfg = AgentPoolConfig(
+        capacity_total=2,
+        max_age_seconds=600,
+        target_depth_per_hash=1,
+        prime_timeout_seconds=5,
+        acquire_default_timeout=1,
+        home_dir_base=base,
+        home_dir_template=template,
+    )
+    return HomeDirPool(cfg)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — copies .claude.json when template is missing it
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_initialize_seeds_claude_json_into_template(monkeypatch, tmp_path):
+    """initialize() copies /home/tether/.claude.json to template when absent."""
+    # Fake source home dir — has .claude.json with credentials
+    source_home = tmp_path / "tether-home"
+    source_home.mkdir()
+    source_claude_json = source_home / ".claude.json"
+    source_claude_json.write_text(json.dumps({"oauthToken": "sk-ant-test-123"}))
+
+    # Template dir exists but does NOT have .claude.json yet
+    template_dir = tmp_path / "template"
+    template_dir.mkdir()
+
+    # Base dir for home dirs
+    base_dir = tmp_path / "homes"
+    base_dir.mkdir()
+
+    monkeypatch.setattr(homes_module, "_AUTH_SOURCE_PATH", source_claude_json)
+
+    pool = _make_pool(str(base_dir), str(template_dir))
+    await pool.initialize()
+
+    seeded = template_dir / ".claude.json"
+    assert seeded.exists(), "initialize() must copy .claude.json into the template dir"
+    assert json.loads(seeded.read_text())["oauthToken"] == "sk-ant-test-123"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — does NOT overwrite existing template .claude.json
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_initialize_does_not_overwrite_existing_template_claude_json(monkeypatch, tmp_path):
+    """initialize() must not overwrite template .claude.json if it already exists."""
+    source_home = tmp_path / "tether-home"
+    source_home.mkdir()
+    source_claude_json = source_home / ".claude.json"
+    source_claude_json.write_text(json.dumps({"oauthToken": "new-token"}))
+
+    template_dir = tmp_path / "template"
+    template_dir.mkdir()
+    existing = template_dir / ".claude.json"
+    existing.write_text(json.dumps({"oauthToken": "original-token"}))
+
+    base_dir = tmp_path / "homes"
+    base_dir.mkdir()
+
+    monkeypatch.setattr(homes_module, "_AUTH_SOURCE_PATH", source_claude_json)
+
+    pool = _make_pool(str(base_dir), str(template_dir))
+    await pool.initialize()
+
+    preserved = json.loads((template_dir / ".claude.json").read_text())
+    assert preserved["oauthToken"] == "original-token", (
+        "initialize() must not overwrite template .claude.json that already exists"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — handles missing source gracefully (no crash)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_initialize_skips_seeding_when_source_missing(monkeypatch, tmp_path):
+    """initialize() does not crash when /home/tether/.claude.json doesn't exist."""
+    # Source path points to a nonexistent file
+    source_home = tmp_path / "tether-home"
+    source_home.mkdir()
+    missing_source = source_home / ".claude.json"  # NOT created
+
+    template_dir = tmp_path / "template"
+    template_dir.mkdir()
+
+    base_dir = tmp_path / "homes"
+    base_dir.mkdir()
+
+    monkeypatch.setattr(homes_module, "_AUTH_SOURCE_PATH", missing_source)
+
+    pool = _make_pool(str(base_dir), str(template_dir))
+    # Must not raise
+    await pool.initialize()
+
+    assert not (template_dir / ".claude.json").exists(), (
+        "initialize() must not create template .claude.json when source is absent"
+    )
+    # Pool is still usable
+    assert pool.available_count() == 2


### PR DESCRIPTION
## Problem

Three production blockers preventing agent pool warm on Fly:

1. **`/var/lib/tether/claude-homes` doesn't exist** — `/var/lib/` is root-owned; the tether user can't `mkdir` there at runtime. `HomeDirPool.initialize()` fails silently, the queue never populates, and every `acquire()` blocks until timeout then falls back to the shared home dir (lock contention).

2. **`/etc/claude-home-template` is root-owned** — `chmod a+rX` grants read but not write. The new runtime seeding step (copying `/home/tether/.claude.json` into the template) would hit `PermissionError`.

3. **Template has no `.claude.json`** — OAuth credentials come from `claude setup-token` (written to `/home/tether/.claude.json` at first boot), not baked into the image. Without seeding, every warm subprocess starts without auth.

## Fixes

### `Dockerfile`
- Pre-create `/var/lib/tether/claude-homes`, `chown tether:tether`
- `chown tether:tether /etc/claude-home-template` (was root-owned `a+rX`)

### `agent_pool_manager/homes.py`
- Add `_AUTH_SOURCE_PATH` module-level constant (`/home/tether/.claude.json`)
- In `HomeDirPool.initialize()`, after template re-discovery: copy source → `template/.claude.json` if template copy is absent and source exists. Skips gracefully if source absent. Logs both success and OSError.

### `config/app_config.yaml`
- `initialize_timeout_ms: 120000 → 240000` (note: live config is gist-sourced; this updates the committed default for future image builds)

## Tests
3 regression tests in `tests/agent_pool_manager/test_template_seeding.py`:
- seeds `.claude.json` into template when absent
- does NOT overwrite existing template `.claude.json` (idempotent)
- handles missing source gracefully (no crash)

151 tests passing.