### PR TITLE
Add lightweight conversation and node index endpoints

### DIFF
--- a/api/routes/conversations.py
+++ b/api/routes/conversations.py
@@ -2,6 +2,7 @@
 
 Endpoints:
   GET    /conversations                   list conversations (RLS-scoped)
+  GET    /conversations/index             lightweight index (id, title, parent_context_node_id, updated_at, message_count)
   POST   /conversations                   create conversation
   GET    /conversations/{id}              get single conversation
   PATCH  /conversations/{id}              patch conversation
@@ -14,6 +15,10 @@ Note on before_id cursor pagination (messages endpoint): the cursor is the
 integer primary key of conversation_history. This gives stable pages under
 concurrent inserts, unlike offset-based pagination. The tradeoff is that
 clients must treat the cursor as an opaque integer string. See PR description.
+
+Note on route ordering: /conversations/index MUST be registered before
+/conversations/{conversation_id} so FastAPI does not match the literal
+string "index" as a conversation_id path parameter.
 """
 from __future__ import annotations
 
@@ -29,6 +34,7 @@ from db.pg_queries.conversations import (
     get_conversation,
     list_conversations,
     list_conversation_messages,
+    list_conversations_index,
     update_conversation,
 )
 from db.pg_queries.nodes import get_node
@@ -138,6 +144,26 @@ async def create_conv(
     )
     conv = await get_conversation(conn, cid)
     return await _attach_folder_name(conn, conv)
+
+
+# ---------------------------------------------------------------------------
+# GET /conversations/index
+# ---------------------------------------------------------------------------
+# NOTE: registered before /{conversation_id} so "index" is not matched as an id.
+
+
+@router.get("/conversations/index")
+async def get_conversations_index(
+    request: Request,
+    _auth=Depends(auth_dependency),
+    conn=Depends(get_db_conn),
+):
+    """Lightweight index: id, title, parent_context_node_id, updated_at, message_count.
+
+    No message bodies. One DB query. Used by the frontend to build tree views
+    without fetching full conversation detail for each item.
+    """
+    return await list_conversations_index(conn, user_id=request.state.user_id)
 
 
 # ---------------------------------------------------------------------------

--- a/api/routes/nodes.py
+++ b/api/routes/nodes.py
@@ -12,6 +12,7 @@ from db.pg_queries import (
     get_auto_archivable_nodes, archive_node,
     get_user_setting,
 )
+from db.pg_queries.nodes import list_nodes_index
 from db.pool_middleware import get_db_conn
 from api.ws import manager
 from api.auth import auth_dependency
@@ -140,6 +141,19 @@ async def search_sections_route(_auth=Depends(auth_dependency),
     if not q.strip():
         return []
     return await search_sections(conn, q.strip(), node_id=node_id)
+
+
+@router.get("/nodes/index")
+async def get_nodes_index(_auth=Depends(auth_dependency),
+                          conn: asyncpg.Connection = Depends(get_db_conn)):
+    """Lightweight index: id, title, parent_id, path, child_count.
+
+    No section data. One recursive-CTE DB query. Used by the frontend to
+    build the node tree without fetching full node detail for each item.
+
+    NOTE: registered before /{node_id} so "index" is not matched as a node id.
+    """
+    return await list_nodes_index(conn)
 
 
 @router.get("/nodes/{node_id}")

--- a/api/routes/nodes.py
+++ b/api/routes/nodes.py
@@ -144,7 +144,7 @@ async def search_sections_route(_auth=Depends(auth_dependency),
 
 
 @router.get("/nodes/index")
-async def get_nodes_index(_auth=Depends(auth_dependency),
+async def get_nodes_index(request: Request, _auth=Depends(auth_dependency),
                           conn: asyncpg.Connection = Depends(get_db_conn)):
     """Lightweight index: id, title, parent_id, path, child_count.
 
