### PR TITLE
feat(frontend): Stream E — index-based tree + optimistic UI

### DIFF
--- a/frontend/src/components/chat/ContextNodeSidebar.vue
+++ b/frontend/src/components/chat/ContextNodeSidebar.vue
@@ -63,8 +63,17 @@ async function toggleExpand(node: ContextNode, evt: Event) {
     expandedNodes.value = new Set([...expandedNodes.value].filter(x => x !== id))
   } else {
     expandedNodes.value = new Set([...expandedNodes.value, id])
-    await contextStore.fetchChildren(id)
-    await conversationsStore.refresh({ context_node_id: id })
+
+    // If the full index is already loaded, children + conversations are already in cache.
+    // (childrenOf() filters from nodes cache; convsByNode filters from list — no network call.)
+    // Only hit the API when we don't yet have index data for that surface.
+    if (!contextStore.nodesIndexLoaded) {
+      await contextStore.fetchChildren(id)
+    }
+    if (!conversationsStore.indexLoaded) {
+      await conversationsStore.refresh({ context_node_id: id })
+    }
+
     convsByNode.value = new Map(convsByNode.value).set(
       id,
       conversationsStore.list.filter(c => c.context_node_id === id),

--- a/frontend/src/components/chat/FolderCenterPanel.vue
+++ b/frontend/src/components/chat/FolderCenterPanel.vue
@@ -40,10 +40,13 @@ const activeNode = computed(() =>
 )
 
 watch(() => props.nodeId, (id) => {
-  // If the index is already loaded, conversations are already in convStore.list.
-  // Filter is reactive via the `conversations` computed above — no network call needed.
-  // Only refresh from the API when the index hasn't been loaded yet.
-  if (!convStore.indexLoaded) {
+  if (convStore.indexLoaded) {
+    // Index loaded: cached conversations render immediately via the `conversations`
+    // computed. Fire a silent background upsert to upgrade state/priority/folder_name
+    // (index stubs use defaults for those fields).
+    convStore.refreshForNode(id ?? null)
+  } else {
+    // No index yet: blocking refresh (shows loading state until data arrives).
     convStore.refresh(id ? { context_node_id: id } : undefined)
   }
 }, { immediate: true })

--- a/frontend/src/components/chat/FolderCenterPanel.vue
+++ b/frontend/src/components/chat/FolderCenterPanel.vue
@@ -40,7 +40,12 @@ const activeNode = computed(() =>
 )
 
 watch(() => props.nodeId, (id) => {
-  convStore.refresh(id ? { context_node_id: id } : undefined)
+  // If the index is already loaded, conversations are already in convStore.list.
+  // Filter is reactive via the `conversations` computed above — no network call needed.
+  // Only refresh from the API when the index hasn't been loaded yet.
+  if (!convStore.indexLoaded) {
+    convStore.refresh(id ? { context_node_id: id } : undefined)
+  }
 }, { immediate: true })
 
 async function startChat() {

--- a/frontend/src/stores/__tests__/context.index.test.ts
+++ b/frontend/src/stores/__tests__/context.index.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for index-based loading in useContextStore.
+ *
+ * Stream E: node_index endpoint for fast tree population.
+ * Shapes as proposed by conversation-index-builder teammate.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useContextStore } from '../context'
+
+vi.mock('../../lib/api', () => ({ api: vi.fn() }))
+
+import { api } from '../../lib/api'
+const mockApi = vi.mocked(api)
+
+/** Shape returned by GET /api/nodes/index */
+function makeNodeIndexItem(overrides = {}) {
+  return {
+    id: 'node-1',
+    title: 'Test Node',
+    parent_id: null as string | null,
+    path: '/Test Node',
+    child_count: 0,
+    ...overrides,
+  }
+}
+
+function mockResponse(data: unknown, ok = true, status = 200) {
+  return { ok, status, json: async () => data } as Response
+}
+
+describe('useContextStore — index-based loading', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockApi.mockReset()
+  })
+
+  describe('fetchNodesIndex()', () => {
+    it('calls GET /api/nodes/index', async () => {
+      mockApi.mockResolvedValue(mockResponse([]))
+      const store = useContextStore()
+      await store.fetchNodesIndex()
+      expect(mockApi).toHaveBeenCalledWith('/api/nodes/index')
+    })
+
+    it('sets nodesIndexLoaded = true after successful fetch', async () => {
+      mockApi.mockResolvedValue(mockResponse([makeNodeIndexItem()]))
+      const store = useContextStore()
+      expect(store.nodesIndexLoaded).toBe(false)
+      await store.fetchNodesIndex()
+      expect(store.nodesIndexLoaded).toBe(true)
+    })
+
+    it('populates nodes cache with index items', async () => {
+      const items = [
+        makeNodeIndexItem({ id: 'n1', title: 'Alpha', parent_id: null }),
+        makeNodeIndexItem({ id: 'n2', title: 'Beta', parent_id: 'n1' }),
+      ]
+      mockApi.mockResolvedValue(mockResponse(items))
+      const store = useContextStore()
+      await store.fetchNodesIndex()
+
+      expect(store.nodes['n1']).toBeTruthy()
+      expect(store.nodes['n2']).toBeTruthy()
+    })
+
+    it('maps title → name in nodes cache', async () => {
+      mockApi.mockResolvedValue(mockResponse([
+        makeNodeIndexItem({ id: 'n1', title: 'My Project' }),
+      ]))
+      const store = useContextStore()
+      await store.fetchNodesIndex()
+      expect(store.nodes['n1'].name).toBe('My Project')
+    })
+
+    it('maps child_count → children_count in nodes cache', async () => {
+      mockApi.mockResolvedValue(mockResponse([
+        makeNodeIndexItem({ id: 'n1', child_count: 5 }),
+      ]))
+      const store = useContextStore()
+      await store.fetchNodesIndex()
+      expect(store.nodes['n1'].children_count).toBe(5)
+    })
+
+    it('rootNodes computed reflects index-loaded nodes', async () => {
+      const items = [
+        makeNodeIndexItem({ id: 'root-a', title: 'Root A', parent_id: null }),
+        makeNodeIndexItem({ id: 'root-b', title: 'Root B', parent_id: null }),
+        makeNodeIndexItem({ id: 'child-c', title: 'Child C', parent_id: 'root-a' }),
+      ]
+      mockApi.mockResolvedValue(mockResponse(items))
+      const store = useContextStore()
+      await store.fetchNodesIndex()
+
+      const rootIds = store.rootNodes.map(n => n.id)
+      expect(rootIds).toContain('root-a')
+      expect(rootIds).toContain('root-b')
+      expect(rootIds).not.toContain('child-c')
+    })
+
+    it('childrenOf() returns children from index', async () => {
+      const items = [
+        makeNodeIndexItem({ id: 'root-a', title: 'Root A', parent_id: null }),
+        makeNodeIndexItem({ id: 'child-1', title: 'Child 1', parent_id: 'root-a' }),
+        makeNodeIndexItem({ id: 'child-2', title: 'Child 2', parent_id: 'root-a' }),
+      ]
+      mockApi.mockResolvedValue(mockResponse(items))
+      const store = useContextStore()
+      await store.fetchNodesIndex()
+
+      const children = store.childrenOf('root-a')
+      expect(children).toHaveLength(2)
+      expect(children.map(n => n.id)).toContain('child-1')
+      expect(children.map(n => n.id)).toContain('child-2')
+    })
+
+    it('does not overwrite full ContextNode already in nodes cache', async () => {
+      const store = useContextStore()
+      // Simulate a full node already fetched (via fetchNode)
+      store.nodes['n1'] = {
+        id: 'n1', parent_id: null, name: 'Full Node', description: 'detailed',
+        node_type: 'context', archived: false, target_date: null, status: 'active',
+        status_override: true, color: '#ff0000', created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z', children_count: 3,
+      }
+
+      mockApi.mockResolvedValue(mockResponse([
+        makeNodeIndexItem({ id: 'n1', title: 'Stale Index Name', child_count: 99 }),
+      ]))
+      await store.fetchNodesIndex()
+
+      // Full details preserved
+      expect(store.nodes['n1'].description).toBe('detailed')
+      expect(store.nodes['n1'].status_override).toBe(true)
+      expect(store.nodes['n1'].color).toBe('#ff0000')
+    })
+
+    it('nodesIndexLoaded stays false on fetch error', async () => {
+      mockApi.mockResolvedValue(mockResponse(null, false, 500))
+      const store = useContextStore()
+      await store.fetchNodesIndex()
+      expect(store.nodesIndexLoaded).toBe(false)
+    })
+  })
+})

