### PR TITLE
fix(chat): capture turn_complete.final_text in useConversationChat

### DIFF
--- a/frontend/src/components/chat/ConversationView.vue
+++ b/frontend/src/components/chat/ConversationView.vue
@@ -143,19 +143,21 @@ async function onSend() {
   streamingBubble.value = ''
   const convId = selectedId.value
 
-  await chat.send(text, (chunk: string) => {
+  const finalText = await chat.send(text, (chunk: string) => {
     if (streamingBubble.value !== null) {
       streamingBubble.value += chunk
     }
     scrollToBottom()
   })
 
-  // Finalize streaming bubble as assistant message
-  if (streamingBubble.value) {
+  // Prefer turn_complete.final_text as the authoritative message body; fall back
+  // to accumulated delta text for transports that omit final_text.
+  const messageBody = finalText || streamingBubble.value
+  if (messageBody) {
     const assistantMsg: ConversationMessage = {
       id: `local-assistant-${Date.now()}`,
       role: 'assistant',
-      body: streamingBubble.value,
+      body: messageBody,
       source: 'chat',
       channel: 'web',
       created_at: new Date().toISOString(),

--- a/frontend/src/composables/__tests__/useConversationChat.test.ts
+++ b/frontend/src/composables/__tests__/useConversationChat.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { setBotTransport } from '../useBotTransport'
+import { makeTransport } from '../../stores/__tests__/testHelpers'
+import type { WsIncomingEvent } from '../../types/chat'
+import { useConversationChat } from '../useConversationChat'
+
+vi.mock('../../stores/agentPicker', () => ({
+  useAgentPickerStore: () => ({ selectedAgent: 'tether-agent-2.0', fetchPreference: vi.fn() }),
+}))
+
+describe('useConversationChat', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  describe('send() — turn_complete.final_text handling', () => {
+    it('returns final_text when only turn_complete arrives (no deltas)', async () => {
+      // Simulates one_shot / non-streaming responses where the bot sends only
+      // turn_complete with the full answer and no preceding agent_text_delta events.
+      // Before fix: send() returned void — streamingBubble stayed '' and the
+      // message was silently dropped. After fix: send() returns final_text.
+      setBotTransport(makeTransport([
+        { type: 'turn_complete', session_id: 's1', final_text: 'Hello from server' },
+      ]))
+
+      const { send } = useConversationChat('conv-1')
+      const chunks: string[] = []
+      const finalText = await send('ping', (c) => chunks.push(c))
+
+      expect(finalText).toBe('Hello from server')
+      expect(chunks).toHaveLength(0) // no chunks fired — delta path not triggered
+    })
+
+    it('returns final_text from turn_complete even when deltas also arrive', async () => {
+      // The authoritative text is always turn_complete.final_text.
+      // Deltas are for progressive display only — final_text is the canonical record.
+      setBotTransport(makeTransport([
+        { type: 'agent_text_delta', session_id: 's1', delta: 'Hello ' },
+        { type: 'agent_text_delta', session_id: 's1', delta: 'world' },
+        { type: 'turn_complete', session_id: 's1', final_text: 'Hello world' },
+      ]))
+
+      const { send } = useConversationChat('conv-2')
+      const chunks: string[] = []
+      const finalText = await send('ping', (c) => chunks.push(c))
+
+      expect(finalText).toBe('Hello world')
+      expect(chunks).toEqual(['Hello ', 'world']) // deltas still fire onChunk for streaming display
+    })
+
+    it('returns empty string when turn_complete.final_text is empty', async () => {
+      // Caller (ConversationView) falls back to accumulated delta text when finalText is ''.
+      // This covers future protocol extensions where final_text may be omitted.
+      setBotTransport(makeTransport([
+        { type: 'agent_text_delta', session_id: 's1', delta: 'streamed text' },
+        { type: 'turn_complete', session_id: 's1', final_text: '' },
+      ]))
+
+      const { send } = useConversationChat('conv-3')
+      const chunks: string[] = []
+      const finalText = await send('ping', (c) => chunks.push(c))
+
+      expect(finalText).toBe('')
+      expect(chunks).toEqual(['streamed text'])
+    })
+
+    it('still calls onChunk for every agent_text_delta (streaming display unaffected)', async () => {
+      // Ensure the streaming display path is not broken by the return-type change.
+      const events: WsIncomingEvent[] = [
+        { type: 'agent_text_delta', session_id: 's1', delta: 'A' },
+        { type: 'agent_text_delta', session_id: 's1', delta: 'B' },
+        { type: 'agent_text_delta', session_id: 's1', delta: 'C' },
+        { type: 'turn_complete', session_id: 's1', final_text: 'ABC' },
+      ]
+      setBotTransport(makeTransport(events))
+
+      const { send } = useConversationChat('conv-4')
+      const onChunk = vi.fn()
+      await send('test', onChunk)
+
+      expect(onChunk).toHaveBeenCalledTimes(3)
+      expect(onChunk).toHaveBeenNthCalledWith(1, 'A')
+      expect(onChunk).toHaveBeenNthCalledWith(2, 'B')
+      expect(onChunk).toHaveBeenNthCalledWith(3, 'C')
+    })
+  })
+})

--- a/frontend/src/composables/useConversationChat.ts
+++ b/frontend/src/composables/useConversationChat.ts
@@ -6,9 +6,10 @@ export function useConversationChat(_conversationId: string) {
   const isStreaming = ref(false)
   const streamingContent = ref('')
 
-  async function send(text: string, onChunk: (chunk: string) => void): Promise<void> {
+  async function send(text: string, onChunk: (chunk: string) => void): Promise<string> {
     isStreaming.value = true
     streamingContent.value = ''
+    let finalText = ''
     try {
       const agentVersion = useAgentPickerStore().selectedAgent
       for await (const event of getBotTransport().send(text, agentVersion)) {
@@ -16,7 +17,10 @@ export function useConversationChat(_conversationId: string) {
           streamingContent.value += event.delta
           onChunk(event.delta)
         } else if (event.type === 'turn_complete') {
-          // Final text already accumulated via deltas; nothing extra needed
+          // Capture the authoritative final text from the server. Callers use
+          // this as the canonical message body; accumulated delta text is only
+          // for progressive display and may be incomplete if the stream drops.
+          finalText = event.final_text
         }
         // Other event types (agent_action, permission_request, status, etc.)
         // are handled by picker-builder's full composable — ignored here in stub.
@@ -25,6 +29,7 @@ export function useConversationChat(_conversationId: string) {
       isStreaming.value = false
       streamingContent.value = ''
     }
+    return finalText
   }
 
   function interrupt(): void {


### PR DESCRIPTION
## Summary
- `useConversationChat.send()` ignored `turn_complete.final_text`, so messages sent via one_shot paths (no preceding `agent_text_delta` events) were silently dropped — `streamingBubble` stayed `''` and the `if (streamingBubble.value)` guard skipped storing the message
- Changed `send()` return type from `Promise<void>` → `Promise<string>`, capturing `final_text` from the `turn_complete` event
- Updated `ConversationView.onSend()` to use `finalText || streamingBubble.value` as the authoritative message body

## Root cause
```typescript
} else if (event.type === 'turn_complete') {
  // Final text already accumulated via deltas; nothing extra needed  ← wrong stub comment
}
```
Server confirmed delivering `final_text_chars=103`; bug was entirely frontend.

## Test plan
- [x] 4 new Vitest tests in `src/composables/__tests__/useConversationChat.test.ts`
  - no-delta path: only `turn_complete` → `finalText` is captured correctly
  - delta+final path: both events → `finalText` still returned (canonical)
  - empty final_text: returns `''` so caller falls back to delta accumulation
  - onChunk callback unaffected: streaming display still fires correctly
- [x] Full suite: 913 passed, 5 pre-existing failures in `usePoolWarm.test.ts` (unrelated, confirmed pre-existing)
- [x] `npm run build` — zero type errors