### PR TITLE
fix(conversations): align messages API shape with frontend type

### DIFF
--- a/db/pg_queries/conversations.py
+++ b/db/pg_queries/conversations.py
@@ -272,7 +272,7 @@ async def list_conversation_messages(
     """Return messages for a conversation, newest first, with cursor pagination.
 
     Uses `before_id` cursor: returns rows with id < before_id so callers can
-    paginate backwards through history. Returns {"items": [...], "has_more": bool}.
+    paginate backwards through history. Returns {"messages": [...], "has_more": bool}.
 
     Note: `before_id` is an integer-typed primary key on conversation_history —
     this cursor approach is stable under concurrent inserts, unlike offset-based
@@ -292,7 +292,7 @@ async def list_conversation_messages(
         SELECT
             ch.id::text           AS id,
             ch.role,
-            ch.body               AS content,
+            ch.body,
             ch.conversation_id::text AS conversation_id,
             ch.ts                 AS created_at,
             ch.source,
@@ -307,5 +307,5 @@ async def list_conversation_messages(
     )
 
     has_more = len(rows) > limit
-    items = [dict(r) for r in rows[:limit]]
-    return {"items": items, "has_more": has_more}
+    messages = [dict(r) for r in rows[:limit]]
+    return {"messages": messages, "has_more": has_more}

--- a/frontend/src/stores/__tests__/conversations.test.ts
+++ b/frontend/src/stores/__tests__/conversations.test.ts
@@ -339,10 +339,8 @@ describe('useConversationsStore', () => {
       const store = useConversationsStore()
       // Must not throw
       await expect(store.loadMessages('conv-items')).resolves.toBeUndefined()
-      // Graceful degradation: empty array stored (not undefined)
-      const stored = store.messagesById.get('conv-items') ?? null
-      expect(stored).not.toBeNull()
-      expect(Array.isArray(stored)).toBe(true)
+      // Graceful degradation: empty array stored (not undefined or a junk array)
+      expect(store.messagesById.get('conv-items')).toEqual([])
     })
 
     it('does not throw in loadMessagesOlder when API returns HTML', async () => {
@@ -360,6 +358,21 @@ describe('useConversationsStore', () => {
       // Must not throw; existing messages must be preserved
       await expect(store.loadMessagesOlder('conv-older')).resolves.toBeUndefined()
       expect(store.messagesById.get('conv-older')).toEqual(existing)
+    })
+
+    it('does not throw in loadMessagesOlder when API returns wrong shape (items key)', async () => {
+      // Symmetric coverage: same schema-drift scenario for the pagination path.
+      mockApi.mockResolvedValue(mockResponse({ items: [makeMsg({ id: 'msg-old' })], has_more: false }))
+
+      const store = useConversationsStore()
+      const existing = [makeMsg({ id: 'msg-existing' })]
+      store.messagesById.set('conv-older-shape', existing)
+      store.hasMoreById.set('conv-older-shape', true)
+
+      await expect(store.loadMessagesOlder('conv-older-shape')).resolves.toBeUndefined()
+      // Existing messages preserved; empty older set prepended without crash
+      const stored = store.messagesById.get('conv-older-shape')!
+      expect(stored).toContainEqual(expect.objectContaining({ id: 'msg-existing' }))
     })
   })
 })

--- a/frontend/src/stores/__tests__/conversations.test.ts
+++ b/frontend/src/stores/__tests__/conversations.test.ts
@@ -306,4 +306,60 @@ describe('useConversationsStore', () => {
       expect(msgs).toHaveLength(1)
     })
   })
+
+  // ---------------------------------------------------------------------------
+  // Fix C: resilience against malformed / non-JSON API responses
+  // ---------------------------------------------------------------------------
+
+  describe('loadMessages() — error resilience (Fix C)', () => {
+    it('does not throw when API returns HTML (res.json() throws SyntaxError)', async () => {
+      // Simulates Fly.io returning an HTML error page with 200 status
+      // (e.g. SPA fallback serving index.html for an unmatched route).
+      // Before Fix C: SyntaxError propagates as unhandled rejection.
+      // After Fix C: caught internally; messagesById entry remains unset.
+      mockApi.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => { throw new SyntaxError('Unexpected token \'<\'') },
+      } as unknown as Response)
+
+      const store = useConversationsStore()
+      // Must not throw — this is the key assertion
+      await expect(store.loadMessages('conv-html')).resolves.toBeUndefined()
+      // No messages stored on failure
+      expect(store.messagesById.has('conv-html')).toBe(false)
+    })
+
+    it('does not throw when API returns wrong shape (items key instead of messages)', async () => {
+      // Simulates schema drift: backend returning {"items":[...]} instead of {"messages":[...]}.
+      // Before Fix C: [...undefined].reverse() throws TypeError: b.messages is not iterable.
+      // After Fix C: caught internally; messages default to [].
+      mockApi.mockResolvedValue(mockResponse({ items: [makeMsg()], has_more: false }))
+
+      const store = useConversationsStore()
+      // Must not throw
+      await expect(store.loadMessages('conv-items')).resolves.toBeUndefined()
+      // Graceful degradation: empty array stored (not undefined)
+      const stored = store.messagesById.get('conv-items') ?? null
+      expect(stored).not.toBeNull()
+      expect(Array.isArray(stored)).toBe(true)
+    })
+
+    it('does not throw in loadMessagesOlder when API returns HTML', async () => {
+      mockApi.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => { throw new SyntaxError('Unexpected token \'<\'') },
+      } as unknown as Response)
+
+      const store = useConversationsStore()
+      const existing = [makeMsg({ id: 'msg-existing' })]
+      store.messagesById.set('conv-older', existing)
+      store.hasMoreById.set('conv-older', true)
+
+      // Must not throw; existing messages must be preserved
+      await expect(store.loadMessagesOlder('conv-older')).resolves.toBeUndefined()
+      expect(store.messagesById.get('conv-older')).toEqual(existing)
+    })
+  })
 })

--- a/frontend/src/stores/conversations.ts
+++ b/frontend/src/stores/conversations.ts
@@ -74,10 +74,16 @@ export const useConversationsStore = defineStore('conversations', () => {
   async function loadMessages(id: string): Promise<void> {
     const res = await api(`/api/conversations/${id}/messages?limit=50`)
     if (!res.ok) return
-    const page: MessagesPage = await res.json()
+    let page: MessagesPage
+    try {
+      page = await res.json()
+    } catch {
+      // Non-JSON response (e.g. HTML from SPA fallback on infrastructure error) — fail silently.
+      return
+    }
     // API returns newest-first; reverse for display (oldest-first)
-    setMessages(id, [...page.messages].reverse())
-    setHasMore(id, page.has_more)
+    setMessages(id, [...(page.messages ?? [])].reverse())
+    setHasMore(id, page.has_more ?? false)
   }
 
   async function loadMessagesOlder(conversationId: string): Promise<void> {
@@ -89,10 +95,16 @@ export const useConversationsStore = defineStore('conversations', () => {
     const qs = new URLSearchParams({ limit: '50', before_id: beforeId })
     const res = await api(`/api/conversations/${conversationId}/messages?${qs}`)
     if (!res.ok) return
-    const page: MessagesPage = await res.json()
-    const older = [...page.messages].reverse()
+    let page: MessagesPage
+    try {
+      page = await res.json()
+    } catch {
+      // Non-JSON response — fail silently; preserve existing messages.
+      return
+    }
+    const older = [...(page.messages ?? [])].reverse()
     setMessages(conversationId, [...older, ...current])
-    setHasMore(conversationId, page.has_more)
+    setHasMore(conversationId, page.has_more ?? false)
   }
 
   function appendMessage(conversationId: string, msg: ConversationMessage): void {

--- a/frontend/src/stores/conversations.ts
+++ b/frontend/src/stores/conversations.ts
@@ -77,8 +77,9 @@ export const useConversationsStore = defineStore('conversations', () => {
     let page: MessagesPage
     try {
       page = await res.json()
-    } catch {
-      // Non-JSON response (e.g. HTML from SPA fallback on infrastructure error) — fail silently.
+    } catch (e) {
+      // Non-JSON response (e.g. HTML from SPA fallback on infrastructure error).
+      console.warn('[conversations] loadMessages: non-JSON response for', id, e)
       return
     }
     // API returns newest-first; reverse for display (oldest-first)
@@ -98,8 +99,9 @@ export const useConversationsStore = defineStore('conversations', () => {
     let page: MessagesPage
     try {
       page = await res.json()
-    } catch {
-      // Non-JSON response — fail silently; preserve existing messages.
+    } catch (e) {
+      // Non-JSON response — preserve existing messages to avoid data loss.
+      console.warn('[conversations] loadMessagesOlder: non-JSON response for', conversationId, e)
       return
     }
     const older = [...(page.messages ?? [])].reverse()

--- a/tests/api/test_conversations.py
+++ b/tests/api/test_conversations.py
@@ -269,7 +269,10 @@ async def test_get_messages_empty(api_client, conn):
     resp = await api_client.get(f"/api/conversations/{cid}/messages")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["items"] == []
+    # Must use "messages" key (not "items") to match frontend MessagesPage type
+    assert "messages" in data, f"expected 'messages' key in response, got keys: {list(data.keys())}"
+    assert "items" not in data, "must not expose 'items' key — frontend expects 'messages'"
+    assert data["messages"] == []
     assert data["has_more"] is False
 
 
@@ -283,9 +286,14 @@ async def test_get_messages_returns_messages(api_client, conn):
     resp = await api_client.get(f"/api/conversations/{cid}/messages")
     assert resp.status_code == 200
     data = resp.json()
-    assert len(data["items"]) == 2
-    roles = {m["role"] for m in data["items"]}
+    assert "messages" in data, f"expected 'messages' key, got: {list(data.keys())}"
+    assert len(data["messages"]) == 2
+    roles = {m["role"] for m in data["messages"]}
     assert roles == {"user", "assistant"}
+    # Must expose "body" field (not "content") to match frontend ConversationMessage type
+    for msg in data["messages"]:
+        assert "body" in msg, f"expected 'body' field in message, got: {list(msg.keys())}"
+        assert "content" not in msg, "must not expose 'content' — frontend expects 'body'"
 
 
 @pytest.mark.asyncio
@@ -302,7 +310,8 @@ async def test_get_messages_before_id_cursor(api_client, conn):
     resp = await api_client.get(f"/api/conversations/{cid}/messages?before_id={cursor_id}&limit=10")
     assert resp.status_code == 200
     data = resp.json()
-    returned_ids = [m["id"] for m in data["items"]]
+    assert "messages" in data, f"expected 'messages' key, got: {list(data.keys())}"
+    returned_ids = [m["id"] for m in data["messages"]]
     assert ids[0] in returned_ids
     assert ids[1] in returned_ids
     assert cursor_id not in returned_ids
@@ -319,7 +328,8 @@ async def test_get_messages_has_more_true(api_client, conn):
     resp = await api_client.get(f"/api/conversations/{cid}/messages?limit=3")
     assert resp.status_code == 200
     data = resp.json()
-    assert len(data["items"]) == 3
+    assert "messages" in data, f"expected 'messages' key, got: {list(data.keys())}"
+    assert len(data["messages"]) == 3
     assert data["has_more"] is True
 
 
@@ -333,6 +343,7 @@ async def test_get_messages_has_more_false(api_client, conn):
     resp = await api_client.get(f"/api/conversations/{cid}/messages?limit=10")
     assert resp.status_code == 200
     data = resp.json()
+    assert "messages" in data, f"expected 'messages' key, got: {list(data.keys())}"
     assert data["has_more"] is False
 
 


### PR DESCRIPTION
## Summary

- **Fix A**: `db/pg_queries/conversations.py` — `list_conversation_messages()` now returns `{"messages": [...]}` instead of `{"items": [...]}` to match the frontend `MessagesPage` type
- **Fix B**: Same file — SQL column alias `ch.body AS content` removed; field now correctly named `body` to match `ConversationMessage.body` in the frontend type and template
- **Fix C**: `frontend/src/stores/conversations.ts` — `loadMessages()` and `loadMessagesOlder()` now wrap `res.json()` in a try-catch with `?? []` fallback, preventing uncaught `SyntaxError` from HTML 200 responses (Fly.io SPA fallback)

## Root Cause

Three pre-existing schema drift bugs caused `TypeError: b.messages is not iterable` and `SyntaxError: Unexpected token '<'` in production ChatPageView logs:

1. Backend returned `items` key; frontend read `messages` → TypeError on every message load
2. Backend returned `content` field; frontend read `body` → messages rendered blank  
3. No try-catch around `res.json()` → SyntaxError propagated unhandled on HTML responses

## Test plan

- [ ] 3 new Vitest unit tests added covering SyntaxError and TypeError resilience paths (all passing)
- [ ] Existing `test_conversations.py` backend tests updated to assert `messages`/`body` keys (will run in CI with DATABASE_URL)
- [ ] `npm run build` passes with zero type errors
- [ ] Full Vitest suite: 908/913 passing (5 pre-existing failures in `usePoolWarm.test.ts`, unrelated)