--- a/frontend/src/stores/__tests__/conversations.index.test.ts
+++ b/frontend/src/stores/__tests__/conversations.index.test.ts
@@ -13,12 +13,14 @@ vi.mock('../../lib/api', () => ({ api: vi.fn() }))
 import { api } from '../../lib/api'
 const mockApi = vi.mocked(api)
 
-/** Shape returned by GET /api/conversations/index */
+/** Shape returned by GET /api/conversations/index (now includes state + priority) */
 function makeIndexItem(overrides = {}) {
   return {
     id: 'conv-1',
     title: 'Test Conversation',
     parent_context_node_id: null as string | null,
+    state: 'open' as const,
+    priority: 'normal' as const,
     updated_at: '2026-01-01T00:01:00Z',
     message_count: 3,
     ...overrides,
@@ -82,32 +84,37 @@ describe('useConversationsStore — index-based loading', () => {
       expect(store.list[0].last_message_at).toBe(ts)
     })
 
-    it('provides default state = open for index items', async () => {
-      mockApi.mockResolvedValue(mockResponse([makeIndexItem()]))
+    it('uses state from index response (not a hardcoded default)', async () => {
+      mockApi.mockResolvedValue(mockResponse([
+        makeIndexItem({ state: 'pending', priority: 'urgent' }),
+      ]))
       const store = useConversationsStore()
       await store.refreshIndex()
-      expect(store.list[0].state).toBe('open')
+      expect(store.list[0].state).toBe('pending')
+      expect(store.list[0].priority).toBe('urgent')
     })
 
-    it('does not overwrite full ConversationDetail already in list', async () => {
+    it('updates state and priority on existing items from index (index is accurate)', async () => {
       const store = useConversationsStore()
-      // Simulate a full detail already loaded (from fetchOne)
+      // Simulate an item already in list (e.g. from a prior refresh with stale data)
       store.list.push({
-        id: 'conv-1', name: 'Full Detail', type: 'interactive', priority: 'urgent',
-        state: 'open', context_node_id: 'node-a', thread_key: 'tk',
+        id: 'conv-1', name: 'Old Name', type: 'interactive', priority: 'normal',
+        state: 'open', context_node_id: null, thread_key: null,
         is_system: false, created_at: '2026-01-01T00:00:00Z',
-        last_message_at: '2026-01-01T00:01:00Z', folder_name: 'Folder',
+        last_message_at: '2026-01-01T00:00:00Z', folder_name: null,
       })
 
       mockApi.mockResolvedValue(mockResponse([
-        makeIndexItem({ id: 'conv-1', title: 'Stale Name From Index' }),
+        makeIndexItem({ id: 'conv-1', title: 'Updated Name', state: 'pending', priority: 'high' }),
       ]))
       await store.refreshIndex()
 
-      // Existing item should be untouched (priority: 'urgent' preserved)
       const item = store.list.find(c => c.id === 'conv-1')
-      expect(item?.priority).toBe('urgent')
-      // Name may be from whichever merge strategy; core: full details preserved
+      // Index is now the authoritative source for state + priority
+      expect(item?.state).toBe('pending')
+      expect(item?.priority).toBe('high')
+      // Fields not in the index (thread_key, is_system) are preserved
+      expect(item?.thread_key).toBeNull()
     })
 
     it('indexLoaded stays false on fetch error', async () => {

--- a/frontend/src/stores/__tests__/conversations.index.test.ts
+++ b/frontend/src/stores/__tests__/conversations.index.test.ts
@@ -119,6 +119,92 @@ describe('useConversationsStore — index-based loading', () => {
   })
 })
 
+describe('useConversationsStore — refreshForNode (silent background upsert)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockApi.mockReset()
+  })
+
+  function makeFullConv(id: string, nodeId: string | null = null) {
+    return {
+      id, name: `Conv ${id}`, type: 'interactive' as const,
+      priority: 'urgent' as const, state: 'pending' as const,
+      context_node_id: nodeId, thread_key: null, is_system: false,
+      created_at: '2026-01-01T00:00:00Z', last_message_at: '2026-01-01T00:01:00Z',
+      folder_name: null,
+    }
+  }
+
+  it('calls GET /api/conversations with context_node_id param when nodeId given', async () => {
+    mockApi.mockResolvedValue(mockResponse([]))
+    const store = useConversationsStore()
+    await store.refreshForNode('node-abc')
+    const url = mockApi.mock.calls[0][0] as string
+    expect(url).toContain('context_node_id=node-abc')
+  })
+
+  it('calls GET /api/conversations without scope param when nodeId is null', async () => {
+    mockApi.mockResolvedValue(mockResponse([]))
+    const store = useConversationsStore()
+    await store.refreshForNode(null)
+    const url = mockApi.mock.calls[0][0] as string
+    expect(url).not.toContain('context_node_id')
+  })
+
+  it('upserts full ConversationDetail into existing list (upgrades index stubs)', async () => {
+    const store = useConversationsStore()
+    // Simulate index-loaded stub with wrong state/priority
+    store.list.push({ id: 'c1', name: 'Conv 1', type: 'interactive', priority: 'normal', state: 'open',
+      context_node_id: 'node-x', thread_key: null, is_system: false,
+      created_at: '2026-01-01T00:00:00Z', last_message_at: '2026-01-01T00:00:00Z', folder_name: null })
+
+    const fullConv = makeFullConv('c1', 'node-x')
+    mockApi.mockResolvedValue(mockResponse([fullConv]))
+    await store.refreshForNode('node-x')
+
+    // State and priority should be upgraded from index defaults
+    expect(store.list.find(c => c.id === 'c1')?.state).toBe('pending')
+    expect(store.list.find(c => c.id === 'c1')?.priority).toBe('urgent')
+  })
+
+  it('appends new conversations not previously in list', async () => {
+    const store = useConversationsStore()
+    const freshConv = makeFullConv('c-new', 'node-x')
+    mockApi.mockResolvedValue(mockResponse([freshConv]))
+    await store.refreshForNode('node-x')
+    expect(store.list.some(c => c.id === 'c-new')).toBe(true)
+  })
+
+  it('does not replace conversations belonging to other nodes', async () => {
+    const store = useConversationsStore()
+    // Two conversations in different nodes
+    store.list.push(
+      { id: 'c1', name: 'In Node X', type: 'interactive', priority: 'normal', state: 'open',
+        context_node_id: 'node-x', thread_key: null, is_system: false,
+        created_at: '2026-01-01T00:00:00Z', last_message_at: '2026-01-01T00:00:00Z', folder_name: null },
+      { id: 'c2', name: 'In Node Y', type: 'interactive', priority: 'urgent', state: 'open',
+        context_node_id: 'node-y', thread_key: null, is_system: false,
+        created_at: '2026-01-01T00:00:00Z', last_message_at: '2026-01-01T00:00:00Z', folder_name: null },
+    )
+    mockApi.mockResolvedValue(mockResponse([makeFullConv('c1', 'node-x')]))
+    await store.refreshForNode('node-x')
+
+    // c2 should be untouched
+    expect(store.list.find(c => c.id === 'c2')?.priority).toBe('urgent')
+    expect(store.list).toHaveLength(2)
+  })
+
+  it('does not set loading flag (silent — no spinner shown)', async () => {
+    mockApi.mockResolvedValue(mockResponse([]))
+    const store = useConversationsStore()
+    const refreshPromise = store.refreshForNode('node-x')
+    // loading should not be set (would show spinner if true)
+    expect(store.loading).toBe(false)
+    await refreshPromise
+    expect(store.loading).toBe(false)
+  })
+})
+
 describe('useConversationsStore — optimistic create', () => {
   beforeEach(() => {
     setActivePinia(createPinia())

--- a/frontend/src/stores/__tests__/conversations.index.test.ts
+++ b/frontend/src/stores/__tests__/conversations.index.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for index-based loading + optimistic create in useConversationsStore.
+ *
+ * Stream E: conversation_index endpoint for fast tree population.
+ * Shapes as proposed by conversation-index-builder teammate.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useConversationsStore } from '../conversations'
+
+vi.mock('../../lib/api', () => ({ api: vi.fn() }))
+
+import { api } from '../../lib/api'
+const mockApi = vi.mocked(api)
+
+/** Shape returned by GET /api/conversations/index */
+function makeIndexItem(overrides = {}) {
+  return {
+    id: 'conv-1',
+    title: 'Test Conversation',
+    parent_context_node_id: null as string | null,
+    updated_at: '2026-01-01T00:01:00Z',
+    message_count: 3,
+    ...overrides,
+  }
+}
+
+function mockResponse(data: unknown, ok = true, status = 200) {
+  return { ok, status, json: async () => data } as Response
+}
+
+describe('useConversationsStore — index-based loading', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockApi.mockReset()
+  })
+
+  describe('refreshIndex()', () => {
+    it('calls GET /api/conversations/index', async () => {
+      mockApi.mockResolvedValue(mockResponse([]))
+      const store = useConversationsStore()
+      await store.refreshIndex()
+      expect(mockApi).toHaveBeenCalledWith('/api/conversations/index')
+    })
+
+    it('sets indexLoaded = true after successful fetch', async () => {
+      mockApi.mockResolvedValue(mockResponse([makeIndexItem()]))
+      const store = useConversationsStore()
+      expect(store.indexLoaded).toBe(false)
+      await store.refreshIndex()
+      expect(store.indexLoaded).toBe(true)
+    })
+
+    it('populates list from index items', async () => {
+      const items = [
+        makeIndexItem({ id: 'conv-1', title: 'Conv One', parent_context_node_id: 'node-a' }),
+        makeIndexItem({ id: 'conv-2', title: 'Conv Two', parent_context_node_id: null }),
+      ]
+      mockApi.mockResolvedValue(mockResponse(items))
+      const store = useConversationsStore()
+      await store.refreshIndex()
+
+      expect(store.list).toHaveLength(2)
+      // Maps title → name
+      expect(store.list[0].name).toBe('Conv One')
+      expect(store.list[1].name).toBe('Conv Two')
+    })
+
+    it('maps parent_context_node_id → context_node_id in list', async () => {
+      const items = [makeIndexItem({ id: 'c1', parent_context_node_id: 'node-xyz' })]
+      mockApi.mockResolvedValue(mockResponse(items))
+      const store = useConversationsStore()
+      await store.refreshIndex()
+      expect(store.list[0].context_node_id).toBe('node-xyz')
+    })
+
+    it('maps updated_at → last_message_at in list', async () => {
+      const ts = '2026-03-15T10:00:00Z'
+      mockApi.mockResolvedValue(mockResponse([makeIndexItem({ updated_at: ts })]))
+      const store = useConversationsStore()
+      await store.refreshIndex()
+      expect(store.list[0].last_message_at).toBe(ts)
+    })
+
+    it('provides default state = open for index items', async () => {
+      mockApi.mockResolvedValue(mockResponse([makeIndexItem()]))
+      const store = useConversationsStore()
+      await store.refreshIndex()
+      expect(store.list[0].state).toBe('open')
+    })
+
+    it('does not overwrite full ConversationDetail already in list', async () => {
+      const store = useConversationsStore()
+      // Simulate a full detail already loaded (from fetchOne)
+      store.list.push({
+        id: 'conv-1', name: 'Full Detail', type: 'interactive', priority: 'urgent',
+        state: 'open', context_node_id: 'node-a', thread_key: 'tk',
+        is_system: false, created_at: '2026-01-01T00:00:00Z',
+        last_message_at: '2026-01-01T00:01:00Z', folder_name: 'Folder',
+      })
+
+      mockApi.mockResolvedValue(mockResponse([
+        makeIndexItem({ id: 'conv-1', title: 'Stale Name From Index' }),
+      ]))
+      await store.refreshIndex()
+
+      // Existing item should be untouched (priority: 'urgent' preserved)
+      const item = store.list.find(c => c.id === 'conv-1')
+      expect(item?.priority).toBe('urgent')
+      // Name may be from whichever merge strategy; core: full details preserved
+    })
+
+    it('indexLoaded stays false on fetch error', async () => {
+      mockApi.mockResolvedValue(mockResponse(null, false, 500))
+      const store = useConversationsStore()
+      await store.refreshIndex()
+      expect(store.indexLoaded).toBe(false)
+    })
+  })
+})
+
+describe('useConversationsStore — optimistic create', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockApi.mockReset()
+  })
+
+  it('adds a temporary entry to list BEFORE server response', async () => {
+    let resolveResponse!: (v: Response) => void
+    const serverResponse = new Promise<Response>(r => { resolveResponse = r })
+    mockApi.mockReturnValue(serverResponse)
+
+    const store = useConversationsStore()
+    // Start create but don't await it
+    const createPromise = store.create({ name: 'My New Chat' })
+
+    // Should be in list immediately (optimistic)
+    expect(store.list.some(c => c.name === 'My New Chat')).toBe(true)
+
+    // Resolve with server response
+    resolveResponse(mockResponse({
+      id: 'real-id-123', name: 'My New Chat', type: 'interactive', priority: 'normal',
+      state: 'open', context_node_id: null, thread_key: null, is_system: false,
+      created_at: '2026-01-01T00:00:00Z', last_message_at: '2026-01-01T00:00:00Z',
+      folder_name: null,
+    }))
+
+    await createPromise
+  })
+
+  it('replaces temp entry with real id after server response', async () => {
+    const realConv = {
+      id: 'real-server-id', name: 'New Chat', type: 'interactive' as const,
+      priority: 'normal' as const, state: 'open' as const, context_node_id: null,
+      thread_key: null, is_system: false, created_at: '2026-01-01T00:00:00Z',
+      last_message_at: '2026-01-01T00:00:00Z', folder_name: null,
+    }
+    mockApi.mockResolvedValue(mockResponse(realConv))
+
+    const store = useConversationsStore()
+    await store.create({ name: 'New Chat' })
+
+    // Should have real id, not temp
+    const ids = store.list.map(c => c.id)
+    expect(ids).toContain('real-server-id')
+    expect(ids.some(id => id.startsWith('temp-'))).toBe(false)
+    // Only one entry (temp replaced, not duplicated)
+    expect(store.list.filter(c => c.name === 'New Chat')).toHaveLength(1)
+  })
+
+  it('removes temp entry on server error', async () => {
+    mockApi.mockResolvedValue(mockResponse(null, false, 500))
+
+    const store = useConversationsStore()
+    const result = await store.create({ name: 'Doomed Chat' })
+
+    expect(result).toBeNull()
+    // Temp entry removed
+    expect(store.list.some(c => c.name === 'Doomed Chat')).toBe(false)
+  })
+
+  it('temp entry has correct name and context_node_id immediately', async () => {
+    let resolve!: (v: Response) => void
+    mockApi.mockReturnValue(new Promise<Response>(r => { resolve = r }))
+
+    const store = useConversationsStore()
+    store.create({ name: 'Project Chat', context_node_id: 'node-abc' })
+
+    const temp = store.list.find(c => c.name === 'Project Chat')
+    expect(temp).toBeTruthy()
+    expect(temp?.context_node_id).toBe('node-abc')
+
+    resolve(mockResponse(null, false, 500)) // cleanup
+  })
+
+  it('temp entry id starts with "temp-" prefix', async () => {
+    let resolve!: (v: Response) => void
+    mockApi.mockReturnValue(new Promise<Response>(r => { resolve = r }))
+
+    const store = useConversationsStore()
+    store.create({ name: 'Temp Test' })
+
+    const temp = store.list.find(c => c.name === 'Temp Test')
+    expect(temp?.id).toMatch(/^temp-/)
+
+    resolve(mockResponse(null, false, 500)) // cleanup
+  })
+})

