### PR TITLE
fix: wire all subprocess spawns through pool manager

### DIFF
--- a/bot/llm.py
+++ b/bot/llm.py
@@ -212,24 +212,10 @@ class PipelineBackend(LLMBackend):
         effective_user_id = _llm_user_id.get() or self._user_id
 
         if self._pool_client is not None and effective_user_id is not None:
-            try:
-                output = await asyncio.wait_for(
-                    self._complete_via_pool(prompt, model, env),
-                    timeout=180,
-                )
-            except Exception as exc:
-                # Pool unreachable / exhausted — fall back to inline spawn so the
-                # request still gets a response.  Log at warning so ops can see
-                # when pool routing is degraded.
-                logger.warning(
-                    "PipelineBackend: pool path failed for user_id=%s, falling back to inline: %s",
-                    effective_user_id,
-                    exc,
-                )
-                output = await asyncio.wait_for(
-                    self._complete_inline(prompt, model, env),
-                    timeout=180,
-                )
+            output = await asyncio.wait_for(
+                self._complete_via_pool(prompt, model, env),
+                timeout=180,
+            )
         else:
             output = await asyncio.wait_for(
                 self._complete_inline(prompt, model, env),

--- a/config/app_config.yaml
+++ b/config/app_config.yaml
@@ -35,6 +35,7 @@ agent_pool:
   home_dir_template: /etc/claude-home-template   # seed state copied into each home dir at init
 
 llm:
+  layer_base_url: "http://127.0.0.1:5003"
   use_v3: false
   v2_fallback: true
   mcp_server_url: "http://localhost:5001/sse"

--- a/tests/bot/test_pipeline_pool.py
+++ b/tests/bot/test_pipeline_pool.py
@@ -397,7 +397,8 @@ class TestPipelineBackendPoolAcquire:
         """release() must be called in a finally block even if query_stream raises.
 
         When query_stream fails, _complete_via_pool's finally block must still call
-        release before the error propagates.  The pool path then falls back to inline.
+        release before the error propagates to the caller.  There is no inline fallback —
+        the error propagates as-is so callers can detect pool failures explicitly.
         """
         from bot.llm import PipelineBackend
 
@@ -413,15 +414,15 @@ class TestPipelineBackendPoolAcquire:
 
         backend = PipelineBackend(pool_client=pool_client, user_id=TEST_USER_ID)
 
-        # Pool error now triggers inline fallback — mock inline so we don't need claude_agent_sdk
-        with patch.object(backend, "_complete_inline", AsyncMock(return_value="inline-fallback")):
+        # Error must propagate — no inline fallback
+        with pytest.raises(RuntimeError, match="pool query failed"):
             await backend.complete(
                 messages=[{"role": "user", "content": "test"}],
                 system="sys",
                 model="claude-haiku-4-5-20251001",
             )
 
-        # release must be called despite the stream error (via finally block in _complete_via_pool)
+        # release must still be called despite the stream error (via finally block in _complete_via_pool)
         pool_client.release.assert_awaited_once()
 
     def test_pipeline_backend_without_pool_client_is_pool_unaware(self):
@@ -459,9 +460,9 @@ class TestCodeReviewFindings:
         """release must be called with reusable=False when query_stream raises.
 
         Previously reusable=True was unconditional — poisoned handles were
-        returned to the pool and given to the next request.  After Fix 5 the pool
-        path falls back to inline on error, but the finally block in _complete_via_pool
-        still calls release before the error propagates up to the fallback logic.
+        returned to the pool and given to the next request.  The finally block in
+        _complete_via_pool calls release(reusable=False) before the error propagates
+        to the caller.  There is no inline fallback — the error surfaces as-is.
         """
         from bot.llm import PipelineBackend
 
@@ -477,8 +478,8 @@ class TestCodeReviewFindings:
 
         backend = PipelineBackend(pool_client=pool_client, user_id=TEST_USER_ID)
 
-        # Pool path falls back to inline after stream error — mock inline
-        with patch.object(backend, "_complete_inline", AsyncMock(return_value="inline-fallback")):
+        # Error must propagate — no inline fallback
+        with pytest.raises(RuntimeError, match="stream error"):
             await backend.complete(
                 messages=[{"role": "user", "content": "test"}],
                 system="sys",
@@ -530,12 +531,14 @@ class TestCodeReviewFindings:
             f"Content: {result.content!r}"
         )
 
-    # Fix 5 — pool fallback to inline on acquire failure
+    # Fix 5 — pool acquire failure raises (no silent fallback)
     @pytest.mark.asyncio
-    async def test_pool_acquire_failure_falls_back_to_inline(self):
-        """When pool acquire() raises, PipelineBackend must fall back to _complete_inline.
+    async def test_pool_acquire_failure_raises(self):
+        """When pool acquire() raises, PipelineBackend must propagate the error.
 
-        Pool may be exhausted or unreachable; inline spawn must be the safety net.
+        Pool errors must be visible to the caller — silent fallback to inline spawn
+        would hide pool health issues and re-introduce unbounded subprocess growth.
+        Only when pool_client is None does PipelineBackend use inline.
         """
         from bot.llm import PipelineBackend
 
@@ -544,21 +547,17 @@ class TestCodeReviewFindings:
 
         backend = PipelineBackend(pool_client=pool_client, user_id=TEST_USER_ID)
 
-        inline_calls: list = []
+        # _complete_inline must NOT be called — verify by making it raise a distinct error
+        async def _must_not_be_called(*args, **kwargs):
+            raise AssertionError("_complete_inline must not be called when pool_client is set")
 
-        async def _fake_inline(prompt: str, model: str, env: dict) -> str:
-            inline_calls.append(prompt)
-            return "inline-response"
-
-        with patch.object(backend, "_complete_inline", side_effect=_fake_inline):
-            result = await backend.complete(
-                messages=[{"role": "user", "content": "test"}],
-                system="sys",
-                model="claude-haiku-4-5-20251001",
-            )
-
-        assert len(inline_calls) == 1, "_complete_inline must be called as fallback on pool error"
-        assert result.content == "inline-response"
+        with patch.object(backend, "_complete_inline", side_effect=_must_not_be_called):
+            with pytest.raises(RuntimeError, match="pool exhausted"):
+                await backend.complete(
+                    messages=[{"role": "user", "content": "test"}],
+                    system="sys",
+                    model="claude-haiku-4-5-20251001",
+                )
 
     # Fix 1 — _llm_user_id contextvar overrides frozen self._user_id
     @pytest.mark.asyncio

--- a/tests/bot/test_pool_wiring_fixes.py
+++ b/tests/bot/test_pool_wiring_fixes.py
@@ -1,0 +1,80 @@
+"""Tests for pool-wiring Fix 3 (tether repo).
+
+Fix 3: PipelineBackend.complete() raises when the pool path fails —
+       silent fallback to inline spawn is removed.
+
+SAFETY: All tests patch _complete_inline to avoid real subprocess spawning.
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestPipelineBackendNoInlineFallback:
+    """When pool_client is set and the pool path raises, the error must
+    propagate to the caller.  _complete_inline must never be reached."""
+
+    @pytest.mark.asyncio
+    async def test_pool_error_propagates_not_swallowed(self):
+        """Pool PoolClientError must propagate — not trigger inline spawn."""
+        from bot.llm import PipelineBackend
+        from agent_pool_manager.client import PoolClientError
+
+        mock_pool = MagicMock()
+        mock_pool.acquire = AsyncMock(side_effect=PoolClientError("pool exhausted"))
+
+        backend = PipelineBackend(pool_client=mock_pool, user_id="user-123")
+
+        # Patch _complete_inline so any call immediately fails the test with
+        # a clear message, rather than timing out on a real subprocess spawn.
+        async def _must_not_be_called(*args, **kwargs):
+            raise AssertionError("_complete_inline must not be called when pool_client is set")
+
+        with patch.object(backend, "_complete_inline", side_effect=_must_not_be_called):
+            with pytest.raises(PoolClientError):
+                await backend.complete(
+                    messages=[{"role": "user", "content": "do work"}],
+                    system="system",
+                    model="claude-sonnet-4-6",
+                )
+
+    @pytest.mark.asyncio
+    async def test_pool_runtime_error_propagates(self):
+        """Generic pool RuntimeError also propagates without falling back."""
+        from bot.llm import PipelineBackend
+
+        mock_pool = MagicMock()
+        mock_pool.acquire = AsyncMock(side_effect=RuntimeError("pool service down"))
+
+        backend = PipelineBackend(pool_client=mock_pool, user_id="user-456")
+
+        with patch.object(backend, "_complete_inline", new=AsyncMock()) as mock_inline:
+            with pytest.raises(RuntimeError):
+                await backend.complete(
+                    messages=[{"role": "user", "content": "hi"}],
+                    system="system",
+                    model="claude-haiku-4-5-20251001",
+                )
+            mock_inline.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_pool_client_still_uses_inline(self):
+        """Without pool_client, _complete_inline is still used (backward compat)."""
+        from bot.llm import PipelineBackend, LLMResponse
+
+        backend = PipelineBackend(pool_client=None, user_id=None)
+
+        with patch.object(
+            backend, "_complete_inline",
+            new=AsyncMock(return_value="inline result"),
+        ) as mock_inline:
+            result = await backend.complete(
+                messages=[{"role": "user", "content": "hi"}],
+                system="system",
+                model="claude-haiku-4-5-20251001",
+            )
+
+        mock_inline.assert_called_once()
+        assert isinstance(result, LLMResponse)
+        assert result.content == "inline result"


### PR DESCRIPTION
## Summary

- **Fix 3 (PipelineBackend):** Remove silent `except` block that fell back to inline subprocess spawn when pool path failed. Pool errors now propagate to the caller instead of silently spawning a cold process.
- **Fix 4 (config):** Add `llm.layer_base_url: http://127.0.0.1:5003` to `app_config.yaml` so Session M4 layer mode can read the interactive-agent-layer URL from config.

## Test plan
- `tests/bot/test_pool_wiring_fixes.py` — 3 tests covering pool error propagation and backward compat
- All 3 pass, run in <0.1s with no subprocess spawning