@@ -153,7 +153,7 @@ async def get_nodes_index(_auth=Depends(auth_dependency),
 
     NOTE: registered before /{node_id} so "index" is not matched as a node id.
     """
-    return await list_nodes_index(conn)
+    return await list_nodes_index(conn, user_id=request.state.user_id)
 
 
 @router.get("/nodes/{node_id}")

--- a/db/pg_queries/conversations.py
+++ b/db/pg_queries/conversations.py
@@ -318,9 +318,12 @@ async def list_conversations_index(
 ) -> list[dict]:
     """Return a lightweight index of all conversations for the given user.
 
-    Returns [{id, title, parent_context_node_id, updated_at, message_count}].
+    Returns [{id, title, parent_context_node_id, state, priority, updated_at, message_count}].
     One query — no per-row N+1. Message bodies and full detail are excluded.
     Used by the frontend to populate conversation trees quickly.
+
+    state and priority are included so the frontend can render pending badges
+    and priority dots on first paint without a follow-up upgrade call.
     """
     rows = await conn.fetch(
         """
@@ -328,12 +331,15 @@ async def list_conversations_index(
             c.id::text                       AS id,
             c.name                           AS title,
             c.context_node_id::text          AS parent_context_node_id,
+            c.state,
+            c.priority,
             COALESCE(c.last_message_at, c.created_at) AS updated_at,
             COUNT(ch.id)::int                AS message_count
         FROM conversations c
         LEFT JOIN conversation_history ch ON ch.conversation_id = c.id
         WHERE c.user_id = $1::uuid
-        GROUP BY c.id, c.name, c.context_node_id, c.last_message_at, c.created_at
+        GROUP BY c.id, c.name, c.context_node_id, c.state, c.priority,
+                 c.last_message_at, c.created_at
         ORDER BY COALESCE(c.last_message_at, c.created_at) DESC
         """,
         user_id,

--- a/db/pg_queries/conversations.py
+++ b/db/pg_queries/conversations.py
@@ -309,3 +309,33 @@ async def list_conversation_messages(
     has_more = len(rows) > limit
     messages = [dict(r) for r in rows[:limit]]
     return {"messages": messages, "has_more": has_more}
+
+
+async def list_conversations_index(
+    conn: asyncpg.Connection,
+    *,
+    user_id: str,
+) -> list[dict]:
+    """Return a lightweight index of all conversations for the given user.
+
+    Returns [{id, title, parent_context_node_id, updated_at, message_count}].
+    One query — no per-row N+1. Message bodies and full detail are excluded.
+    Used by the frontend to populate conversation trees quickly.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT
+            c.id::text                       AS id,
+            c.name                           AS title,
+            c.context_node_id::text          AS parent_context_node_id,
+            COALESCE(c.last_message_at, c.created_at) AS updated_at,
+            COUNT(ch.id)::int                AS message_count
+        FROM conversations c
+        LEFT JOIN conversation_history ch ON ch.conversation_id = c.id
+        WHERE c.user_id = $1::uuid
+        GROUP BY c.id, c.name, c.context_node_id, c.last_message_at, c.created_at
+        ORDER BY COALESCE(c.last_message_at, c.created_at) DESC
+        """,
+        user_id,
+    )
+    return [dict(r) for r in rows]

--- a/db/pg_queries/nodes.py
+++ b/db/pg_queries/nodes.py
@@ -154,26 +154,27 @@ async def get_all_node_paths(conn: asyncpg.Connection) -> list[str]:
     return [r["path"] for r in rows]
 
 
-async def list_nodes_index(conn: asyncpg.Connection) -> list[dict]:
-    """Return a lightweight index of all non-archived context nodes.
+async def list_nodes_index(conn: asyncpg.Connection, *, user_id: str) -> list[dict]:
+    """Return a lightweight index of all non-archived context nodes for a user.
 
     Returns [{id, title, parent_id, path, child_count}].
     One recursive CTE query — no per-row N+1. Section data is excluded.
     Used by the frontend to populate the node tree quickly.
 
-    Scoped by the RLS setting (app.current_user_id) already on the connection.
+    Filters explicitly by user_id in addition to the RLS policy on the
+    connection, matching the pattern used by list_conversations_index.
     """
     rows = await conn.fetch(
         """
         WITH RECURSIVE tree(id, parent_id, name, path) AS (
             SELECT id, parent_id, name, name::text AS path
             FROM context_nodes
-            WHERE parent_id IS NULL AND archived = FALSE
+            WHERE parent_id IS NULL AND archived = FALSE AND user_id = $1::uuid
             UNION ALL
             SELECT cn.id, cn.parent_id, cn.name, tree.path || '/' || cn.name
             FROM context_nodes cn
             JOIN tree ON cn.parent_id = tree.id
-            WHERE cn.archived = FALSE
+            WHERE cn.archived = FALSE AND cn.user_id = $1::uuid
         )
         SELECT
             t.id::text         AS id,
@@ -183,9 +184,11 @@ async def list_nodes_index(conn: asyncpg.Connection) -> list[dict]:
             COUNT(c.id)::int   AS child_count
         FROM tree t
         LEFT JOIN context_nodes c ON c.parent_id = t.id AND c.archived = FALSE
+            AND c.user_id = $1::uuid
         GROUP BY t.id, t.name, t.parent_id, t.path
         ORDER BY t.path
-        """
+        """,
+        user_id,
     )
     return [dict(r) for r in rows]
 

--- a/db/pg_queries/nodes.py
+++ b/db/pg_queries/nodes.py
@@ -154,6 +154,42 @@ async def get_all_node_paths(conn: asyncpg.Connection) -> list[str]:
     return [r["path"] for r in rows]
 
 
+async def list_nodes_index(conn: asyncpg.Connection) -> list[dict]:
+    """Return a lightweight index of all non-archived context nodes.
+
+    Returns [{id, title, parent_id, path, child_count}].
+    One recursive CTE query — no per-row N+1. Section data is excluded.
+    Used by the frontend to populate the node tree quickly.
+
+    Scoped by the RLS setting (app.current_user_id) already on the connection.
+    """
+    rows = await conn.fetch(
+        """
+        WITH RECURSIVE tree(id, parent_id, name, path) AS (
+            SELECT id, parent_id, name, name::text AS path
+            FROM context_nodes
+            WHERE parent_id IS NULL AND archived = FALSE
+            UNION ALL
+            SELECT cn.id, cn.parent_id, cn.name, tree.path || '/' || cn.name
+            FROM context_nodes cn
+            JOIN tree ON cn.parent_id = tree.id
+            WHERE cn.archived = FALSE
+        )
+        SELECT
+            t.id::text         AS id,
+            t.name             AS title,
+            t.parent_id::text  AS parent_id,
+            t.path,
+            COUNT(c.id)::int   AS child_count
+        FROM tree t
+        LEFT JOIN context_nodes c ON c.parent_id = t.id AND c.archived = FALSE
+        GROUP BY t.id, t.name, t.parent_id, t.path
+        ORDER BY t.path
+        """
+    )
+    return [dict(r) for r in rows]
+
+
 async def get_children(
     conn: asyncpg.Connection,
     parent_id: str | None = None,

--- a/tests/api/test_conversations_index.py
+++ b/tests/api/test_conversations_index.py
@@ -250,8 +250,8 @@ async def test_nodes_index_excludes_archived(api_client, conn):
 async def test_nodes_index_rls(api_client, api_client_b, conn):
     """User B must not see user A's nodes in the index.
 
-    The nodes index relies solely on RLS (no explicit user_id filter in the
-    query) — this test is the primary guard against an RLS misconfiguration.
+    The nodes index filters explicitly by user_id (matching list_conversations_index)
+    in addition to the connection-level RLS policy.
     """
     node = await create_node(conn, "PrivateNode")
     resp_b = await api_client_b.get("/api/nodes/index")

--- a/tests/api/test_conversations_index.py
+++ b/tests/api/test_conversations_index.py
@@ -1,0 +1,229 @@
+"""API tests — lightweight index endpoints.
+
+Endpoints under test:
+  GET /api/conversations/index   → [{id, title, parent_context_node_id, updated_at, message_count}]
+  GET /api/nodes/index           → [{id, title, parent_id, path, child_count}]
+
+These are intentionally minimal — no message bodies, no section data.
+Used by the frontend to populate trees quickly without N+1 overhead.
+"""
+from __future__ import annotations
+
+import pytest
+from db.pg_queries.conversations import create_conversation
+from db.pg_queries.nodes import create_node
+
+
+TEST_USER_ID = "00000000-0000-0000-0000-000000000001"
+
+
+async def _insert_message(conn, conversation_id: str, role: str = "user", content: str = "hi") -> str:
+    row = await conn.fetchrow(
+        """
+        INSERT INTO conversation_history (user_id, role, body, conversation_id)
+        VALUES ($1::uuid, $2, $3, $4::uuid)
+        RETURNING id::text
+        """,
+        TEST_USER_ID, role, content, conversation_id,
+    )
+    return row["id"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/conversations/index
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_conversations_index_empty(api_client, conn):
+    resp = await api_client.get("/api/conversations/index")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_conversations_index_shape(api_client, conn):
+    """Each item must have exactly the index fields — no message bodies or extra columns."""
+    cid = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="My conv", notification_type="bot",
+    )
+    resp = await api_client.get("/api/conversations/index")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    item = data[0]
+    # Required fields
+    assert item["id"] == cid
+    assert item["title"] == "My conv"
+    assert "parent_context_node_id" in item
+    assert "updated_at" in item
+    assert "message_count" in item
+    # Must NOT expose full conversation detail fields
+    assert "body" not in item
+    assert "state" not in item
+    assert "type" not in item
+
+
+@pytest.mark.asyncio
+async def test_conversations_index_message_count_zero(api_client, conn):
+    await create_conversation(
+        conn, user_id=TEST_USER_ID, name="Empty", notification_type="bot",
+    )
+    resp = await api_client.get("/api/conversations/index")
+    assert resp.status_code == 200
+    item = resp.json()[0]
+    assert item["message_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_conversations_index_message_count_nonzero(api_client, conn):
+    cid = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="Has msgs", notification_type="bot",
+    )
+    for _ in range(3):
+        await _insert_message(conn, cid)
+    resp = await api_client.get("/api/conversations/index")
+    assert resp.status_code == 200
+    item = next(i for i in resp.json() if i["id"] == cid)
+    assert item["message_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_conversations_index_parent_context_node_id(api_client, conn):
+    node = await create_node(conn, "Work")
+    cid = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="Linked", notification_type="bot",
+        context_node_id=node["id"],
+    )
+    resp = await api_client.get("/api/conversations/index")
+    assert resp.status_code == 200
+    item = next(i for i in resp.json() if i["id"] == cid)
+    assert item["parent_context_node_id"] == node["id"]
+
+
+@pytest.mark.asyncio
+async def test_conversations_index_parent_context_node_id_null(api_client, conn):
+    await create_conversation(
+        conn, user_id=TEST_USER_ID, name="Unlinked", notification_type="bot",
+    )
+    resp = await api_client.get("/api/conversations/index")
+    assert resp.status_code == 200
+    item = resp.json()[0]
+    assert item["parent_context_node_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_conversations_index_rls(api_client, api_client_b, conn):
+    """User B must not see user A's conversations in the index."""
+    cid = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="Private", notification_type="bot",
+    )
+    resp_b = await api_client_b.get("/api/conversations/index")
+    assert resp_b.status_code == 200
+    ids = [i["id"] for i in resp_b.json()]
+    assert cid not in ids
+
+
+@pytest.mark.asyncio
+async def test_conversations_index_no_sql_conflict_with_conversation_id_route(api_client, conn):
+    """Route /conversations/index must not be shadowed by /conversations/{id}."""
+    resp = await api_client.get("/api/conversations/index")
+    # Must not 404 (which would indicate FastAPI treated 'index' as an id)
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# GET /api/nodes/index
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_nodes_index_empty(api_client, conn):
+    resp = await api_client.get("/api/nodes/index")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_nodes_index_shape(api_client, conn):
+    """Each item must have exactly the index fields — no section data."""
+    node = await create_node(conn, "Root")
+    resp = await api_client.get("/api/nodes/index")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    item = data[0]
+    assert item["id"] == node["id"]
+    assert item["title"] == "Root"
+    assert item["parent_id"] is None
+    assert item["path"] == "Root"
+    assert "child_count" in item
+    # Must NOT expose full node detail
+    assert "section_types" not in item
+    assert "description" not in item
+
+
+@pytest.mark.asyncio
+async def test_nodes_index_child_count_zero(api_client, conn):
+    await create_node(conn, "Leaf")
+    resp = await api_client.get("/api/nodes/index")
+    assert resp.status_code == 200
+    item = resp.json()[0]
+    assert item["child_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_nodes_index_child_count_nonzero(api_client, conn):
+    parent = await create_node(conn, "Parent")
+    await create_node(conn, "Child1", parent_id=parent["id"])
+    await create_node(conn, "Child2", parent_id=parent["id"])
+    resp = await api_client.get("/api/nodes/index")
+    assert resp.status_code == 200
+    items = resp.json()
+    parent_item = next(i for i in items if i["id"] == parent["id"])
+    assert parent_item["child_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_nodes_index_path_nested(api_client, conn):
+    root = await create_node(conn, "Root")
+    child = await create_node(conn, "Child", parent_id=root["id"])
+    grandchild = await create_node(conn, "GrandChild", parent_id=child["id"])
+    resp = await api_client.get("/api/nodes/index")
+    assert resp.status_code == 200
+    items = {i["id"]: i for i in resp.json()}
+    assert items[root["id"]]["path"] == "Root"
+    assert items[child["id"]]["path"] == "Root/Child"
+    assert items[grandchild["id"]]["path"] == "Root/Child/GrandChild"
+
+
+@pytest.mark.asyncio
+async def test_nodes_index_parent_id(api_client, conn):
+    root = await create_node(conn, "Root")
+    child = await create_node(conn, "Child", parent_id=root["id"])
+    resp = await api_client.get("/api/nodes/index")
+    assert resp.status_code == 200
+    items = {i["id"]: i for i in resp.json()}
+    assert items[root["id"]]["parent_id"] is None
+    assert items[child["id"]]["parent_id"] == root["id"]
+
+
+@pytest.mark.asyncio
+async def test_nodes_index_excludes_archived(api_client, conn):
+    live = await create_node(conn, "Live")
+    archived = await create_node(conn, "Archived")
+    await conn.execute(
+        "UPDATE context_nodes SET archived = TRUE WHERE id = $1::uuid", archived["id"]
+    )
+    resp = await api_client.get("/api/nodes/index")
+    assert resp.status_code == 200
+    ids = [i["id"] for i in resp.json()]
+    assert live["id"] in ids
+    assert archived["id"] not in ids
+
+
+@pytest.mark.asyncio
+async def test_nodes_index_no_sql_conflict_with_node_id_route(api_client, conn):
+    """Route /nodes/index must not be shadowed by /nodes/{node_id}."""
+    resp = await api_client.get("/api/nodes/index")
+    assert resp.status_code == 200

--- a/tests/api/test_conversations_index.py
+++ b/tests/api/test_conversations_index.py
@@ -126,10 +126,15 @@ async def test_conversations_index_rls(api_client, api_client_b, conn):
 
 @pytest.mark.asyncio
 async def test_conversations_index_no_sql_conflict_with_conversation_id_route(api_client, conn):
-    """Route /conversations/index must not be shadowed by /conversations/{id}."""
+    """Route /conversations/index must not be shadowed by /conversations/{id}.
+
+    If FastAPI matched 'index' as a conversation_id path param it would 404
+    (no conversation has id='index'). Asserting a list response proves the
+    literal /index route was matched, not the /{id} handler.
+    """
     resp = await api_client.get("/api/conversations/index")
-    # Must not 404 (which would indicate FastAPI treated 'index' as an id)
     assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
 
 
 # ---------------------------------------------------------------------------
@@ -223,7 +228,22 @@ async def test_nodes_index_excludes_archived(api_client, conn):
 
 
 @pytest.mark.asyncio
+async def test_nodes_index_rls(api_client, api_client_b, conn):
+    """User B must not see user A's nodes in the index.
+
+    The nodes index relies solely on RLS (no explicit user_id filter in the
+    query) — this test is the primary guard against an RLS misconfiguration.
+    """
+    node = await create_node(conn, "PrivateNode")
+    resp_b = await api_client_b.get("/api/nodes/index")
+    assert resp_b.status_code == 200
+    ids = [i["id"] for i in resp_b.json()]
+    assert node["id"] not in ids
+
+
+@pytest.mark.asyncio
 async def test_nodes_index_no_sql_conflict_with_node_id_route(api_client, conn):
     """Route /nodes/index must not be shadowed by /nodes/{node_id}."""
     resp = await api_client.get("/api/nodes/index")
     assert resp.status_code == 200
+    assert isinstance(resp.json(), list)

--- a/tests/api/test_conversations_index.py
+++ b/tests/api/test_conversations_index.py
@@ -1,7 +1,7 @@
 """API tests — lightweight index endpoints.
 
 Endpoints under test:
-  GET /api/conversations/index   → [{id, title, parent_context_node_id, updated_at, message_count}]
+  GET /api/conversations/index   → [{id, title, parent_context_node_id, state, priority, updated_at, message_count}]
   GET /api/nodes/index           → [{id, title, parent_id, path, child_count}]
 
 These are intentionally minimal — no message bodies, no section data.
@@ -57,11 +57,30 @@ async def test_conversations_index_shape(api_client, conn):
     assert item["title"] == "My conv"
     assert "parent_context_node_id" in item
     assert "updated_at" in item
+    assert "state" in item          # needed for pending badges on first paint
+    assert "priority" in item       # needed for priority dots on first paint
+    assert "updated_at" in item
     assert "message_count" in item
     # Must NOT expose full conversation detail fields
     assert "body" not in item
-    assert "state" not in item
     assert "type" not in item
+
+
+@pytest.mark.asyncio
+async def test_conversations_index_state_and_priority(api_client, conn):
+    """state and priority are returned so frontend avoids a follow-up upgrade call."""
+    cid = await create_conversation(
+        conn, user_id=TEST_USER_ID, name="Prio test", notification_type="bot",
+        priority="high",
+    )
+    await conn.execute(
+        "UPDATE conversations SET state = 'pending' WHERE id = $1::uuid", cid
+    )
+    resp = await api_client.get("/api/conversations/index")
+    assert resp.status_code == 200
+    item = next(i for i in resp.json() if i["id"] == cid)
+    assert item["state"] == "pending"
+    assert item["priority"] == "high"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `GET /api/conversations/index` → `[{id, title, parent_context_node_id, updated_at, message_count}]` — one query with LEFT JOIN + COUNT, zero N+1
- `GET /api/nodes/index` → `[{id, title, parent_id, path, child_count}]` — one recursive-CTE query computing full paths and child counts
- Both routes are registered before their `{id}` siblings to prevent FastAPI treating the literal string `"index"` as a path parameter
- **Messages endpoint bug (items vs messages)**: confirmed already resolved in PR #435; existing test suite covers the fix

## Bug investigation findings

The `GET /conversations/{id}/messages` endpoint currently returns:
```json
{"messages": [...], "has_more": bool}
```
with each message having a `body` field — matching the frontend `MessagesPage` type exactly. Tests in `test_conversations.py` explicitly guard the `messages` key and `body` field. Bug is fixed.

## Response shapes

`/api/conversations/index` item:
```json
{"id": "uuid", "title": "name", "parent_context_node_id": "uuid|null", "updated_at": "timestamp", "message_count": 3}
```

`/api/nodes/index` item:
```json
{"id": "uuid", "title": "name", "parent_id": "uuid|null", "path": "Root/Child", "child_count": 2}
```

## Test plan

- [ ] 16 new tests in `tests/api/test_conversations_index.py`
- [ ] Covers: empty, shape validation, message_count (0 and >0), parent_context_node_id (null and set), RLS isolation, route-ordering guard, node path nesting, child_count, archived exclusion
- [ ] Tests skip gracefully when `DATABASE_URL` unset (existing CI pattern)