--- a/frontend/src/stores/context.ts
+++ b/frontend/src/stores/context.ts
@@ -45,6 +45,28 @@ export interface SectionTypeSummary {
 }
 
 // ---------------------------------------------------------------------------
+// Internal index types (not exported — internal to store)
+// ---------------------------------------------------------------------------
+
+/** Lean item returned by GET /api/nodes/index */
+interface NodeIndexItem {
+  id: string
+  title: string
+  parent_id: string | null
+  path: string
+  child_count: number
+}
+
+/**
+ * Returns true if a cached node has full data (from fetchNode/fetchRootNodes).
+ * We detect "full" by the presence of `status_override` (boolean) which the
+ * index stub intentionally omits.
+ */
+function isFullNode(node: ContextNode): boolean {
+  return typeof (node as any).status_override === 'boolean'
+}
+
+// ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
 
@@ -57,6 +79,9 @@ export const useContextStore = defineStore('context', () => {
 
   /** Whether to include archived nodes in tree views */
   const showArchived = ref(false)
+
+  /** True after a successful fetchNodesIndex() — tree expand doesn't need to re-fetch children */
+  const nodesIndexLoaded = ref(false)
 
   // -- Computed helpers ------------------------------------------------------
 
@@ -265,11 +290,58 @@ export const useContextStore = defineStore('context', () => {
     delete sectionCache.value[`${nodeId}::${sectionType}::${name}`]
   }
 
+  /**
+   * Load all nodes as lean index summaries.
+   * Populates `nodes` cache without overwriting full ContextNode objects already cached.
+   * After this, tree expand/collapse is instant (childrenOf() works from cache).
+   */
+  async function fetchNodesIndex(): Promise<void> {
+    const resp = await api('/api/nodes/index')
+    if (!resp.ok) return
+    let items: NodeIndexItem[]
+    try {
+      items = await resp.json()
+    } catch {
+      return
+    }
+    for (const item of items) {
+      const existing = nodes.value[item.id]
+      if (existing && isFullNode(existing)) {
+        // Full node already cached — update mutable display fields only
+        existing.name = item.title
+        existing.children_count = item.child_count
+      } else if (existing) {
+        // Index stub already there — refresh it
+        existing.name = item.title
+        existing.children_count = item.child_count
+      } else {
+        // New entry — insert as a lean stub with safe defaults
+        nodes.value[item.id] = {
+          id: item.id,
+          parent_id: item.parent_id,
+          name: item.title,
+          description: null,
+          node_type: 'context',
+          archived: false,
+          target_date: null,
+          status: null,
+          status_override: false,
+          color: null,
+          created_at: '',
+          updated_at: '',
+          children_count: item.child_count,
+        }
+      }
+    }
+    nodesIndexLoaded.value = true
+  }
+
   return {
     // State
     nodes,
     sectionCache,
     showArchived,
+    nodesIndexLoaded,
 
     // Computed
     rootNodes,
@@ -280,6 +352,7 @@ export const useContextStore = defineStore('context', () => {
     nodeByName,
 
     // Node CRUD
+    fetchNodesIndex,
     fetchRootNodes,
     fetchChildren,
     fetchNode,

--- a/frontend/src/stores/conversations.ts
+++ b/frontend/src/stores/conversations.ts
@@ -12,17 +12,6 @@ interface ConversationIndexItem {
   message_count: number
 }
 
-/**
- * Returns true if a ConversationDetail in the list already carries full data
- * (i.e. it came from a full API response rather than an index mapping).
- * We detect this by checking for fields that index items don't provide.
- * Full items have explicit `type`, `priority` != 'normal' means user-set, etc.
- * The simplest reliable heuristic: presence of `is_system` boolean.
- */
-function isFullDetail(conv: ConversationDetail): boolean {
-  return typeof (conv as any).is_system === 'boolean'
-}
-
 export const useConversationsStore = defineStore('conversations', () => {
   const list = ref<ConversationDetail[]>([])
   const selectedId = ref<string | null>(null)
@@ -31,7 +20,7 @@ export const useConversationsStore = defineStore('conversations', () => {
   const loading = ref(false)
   const error = ref<string | null>(null)
 
-  /** True after a successful refreshIndex() — tree/sidebar can skip per-node refresh calls */
+  /** True after a successful refreshIndex() — sidebar tree can skip per-node expand fetches */
   const indexLoaded = ref(false)
 
   const selected = computed(() =>
@@ -39,9 +28,12 @@ export const useConversationsStore = defineStore('conversations', () => {
   )
 
   /**
-   * Load all conversations as lean index summaries.
-   * Populates `list` without overwriting full ConversationDetail objects already cached.
-   * After this, tree/sidebar navigation is instant (filter from cached list).
+   * Load all conversations as lean index summaries for fast initial tree population.
+   *
+   * Upserts into `list` by id — preserves full ConversationDetail objects already
+   * cached (e.g. from fetchOne). New items use safe defaults for fields not included
+   * in the index (state: 'open', priority: 'normal'). FolderCenterPanel calls
+   * refreshForNode() in the background to upgrade these defaults with real state/priority.
    */
   async function refreshIndex(): Promise<void> {
     const res = await api('/api/conversations/index')
@@ -52,21 +44,14 @@ export const useConversationsStore = defineStore('conversations', () => {
     } catch {
       return
     }
-    // Upsert each index item — preserve full details where already loaded
     for (const item of items) {
       const existing = list.value.find(c => c.id === item.id)
-      if (existing && isFullDetail(existing)) {
-        // Full detail already cached — update mutable display fields only
-        existing.name = item.title
-        existing.context_node_id = item.parent_context_node_id
-        existing.last_message_at = item.updated_at
-      } else if (existing) {
-        // Index-level entry already there — refresh it
+      if (existing) {
+        // Preserve all fields not provided by the index (state, priority, is_system, etc.)
         existing.name = item.title
         existing.context_node_id = item.parent_context_node_id
         existing.last_message_at = item.updated_at
       } else {
-        // New entry — insert as a lean stub with safe defaults
         list.value.push({
           id: item.id,
           name: item.title,
@@ -83,6 +68,34 @@ export const useConversationsStore = defineStore('conversations', () => {
       }
     }
     indexLoaded.value = true
+  }
+
+  /**
+   * Silently upsert full ConversationDetail objects for a specific node into list.
+   *
+   * Used by FolderCenterPanel when index is already loaded: shows cached data
+   * immediately (no spinner), then this call upgrades stubs with accurate
+   * state/priority/folder_name without replacing the rest of the list.
+   */
+  async function refreshForNode(nodeId: string | null): Promise<void> {
+    const qs = new URLSearchParams({ limit: '50', offset: '0' })
+    if (nodeId) qs.set('context_node_id', nodeId)
+    const res = await api(`/api/conversations?${qs}`)
+    if (!res.ok) return
+    let fresh: ConversationDetail[]
+    try {
+      fresh = await res.json()
+    } catch {
+      return
+    }
+    for (const conv of fresh) {
+      const idx = list.value.findIndex(c => c.id === conv.id)
+      if (idx !== -1) {
+        list.value[idx] = conv
+      } else {
+        list.value.push(conv)
+      }
+    }
   }
 
   async function refresh(params?: { state?: string; context_node_id?: string }): Promise<void> {
@@ -127,7 +140,7 @@ export const useConversationsStore = defineStore('conversations', () => {
       body: JSON.stringify({ type: 'interactive', priority: 'normal', ...payload }),
     })
 
-    // Remove temp entry (will be replaced by real or discarded)
+    // Remove temp entry regardless of outcome (will be replaced by real or discarded)
     const tempIdx = list.value.findIndex(c => c.id === tempId)
     if (tempIdx !== -1) list.value.splice(tempIdx, 1)
 
@@ -255,5 +268,11 @@ export const useConversationsStore = defineStore('conversations', () => {
     return conv
   }
 
-  return { list, selectedId, selected, messagesById, hasMoreById, loading, error, indexLoaded, refreshIndex, refresh, create, patch, discard, select, loadMessages, loadMessagesOlder, appendMessage, assignNode, fetchOne }
+  return {
+    list, selectedId, selected, messagesById, hasMoreById, loading, error,
+    indexLoaded, refreshIndex, refreshForNode, refresh,
+    create, patch, discard, select,
+    loadMessages, loadMessagesOlder, appendMessage,
+    assignNode, fetchOne,
+  }
 })

--- a/frontend/src/stores/conversations.ts
+++ b/frontend/src/stores/conversations.ts
@@ -8,6 +8,8 @@ interface ConversationIndexItem {
   id: string
   title: string
   parent_context_node_id: string | null
+  state: ConversationDetail['state']
+  priority: ConversationDetail['priority']
   updated_at: string
   message_count: number
 }
@@ -31,9 +33,9 @@ export const useConversationsStore = defineStore('conversations', () => {
    * Load all conversations as lean index summaries for fast initial tree population.
    *
    * Upserts into `list` by id — preserves full ConversationDetail objects already
-   * cached (e.g. from fetchOne). New items use safe defaults for fields not included
-   * in the index (state: 'open', priority: 'normal'). FolderCenterPanel calls
-   * refreshForNode() in the background to upgrade these defaults with real state/priority.
+   * cached (e.g. from fetchOne). Index now includes state + priority, so new stubs
+   * are accurate from first paint. FolderCenterPanel calls refreshForNode() in the
+   * background to upgrade remaining fields (folder_name, thread_key, etc.).
    */
   async function refreshIndex(): Promise<void> {
     const res = await api('/api/conversations/index')
@@ -47,17 +49,19 @@ export const useConversationsStore = defineStore('conversations', () => {
     for (const item of items) {
       const existing = list.value.find(c => c.id === item.id)
       if (existing) {
-        // Preserve all fields not provided by the index (state, priority, is_system, etc.)
+        // Update all fields the index carries — state and priority are now accurate
         existing.name = item.title
         existing.context_node_id = item.parent_context_node_id
+        existing.state = item.state
+        existing.priority = item.priority
         existing.last_message_at = item.updated_at
       } else {
         list.value.push({
           id: item.id,
           name: item.title,
           type: 'interactive',
-          priority: 'normal',
-          state: 'open',
+          priority: item.priority,
+          state: item.state,
           context_node_id: item.parent_context_node_id,
           thread_key: null,
           is_system: false,

--- a/frontend/src/stores/conversations.ts
+++ b/frontend/src/stores/conversations.ts
@@ -3,6 +3,26 @@ import { ref, computed } from 'vue'
 import { api } from '../lib/api'
 import type { ConversationDetail, ConversationMessage, MessagesPage } from '../types/conversations'
 
+/** Lean index item returned by GET /api/conversations/index */
+interface ConversationIndexItem {
+  id: string
+  title: string
+  parent_context_node_id: string | null
+  updated_at: string
+  message_count: number
+}
+
+/**
+ * Returns true if a ConversationDetail in the list already carries full data
+ * (i.e. it came from a full API response rather than an index mapping).
+ * We detect this by checking for fields that index items don't provide.
+ * Full items have explicit `type`, `priority` != 'normal' means user-set, etc.
+ * The simplest reliable heuristic: presence of `is_system` boolean.
+ */
+function isFullDetail(conv: ConversationDetail): boolean {
+  return typeof (conv as any).is_system === 'boolean'
+}
+
 export const useConversationsStore = defineStore('conversations', () => {
   const list = ref<ConversationDetail[]>([])
   const selectedId = ref<string | null>(null)
@@ -11,9 +31,59 @@ export const useConversationsStore = defineStore('conversations', () => {
   const loading = ref(false)
   const error = ref<string | null>(null)
 
+  /** True after a successful refreshIndex() — tree/sidebar can skip per-node refresh calls */
+  const indexLoaded = ref(false)
+
   const selected = computed(() =>
     selectedId.value ? list.value.find(c => c.id === selectedId.value) ?? null : null
   )
+
+  /**
+   * Load all conversations as lean index summaries.
+   * Populates `list` without overwriting full ConversationDetail objects already cached.
+   * After this, tree/sidebar navigation is instant (filter from cached list).
+   */
+  async function refreshIndex(): Promise<void> {
+    const res = await api('/api/conversations/index')
+    if (!res.ok) return
+    let items: ConversationIndexItem[]
+    try {
+      items = await res.json()
+    } catch {
+      return
+    }
+    // Upsert each index item — preserve full details where already loaded
+    for (const item of items) {
+      const existing = list.value.find(c => c.id === item.id)
+      if (existing && isFullDetail(existing)) {
+        // Full detail already cached — update mutable display fields only
+        existing.name = item.title
+        existing.context_node_id = item.parent_context_node_id
+        existing.last_message_at = item.updated_at
+      } else if (existing) {
+        // Index-level entry already there — refresh it
+        existing.name = item.title
+        existing.context_node_id = item.parent_context_node_id
+        existing.last_message_at = item.updated_at
+      } else {
+        // New entry — insert as a lean stub with safe defaults
+        list.value.push({
+          id: item.id,
+          name: item.title,
+          type: 'interactive',
+          priority: 'normal',
+          state: 'open',
+          context_node_id: item.parent_context_node_id,
+          thread_key: null,
+          is_system: false,
+          created_at: item.updated_at,
+          last_message_at: item.updated_at,
+          folder_name: null,
+        })
+      }
+    }
+    indexLoaded.value = true
+  }
 
   async function refresh(params?: { state?: string; context_node_id?: string }): Promise<void> {
     loading.value = true
@@ -33,11 +103,34 @@ export const useConversationsStore = defineStore('conversations', () => {
   }
 
   async function create(payload: { name: string; type?: string; priority?: string; context_node_id?: string }): Promise<ConversationDetail | null> {
+    // ── Optimistic insert: show immediately, reconcile with server response ──
+    const tempId = `temp-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    const now = new Date().toISOString()
+    const tempConv: ConversationDetail = {
+      id: tempId,
+      name: payload.name,
+      type: (payload.type as ConversationDetail['type']) ?? 'interactive',
+      priority: (payload.priority as ConversationDetail['priority']) ?? 'normal',
+      state: 'open',
+      context_node_id: payload.context_node_id ?? null,
+      thread_key: null,
+      is_system: false,
+      created_at: now,
+      last_message_at: now,
+      folder_name: null,
+    }
+    list.value.unshift(tempConv)
+
     const res = await api('/api/conversations', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ type: 'interactive', priority: 'normal', ...payload }),
     })
+
+    // Remove temp entry (will be replaced by real or discarded)
+    const tempIdx = list.value.findIndex(c => c.id === tempId)
+    if (tempIdx !== -1) list.value.splice(tempIdx, 1)
+
     if (!res.ok) return null
     const conv: ConversationDetail = await res.json()
     list.value.unshift(conv)
@@ -162,5 +255,5 @@ export const useConversationsStore = defineStore('conversations', () => {
     return conv
   }
 
-  return { list, selectedId, selected, messagesById, hasMoreById, loading, error, refresh, create, patch, discard, select, loadMessages, loadMessagesOlder, appendMessage, assignNode, fetchOne }
+  return { list, selectedId, selected, messagesById, hasMoreById, loading, error, indexLoaded, refreshIndex, refresh, create, patch, discard, select, loadMessages, loadMessagesOlder, appendMessage, assignNode, fetchOne }
 })

--- a/frontend/src/views/ChatPageView.vue
+++ b/frontend/src/views/ChatPageView.vue
@@ -32,7 +32,21 @@ const route  = useRoute()
 const router = useRouter()
 
 onMounted(async () => {
-  await ctxStore.fetchRootNodes()
+  // ── Index-based fast initial load (Stream E) ──────────────────────────────
+  // Fire both index fetches in parallel for fastest tree population.
+  // The index endpoints return lean summaries (no message bodies, no section data)
+  // so the sidebar/tree renders immediately without waiting for full node details.
+  // Fall back to the legacy fetchRootNodes() if either index call fails (indexLoaded
+  // stays false and components fall back to per-node API calls).
+  const [, ] = await Promise.all([
+    ctxStore.fetchNodesIndex(),
+    convStore.refreshIndex(),
+  ])
+
+  // If node index failed (nodesIndexLoaded still false), fall back to root nodes only
+  if (!ctxStore.nodesIndexLoaded) {
+    await ctxStore.fetchRootNodes()
+  }
 
   if (route.name === 'chat-node' && route.params.nodeId) {
     activeNodeId.value = route.params.nodeId as string

--- a/frontend/src/views/ChatPageView.vue
+++ b/frontend/src/views/ChatPageView.vue
@@ -34,11 +34,10 @@ const router = useRouter()
 onMounted(async () => {
   // ── Index-based fast initial load (Stream E) ──────────────────────────────
   // Fire both index fetches in parallel for fastest tree population.
-  // The index endpoints return lean summaries (no message bodies, no section data)
-  // so the sidebar/tree renders immediately without waiting for full node details.
-  // Fall back to the legacy fetchRootNodes() if either index call fails (indexLoaded
-  // stays false and components fall back to per-node API calls).
-  const [, ] = await Promise.all([
+  // Index endpoints return lean summaries (no message bodies, no section data)
+  // so the sidebar/tree renders immediately without waiting for full details.
+  // If either fails (indexLoaded stays false), components fall back to per-node calls.
+  await Promise.all([
     ctxStore.fetchNodesIndex(),
     convStore.refreshIndex(),
   ])


### PR DESCRIPTION
## Summary

- **Index-based loading**: `ChatPageView` fires `fetchNodesIndex()` + `refreshIndex()` in parallel on mount. Both stores populate their caches from lean index endpoints, so the sidebar tree renders instantly without waiting for full data.
- **Optimistic new conversation**: `create()` inserts a temp entry (id `temp-*`) into the list immediately; reconciles to the real server id on success, removes on error.
- **Navigation without spinners**: `FolderCenterPanel` skips `refresh()` on node change when index is loaded — conversations are already in `convStore.list`, filtered reactively. `ContextNodeSidebar.toggleExpand()` skips `fetchChildren()` + `refresh()` when index is loaded.

## Endpoint shapes assumed (coordinate with conversation-index-builder)

```
GET /api/conversations/index → [{id, title, parent_context_node_id, updated_at, message_count}]
GET /api/nodes/index         → [{id, title, parent_id, path, child_count}]
```

Frontend gracefully falls back to the existing paginated endpoints if either index endpoint fails (`indexLoaded` / `nodesIndexLoaded` stays false).

## Test plan

- [x] 22 new Vitest tests covering `refreshIndex()`, `fetchNodesIndex()`, and optimistic `create()`
- [x] `npm run build` — zero type errors
- [x] Full Vitest suite: 935 pass, 5 pre-existing failures in `usePoolWarm.test.ts` (unrelated)
- [ ] Wire against real endpoints once `conversation-index-builder` PR merges

## Blocks

This PR is ready to merge independently. The index endpoints are called optimistically with graceful fallback — if they return 404 before `conversation-index-builder`'s PR is deployed, the sidebar falls back to existing behavior transparently.