### PR TITLE
feat: memory-context v2 schema + MCP tools (Stream A foundations)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,7 @@ jobs:
                  tests/db/test_pg_sections.py \
                  tests/db/test_pg_auth_queries.py \
                  tests/db/test_pg_integrations.py \
+                 tests/db/test_memory_context_schema.py \
                  tests/api/ \
                  -v
 

--- a/db/migrations/versions/k1l2m3n4o5p6_memory_context_v2.py
+++ b/db/migrations/versions/k1l2m3n4o5p6_memory_context_v2.py
@@ -1,0 +1,236 @@
+"""Memory-context v2 schema additions.
+
+Adds the infrastructure required for agent memory + context access system:
+
+1. node_sections gains:
+   - origin TEXT NOT NULL DEFAULT 'user'
+     Tracks who wrote the section: 'user' | 'conversation_agent' | 'system'
+   - visible_to_user BOOL NOT NULL DEFAULT true
+     Controls whether the section surfaces in user-facing context reads.
+     Bot-internal notes (origin='conversation_agent', visible_to_user=false)
+     are hidden from the UI but readable by agents with the right scope.
+
+2. node_data_summary — M-level summarization cache per node.
+   Beacon populates this table (Stream D); agents read from it (Stream A tools).
+   Each row is one M-level for one node. value carries the full key tree at
+   that level: {keys: {key_name: {value, expands_to_M(k+1)}}}.
+   Degrades gracefully when no rows exist (tools fall back to node_sections).
+
+3. user_memory — L2 working memory for user facts/patterns/preferences.
+   Written by Beacon; read by interactive 2.5 agents at session start.
+   Mirrored from beacon_memory (Beacon spec §5.1).
+
+4. user_durable_memory — L3 compacted long-term user patterns.
+   Written by Beacon compaction only (monthly+).
+   Mirrored from beacon_durable_memory (Beacon spec §5.1).
+
+5. pending_memory_writes — staging table for propose_user_memory_write.
+   MCP tool propose_user_memory_write() inserts here; Beacon evaluator
+   reviews and commits or discards after the conversation concludes.
+
+6. node_read_log — read-credit tracking per conversation.
+   Every read_context / read_node_memory call inserts a row.
+   write_node_memory consults this table for advisory read-before-write check
+   (v1: warns on violation; v2: hard block once Stream C is stable).
+
+All new tables have:
+  - ENABLE ROW LEVEL SECURITY
+  - FORCE ROW LEVEL SECURITY
+  - USING (user_id = current_setting('app.current_user_id', true)::uuid)
+
+Revision ID: k1l2m3n4o5p6
+Revises: j1k2l3m4n5o6
+Create Date: 2026-06-02
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "k1l2m3n4o5p6"
+down_revision: Union[str, Sequence[str], None] = "j1k2l3m4n5o6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------ #
+    # 1. node_sections — add origin + visible_to_user                     #
+    # ------------------------------------------------------------------ #
+    op.execute(
+        """
+        ALTER TABLE node_sections
+            ADD COLUMN origin TEXT NOT NULL DEFAULT 'user',
+            ADD COLUMN visible_to_user BOOL NOT NULL DEFAULT true
+        """
+    )
+
+    # ------------------------------------------------------------------ #
+    # 2. node_data_summary                                                #
+    # ------------------------------------------------------------------ #
+    op.execute(
+        """
+        CREATE TABLE node_data_summary (
+            id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id          UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            node_id          UUID NOT NULL REFERENCES context_nodes(id) ON DELETE CASCADE,
+            level_ordinal    INT  NOT NULL,
+            value            JSONB NOT NULL,
+            abstract         TEXT,
+            source_checksum  TEXT NOT NULL,
+            generated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+            UNIQUE (node_id, level_ordinal)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX idx_node_data_summary_node ON node_data_summary (node_id)"
+    )
+    op.execute(
+        "CREATE INDEX idx_node_data_summary_user ON node_data_summary (user_id)"
+    )
+    op.execute("ALTER TABLE node_data_summary ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE node_data_summary FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY node_data_summary_isolation ON node_data_summary
+            USING (user_id = current_setting('app.current_user_id', true)::uuid)
+        """
+    )
+
+    # ------------------------------------------------------------------ #
+    # 3. user_memory (L2 — working memory for user facts/patterns)        #
+    # ------------------------------------------------------------------ #
+    op.execute(
+        """
+        CREATE TABLE user_memory (
+            id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id      UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            key          TEXT NOT NULL,
+            value        TEXT NOT NULL,
+            updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+            last_read_at TIMESTAMPTZ,
+            UNIQUE (user_id, key)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX user_memory_user_key ON user_memory (user_id, key text_pattern_ops)"
+    )
+    op.execute("ALTER TABLE user_memory ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE user_memory FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY user_memory_isolation ON user_memory
+            USING (user_id = current_setting('app.current_user_id', true)::uuid)
+        """
+    )
+
+    # ------------------------------------------------------------------ #
+    # 4. user_durable_memory (L3 — compacted long-term user patterns)     #
+    # ------------------------------------------------------------------ #
+    op.execute(
+        """
+        CREATE TABLE user_durable_memory (
+            id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            key         TEXT NOT NULL,
+            value       TEXT NOT NULL,
+            source      TEXT NOT NULL,
+            evidence    JSONB,
+            confidence  TEXT NOT NULL DEFAULT 'medium',
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+            UNIQUE (user_id, key)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX user_durable_memory_user_key ON user_durable_memory (user_id, key text_pattern_ops)"
+    )
+    op.execute("ALTER TABLE user_durable_memory ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE user_durable_memory FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY user_durable_memory_isolation ON user_durable_memory
+            USING (user_id = current_setting('app.current_user_id', true)::uuid)
+        """
+    )
+
+    # ------------------------------------------------------------------ #
+    # 5. pending_memory_writes — staging for propose_user_memory_write    #
+    # ------------------------------------------------------------------ #
+    op.execute(
+        """
+        CREATE TABLE pending_memory_writes (
+            id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            conversation_id UUID REFERENCES conversations(id) ON DELETE SET NULL,
+            key             TEXT NOT NULL,
+            value           TEXT NOT NULL,
+            reason          TEXT NOT NULL,
+            status          TEXT NOT NULL DEFAULT 'pending',
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+            reviewed_at     TIMESTAMPTZ
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX pending_memory_writes_user_status ON pending_memory_writes (user_id, status)"
+    )
+    op.execute("ALTER TABLE pending_memory_writes ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE pending_memory_writes FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY pending_memory_writes_isolation ON pending_memory_writes
+            USING (user_id = current_setting('app.current_user_id', true)::uuid)
+        """
+    )
+
+    # ------------------------------------------------------------------ #
+    # 6. node_read_log — per-conversation read-credit tracking            #
+    # ------------------------------------------------------------------ #
+    op.execute(
+        """
+        CREATE TABLE node_read_log (
+            id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            conversation_id UUID REFERENCES conversations(id) ON DELETE CASCADE,
+            node_id         UUID NOT NULL REFERENCES context_nodes(id) ON DELETE CASCADE,
+            level_ordinal   INT  NOT NULL,
+            title           TEXT,
+            read_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX node_read_log_conv_node ON node_read_log
+            (conversation_id, node_id, level_ordinal)
+        """
+    )
+    op.execute(
+        "CREATE INDEX node_read_log_user ON node_read_log (user_id)"
+    )
+    op.execute("ALTER TABLE node_read_log ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE node_read_log FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY node_read_log_isolation ON node_read_log
+            USING (user_id = current_setting('app.current_user_id', true)::uuid)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS node_read_log")
+    op.execute("DROP TABLE IF EXISTS pending_memory_writes")
+    op.execute("DROP TABLE IF EXISTS user_durable_memory")
+    op.execute("DROP TABLE IF EXISTS user_memory")
+    op.execute("DROP TABLE IF EXISTS node_data_summary")
+    op.execute(
+        """
+        ALTER TABLE node_sections
+            DROP COLUMN IF EXISTS visible_to_user,
+            DROP COLUMN IF EXISTS origin
+        """
+    )

--- a/db/migrations/versions/l1m2n3o4p5q6_memory_context_v2.py
+++ b/db/migrations/versions/l1m2n3o4p5q6_memory_context_v2.py
@@ -38,15 +38,16 @@ All new tables have:
   - FORCE ROW LEVEL SECURITY
   - USING (user_id = current_setting('app.current_user_id', true)::uuid)
 
-Revision ID: k1l2m3n4o5p6
+Revision ID: l1m2n3o4p5q6
 Revises: j1k2l3m4n5o6
-Create Date: 2026-06-02
+Create Date: 2026-06-03
+Note: k1l2m3n4o5p6 is taken by Stream B (permission_grants); renamed to l1m2n3o4p5q6.
 """
 from typing import Sequence, Union
 
 from alembic import op
 
-revision: str = "k1l2m3n4o5p6"
+revision: str = "l1m2n3o4p5q6"
 down_revision: Union[str, Sequence[str], None] = "j1k2l3m4n5o6"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/db/pg_queries/__init__.py
+++ b/db/pg_queries/__init__.py
@@ -75,3 +75,13 @@ from db.pg_queries.subscriptions import (
     get_user_is_paid,
     get_user_is_paid_by_id,
 )
+from db.pg_queries.memory import (
+    list_user_memory, get_user_memory_entry, upsert_user_memory, delete_user_memory,
+    list_user_durable_memory, get_user_durable_memory_entry, upsert_user_durable_memory,
+    insert_pending_memory_write, get_pending_memory_write,
+    list_pending_memory_writes, review_pending_memory_write,
+)
+from db.pg_queries.node_memory import (
+    get_node_summary, list_node_summary_levels, upsert_node_summary,
+    log_node_read, has_read_node_in_conversation, get_conversation_reads,
+)

--- a/db/pg_queries/__init__.py
+++ b/db/pg_queries/__init__.py
@@ -33,7 +33,7 @@ from db.pg_queries.nodes import (
 from db.pg_queries.sections import (
     get_sections, get_section, upsert_section, append_section, delete_section,
     list_section_files, create_section_file, rename_section_file,
-    reorder_section_files, search_sections,
+    reorder_section_files, search_sections, grep_sections,
 )
 from db.pg_queries.milestones import (
     create_milestone, get_milestones, patch_milestone, delete_milestone,
@@ -84,4 +84,5 @@ from db.pg_queries.memory import (
 from db.pg_queries.node_memory import (
     get_node_summary, list_node_summary_levels, upsert_node_summary,
     log_node_read, has_read_node_in_conversation, get_conversation_reads,
+    get_context_node_id_for_conversation, get_node_tree_distance,
 )

--- a/db/pg_queries/memory.py
+++ b/db/pg_queries/memory.py
@@ -1,0 +1,285 @@
+"""Async Postgres queries — user_memory, user_durable_memory, pending_memory_writes.
+
+user_memory: L2 working memory (user facts, patterns, preferences).
+  Written by Beacon; read by interactive 2.5 agents at session start (full M=4).
+  Keyed by hierarchical convention: 'preferences/morning_routine', 'facts/work/role', etc.
+
+user_durable_memory: L3 compacted long-term user patterns.
+  Written by Beacon compaction only (monthly+). More stable than L2.
+
+pending_memory_writes: proposals from MCP tool propose_user_memory_write().
+  Beacon post-conversation evaluator reviews and commits or discards.
+
+All three tables carry RLS — callers must have set app.current_user_id before
+invoking these functions.
+"""
+from __future__ import annotations
+
+import asyncpg
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# user_memory (L2)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def list_user_memory(
+    conn: asyncpg.Connection,
+    *,
+    prefix: str | None = None,
+    M: int = 2,
+) -> list[dict]:
+    """Return user_memory entries for the current RLS user.
+
+    M controls how much data is returned per entry:
+      M=1  key only
+      M=2  key + ~50-char preview of value
+      M=3  key + ~200-char truncated value
+      M=4  key + full value
+
+    Optional prefix filters by key prefix (e.g., 'preferences/').
+    """
+    if M == 1:
+        select = "key"
+    elif M == 2:
+        select = "key, left(value, 50) AS value"
+    elif M == 3:
+        select = "key, left(value, 200) AS value"
+    else:
+        select = "key, value, updated_at, last_read_at"
+
+    if prefix:
+        rows = await conn.fetch(
+            f"SELECT {select} FROM user_memory WHERE key LIKE $1 || '%' ORDER BY key",
+            prefix,
+        )
+    else:
+        rows = await conn.fetch(
+            f"SELECT {select} FROM user_memory ORDER BY key",
+        )
+    return [dict(r) for r in rows]
+
+
+async def get_user_memory_entry(
+    conn: asyncpg.Connection,
+    key: str,
+) -> dict | None:
+    """Fetch a single user_memory entry by exact key.
+
+    Updates last_read_at as a side effect (tracks when Beacon last accessed it).
+    """
+    row = await conn.fetchrow(
+        """
+        UPDATE user_memory
+           SET last_read_at = now()
+         WHERE user_id = current_setting('app.current_user_id', true)::uuid
+           AND key = $1
+        RETURNING key, value, updated_at, last_read_at
+        """,
+        key,
+    )
+    return dict(row) if row else None
+
+
+async def upsert_user_memory(
+    conn: asyncpg.Connection,
+    key: str,
+    value: str,
+) -> dict:
+    """Write a user_memory entry (insert or update). Returns the final row."""
+    row = await conn.fetchrow(
+        """
+        INSERT INTO user_memory (user_id, key, value, updated_at)
+        VALUES (current_setting('app.current_user_id', true)::uuid, $1, $2, now())
+        ON CONFLICT (user_id, key) DO UPDATE
+            SET value = EXCLUDED.value, updated_at = now()
+        RETURNING key, value, updated_at
+        """,
+        key, value,
+    )
+    return dict(row)
+
+
+async def delete_user_memory(
+    conn: asyncpg.Connection,
+    key: str,
+) -> bool:
+    """Delete a user_memory entry. Returns True if a row was deleted."""
+    result = await conn.execute(
+        """
+        DELETE FROM user_memory
+        WHERE user_id = current_setting('app.current_user_id', true)::uuid
+          AND key = $1
+        """,
+        key,
+    )
+    return result.split()[-1] != "0"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# user_durable_memory (L3)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def list_user_durable_memory(
+    conn: asyncpg.Connection,
+    *,
+    prefix: str | None = None,
+    M: int = 2,
+) -> list[dict]:
+    """Return user_durable_memory entries for the current RLS user.
+
+    Same M-level semantics as list_user_memory.
+    """
+    if M == 1:
+        select = "key"
+    elif M == 2:
+        select = "key, left(value, 50) AS value"
+    elif M == 3:
+        select = "key, left(value, 200) AS value"
+    else:
+        select = "key, value, source, confidence, created_at, updated_at"
+
+    if prefix:
+        rows = await conn.fetch(
+            f"SELECT {select} FROM user_durable_memory WHERE key LIKE $1 || '%' ORDER BY key",
+            prefix,
+        )
+    else:
+        rows = await conn.fetch(
+            f"SELECT {select} FROM user_durable_memory ORDER BY key",
+        )
+    return [dict(r) for r in rows]
+
+
+async def get_user_durable_memory_entry(
+    conn: asyncpg.Connection,
+    key: str,
+) -> dict | None:
+    """Fetch a single user_durable_memory entry by exact key (full data)."""
+    row = await conn.fetchrow(
+        """
+        SELECT key, value, source, evidence, confidence, created_at, updated_at
+        FROM user_durable_memory
+        WHERE user_id = current_setting('app.current_user_id', true)::uuid
+          AND key = $1
+        """,
+        key,
+    )
+    return dict(row) if row else None
+
+
+async def upsert_user_durable_memory(
+    conn: asyncpg.Connection,
+    key: str,
+    value: str,
+    source: str,
+    *,
+    evidence: dict | None = None,
+    confidence: str = "medium",
+) -> dict:
+    """Write a user_durable_memory entry (insert or update). Returns the final row."""
+    row = await conn.fetchrow(
+        """
+        INSERT INTO user_durable_memory (user_id, key, value, source, evidence, confidence, updated_at)
+        VALUES (
+            current_setting('app.current_user_id', true)::uuid,
+            $1, $2, $3, $4, $5, now()
+        )
+        ON CONFLICT (user_id, key) DO UPDATE
+            SET value      = EXCLUDED.value,
+                source     = EXCLUDED.source,
+                evidence   = EXCLUDED.evidence,
+                confidence = EXCLUDED.confidence,
+                updated_at = now()
+        RETURNING key, value, source, confidence, updated_at
+        """,
+        key, value, source, evidence, confidence,
+    )
+    return dict(row)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# pending_memory_writes
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def insert_pending_memory_write(
+    conn: asyncpg.Connection,
+    key: str,
+    value: str,
+    reason: str,
+    *,
+    conversation_id: str | None = None,
+) -> str:
+    """Insert a pending_memory_write proposal. Returns the new UUID."""
+    import uuid as _uuid
+    conv_uuid = _uuid.UUID(conversation_id) if conversation_id else None
+    row = await conn.fetchrow(
+        """
+        INSERT INTO pending_memory_writes (user_id, conversation_id, key, value, reason)
+        VALUES (
+            current_setting('app.current_user_id', true)::uuid,
+            $1, $2, $3, $4
+        )
+        RETURNING id::text
+        """,
+        conv_uuid, key, value, reason,
+    )
+    return row["id"]
+
+
+async def get_pending_memory_write(
+    conn: asyncpg.Connection,
+    proposal_id: str,
+) -> dict | None:
+    """Fetch a single pending_memory_write by ID."""
+    import uuid as _uuid
+    row = await conn.fetchrow(
+        """
+        SELECT id::text, key, value, reason, status, conversation_id::text, created_at, reviewed_at
+        FROM pending_memory_writes
+        WHERE id = $1::uuid
+          AND user_id = current_setting('app.current_user_id', true)::uuid
+        """,
+        _uuid.UUID(proposal_id),
+    )
+    return dict(row) if row else None
+
+
+async def list_pending_memory_writes(
+    conn: asyncpg.Connection,
+    *,
+    status: str = "pending",
+) -> list[dict]:
+    """Return pending_memory_write proposals with the given status."""
+    rows = await conn.fetch(
+        """
+        SELECT id::text, key, value, reason, status, conversation_id::text, created_at
+        FROM pending_memory_writes
+        WHERE user_id = current_setting('app.current_user_id', true)::uuid
+          AND status = $1
+        ORDER BY created_at DESC
+        """,
+        status,
+    )
+    return [dict(r) for r in rows]
+
+
+async def review_pending_memory_write(
+    conn: asyncpg.Connection,
+    proposal_id: str,
+    new_status: str,
+) -> bool:
+    """Mark a proposal as 'accepted' or 'rejected'. Returns True if found."""
+    import uuid as _uuid
+    result = await conn.execute(
+        """
+        UPDATE pending_memory_writes
+           SET status = $1, reviewed_at = now()
+         WHERE id = $2::uuid
+           AND user_id = current_setting('app.current_user_id', true)::uuid
+        """,
+        new_status, _uuid.UUID(proposal_id),
+    )
+    return result.split()[-1] != "0"

--- a/db/pg_queries/node_memory.py
+++ b/db/pg_queries/node_memory.py
@@ -1,0 +1,174 @@
+"""Async Postgres queries — node_data_summary and node_read_log.
+
+node_data_summary: M-level summarization cache per context_node.
+  Populated by Beacon (Stream D summarization — NOT this module's concern).
+  Read by MCP tools to serve M-level detail without loading all sections.
+  Degrades gracefully when no rows exist (callers fall back to node_sections).
+
+node_read_log: per-conversation read-credit tracking.
+  Inserted by read_context / read_node_memory on every access.
+  Consulted by write_node_memory for advisory read-before-write check.
+
+All queries use RLS — callers must have set app.current_user_id.
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+
+import asyncpg
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# node_data_summary
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def get_node_summary(
+    conn: asyncpg.Connection,
+    node_id: str,
+    level_ordinal: int,
+) -> dict | None:
+    """Return the summary row for (node_id, level_ordinal), or None if absent.
+
+    Callers should degrade gracefully when None is returned:
+    - For M < last: no summary cached yet (Beacon hasn't summarized)
+    - For M = last: fall back to node_sections directly
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT node_id::text, level_ordinal, value, abstract, source_checksum, generated_at
+        FROM node_data_summary
+        WHERE node_id = $1::uuid AND level_ordinal = $2
+        """,
+        _uuid.UUID(node_id), level_ordinal,
+    )
+    return dict(row) if row else None
+
+
+async def list_node_summary_levels(
+    conn: asyncpg.Connection,
+    node_id: str,
+) -> list[int]:
+    """Return all available level_ordinal values for a node (sorted ascending).
+
+    Useful for read_context to know which M-levels are cached vs. must fall back.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT level_ordinal
+        FROM node_data_summary
+        WHERE node_id = $1::uuid
+        ORDER BY level_ordinal
+        """,
+        _uuid.UUID(node_id),
+    )
+    return [r["level_ordinal"] for r in rows]
+
+
+async def upsert_node_summary(
+    conn: asyncpg.Connection,
+    node_id: str,
+    level_ordinal: int,
+    value: dict,
+    source_checksum: str,
+    *,
+    abstract: str | None = None,
+) -> dict:
+    """Upsert a summary row. Called by Beacon summarization (Stream D).
+
+    Not called by read tools — this is write-only from the summarizer side.
+    """
+    row = await conn.fetchrow(
+        """
+        INSERT INTO node_data_summary
+            (user_id, node_id, level_ordinal, value, abstract, source_checksum, generated_at)
+        VALUES (
+            current_setting('app.current_user_id', true)::uuid,
+            $1::uuid, $2, $3::jsonb, $4, $5, now()
+        )
+        ON CONFLICT (node_id, level_ordinal) DO UPDATE
+            SET value           = EXCLUDED.value,
+                abstract        = EXCLUDED.abstract,
+                source_checksum = EXCLUDED.source_checksum,
+                generated_at    = now()
+        RETURNING node_id::text, level_ordinal, abstract, source_checksum, generated_at
+        """,
+        _uuid.UUID(node_id), level_ordinal, value, abstract, source_checksum,
+    )
+    return dict(row)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# node_read_log
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def log_node_read(
+    conn: asyncpg.Connection,
+    node_id: str,
+    level_ordinal: int,
+    *,
+    conversation_id: str | None = None,
+    title: str | None = None,
+) -> None:
+    """Record that the current user read node_id at level_ordinal in this conversation.
+
+    Called by read_context and read_node_memory on every access.
+    conversation_id may be None for admin/debug calls without conversation context.
+    """
+    conv_uuid = _uuid.UUID(conversation_id) if conversation_id else None
+    await conn.execute(
+        """
+        INSERT INTO node_read_log (user_id, conversation_id, node_id, level_ordinal, title)
+        VALUES (
+            current_setting('app.current_user_id', true)::uuid,
+            $1, $2::uuid, $3, $4
+        )
+        """,
+        conv_uuid, _uuid.UUID(node_id), level_ordinal, title,
+    )
+
+
+async def has_read_node_in_conversation(
+    conn: asyncpg.Connection,
+    node_id: str,
+    conversation_id: str,
+) -> bool:
+    """Return True if any read of node_id was logged for this conversation.
+
+    Used by write_node_memory advisory read-before-write check:
+      v1: log WARNING if False but allow the write
+      v2: hard block if False once Stream C callers always provide conversation_id
+    """
+    count = await conn.fetchval(
+        """
+        SELECT COUNT(*)
+        FROM node_read_log
+        WHERE user_id         = current_setting('app.current_user_id', true)::uuid
+          AND conversation_id = $1::uuid
+          AND node_id         = $2::uuid
+        """,
+        _uuid.UUID(conversation_id), _uuid.UUID(node_id),
+    )
+    return (count or 0) > 0
+
+
+async def get_conversation_reads(
+    conn: asyncpg.Connection,
+    conversation_id: str,
+) -> list[dict]:
+    """Return all node read credits for a conversation (newest first).
+
+    Used for diagnostics and advisory enforcement reports.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT node_id::text, level_ordinal, title, read_at
+        FROM node_read_log
+        WHERE user_id         = current_setting('app.current_user_id', true)::uuid
+          AND conversation_id = $1::uuid
+        ORDER BY read_at DESC
+        """,
+        _uuid.UUID(conversation_id),
+    )
+    return [dict(r) for r in rows]

--- a/db/pg_queries/node_memory.py
+++ b/db/pg_queries/node_memory.py
@@ -1,4 +1,4 @@
-"""Async Postgres queries — node_data_summary and node_read_log.
+"""Async Postgres queries — node_data_summary, node_read_log, and scope helpers.
 
 node_data_summary: M-level summarization cache per context_node.
   Populated by Beacon (Stream D summarization — NOT this module's concern).
@@ -151,6 +151,57 @@ async def has_read_node_in_conversation(
         _uuid.UUID(conversation_id), _uuid.UUID(node_id),
     )
     return (count or 0) > 0
+
+
+async def get_context_node_id_for_conversation(
+    conn: asyncpg.Connection,
+    conversation_id: str,
+) -> str | None:
+    """Return the context_node_id linked to a conversation, or None if unlinked."""
+    row = await conn.fetchrow(
+        "SELECT context_node_id::text FROM conversations WHERE id = $1::uuid",
+        _uuid.UUID(conversation_id),
+    )
+    if not row:
+        return None
+    return row["context_node_id"]
+
+
+async def get_node_tree_distance(
+    conn: asyncpg.Connection,
+    from_id: str,
+    to_id: str,
+    max_N: int,
+) -> int | None:
+    """Return the tree distance (edges) between two context nodes, or None if > max_N.
+
+    Uses a recursive CTE that walks both parent and child edges, bounded by max_N.
+    Returns 0 if from_id == to_id.
+    """
+    if from_id == to_id:
+        return 0
+
+    row = await conn.fetchrow(
+        """
+        WITH RECURSIVE reachable(node_id, dist) AS (
+            SELECT $1::uuid, 0
+          UNION ALL
+            SELECT
+              CASE WHEN cn.parent_id = r.node_id THEN cn.id
+                   ELSE cn.parent_id
+              END,
+              r.dist + 1
+            FROM reachable r
+            JOIN context_nodes cn
+              ON (cn.id = r.node_id AND cn.parent_id IS NOT NULL)
+              OR (cn.parent_id = r.node_id)
+            WHERE r.dist < $3
+        )
+        SELECT dist FROM reachable WHERE node_id = $2::uuid LIMIT 1
+        """,
+        _uuid.UUID(from_id), _uuid.UUID(to_id), max_N,
+    )
+    return row["dist"] if row else None
 
 
 async def get_conversation_reads(

--- a/db/pg_queries/sections.py
+++ b/db/pg_queries/sections.py
@@ -8,7 +8,8 @@ import asyncpg
 async def get_sections(conn: asyncpg.Connection, node_id: str) -> list[dict]:
     rows = await conn.fetch(
         """
-        SELECT section_type, name, body, position, version, updated_at
+        SELECT section_type, name, body, position, version, updated_at,
+               origin, visible_to_user
         FROM node_sections WHERE node_id = $1
         ORDER BY section_type, position
         """,
@@ -22,7 +23,8 @@ async def get_section(
 ) -> dict | None:
     row = await conn.fetchrow(
         """
-        SELECT section_type, name, body, position, version, updated_at
+        SELECT section_type, name, body, position, version, updated_at,
+               origin, visible_to_user
         FROM node_sections
         WHERE node_id = $1 AND section_type = $2 AND name = $3
         """,
@@ -37,7 +39,15 @@ async def upsert_section(
     section_type: str,
     body: str,
     name: str = "main",
+    *,
+    origin: str = "user",
+    visible_to_user: bool = True,
 ) -> dict:
+    """Insert or replace a node section.
+
+    origin: 'user' | 'conversation_agent' | 'system' — who authored this section.
+    visible_to_user: False hides the section from user-facing reads.
+    """
     nid = _uuid.UUID(node_id)
     user_uuid = await conn.fetchval(
         "SELECT current_setting('app.current_user_id', true)::uuid"
@@ -48,13 +58,19 @@ async def upsert_section(
     )
     row = await conn.fetchrow(
         """
-        INSERT INTO node_sections (user_id, node_id, section_type, name, body, position, updated_at)
-        VALUES ($1, $2, $3, $4, $5, $6, now())
+        INSERT INTO node_sections
+            (user_id, node_id, section_type, name, body, position,
+             origin, visible_to_user, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())
         ON CONFLICT (node_id, section_type, name) DO UPDATE
-            SET body = EXCLUDED.body, updated_at = now(), version = node_sections.version + 1
-        RETURNING section_type, name, body, version, updated_at
+            SET body           = EXCLUDED.body,
+                origin         = EXCLUDED.origin,
+                visible_to_user = EXCLUDED.visible_to_user,
+                updated_at     = now(),
+                version        = node_sections.version + 1
+        RETURNING section_type, name, body, version, updated_at, origin, visible_to_user
         """,
-        user_uuid, nid, section_type, name, body, next_pos,
+        user_uuid, nid, section_type, name, body, next_pos, origin, visible_to_user,
     )
     await conn.execute(
         "UPDATE context_nodes SET updated_at = now() WHERE id = $1", nid
@@ -68,13 +84,20 @@ async def append_section(
     section_type: str,
     content: str,
     name: str = "main",
+    *,
+    origin: str = "user",
+    visible_to_user: bool = True,
 ) -> dict:
+    """Append content to an existing section (or create it). Preserves existing body."""
     existing = await get_section(conn, node_id, section_type, name=name)
     if existing and existing["body"]:
         new_body = existing["body"] + "\n\n" + content
     else:
         new_body = content
-    return await upsert_section(conn, node_id, section_type, new_body, name=name)
+    return await upsert_section(
+        conn, node_id, section_type, new_body, name=name,
+        origin=origin, visible_to_user=visible_to_user,
+    )
 
 
 async def delete_section(
@@ -228,5 +251,73 @@ async def search_sections(
     return [
         {"node_id": str(r["node_id"]), "section_type": r["section_type"],
          "name": r["name"], "snippet": r["snippet"]}
+        for r in rows
+    ]
+
+
+async def grep_sections(
+    conn: asyncpg.Connection,
+    pattern: str,
+    node_ids: list[str] | None = None,
+    limit: int = 20,
+) -> list[dict]:
+    """ILIKE text search over node section bodies.
+
+    pattern: SQL ILIKE pattern (caller wraps in % if needed).
+    node_ids: Optional list of node UUID strings to restrict results.
+    limit:    Max rows returned (capped at 100 by callers).
+
+    Returns list of dicts: {node_id, node_name, section_type, section_name,
+                             snippet, origin, visible_to_user}.
+    """
+    if node_ids:
+        rows = await conn.fetch(
+            """
+            SELECT
+                ns.node_id::text,
+                cn.name AS node_name,
+                ns.section_type,
+                ns.name AS section_name,
+                left(ns.body, 300) AS snippet,
+                ns.origin,
+                ns.visible_to_user
+            FROM node_sections ns
+            JOIN context_nodes cn ON cn.id = ns.node_id
+            WHERE ns.node_id = ANY($1::uuid[])
+              AND ns.body ILIKE $2
+            ORDER BY cn.name, ns.section_type, ns.name
+            LIMIT $3
+            """,
+            node_ids, pattern, limit,
+        )
+    else:
+        rows = await conn.fetch(
+            """
+            SELECT
+                ns.node_id::text,
+                cn.name AS node_name,
+                ns.section_type,
+                ns.name AS section_name,
+                left(ns.body, 300) AS snippet,
+                ns.origin,
+                ns.visible_to_user
+            FROM node_sections ns
+            JOIN context_nodes cn ON cn.id = ns.node_id
+            WHERE ns.body ILIKE $1
+            ORDER BY cn.name, ns.section_type, ns.name
+            LIMIT $2
+            """,
+            pattern, limit,
+        )
+    return [
+        {
+            "node_id": r["node_id"],
+            "node_name": r["node_name"],
+            "section_type": r["section_type"],
+            "section_name": r["section_name"],
+            "snippet": r["snippet"],
+            "origin": r["origin"],
+            "visible_to_user": r["visible_to_user"],
+        }
         for r in rows
     ]

--- a/tests/db/test_memory_context_schema.py
+++ b/tests/db/test_memory_context_schema.py
@@ -64,20 +64,27 @@ async def _cleanup_seed_users(url: str) -> None:
 
 
 @pytest.fixture(scope="module", autouse=True)
-async def cleanup_schema_test_users():
+def cleanup_schema_test_users():
     """Module-scoped teardown: remove seeded users after all schema tests finish.
 
     These users are inserted with _seed_users() outside any rolled-back
     transaction, so they persist in the DB.  Without this cleanup they cause
     test_auth_routes.py (which runs next) to see get_user_count() > 0 and
     reject first-user registration with 400 instead of 200.
+
+    Sync fixture (not async) so it works with asyncio_default_fixture_loop_scope=function.
     """
+    import asyncio
+
     url = os.environ.get("DATABASE_URL")
-    if not url:
-        yield
-        return
     yield
-    await _cleanup_seed_users(url)
+    if not url:
+        return
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_cleanup_seed_users(url))
+    finally:
+        loop.close()
 
 
 @pytest.fixture

--- a/tests/db/test_memory_context_schema.py
+++ b/tests/db/test_memory_context_schema.py
@@ -51,6 +51,35 @@ async def _seed_users(url: str) -> None:
         await c.close()
 
 
+async def _cleanup_seed_users(url: str) -> None:
+    """Delete the seeded schema-test users so they don't pollute auth tests."""
+    c = await asyncpg.connect(dsn=url)
+    try:
+        await c.execute(
+            "DELETE FROM users WHERE id = ANY($1::uuid[])",
+            [USER_A, USER_B],
+        )
+    finally:
+        await c.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+async def cleanup_schema_test_users():
+    """Module-scoped teardown: remove seeded users after all schema tests finish.
+
+    These users are inserted with _seed_users() outside any rolled-back
+    transaction, so they persist in the DB.  Without this cleanup they cause
+    test_auth_routes.py (which runs next) to see get_user_count() > 0 and
+    reject first-user registration with 400 instead of 200.
+    """
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        yield
+        return
+    yield
+    await _cleanup_seed_users(url)
+
+
 @pytest.fixture
 async def conn_a():
     """Connection scoped to USER_A, wrapped in a rolled-back transaction."""

--- a/tests/db/test_memory_context_schema.py
+++ b/tests/db/test_memory_context_schema.py
@@ -1,0 +1,491 @@
+"""Schema-level tests for memory-context v2 migration.
+
+Covers:
+  - node_sections gains origin + visible_to_user columns with correct defaults
+  - node_data_summary table exists with correct schema + RLS (ENABLED + FORCED)
+  - user_memory table exists with correct schema + RLS
+  - user_durable_memory table exists with correct schema + RLS
+  - pending_memory_writes table exists with correct schema + RLS
+  - node_read_log table exists with correct schema + RLS
+  - RLS cross-user isolation: User B cannot see User A's rows on each table
+  - node_data_summary enforces UNIQUE (node_id, level_ordinal)
+
+All tests require DATABASE_URL and a non-superuser app role; they skip otherwise.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import asyncpg
+import pytest
+
+from db.postgres import register_jsonb_codec
+
+USER_A = "00000000-0000-0000-0000-aa0000000001"
+USER_B = "00000000-0000-0000-0000-bb0000000001"
+
+
+def _db_url() -> str:
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        pytest.skip("DATABASE_URL not set — Postgres tests skipped")
+    return url
+
+
+async def _seed_users(url: str) -> None:
+    """Seed deterministic test users outside any rolled-back transaction."""
+    c = await asyncpg.connect(dsn=url)
+    try:
+        await register_jsonb_codec(c)
+        for uid, uname, email in [
+            (USER_A, "mc_test_a", "mc_a@test.com"),
+            (USER_B, "mc_test_b", "mc_b@test.com"),
+        ]:
+            await c.execute(
+                "INSERT INTO users (id, username, email, password_hash) "
+                "VALUES ($1::uuid, $2, $3, 'x') ON CONFLICT (id) DO NOTHING",
+                uid, uname, email,
+            )
+    finally:
+        await c.close()
+
+
+@pytest.fixture
+async def conn_a():
+    """Connection scoped to USER_A, wrapped in a rolled-back transaction."""
+    url = _db_url()
+    await _seed_users(url)
+    c = await asyncpg.connect(dsn=url)
+    await register_jsonb_codec(c)
+    tr = c.transaction()
+    await tr.start()
+    await c.execute("SELECT set_config('app.current_user_id', $1, true)", USER_A)
+    yield c
+    await tr.rollback()
+    await c.close()
+
+
+@pytest.fixture
+async def conn_b():
+    """Connection scoped to USER_B, wrapped in a rolled-back transaction."""
+    url = _db_url()
+    await _seed_users(url)
+    c = await asyncpg.connect(dsn=url)
+    await register_jsonb_codec(c)
+    tr = c.transaction()
+    await tr.start()
+    await c.execute("SELECT set_config('app.current_user_id', $1, true)", USER_B)
+    yield c
+    await tr.rollback()
+    await c.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _make_context_node(conn, user_id: str) -> str:
+    """Insert a minimal context_node and return its UUID string."""
+    row = await conn.fetchrow(
+        """
+        INSERT INTO context_nodes (id, user_id, name, node_type)
+        VALUES (gen_random_uuid(), $1::uuid, 'Test Node', 'topic')
+        RETURNING id::text
+        """,
+        user_id,
+    )
+    return row["id"]
+
+
+def _rls_enabled(row) -> bool:
+    return row["relrowsecurity"] is True
+
+
+def _rls_forced(row) -> bool:
+    return row["relforcerowsecurity"] is True
+
+
+async def _rls_info(conn, table_name: str):
+    return await conn.fetchrow(
+        """
+        SELECT relrowsecurity, relforcerowsecurity
+        FROM pg_class
+        WHERE relname = $1
+          AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+        """,
+        table_name,
+    )
+
+
+async def _columns(conn, table_name: str) -> set[str]:
+    rows = await conn.fetch(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = $1
+        """,
+        table_name,
+    )
+    return {r["column_name"] for r in rows}
+
+
+async def _column_default(conn, table_name: str, column_name: str) -> str | None:
+    row = await conn.fetchrow(
+        """
+        SELECT column_default
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = $1
+          AND column_name = $2
+        """,
+        table_name, column_name,
+    )
+    return row["column_default"] if row else None
+
+
+# ===========================================================================
+# node_sections — new columns
+# ===========================================================================
+
+class TestNodeSectionsColumns:
+    async def test_origin_column_exists(self, conn_a):
+        """node_sections must have origin TEXT column after migration."""
+        cols = await _columns(conn_a, "node_sections")
+        assert "origin" in cols, "origin column missing from node_sections — run migration"
+
+    async def test_visible_to_user_column_exists(self, conn_a):
+        """node_sections must have visible_to_user BOOL column after migration."""
+        cols = await _columns(conn_a, "node_sections")
+        assert "visible_to_user" in cols, "visible_to_user column missing from node_sections — run migration"
+
+    async def test_origin_default_is_user(self, conn_a):
+        """origin column must default to 'user'."""
+        default = await _column_default(conn_a, "node_sections", "origin")
+        assert default is not None, "origin has no default"
+        assert "'user'" in default, f"origin default should be 'user', got: {default}"
+
+    async def test_visible_to_user_default_is_true(self, conn_a):
+        """visible_to_user column must default to true."""
+        default = await _column_default(conn_a, "node_sections", "visible_to_user")
+        assert default is not None, "visible_to_user has no default"
+        assert "true" in default.lower(), f"visible_to_user default should be true, got: {default}"
+
+    async def test_origin_persists_in_insert(self, conn_a):
+        """Inserting a section with origin='conversation_agent' round-trips correctly."""
+        node_id = await _make_context_node(conn_a, USER_A)
+        row = await conn_a.fetchrow(
+            """
+            INSERT INTO node_sections (user_id, node_id, section_type, name, body, origin)
+            VALUES (
+                current_setting('app.current_user_id', true)::uuid,
+                $1::uuid, 'notes', 'main', 'Bot wrote this.', 'conversation_agent'
+            )
+            RETURNING origin, visible_to_user
+            """,
+            node_id,
+        )
+        assert row["origin"] == "conversation_agent"
+        assert row["visible_to_user"] is True  # default
+
+    async def test_visible_to_user_false_persists(self, conn_a):
+        """visible_to_user=false must round-trip correctly."""
+        node_id = await _make_context_node(conn_a, USER_A)
+        row = await conn_a.fetchrow(
+            """
+            INSERT INTO node_sections (user_id, node_id, section_type, name, body, visible_to_user)
+            VALUES (
+                current_setting('app.current_user_id', true)::uuid,
+                $1::uuid, 'notes', 'hidden', 'Internal note.', false
+            )
+            RETURNING visible_to_user
+            """,
+            node_id,
+        )
+        assert row["visible_to_user"] is False
+
+
+# ===========================================================================
+# node_data_summary
+# ===========================================================================
+
+class TestNodeDataSummarySchema:
+    async def test_table_exists(self, conn_a):
+        row = await conn_a.fetchrow(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = 'public' AND table_name = 'node_data_summary'"
+        )
+        assert row is not None, "node_data_summary table does not exist — run migration"
+
+    async def test_rls_enabled_and_forced(self, conn_a):
+        info = await _rls_info(conn_a, "node_data_summary")
+        assert info is not None
+        assert _rls_enabled(info), "RLS not enabled on node_data_summary"
+        assert _rls_forced(info), "RLS not forced on node_data_summary"
+
+    async def test_required_columns_present(self, conn_a):
+        cols = await _columns(conn_a, "node_data_summary")
+        required = {"id", "user_id", "node_id", "level_ordinal", "value", "abstract",
+                    "source_checksum", "generated_at"}
+        assert required <= cols, f"Missing columns: {required - cols}"
+
+    async def test_unique_node_level_constraint(self, conn_a):
+        """(node_id, level_ordinal) must be unique."""
+        node_id = await _make_context_node(conn_a, USER_A)
+        nds_id = str(uuid.uuid4())
+        await conn_a.execute(
+            """
+            INSERT INTO node_data_summary (id, user_id, node_id, level_ordinal, value, source_checksum, generated_at)
+            VALUES ($1::uuid,
+                    current_setting('app.current_user_id', true)::uuid,
+                    $2::uuid, 2, '{"keys": {}}'::jsonb, 'abc123', now())
+            """,
+            nds_id, node_id,
+        )
+        with pytest.raises(asyncpg.UniqueViolationError):
+            await conn_a.execute(
+                """
+                INSERT INTO node_data_summary (id, user_id, node_id, level_ordinal, value, source_checksum, generated_at)
+                VALUES (gen_random_uuid(),
+                        current_setting('app.current_user_id', true)::uuid,
+                        $1::uuid, 2, '{"keys": {}}'::jsonb, 'def456', now())
+                """,
+                node_id,
+            )
+
+    async def test_rls_isolation(self, conn_a, conn_b):
+        """User B cannot see User A's node_data_summary rows."""
+        node_id_a = await _make_context_node(conn_a, USER_A)
+        await conn_a.execute(
+            """
+            INSERT INTO node_data_summary (id, user_id, node_id, level_ordinal, value, source_checksum, generated_at)
+            VALUES (gen_random_uuid(),
+                    current_setting('app.current_user_id', true)::uuid,
+                    $1::uuid, 1, '{"title": "test"}'::jsonb, 'chk1', now())
+            """,
+            node_id_a,
+        )
+        count_b = await conn_b.fetchval("SELECT COUNT(*) FROM node_data_summary")
+        assert count_b == 0, "User B should see 0 rows from user A's node_data_summary"
+
+
+# ===========================================================================
+# user_memory
+# ===========================================================================
+
+class TestUserMemorySchema:
+    async def test_table_exists(self, conn_a):
+        row = await conn_a.fetchrow(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = 'public' AND table_name = 'user_memory'"
+        )
+        assert row is not None, "user_memory table does not exist — run migration"
+
+    async def test_rls_enabled_and_forced(self, conn_a):
+        info = await _rls_info(conn_a, "user_memory")
+        assert info is not None
+        assert _rls_enabled(info), "RLS not enabled on user_memory"
+        assert _rls_forced(info), "RLS not forced on user_memory"
+
+    async def test_required_columns_present(self, conn_a):
+        cols = await _columns(conn_a, "user_memory")
+        required = {"id", "user_id", "key", "value", "updated_at", "last_read_at"}
+        assert required <= cols, f"Missing columns: {required - cols}"
+
+    async def test_unique_user_key_constraint(self, conn_a):
+        """(user_id, key) must be unique."""
+        await conn_a.execute(
+            """
+            INSERT INTO user_memory (user_id, key, value)
+            VALUES (current_setting('app.current_user_id', true)::uuid,
+                    'preferences/test', 'v1')
+            """
+        )
+        with pytest.raises(asyncpg.UniqueViolationError):
+            await conn_a.execute(
+                """
+                INSERT INTO user_memory (user_id, key, value)
+                VALUES (current_setting('app.current_user_id', true)::uuid,
+                        'preferences/test', 'v2')
+                """
+            )
+
+    async def test_rls_isolation(self, conn_a, conn_b):
+        """User B cannot read User A's user_memory rows."""
+        await conn_a.execute(
+            """
+            INSERT INTO user_memory (user_id, key, value)
+            VALUES (current_setting('app.current_user_id', true)::uuid,
+                    'facts/work/role', 'engineering lead')
+            """
+        )
+        count_b = await conn_b.fetchval("SELECT COUNT(*) FROM user_memory")
+        assert count_b == 0
+
+
+# ===========================================================================
+# user_durable_memory
+# ===========================================================================
+
+class TestUserDurableMemorySchema:
+    async def test_table_exists(self, conn_a):
+        row = await conn_a.fetchrow(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = 'public' AND table_name = 'user_durable_memory'"
+        )
+        assert row is not None, "user_durable_memory table does not exist — run migration"
+
+    async def test_rls_enabled_and_forced(self, conn_a):
+        info = await _rls_info(conn_a, "user_durable_memory")
+        assert info is not None
+        assert _rls_enabled(info), "RLS not enabled on user_durable_memory"
+        assert _rls_forced(info), "RLS not forced on user_durable_memory"
+
+    async def test_required_columns_present(self, conn_a):
+        cols = await _columns(conn_a, "user_durable_memory")
+        required = {"id", "user_id", "key", "value", "source", "evidence",
+                    "confidence", "created_at", "updated_at"}
+        assert required <= cols, f"Missing columns: {required - cols}"
+
+    async def test_unique_user_key_constraint(self, conn_a):
+        """(user_id, key) must be unique in user_durable_memory."""
+        await conn_a.execute(
+            """
+            INSERT INTO user_durable_memory (user_id, key, value, source)
+            VALUES (current_setting('app.current_user_id', true)::uuid,
+                    'inferred_preferences/morning', 'prefers 7am', 'compaction_monthly')
+            """
+        )
+        with pytest.raises(asyncpg.UniqueViolationError):
+            await conn_a.execute(
+                """
+                INSERT INTO user_durable_memory (user_id, key, value, source)
+                VALUES (current_setting('app.current_user_id', true)::uuid,
+                        'inferred_preferences/morning', 'prefers 8am', 'compaction_monthly')
+                """
+            )
+
+    async def test_confidence_default_is_medium(self, conn_a):
+        default = await _column_default(conn_a, "user_durable_memory", "confidence")
+        assert default is not None
+        assert "'medium'" in default, f"confidence default should be 'medium', got: {default}"
+
+    async def test_rls_isolation(self, conn_a, conn_b):
+        await conn_a.execute(
+            """
+            INSERT INTO user_durable_memory (user_id, key, value, source)
+            VALUES (current_setting('app.current_user_id', true)::uuid,
+                    'historical_summaries/2026-Q1', 'Q1 focused on launch', 'compaction_monthly')
+            """
+        )
+        count_b = await conn_b.fetchval("SELECT COUNT(*) FROM user_durable_memory")
+        assert count_b == 0
+
+
+# ===========================================================================
+# pending_memory_writes
+# ===========================================================================
+
+class TestPendingMemoryWritesSchema:
+    async def test_table_exists(self, conn_a):
+        row = await conn_a.fetchrow(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = 'public' AND table_name = 'pending_memory_writes'"
+        )
+        assert row is not None, "pending_memory_writes table does not exist — run migration"
+
+    async def test_rls_enabled_and_forced(self, conn_a):
+        info = await _rls_info(conn_a, "pending_memory_writes")
+        assert info is not None
+        assert _rls_enabled(info), "RLS not enabled on pending_memory_writes"
+        assert _rls_forced(info), "RLS not forced on pending_memory_writes"
+
+    async def test_required_columns_present(self, conn_a):
+        cols = await _columns(conn_a, "pending_memory_writes")
+        required = {"id", "user_id", "key", "value", "reason", "status",
+                    "conversation_id", "created_at", "reviewed_at"}
+        assert required <= cols, f"Missing columns: {required - cols}"
+
+    async def test_status_default_is_pending(self, conn_a):
+        default = await _column_default(conn_a, "pending_memory_writes", "status")
+        assert default is not None
+        assert "'pending'" in default, f"status default should be 'pending', got: {default}"
+
+    async def test_insert_and_read(self, conn_a):
+        """Can insert a proposal and read it back."""
+        row = await conn_a.fetchrow(
+            """
+            INSERT INTO pending_memory_writes (user_id, key, value, reason)
+            VALUES (current_setting('app.current_user_id', true)::uuid,
+                    'preferences/morning_routine', 'structured plan by 8am',
+                    'User explicitly stated this preference.')
+            RETURNING id, status
+            """
+        )
+        assert row["id"] is not None
+        assert row["status"] == "pending"
+
+    async def test_rls_isolation(self, conn_a, conn_b):
+        await conn_a.execute(
+            """
+            INSERT INTO pending_memory_writes (user_id, key, value, reason)
+            VALUES (current_setting('app.current_user_id', true)::uuid,
+                    'preferences/comms', 'terse', 'User preference.')
+            """
+        )
+        count_b = await conn_b.fetchval("SELECT COUNT(*) FROM pending_memory_writes")
+        assert count_b == 0
+
+
+# ===========================================================================
+# node_read_log
+# ===========================================================================
+
+class TestNodeReadLogSchema:
+    async def test_table_exists(self, conn_a):
+        row = await conn_a.fetchrow(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = 'public' AND table_name = 'node_read_log'"
+        )
+        assert row is not None, "node_read_log table does not exist — run migration"
+
+    async def test_rls_enabled_and_forced(self, conn_a):
+        info = await _rls_info(conn_a, "node_read_log")
+        assert info is not None
+        assert _rls_enabled(info), "RLS not enabled on node_read_log"
+        assert _rls_forced(info), "RLS not forced on node_read_log"
+
+    async def test_required_columns_present(self, conn_a):
+        cols = await _columns(conn_a, "node_read_log")
+        required = {"id", "user_id", "conversation_id", "node_id", "level_ordinal",
+                    "title", "read_at"}
+        assert required <= cols, f"Missing columns: {required - cols}"
+
+    async def test_insert_and_read(self, conn_a):
+        """Can log a read event and retrieve it."""
+        node_id = await _make_context_node(conn_a, USER_A)
+        row = await conn_a.fetchrow(
+            """
+            INSERT INTO node_read_log (user_id, node_id, level_ordinal, title)
+            VALUES (current_setting('app.current_user_id', true)::uuid,
+                    $1::uuid, 2, 'Intellipat')
+            RETURNING id, read_at
+            """,
+            node_id,
+        )
+        assert row["id"] is not None
+        assert row["read_at"] is not None
+
+    async def test_rls_isolation(self, conn_a, conn_b):
+        """User B cannot see User A's read log."""
+        node_id_a = await _make_context_node(conn_a, USER_A)
+        await conn_a.execute(
+            """
+            INSERT INTO node_read_log (user_id, node_id, level_ordinal, title)
+            VALUES (current_setting('app.current_user_id', true)::uuid,
+                    $1::uuid, 1, 'test')
+            """,
+            node_id_a,
+        )
+        count_b = await conn_b.fetchval("SELECT COUNT(*) FROM node_read_log")
+        assert count_b == 0

--- a/tether_mcp/server.py
+++ b/tether_mcp/server.py
@@ -119,13 +119,214 @@ async def read_context(
     depth: int = 0,
     include_sections: bool = False,
     include_tasks: bool = False,
+    conversation_id: str = "",
+    M: int = 4,
+    N: int = 3,
+    source: str = "sections",
 ) -> list:
     """Read context nodes. No params=roots. depth: 0=node only, 1=children, -1=full subtree.
-    Section bodies in cat-n format (1-indexed line numbers with tabs)."""
+    Section bodies in cat-n format (1-indexed line numbers with tabs).
+
+    conversation_id: Current conversation UUID. Required for scope-envelope enforcement.
+        When absent, scope is not enforced (legacy/debug use — logs a warning).
+    M: Detail level for node data summary (1=title, 2=one-liner, 3=themes, 4=full sections).
+    N: Scope envelope — max tree-edges from conversation's context node. Nodes outside
+        N edges return {error: 'out_of_scope', target: ...} instead of data.
+    source: 'sections' (user-authored, default) | 'memory' (bot-authored) | 'both'.
+    """
     from tether_mcp.tools.read_context import execute_read_context
     pool = await _get_pool()
     async with pg.get_conn(pool, get_user_id()) as conn:
-        return await execute_read_context(conn, paths, node_ids, depth, include_sections, include_tasks)
+        return await execute_read_context(
+            conn, paths, node_ids, depth, include_sections, include_tasks,
+            conversation_id=conversation_id or None,
+            M=M, N=N, source=source,
+        )
+
+
+@mcp.tool()
+async def read_memory(
+    scope: str = "user",
+    key: str = "",
+    prefix: str = "",
+    M: int = 2,
+) -> dict:
+    """Read user memory (L2 or L3) at a given detail level.
+
+    scope: 'user' (L2 working memory) | 'user_durable' (L3 compacted patterns).
+    key:    Exact key for a single-entry lookup (returns full value).
+    prefix: Filter by key prefix, e.g. 'preferences/'.
+    M:      1=keys only, 2=key+preview (default), 3=key+truncated, 4=full value.
+    """
+    from tether_mcp.tools.read_memory import execute_read_memory
+    pool = await _get_pool()
+    async with pg.get_conn(pool, get_user_id()) as conn:
+        return await execute_read_memory(
+            conn,
+            scope=scope,
+            key=key or None,
+            prefix=prefix or None,
+            M=M,
+        )
+
+
+@mcp.tool()
+async def read_node_memory(
+    node_id: str,
+    title: str = "",
+    M: int = 4,
+    conversation_id: str = "",
+) -> dict:
+    """Read bot-authored notes (origin='conversation_agent') on a context node.
+
+    node_id:         UUID of the context node.
+    title:           Optional section name filter.
+    M:               1=names only, 2=preview, 3=truncated, 4=full (default).
+    conversation_id: Current conversation UUID (for read-credit logging).
+    """
+    from tether_mcp.tools.read_node_memory import execute_read_node_memory
+    pool = await _get_pool()
+    async with pg.get_conn(pool, get_user_id()) as conn:
+        return await execute_read_node_memory(
+            conn,
+            node_id=node_id,
+            title=title or None,
+            M=M,
+            conversation_id=conversation_id or None,
+        )
+
+
+@mcp.tool()
+async def write_node_memory(
+    node_id: str,
+    title: str,
+    data_type: str,
+    value: str,
+    mode: str = "additive",
+    conversation_id: str = "",
+    visible_to_user: bool = True,
+) -> dict:
+    """Write bot-authored notes to a context node section.
+
+    node_id:         UUID of the context node to write to.
+    title:           Section name (key within the node).
+    data_type:       Content type hint: 'text' | 'list' | 'json' | 'file'.
+    value:           Content to write.
+    mode:            'additive' (append) | 'edit' (replace) | 'delete'.
+    conversation_id: Current conversation UUID (for read-before-write advisory).
+    visible_to_user: False hides this section from user-facing reads.
+
+    Advisory: edit/delete without a prior read in this conversation logs a warning
+    but still allows the write (v1). v2 will hard-block on violation.
+    """
+    from tether_mcp.tools.write_node_memory import execute_write_node_memory
+    pool = await _get_pool()
+    async with pg.get_conn(pool, get_user_id()) as conn:
+        return await execute_write_node_memory(
+            conn,
+            node_id=node_id,
+            title=title,
+            data_type=data_type,
+            value=value,
+            mode=mode,
+            conversation_id=conversation_id or None,
+            visible_to_user=visible_to_user,
+        )
+
+
+@mcp.tool()
+async def propose_user_memory_write(
+    key: str,
+    value: str,
+    reason: str,
+    conversation_id: str = "",
+) -> dict:
+    """Stage a user_memory write proposal for Beacon review.
+
+    key:             Memory key, e.g. 'preferences/morning_routine'.
+    value:           Value to write.
+    reason:          Why this write is proposed (used by Beacon evaluator to decide).
+    conversation_id: Current conversation UUID (linked to the proposal).
+
+    The write is NOT committed immediately. Beacon evaluates after the conversation
+    concludes and auto-accepts user-invoked proposals.
+    """
+    from tether_mcp.tools.propose_user_memory_write import execute_propose_user_memory_write
+    pool = await _get_pool()
+    async with pg.get_conn(pool, get_user_id()) as conn:
+        return await execute_propose_user_memory_write(
+            conn,
+            key=key,
+            value=value,
+            reason=reason,
+            conversation_id=conversation_id or None,
+        )
+
+
+@mcp.tool()
+async def search_context(
+    query: str,
+    scope: str = "user",
+    limit: int = 5,
+) -> dict:
+    """Semantic search over context nodes (v1 stub — returns empty, API is final).
+
+    query: Natural language search query.
+    scope: 'user' (all user nodes) or a node path prefix.
+    limit: Max results (1-20).
+    """
+    from tether_mcp.tools.search_context import execute_search_context
+    pool = await _get_pool()
+    async with pg.get_conn(pool, get_user_id()) as conn:
+        return await execute_search_context(conn, query=query, scope=scope, limit=limit)
+
+
+@mcp.tool()
+async def search_memory(
+    query: str,
+    scope: str = "user",
+    tier: str = "both",
+    limit: int = 5,
+) -> dict:
+    """Semantic search over user memory (v1 stub — returns empty, API is final).
+
+    query: Natural language search query.
+    scope: 'user' (default).
+    tier:  'l2' | 'l3' | 'both'.
+    limit: Max results (1-20).
+    """
+    from tether_mcp.tools.search_memory import execute_search_memory
+    pool = await _get_pool()
+    async with pg.get_conn(pool, get_user_id()) as conn:
+        return await execute_search_memory(
+            conn, query=query, scope=scope, tier=tier, limit=limit
+        )
+
+
+@mcp.tool()
+async def grep_context(
+    pattern: str,
+    scope: str = "user",
+    paths: list[str] = [],
+    limit: int = 20,
+) -> dict:
+    """Text search (ILIKE) over node section bodies.
+
+    pattern: Search string. Plain text wraps in % automatically; use % for custom wildcards.
+    scope:   'user' (RLS-enforced user nodes only).
+    paths:   Optional node paths to restrict search to their subtrees.
+    limit:   Max results (default 20, max 100).
+    """
+    from tether_mcp.tools.grep_context import execute_grep_context
+    pool = await _get_pool()
+    async with pg.get_conn(pool, get_user_id()) as conn:
+        return await execute_grep_context(
+            conn,
+            pattern=pattern,
+            scope=scope,
+            paths=paths or None,
+            limit=limit,
+        )
 
 
 @mcp.tool()

--- a/tether_mcp/tools/grep_context.py
+++ b/tether_mcp/tools/grep_context.py
@@ -1,17 +1,6 @@
-"""grep_context MCP tool — text search over node sections.
+"""grep_context MCP tool — text search (ILIKE) over node section bodies.
 
-Uses Postgres ILIKE for simple substring matches and tsvector GIN index for
-full-text queries. Results are returned with node context so the bot knows
-where each match lives in the tree.
-
-v1 scope:
-  ILIKE search over node_sections.body (simple, reliable, no stemming).
-  The existing tsvector GIN index on node_sections.search_vector is used
-  when ts_query mode is requested (mode='fts').
-
-Scope filtering:
-  paths — list of node paths (resolved to subtrees); if empty, searches all
-          nodes accessible to the current user via RLS.
+All SQL lives in db/pg_queries/sections.grep_sections().
 """
 from __future__ import annotations
 
@@ -29,89 +18,39 @@ async def execute_grep_context(
 
     Args:
         conn:    asyncpg connection (user-scoped via RLS).
-        pattern: Search string. Use % for ILIKE wildcards, or plain text
-                 for substring match (automatically wrapped in %).
+        pattern: Search string. Plain text is auto-wrapped in % (substring match).
+                 Use % explicitly for custom wildcard positioning.
         scope:   'user' (default) — search user's own nodes only (RLS enforced).
         paths:   Optional list of node paths to restrict search to their subtrees.
         limit:   Max results (default 20, max 100).
 
     Returns:
-        {matches: [{node_id, node_name, path, section_type, name, snippet}], total}
+        {matches: [{node_id, node_name, section_type, section_name, snippet,
+                    origin, visible_to_user}], total}
     """
-    from db.pg_queries.context import get_node_by_path
+    from db.pg_queries.sections import grep_sections
+    from db.pg_queries.nodes import get_node_by_path
 
     if not pattern or not pattern.strip():
         return {"error": "pattern_required"}
 
     limit = min(limit, 100)
 
-    # Normalize pattern: if no % wildcards, treat as substring
+    # Normalize: wrap plain text in % wildcards for substring match
     search_pattern = pattern.strip()
     if "%" not in search_pattern:
         search_pattern = f"%{search_pattern}%"
 
-    # Build node_id restriction if paths provided
-    node_uuids: list[str] | None = None
+    # Resolve path restrictions to node UUIDs
+    node_ids: list[str] | None = None
     if paths:
-        node_uuids = []
+        node_ids = []
         for p in paths:
             node = await get_node_by_path(conn, p)
             if node:
-                node_uuids.append(str(node["id"]))
-        if not node_uuids:
+                node_ids.append(str(node["id"]))
+        if not node_ids:
             return {"matches": [], "total": 0}
 
-    if node_uuids:
-        rows = await conn.fetch(
-            """
-            SELECT
-                ns.node_id::text,
-                cn.name AS node_name,
-                ns.section_type,
-                ns.name AS section_name,
-                left(ns.body, 300) AS snippet,
-                ns.origin,
-                ns.visible_to_user
-            FROM node_sections ns
-            JOIN context_nodes cn ON cn.id = ns.node_id
-            WHERE ns.node_id = ANY($1::uuid[])
-              AND ns.body ILIKE $2
-            ORDER BY cn.name, ns.section_type, ns.name
-            LIMIT $3
-            """,
-            node_uuids, search_pattern, limit,
-        )
-    else:
-        rows = await conn.fetch(
-            """
-            SELECT
-                ns.node_id::text,
-                cn.name AS node_name,
-                ns.section_type,
-                ns.name AS section_name,
-                left(ns.body, 300) AS snippet,
-                ns.origin,
-                ns.visible_to_user
-            FROM node_sections ns
-            JOIN context_nodes cn ON cn.id = ns.node_id
-            WHERE ns.body ILIKE $1
-            ORDER BY cn.name, ns.section_type, ns.name
-            LIMIT $2
-            """,
-            search_pattern, limit,
-        )
-
-    matches = [
-        {
-            "node_id": r["node_id"],
-            "node_name": r["node_name"],
-            "section_type": r["section_type"],
-            "section_name": r["section_name"],
-            "snippet": r["snippet"],
-            "origin": r["origin"],
-            "visible_to_user": r["visible_to_user"],
-        }
-        for r in rows
-    ]
-
+    matches = await grep_sections(conn, search_pattern, node_ids=node_ids, limit=limit)
     return {"matches": matches, "total": len(matches)}

--- a/tether_mcp/tools/grep_context.py
+++ b/tether_mcp/tools/grep_context.py
@@ -1,0 +1,117 @@
+"""grep_context MCP tool — text search over node sections.
+
+Uses Postgres ILIKE for simple substring matches and tsvector GIN index for
+full-text queries. Results are returned with node context so the bot knows
+where each match lives in the tree.
+
+v1 scope:
+  ILIKE search over node_sections.body (simple, reliable, no stemming).
+  The existing tsvector GIN index on node_sections.search_vector is used
+  when ts_query mode is requested (mode='fts').
+
+Scope filtering:
+  paths — list of node paths (resolved to subtrees); if empty, searches all
+          nodes accessible to the current user via RLS.
+"""
+from __future__ import annotations
+
+import asyncpg
+
+
+async def execute_grep_context(
+    conn: asyncpg.Connection,
+    pattern: str,
+    scope: str = "user",
+    paths: list[str] | None = None,
+    limit: int = 20,
+) -> dict:
+    """Search node sections for a text pattern.
+
+    Args:
+        conn:    asyncpg connection (user-scoped via RLS).
+        pattern: Search string. Use % for ILIKE wildcards, or plain text
+                 for substring match (automatically wrapped in %).
+        scope:   'user' (default) — search user's own nodes only (RLS enforced).
+        paths:   Optional list of node paths to restrict search to their subtrees.
+        limit:   Max results (default 20, max 100).
+
+    Returns:
+        {matches: [{node_id, node_name, path, section_type, name, snippet}], total}
+    """
+    from db.pg_queries.context import get_node_by_path
+
+    if not pattern or not pattern.strip():
+        return {"error": "pattern_required"}
+
+    limit = min(limit, 100)
+
+    # Normalize pattern: if no % wildcards, treat as substring
+    search_pattern = pattern.strip()
+    if "%" not in search_pattern:
+        search_pattern = f"%{search_pattern}%"
+
+    # Build node_id restriction if paths provided
+    node_uuids: list[str] | None = None
+    if paths:
+        node_uuids = []
+        for p in paths:
+            node = await get_node_by_path(conn, p)
+            if node:
+                node_uuids.append(str(node["id"]))
+        if not node_uuids:
+            return {"matches": [], "total": 0}
+
+    if node_uuids:
+        rows = await conn.fetch(
+            """
+            SELECT
+                ns.node_id::text,
+                cn.name AS node_name,
+                ns.section_type,
+                ns.name AS section_name,
+                left(ns.body, 300) AS snippet,
+                ns.origin,
+                ns.visible_to_user
+            FROM node_sections ns
+            JOIN context_nodes cn ON cn.id = ns.node_id
+            WHERE ns.node_id = ANY($1::uuid[])
+              AND ns.body ILIKE $2
+            ORDER BY cn.name, ns.section_type, ns.name
+            LIMIT $3
+            """,
+            node_uuids, search_pattern, limit,
+        )
+    else:
+        rows = await conn.fetch(
+            """
+            SELECT
+                ns.node_id::text,
+                cn.name AS node_name,
+                ns.section_type,
+                ns.name AS section_name,
+                left(ns.body, 300) AS snippet,
+                ns.origin,
+                ns.visible_to_user
+            FROM node_sections ns
+            JOIN context_nodes cn ON cn.id = ns.node_id
+            WHERE ns.body ILIKE $1
+            ORDER BY cn.name, ns.section_type, ns.name
+            LIMIT $2
+            """,
+            search_pattern, limit,
+        )
+
+    matches = [
+        {
+            "node_id": r["node_id"],
+            "node_name": r["node_name"],
+            "section_type": r["section_type"],
+            "section_name": r["section_name"],
+            "snippet": r["snippet"],
+            "origin": r["origin"],
+            "visible_to_user": r["visible_to_user"],
+        }
+        for r in rows
+    ]
+
+    return {"matches": matches, "total": len(matches)}

--- a/tether_mcp/tools/propose_user_memory_write.py
+++ b/tether_mcp/tools/propose_user_memory_write.py
@@ -1,0 +1,69 @@
+"""propose_user_memory_write MCP tool — stage a user_memory proposal for Beacon review.
+
+The interactive 2.5 agent calls this tool when the user says something like
+"remember that I prefer mornings." The proposal is NOT committed immediately:
+
+  1. Tool inserts a row in pending_memory_writes with status='pending'.
+  2. Tool returns proposal_id to the agent (can be echoed to the user).
+  3. Beacon's post-conversation evaluator reads pending_memory_writes after
+     the conversation concludes (~40min idle) and decides to accept or reject:
+       - User-invoked proposals: auto-accept.
+       - Agent-inferred without user request: review with caution.
+  4. Accepted proposals: Beacon writes to user_memory via upsert_user_memory().
+  5. Rejected proposals: status set to 'rejected'; no write to user_memory.
+
+This design keeps the interactive agent out of the direct-write path while
+surfacing the intent to the user and Beacon.
+"""
+from __future__ import annotations
+
+import asyncpg
+
+
+async def execute_propose_user_memory_write(
+    conn: asyncpg.Connection,
+    key: str,
+    value: str,
+    reason: str,
+    *,
+    conversation_id: str | None = None,
+) -> dict:
+    """Stage a user_memory write proposal for Beacon review.
+
+    Args:
+        conn:            asyncpg connection (user-scoped via RLS).
+        key:             Memory key (e.g., 'preferences/morning_routine').
+        value:           Value to write (e.g., 'prefers structured plan by 8am').
+        reason:          Why this write is proposed (context for Beacon evaluator).
+        conversation_id: Current conversation UUID (linked to the proposal).
+
+    Returns:
+        {status: 'proposed', proposal_id: str, key: str, message: str}
+        On error: {error: str}
+    """
+    from db.pg_queries.memory import insert_pending_memory_write
+
+    if not key or not key.strip():
+        return {"error": "key_required", "message": "key must be a non-empty string"}
+    if not value:
+        return {"error": "value_required", "message": "value must be non-empty"}
+    if not reason or not reason.strip():
+        return {"error": "reason_required", "message": "reason is required for Beacon review"}
+
+    proposal_id = await insert_pending_memory_write(
+        conn,
+        key.strip(),
+        value,
+        reason.strip(),
+        conversation_id=conversation_id,
+    )
+
+    return {
+        "status": "proposed",
+        "proposal_id": proposal_id,
+        "key": key.strip(),
+        "message": (
+            "Memory write staged for Beacon review. It will be committed after "
+            "this conversation concludes and Beacon evaluates it."
+        ),
+    }

--- a/tether_mcp/tools/read_context.py
+++ b/tether_mcp/tools/read_context.py
@@ -12,10 +12,14 @@ New params added in memory-context v2:
   N               — Scope envelope in tree-edges from current_node.
                     Requests outside N edges are rejected with {error: 'out_of_scope'}.
                     Only enforced when conversation_id is provided.
+                    Note: children returned during depth traversal are also scope-checked;
+                    out-of-scope children are replaced with {error: 'out_of_scope', ...}.
   source          — 'sections' | 'memory' | 'both' (default: 'sections').
-                    'sections': return node_sections content (existing behavior).
+                    'sections': return user-authored sections (origin='user').
                     'memory':   return bot-authored sections (origin='conversation_agent').
                     'both':     return all sections regardless of origin.
+
+All SQL lives in db/pg_queries/.
 """
 from __future__ import annotations
 
@@ -23,49 +27,6 @@ import logging
 import asyncpg
 
 logger = logging.getLogger(__name__)
-
-
-async def _tree_distance(
-    conn: asyncpg.Connection,
-    from_id: str,
-    to_id: str,
-    max_N: int,
-) -> int | None:
-    """Return the tree distance (edges) between two nodes in the context tree.
-
-    Returns None if the nodes are not connected within max_N edges.
-    Uses a recursive CTE that walks both ancestors and descendants.
-
-    O(max_N) queries worth of work — kept bounded by max_N.
-    """
-    if from_id == to_id:
-        return 0
-
-    import uuid as _uuid
-
-    # Walk up to max_N edges in either direction via recursive CTE.
-    # We anchor on from_id and expand both parent and child edges.
-    row = await conn.fetchrow(
-        """
-        WITH RECURSIVE reachable(node_id, dist) AS (
-            SELECT $1::uuid, 0
-          UNION ALL
-            SELECT
-              CASE WHEN cn.parent_id = r.node_id THEN cn.id
-                   ELSE cn.parent_id
-              END,
-              r.dist + 1
-            FROM reachable r
-            JOIN context_nodes cn
-              ON (cn.id = r.node_id AND cn.parent_id IS NOT NULL)
-              OR (cn.parent_id = r.node_id)
-            WHERE r.dist < $3
-        )
-        SELECT dist FROM reachable WHERE node_id = $2::uuid LIMIT 1
-        """,
-        _uuid.UUID(from_id), _uuid.UUID(to_id), max_N,
-    )
-    return row["dist"] if row else None
 
 
 async def _build_node_response(
@@ -76,10 +37,18 @@ async def _build_node_response(
     include_tasks: bool,
     M: int = 4,
     source: str = "sections",
+    *,
+    current_node_id: str | None = None,
+    N: int = 3,
+    conversation_id: str | None = None,
 ) -> dict:
-    """Build the response dict for a single node, optionally with children/sections/tasks."""
+    """Build the response dict for a single node, optionally with children/sections/tasks.
+
+    When current_node_id is set, each child is scope-checked against N edges.
+    Out-of-scope children are represented as {error: 'out_of_scope', target: id}.
+    """
     from db.pg_queries import get_node, get_children, get_sections, get_node_tasks
-    from db.pg_queries.node_memory import get_node_summary
+    from db.pg_queries.node_memory import get_node_summary, log_node_read, get_node_tree_distance
     from tether_mcp.write_modes import format_cat_n, line_count
 
     # Ensure we have full node dict (with section_types and children_count)
@@ -102,23 +71,17 @@ async def _build_node_response(
                 "abstract": summary.get("abstract"),
                 "generated_at": summary.get("generated_at"),
             }
-            # At M < 4 with a cached summary, skip full section load
-            # unless the caller also asked for sections explicitly
+            # With a cached summary and no explicit section request, skip full section load
             if not include_sections:
                 if depth != 0:
-                    children = await get_children(conn, node["id"])
-                    next_depth = depth - 1 if depth > 0 else -1
-                    result["children"] = []
-                    for child in children:
-                        result["children"].append(
-                            await _build_node_response(
-                                conn, child, next_depth, include_sections,
-                                include_tasks, M, source,
-                            )
-                        )
+                    await _add_children(
+                        conn, result, node, depth, include_sections, include_tasks,
+                        M, source, current_node_id=current_node_id, N=N,
+                        conversation_id=conversation_id,
+                    )
                 return result
 
-    # Sections (full M=4 or fallback when no summary)
+    # Sections (full M=4 or fallback when no summary cached)
     if include_sections:
         all_sections = await get_sections(conn, node["id"])
         grouped: dict[str, list[dict]] = {}
@@ -128,7 +91,7 @@ async def _build_node_response(
                 continue
             if source == "sections" and s.get("origin") == "conversation_agent":
                 continue
-            # 'both' passes through all
+            # 'both' passes all
 
             st = s["section_type"]
             if st not in grouped:
@@ -147,45 +110,73 @@ async def _build_node_response(
     if include_tasks:
         result["tasks"] = await get_node_tasks(conn, node["id"])
 
-    # Children (recursive)
+    # Children (recursive, with per-child scope check)
     if depth != 0:
-        children = await get_children(conn, node["id"])
-        next_depth = depth - 1 if depth > 0 else -1
-        result["children"] = []
-        for child in children:
-            result["children"].append(
-                await _build_node_response(
-                    conn, child, next_depth, include_sections, include_tasks, M, source
-                )
-            )
+        await _add_children(
+            conn, result, node, depth, include_sections, include_tasks,
+            M, source, current_node_id=current_node_id, N=N,
+            conversation_id=conversation_id,
+        )
 
     return result
 
 
-async def _resolve_current_node_id(
+async def _add_children(
     conn: asyncpg.Connection,
-    conversation_id: str,
-) -> str | None:
-    """Return the context_node_id for a conversation, or None if unlinked."""
-    import uuid as _uuid
-    row = await conn.fetchrow(
-        "SELECT context_node_id::text FROM conversations WHERE id = $1::uuid",
-        _uuid.UUID(conversation_id),
-    )
-    if not row:
-        return None
-    return row["context_node_id"]
-
-
-async def _check_scope(
-    conn: asyncpg.Connection,
-    node_id: str,
-    current_node_id: str,
+    result: dict,
+    node: dict,
+    depth: int,
+    include_sections: bool,
+    include_tasks: bool,
+    M: int,
+    source: str,
+    *,
+    current_node_id: str | None,
     N: int,
-) -> bool:
-    """Return True if node_id is within N tree-edges of current_node_id."""
-    dist = await _tree_distance(conn, current_node_id, node_id, N)
-    return dist is not None
+    conversation_id: str | None,
+) -> None:
+    """Fetch children and add them to result['children'], applying per-child scope check."""
+    from db.pg_queries import get_children
+    from db.pg_queries.node_memory import get_node_tree_distance, log_node_read
+
+    children = await get_children(conn, node["id"])
+    next_depth = depth - 1 if depth > 0 else -1
+    result["children"] = []
+
+    for child in children:
+        child_id = str(child["id"]) if not isinstance(child["id"], str) else child["id"]
+
+        # Scope check each child independently
+        if current_node_id and N > 0:
+            dist = await get_node_tree_distance(conn, current_node_id, child_id, N)
+            if dist is None:
+                result["children"].append({
+                    "error": "out_of_scope",
+                    "target": child_id,
+                    "message": (
+                        f"Node {child_id} is more than {N} tree-edges from "
+                        f"conversation context node {current_node_id}."
+                    ),
+                })
+                continue
+
+        # Log read credit for in-scope children
+        if conversation_id:
+            try:
+                await log_node_read(
+                    conn, child_id, M,
+                    conversation_id=conversation_id,
+                    title=child.get("name"),
+                )
+            except Exception:
+                pass
+
+        result["children"].append(
+            await _build_node_response(
+                conn, child, next_depth, include_sections, include_tasks, M, source,
+                current_node_id=current_node_id, N=N, conversation_id=conversation_id,
+            )
+        )
 
 
 async def execute_read_context(
@@ -221,26 +212,27 @@ async def execute_read_context(
             When M < 4, returns from node_data_summary cache if available;
             falls back to node_sections at M=4. No descent gating in v1.
         N: Scope envelope — max tree-edges from conversation's current_node.
-            Requests outside N edges return {error: 'out_of_scope', target: <path>}.
+            Requests outside N edges return {error: 'out_of_scope', ...}.
             Only enforced when conversation_id is provided.
-        source: 'sections' (default) | 'memory' | 'both'.
-            'sections' — user-authored sections (origin='user').
-            'memory'   — bot-authored sections (origin='conversation_agent').
-            'both'     — all sections regardless of origin.
+            Children during depth traversal are also scope-checked.
+        source: 'sections' (default, user-authored) | 'memory' (bot-authored) | 'both'.
 
     Returns:
         List of node dicts (or error dicts for out-of-scope entries).
         If no paths and no node_ids, returns root nodes.
     """
     from db.pg_queries import get_node, get_node_by_path, get_children
-    from db.pg_queries.node_memory import log_node_read
+    from db.pg_queries.node_memory import (
+        log_node_read,
+        get_context_node_id_for_conversation,
+        get_node_tree_distance,
+    )
 
     # Resolve conversation scope
     current_node_id: str | None = None
     if conversation_id:
-        current_node_id = await _resolve_current_node_id(conn, conversation_id)
-        # Note: current_node_id may be None even when conversation_id is provided
-        # (conversations without a linked context node skip scope enforcement)
+        current_node_id = await get_context_node_id_for_conversation(conn, conversation_id)
+        # current_node_id may be None for conversations not linked to a context node
     else:
         logger.warning(
             "read_context called without conversation_id (legacy/unscoped path) "
@@ -251,10 +243,10 @@ async def execute_read_context(
         """Apply scope check, log read, build response."""
         node_id = str(node["id"]) if not isinstance(node["id"], str) else node["id"]
 
-        # Scope envelope check
+        # Scope envelope check for the top-level requested node
         if current_node_id and N > 0:
-            in_scope = await _check_scope(conn, node_id, current_node_id, N)
-            if not in_scope:
+            dist = await get_node_tree_distance(conn, current_node_id, node_id, N)
+            if dist is None:
                 return {
                     "error": "out_of_scope",
                     "target": node_id,
@@ -265,7 +257,7 @@ async def execute_read_context(
                     ),
                 }
 
-        # Log read credit
+        # Log read credit for the top-level node
         if conversation_id:
             try:
                 await log_node_read(
@@ -274,19 +266,17 @@ async def execute_read_context(
                     title=node.get("name"),
                 )
             except Exception:
-                pass  # don't fail the read if log fails
+                pass
 
         return await _build_node_response(
-            conn, node, depth, include_sections, include_tasks, M, source
+            conn, node, depth, include_sections, include_tasks, M, source,
+            current_node_id=current_node_id, N=N, conversation_id=conversation_id,
         )
 
     # No args → return root nodes
     if not paths and not node_ids:
         roots = await get_children(conn, parent_id=None)
-        result = []
-        for root in roots:
-            result.append(await _fetch_and_check(root))
-        return result
+        return [await _fetch_and_check(root) for root in roots]
 
     results = []
 

--- a/tether_mcp/tools/read_context.py
+++ b/tether_mcp/tools/read_context.py
@@ -1,8 +1,71 @@
-"""read_context tool — batched reads with depth traversal, sections (cat -n), and tasks."""
+"""read_context tool — batched reads with depth traversal, sections (cat -n), tasks,
+M-level summary, scope envelope enforcement, and source filtering.
 
+New params added in memory-context v2:
+  conversation_id — when provided, enables N scope envelope enforcement.
+                    Optional (legacy callers without it get unscoped reads with a warning).
+                    Required for scope-envelope; v2 will make this mandatory.
+  M               — M-level detail for node data summary.
+                    1=title only, 2=one-liner, 3=themes+abstract, 4=full (default: 4).
+                    When M < last, returns from node_data_summary if cached;
+                    falls back to node_sections at M=4 (no descent gating in v1).
+  N               — Scope envelope in tree-edges from current_node.
+                    Requests outside N edges are rejected with {error: 'out_of_scope'}.
+                    Only enforced when conversation_id is provided.
+  source          — 'sections' | 'memory' | 'both' (default: 'sections').
+                    'sections': return node_sections content (existing behavior).
+                    'memory':   return bot-authored sections (origin='conversation_agent').
+                    'both':     return all sections regardless of origin.
+"""
 from __future__ import annotations
 
+import logging
 import asyncpg
+
+logger = logging.getLogger(__name__)
+
+
+async def _tree_distance(
+    conn: asyncpg.Connection,
+    from_id: str,
+    to_id: str,
+    max_N: int,
+) -> int | None:
+    """Return the tree distance (edges) between two nodes in the context tree.
+
+    Returns None if the nodes are not connected within max_N edges.
+    Uses a recursive CTE that walks both ancestors and descendants.
+
+    O(max_N) queries worth of work — kept bounded by max_N.
+    """
+    if from_id == to_id:
+        return 0
+
+    import uuid as _uuid
+
+    # Walk up to max_N edges in either direction via recursive CTE.
+    # We anchor on from_id and expand both parent and child edges.
+    row = await conn.fetchrow(
+        """
+        WITH RECURSIVE reachable(node_id, dist) AS (
+            SELECT $1::uuid, 0
+          UNION ALL
+            SELECT
+              CASE WHEN cn.parent_id = r.node_id THEN cn.id
+                   ELSE cn.parent_id
+              END,
+              r.dist + 1
+            FROM reachable r
+            JOIN context_nodes cn
+              ON (cn.id = r.node_id AND cn.parent_id IS NOT NULL)
+              OR (cn.parent_id = r.node_id)
+            WHERE r.dist < $3
+        )
+        SELECT dist FROM reachable WHERE node_id = $2::uuid LIMIT 1
+        """,
+        _uuid.UUID(from_id), _uuid.UUID(to_id), max_N,
+    )
+    return row["dist"] if row else None
 
 
 async def _build_node_response(
@@ -11,9 +74,12 @@ async def _build_node_response(
     depth: int,
     include_sections: bool,
     include_tasks: bool,
+    M: int = 4,
+    source: str = "sections",
 ) -> dict:
     """Build the response dict for a single node, optionally with children/sections/tasks."""
     from db.pg_queries import get_node, get_children, get_sections, get_node_tasks
+    from db.pg_queries.node_memory import get_node_summary
     from tether_mcp.write_modes import format_cat_n, line_count
 
     # Ensure we have full node dict (with section_types and children_count)
@@ -25,11 +91,45 @@ async def _build_node_response(
 
     result = dict(node)
 
-    # Sections
+    # M-level summary (if M < 4, try node_data_summary first)
+    if M < 4:
+        summary = await get_node_summary(conn, node["id"], M)
+        if summary:
+            result["summary"] = {
+                "M": M,
+                "level_ordinal": summary["level_ordinal"],
+                "value": summary["value"],
+                "abstract": summary.get("abstract"),
+                "generated_at": summary.get("generated_at"),
+            }
+            # At M < 4 with a cached summary, skip full section load
+            # unless the caller also asked for sections explicitly
+            if not include_sections:
+                if depth != 0:
+                    children = await get_children(conn, node["id"])
+                    next_depth = depth - 1 if depth > 0 else -1
+                    result["children"] = []
+                    for child in children:
+                        result["children"].append(
+                            await _build_node_response(
+                                conn, child, next_depth, include_sections,
+                                include_tasks, M, source,
+                            )
+                        )
+                return result
+
+    # Sections (full M=4 or fallback when no summary)
     if include_sections:
         all_sections = await get_sections(conn, node["id"])
         grouped: dict[str, list[dict]] = {}
         for s in all_sections:
+            # Source filter
+            if source == "memory" and s.get("origin") != "conversation_agent":
+                continue
+            if source == "sections" and s.get("origin") == "conversation_agent":
+                continue
+            # 'both' passes through all
+
             st = s["section_type"]
             if st not in grouped:
                 grouped[st] = []
@@ -38,6 +138,8 @@ async def _build_node_response(
                 "name": s["name"],
                 "body": format_cat_n(body),
                 "line_count": line_count(body),
+                "origin": s.get("origin", "user"),
+                "visible_to_user": s.get("visible_to_user", True),
             })
         result["sections"] = grouped
 
@@ -48,14 +150,42 @@ async def _build_node_response(
     # Children (recursive)
     if depth != 0:
         children = await get_children(conn, node["id"])
-        next_depth = depth - 1 if depth > 0 else -1  # -1 means unlimited
+        next_depth = depth - 1 if depth > 0 else -1
         result["children"] = []
         for child in children:
             result["children"].append(
-                await _build_node_response(conn, child, next_depth, include_sections, include_tasks)
+                await _build_node_response(
+                    conn, child, next_depth, include_sections, include_tasks, M, source
+                )
             )
 
     return result
+
+
+async def _resolve_current_node_id(
+    conn: asyncpg.Connection,
+    conversation_id: str,
+) -> str | None:
+    """Return the context_node_id for a conversation, or None if unlinked."""
+    import uuid as _uuid
+    row = await conn.fetchrow(
+        "SELECT context_node_id::text FROM conversations WHERE id = $1::uuid",
+        _uuid.UUID(conversation_id),
+    )
+    if not row:
+        return None
+    return row["context_node_id"]
+
+
+async def _check_scope(
+    conn: asyncpg.Connection,
+    node_id: str,
+    current_node_id: str,
+    N: int,
+) -> bool:
+    """Return True if node_id is within N tree-edges of current_node_id."""
+    dist = await _tree_distance(conn, current_node_id, node_id, N)
+    return dist is not None
 
 
 async def execute_read_context(
@@ -65,6 +195,10 @@ async def execute_read_context(
     depth: int = 0,
     include_sections: bool = False,
     include_tasks: bool = False,
+    conversation_id: str | None = None,
+    M: int = 4,
+    N: int = 3,
+    source: str = "sections",
 ) -> list:
     """Fetch context nodes with optional depth traversal, section content, and linked tasks.
 
@@ -77,23 +211,81 @@ async def execute_read_context(
             >0 = include children up to that many levels
             -1 = full subtree (unlimited)
         include_sections: If True, add "sections" dict grouped by section_type.
-            Each section entry has {name, body (cat -n format), line_count}.
+            Each section entry has {name, body (cat-n format), line_count, origin}.
         include_tasks: If True, add "tasks" list from get_node_tasks.
+        conversation_id: Current conversation UUID.
+            Required for scope-envelope enforcement (N param). When absent,
+            scope is not enforced and a warning is logged (legacy/debug use only).
+            v2 will make this mandatory once Stream C callers always provide it.
+        M: M-level detail for node data (1=title, 2=one-liner, 3=themes, 4=full).
+            When M < 4, returns from node_data_summary cache if available;
+            falls back to node_sections at M=4. No descent gating in v1.
+        N: Scope envelope — max tree-edges from conversation's current_node.
+            Requests outside N edges return {error: 'out_of_scope', target: <path>}.
+            Only enforced when conversation_id is provided.
+        source: 'sections' (default) | 'memory' | 'both'.
+            'sections' — user-authored sections (origin='user').
+            'memory'   — bot-authored sections (origin='conversation_agent').
+            'both'     — all sections regardless of origin.
 
     Returns:
-        List of node dicts (or None for not-found entries), in same order as inputs.
+        List of node dicts (or error dicts for out-of-scope entries).
         If no paths and no node_ids, returns root nodes.
     """
     from db.pg_queries import get_node, get_node_by_path, get_children
+    from db.pg_queries.node_memory import log_node_read
+
+    # Resolve conversation scope
+    current_node_id: str | None = None
+    if conversation_id:
+        current_node_id = await _resolve_current_node_id(conn, conversation_id)
+        # Note: current_node_id may be None even when conversation_id is provided
+        # (conversations without a linked context node skip scope enforcement)
+    else:
+        logger.warning(
+            "read_context called without conversation_id (legacy/unscoped path) "
+            "— scope envelope not enforced"
+        )
+
+    async def _fetch_and_check(node: dict) -> dict:
+        """Apply scope check, log read, build response."""
+        node_id = str(node["id"]) if not isinstance(node["id"], str) else node["id"]
+
+        # Scope envelope check
+        if current_node_id and N > 0:
+            in_scope = await _check_scope(conn, node_id, current_node_id, N)
+            if not in_scope:
+                return {
+                    "error": "out_of_scope",
+                    "target": node_id,
+                    "message": (
+                        f"Node {node_id} is more than {N} tree-edges from "
+                        f"conversation context node {current_node_id}. "
+                        "Request permission via the conversation to access it."
+                    ),
+                }
+
+        # Log read credit
+        if conversation_id:
+            try:
+                await log_node_read(
+                    conn, node_id, M,
+                    conversation_id=conversation_id,
+                    title=node.get("name"),
+                )
+            except Exception:
+                pass  # don't fail the read if log fails
+
+        return await _build_node_response(
+            conn, node, depth, include_sections, include_tasks, M, source
+        )
 
     # No args → return root nodes
     if not paths and not node_ids:
         roots = await get_children(conn, parent_id=None)
         result = []
         for root in roots:
-            result.append(
-                await _build_node_response(conn, root, depth, include_sections, include_tasks)
-            )
+            result.append(await _fetch_and_check(root))
         return result
 
     results = []
@@ -104,9 +296,7 @@ async def execute_read_context(
         if node is None:
             results.append(None)
         else:
-            results.append(
-                await _build_node_response(conn, node, depth, include_sections, include_tasks)
-            )
+            results.append(await _fetch_and_check(node))
 
     # Resolve node_ids
     for nid in (node_ids or []):
@@ -114,8 +304,6 @@ async def execute_read_context(
         if node is None:
             results.append(None)
         else:
-            results.append(
-                await _build_node_response(conn, node, depth, include_sections, include_tasks)
-            )
+            results.append(await _fetch_and_check(node))
 
     return results

--- a/tether_mcp/tools/read_memory.py
+++ b/tether_mcp/tools/read_memory.py
@@ -1,0 +1,69 @@
+"""read_memory MCP tool — read user_memory or user_durable_memory at a given M-level.
+
+M-level semantics for memory (no descent gates — entries are atomic):
+  M=1  key listing only
+  M=2  key + ~50-char preview    (default — good for triage context)
+  M=3  key + ~200-char truncated value
+  M=4  key + full value
+
+scope controls which table:
+  'user'         → user_memory (L2 working memory)
+  'user_durable' → user_durable_memory (L3 compacted patterns)
+
+key: exact key lookup (returns at most one entry, full M=4 regardless of M param)
+prefix: filter by key prefix (e.g., 'preferences/')
+If neither key nor prefix is provided, returns all entries at the requested M.
+"""
+from __future__ import annotations
+
+import asyncpg
+
+
+async def execute_read_memory(
+    conn: asyncpg.Connection,
+    scope: str = "user",
+    key: str | None = None,
+    prefix: str | None = None,
+    M: int = 2,
+) -> dict:
+    """Fetch user memory entries for the current RLS user.
+
+    Args:
+        conn:   asyncpg connection (user-scoped via RLS).
+        scope:  'user' (L2) or 'user_durable' (L3).
+        key:    Exact key for a single-entry lookup (returns full value, ignores M).
+        prefix: Key prefix filter (e.g., 'preferences/').
+        M:      Detail level — 1 (keys), 2 (preview), 3 (truncated), 4 (full).
+
+    Returns:
+        {scope, M, entries: [...]}
+        For single-key lookup: {scope, entry: {...} | null}
+    """
+    from db.pg_queries.memory import (
+        get_user_memory_entry,
+        get_user_durable_memory_entry,
+        list_user_memory,
+        list_user_durable_memory,
+    )
+
+    if scope not in ("user", "user_durable"):
+        return {"error": "invalid_scope", "valid_scopes": ["user", "user_durable"]}
+
+    if M not in (1, 2, 3, 4):
+        return {"error": "invalid_M", "valid_values": [1, 2, 3, 4]}
+
+    if key is not None:
+        # Single-entry lookup — always full value
+        if scope == "user":
+            entry = await get_user_memory_entry(conn, key)
+        else:
+            entry = await get_user_durable_memory_entry(conn, key)
+        return {"scope": scope, "entry": entry}
+
+    # List (with optional prefix)
+    if scope == "user":
+        entries = await list_user_memory(conn, prefix=prefix, M=M)
+    else:
+        entries = await list_user_durable_memory(conn, prefix=prefix, M=M)
+
+    return {"scope": scope, "M": M, "entries": entries}

--- a/tether_mcp/tools/read_node_memory.py
+++ b/tether_mcp/tools/read_node_memory.py
@@ -1,0 +1,100 @@
+"""read_node_memory MCP tool — read bot-authored notes on a specific context node.
+
+Returns node_sections entries where origin='conversation_agent', optionally
+filtered by title. This is the symmetric read side of write_node_memory.
+
+Also logs the read to node_read_log (enabling the read-before-write advisory
+for subsequent write_node_memory calls in the same conversation).
+
+Alternatively, read_context with source='memory' or source='both' covers this
+case for multi-node reads. read_node_memory is the focused single-node version.
+"""
+from __future__ import annotations
+
+import asyncpg
+
+
+async def execute_read_node_memory(
+    conn: asyncpg.Connection,
+    node_id: str,
+    title: str | None = None,
+    M: int = 4,
+    *,
+    conversation_id: str | None = None,
+) -> dict:
+    """Return bot-authored sections for a context node.
+
+    Args:
+        conn:            asyncpg connection (user-scoped via RLS).
+        node_id:         UUID of the context node.
+        title:           Optional section name filter.
+        M:               Detail level — 1 (names only), 2 (preview), 3 (truncated), 4 (full).
+        conversation_id: Current conversation UUID (for read-credit logging).
+
+    Returns:
+        {node_id, sections: [{section_type, name, body?, preview?, origin}]}
+        Or {error: 'node_not_found'} if node doesn't exist.
+    """
+    from db.pg_queries import get_node
+    from db.pg_queries.node_memory import log_node_read
+    from db.pg_queries.sections import get_sections
+
+    # Verify node exists
+    node = await get_node(conn, node_id)
+    if node is None:
+        return {"error": "node_not_found", "node_id": node_id}
+
+    all_sections = await get_sections(conn, node_id)
+
+    # Filter to bot-authored only
+    bot_sections = [
+        s for s in all_sections
+        if s.get("origin") == "conversation_agent"
+    ]
+
+    # Optional title filter
+    if title is not None:
+        bot_sections = [s for s in bot_sections if s.get("name") == title]
+
+    # Apply M-level to body content
+    def format_body(body: str | None) -> str | None:
+        if not body:
+            return body
+        if M == 1:
+            return None  # name only
+        if M == 2:
+            return body[:50] if len(body) > 50 else body
+        if M == 3:
+            return body[:200] if len(body) > 200 else body
+        return body  # M=4: full
+
+    sections_out = []
+    for s in bot_sections:
+        entry: dict = {
+            "section_type": s["section_type"],
+            "name": s["name"],
+            "origin": s.get("origin", "conversation_agent"),
+            "visible_to_user": s.get("visible_to_user", True),
+        }
+        if M > 1:
+            entry["body"] = format_body(s.get("body"))
+        sections_out.append(entry)
+
+    # Log read credit
+    if conversation_id:
+        try:
+            await log_node_read(
+                conn, node_id, M,
+                conversation_id=conversation_id,
+                title=node.get("name"),
+            )
+        except Exception:
+            pass
+
+    return {
+        "node_id": node_id,
+        "node_name": node.get("name"),
+        "M": M,
+        "sections": sections_out,
+        "total": len(sections_out),
+    }

--- a/tether_mcp/tools/search_context.py
+++ b/tether_mcp/tools/search_context.py
@@ -1,0 +1,35 @@
+"""search_context MCP tool — semantic search over context nodes (v1 stub).
+
+v1: Returns empty results. Full implementation (pgvector or external embedding
+service) deferred to v2 once the embedding pipeline is designed.
+
+The tool signature is final — v2 will fill in the implementation without
+changing the API. Callers can depend on the return shape now.
+"""
+from __future__ import annotations
+
+import asyncpg
+
+
+async def execute_search_context(
+    conn: asyncpg.Connection,
+    query: str,
+    scope: str = "user",
+    limit: int = 5,
+) -> dict:
+    """Semantic search over context nodes (v1 stub — always returns empty).
+
+    Args:
+        conn:  asyncpg connection (user-scoped via RLS).
+        query: Natural language search query.
+        scope: 'user' (all user nodes) or a node path prefix.
+        limit: Max results (1-20).
+
+    Returns:
+        {results: [], total: 0, note: 'stub'}
+    """
+    return {
+        "results": [],
+        "total": 0,
+        "note": "search_context is a v1 stub — semantic search not yet implemented",
+    }

--- a/tether_mcp/tools/search_memory.py
+++ b/tether_mcp/tools/search_memory.py
@@ -1,0 +1,36 @@
+"""search_memory MCP tool — semantic search over user memory (v1 stub).
+
+v1: Returns empty results. Full implementation deferred to v2 (pgvector or
+external embedding service).
+
+The tool signature is final — v2 fills in the implementation without API change.
+"""
+from __future__ import annotations
+
+import asyncpg
+
+
+async def execute_search_memory(
+    conn: asyncpg.Connection,
+    query: str,
+    scope: str = "user",
+    tier: str = "both",
+    limit: int = 5,
+) -> dict:
+    """Semantic search over user memory (v1 stub — always returns empty).
+
+    Args:
+        conn:  asyncpg connection (user-scoped via RLS).
+        query: Natural language search query.
+        scope: 'user' (default).
+        tier:  'l2' | 'l3' | 'both' — which memory tier to search.
+        limit: Max results (1-20).
+
+    Returns:
+        {results: [], total: 0, note: 'stub'}
+    """
+    return {
+        "results": [],
+        "total": 0,
+        "note": "search_memory is a v1 stub — semantic search not yet implemented",
+    }

--- a/tether_mcp/tools/write_node_memory.py
+++ b/tether_mcp/tools/write_node_memory.py
@@ -13,9 +13,7 @@ Read-before-write enforcement (v1 ADVISORY):
   v2 (post-Stream-C-stable): flip to hard block by returning
   {error: 'read_before_write_violated', ...} instead of warning.
 
-All writes set origin='conversation_agent' and visible_to_user=True by default
-(the section is visible to the user in the UI). Pass visible_to_user=False for
-internal bot notes that should be hidden from the user-facing context.
+All SQL lives in db/pg_queries/sections.py and db/pg_queries/node_memory.py.
 """
 from __future__ import annotations
 
@@ -43,8 +41,8 @@ async def execute_write_node_memory(
         conn:            asyncpg connection (user-scoped via RLS).
         node_id:         UUID of the context node to write to.
         title:           Section name (the 'name' column in node_sections).
-        data_type:       Hint for content type ('text' | 'list' | 'json' | 'file').
-                         Stored as the section_type; 'notes' if not provided.
+        data_type:       Content type hint ('text' | 'list' | 'json' | 'file').
+                         Used as the section_type; defaults to 'bot_notes'.
         value:           Content body to write.
         mode:            'additive' | 'edit' | 'delete'.
         conversation_id: Current conversation ID for read-before-write advisory.
@@ -52,16 +50,11 @@ async def execute_write_node_memory(
 
     Returns:
         On success: {status: 'ok', node_id, title, mode, warning?: str}
-        On delete (nothing to delete): {status: 'not_found', node_id, title}
-        On error: {error: str, ...}
+        On delete not found: {status: 'not_found', node_id, title}
+        On bad mode: {error: 'invalid_mode', valid_modes: [...]}
     """
     from db.pg_queries.node_memory import has_read_node_in_conversation, log_node_read
-    from db.pg_queries.sections import (
-        get_section,
-        upsert_section,
-        append_section,
-        delete_section,
-    )
+    from db.pg_queries.sections import get_section, upsert_section, append_section, delete_section
 
     if mode not in ("additive", "edit", "delete"):
         return {
@@ -83,7 +76,6 @@ async def execute_write_node_memory(
         warning = "read_before_write_advisory: conversation_id not provided — skipping read check"
         logger.warning(warning)
 
-    # Derive section_type from data_type or default to 'bot_notes'
     section_type = data_type if data_type else "bot_notes"
 
     if mode == "delete":
@@ -96,51 +88,18 @@ async def execute_write_node_memory(
             result["warning"] = warning
         return result
 
-    # Build the section body with origin marker.
-    # upsert_section / append_section don't yet accept origin/visible_to_user —
-    # we write directly so we can set the new columns properly.
-    import uuid as _uuid
-
-    node_uuid = _uuid.UUID(node_id)
-    user_uuid = await conn.fetchval(
-        "SELECT current_setting('app.current_user_id', true)::uuid"
-    )
-
     if mode == "additive":
-        existing = await get_section(conn, node_id, section_type, name=title)
-        if existing and existing["body"]:
-            new_body = existing["body"] + "\n\n" + value
-        else:
-            new_body = value
+        await append_section(
+            conn, node_id, section_type, value, name=title,
+            origin="conversation_agent", visible_to_user=visible_to_user,
+        )
     else:  # edit
-        new_body = value
+        await upsert_section(
+            conn, node_id, section_type, value, name=title,
+            origin="conversation_agent", visible_to_user=visible_to_user,
+        )
 
-    # Use INSERT ... ON CONFLICT so we can set origin + visible_to_user.
-    next_pos = await conn.fetchval(
-        "SELECT COALESCE(MAX(position), -1) + 1 FROM node_sections "
-        "WHERE node_id = $1 AND section_type = $2",
-        node_uuid, section_type,
-    )
-    await conn.execute(
-        """
-        INSERT INTO node_sections
-            (user_id, node_id, section_type, name, body, position,
-             origin, visible_to_user, updated_at)
-        VALUES ($1, $2, $3, $4, $5, $6, 'conversation_agent', $7, now())
-        ON CONFLICT (node_id, section_type, name) DO UPDATE
-            SET body           = EXCLUDED.body,
-                origin         = 'conversation_agent',
-                visible_to_user = EXCLUDED.visible_to_user,
-                updated_at     = now(),
-                version        = node_sections.version + 1
-        """,
-        user_uuid, node_uuid, section_type, title, new_body, next_pos, visible_to_user,
-    )
-    await conn.execute(
-        "UPDATE context_nodes SET updated_at = now() WHERE id = $1", node_uuid
-    )
-
-    # Log the write read-credit (so future writes know this conversation touched the node)
+    # Log write as a read credit so future reads know this conversation touched the node
     if conversation_id is not None:
         try:
             await log_node_read(

--- a/tether_mcp/tools/write_node_memory.py
+++ b/tether_mcp/tools/write_node_memory.py
@@ -1,0 +1,161 @@
+"""write_node_memory MCP tool — write bot-authored notes to a context node section.
+
+Writes to node_sections with origin='conversation_agent'. Supports three modes:
+  additive — append content to existing body (or create if absent)
+  edit     — replace existing body entirely
+  delete   — remove the named section
+
+Read-before-write enforcement (v1 ADVISORY):
+  On mode='edit' or mode='delete', checks node_read_log for any read of this
+  node in the current conversation. If no read is logged, emits a warning in
+  the response but allows the write.
+
+  v2 (post-Stream-C-stable): flip to hard block by returning
+  {error: 'read_before_write_violated', ...} instead of warning.
+
+All writes set origin='conversation_agent' and visible_to_user=True by default
+(the section is visible to the user in the UI). Pass visible_to_user=False for
+internal bot notes that should be hidden from the user-facing context.
+"""
+from __future__ import annotations
+
+import logging
+
+import asyncpg
+
+logger = logging.getLogger(__name__)
+
+
+async def execute_write_node_memory(
+    conn: asyncpg.Connection,
+    node_id: str,
+    title: str,
+    data_type: str,
+    value: str,
+    mode: str = "additive",
+    *,
+    conversation_id: str | None = None,
+    visible_to_user: bool = True,
+) -> dict:
+    """Write a bot-authored section to a context node.
+
+    Args:
+        conn:            asyncpg connection (user-scoped via RLS).
+        node_id:         UUID of the context node to write to.
+        title:           Section name (the 'name' column in node_sections).
+        data_type:       Hint for content type ('text' | 'list' | 'json' | 'file').
+                         Stored as the section_type; 'notes' if not provided.
+        value:           Content body to write.
+        mode:            'additive' | 'edit' | 'delete'.
+        conversation_id: Current conversation ID for read-before-write advisory.
+        visible_to_user: False hides this section from user-facing reads.
+
+    Returns:
+        On success: {status: 'ok', node_id, title, mode, warning?: str}
+        On delete (nothing to delete): {status: 'not_found', node_id, title}
+        On error: {error: str, ...}
+    """
+    from db.pg_queries.node_memory import has_read_node_in_conversation, log_node_read
+    from db.pg_queries.sections import (
+        get_section,
+        upsert_section,
+        append_section,
+        delete_section,
+    )
+
+    if mode not in ("additive", "edit", "delete"):
+        return {
+            "error": "invalid_mode",
+            "valid_modes": ["additive", "edit", "delete"],
+        }
+
+    # Advisory read-before-write check for edit / delete
+    warning: str | None = None
+    if mode in ("edit", "delete") and conversation_id is not None:
+        has_read = await has_read_node_in_conversation(conn, node_id, conversation_id)
+        if not has_read:
+            warning = (
+                f"read_before_write_advisory: no read of node {node_id} logged "
+                f"in conversation {conversation_id} — writing anyway (v1 advisory mode)"
+            )
+            logger.warning(warning)
+    elif mode in ("edit", "delete") and conversation_id is None:
+        warning = "read_before_write_advisory: conversation_id not provided — skipping read check"
+        logger.warning(warning)
+
+    # Derive section_type from data_type or default to 'bot_notes'
+    section_type = data_type if data_type else "bot_notes"
+
+    if mode == "delete":
+        existing = await get_section(conn, node_id, section_type, name=title)
+        if existing is None:
+            return {"status": "not_found", "node_id": node_id, "title": title}
+        await delete_section(conn, node_id, section_type, name=title)
+        result = {"status": "ok", "node_id": node_id, "title": title, "mode": "delete"}
+        if warning:
+            result["warning"] = warning
+        return result
+
+    # Build the section body with origin marker.
+    # upsert_section / append_section don't yet accept origin/visible_to_user —
+    # we write directly so we can set the new columns properly.
+    import uuid as _uuid
+
+    node_uuid = _uuid.UUID(node_id)
+    user_uuid = await conn.fetchval(
+        "SELECT current_setting('app.current_user_id', true)::uuid"
+    )
+
+    if mode == "additive":
+        existing = await get_section(conn, node_id, section_type, name=title)
+        if existing and existing["body"]:
+            new_body = existing["body"] + "\n\n" + value
+        else:
+            new_body = value
+    else:  # edit
+        new_body = value
+
+    # Use INSERT ... ON CONFLICT so we can set origin + visible_to_user.
+    next_pos = await conn.fetchval(
+        "SELECT COALESCE(MAX(position), -1) + 1 FROM node_sections "
+        "WHERE node_id = $1 AND section_type = $2",
+        node_uuid, section_type,
+    )
+    await conn.execute(
+        """
+        INSERT INTO node_sections
+            (user_id, node_id, section_type, name, body, position,
+             origin, visible_to_user, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6, 'conversation_agent', $7, now())
+        ON CONFLICT (node_id, section_type, name) DO UPDATE
+            SET body           = EXCLUDED.body,
+                origin         = 'conversation_agent',
+                visible_to_user = EXCLUDED.visible_to_user,
+                updated_at     = now(),
+                version        = node_sections.version + 1
+        """,
+        user_uuid, node_uuid, section_type, title, new_body, next_pos, visible_to_user,
+    )
+    await conn.execute(
+        "UPDATE context_nodes SET updated_at = now() WHERE id = $1", node_uuid
+    )
+
+    # Log the write read-credit (so future writes know this conversation touched the node)
+    if conversation_id is not None:
+        try:
+            await log_node_read(
+                conn, node_id, 999, conversation_id=conversation_id, title=title
+            )
+        except Exception:
+            pass  # don't fail the write if log fails
+
+    result = {
+        "status": "ok",
+        "node_id": node_id,
+        "title": title,
+        "mode": mode,
+        "section_type": section_type,
+    }
+    if warning:
+        result["warning"] = warning
+    return result


### PR DESCRIPTION
## Summary

Stream A foundations for the memory-context v2 architecture (see 06-turn-end-to-end.excalidraw gap-summary Stream A).

### Schema migration (k1l2m3n4o5p6)
- `node_sections` gains `origin TEXT DEFAULT 'user'` + `visible_to_user BOOL DEFAULT true`
- New table `node_data_summary` — M-level summary cache; Beacon (Stream D) populates, agents read
- New tables `user_memory` + `user_durable_memory` — L2/L3 per-user memory, mirrored from beacon_memory schema (Beacon spec §5.1)
- New table `pending_memory_writes` — staging for `propose_user_memory_write` proposals
- New table `node_read_log` — per-conversation read-credit tracking for advisory read-before-write
- RLS (`ENABLE` + `FORCE`) on all new tables

### New pg_queries modules
- `db/pg_queries/memory.py` — user_memory, user_durable_memory, pending_memory_writes CRUD
- `db/pg_queries/node_memory.py` — node_data_summary reads/upserts, node_read_log inserts/lookups

### New MCP tools
- `read_memory` — M-level reads from user_memory / user_durable_memory (M=1 keys, M=2 preview, M=3 truncated, M=4 full)
- `read_node_memory` — bot-authored section reads on a specific node
- `write_node_memory` — bot-authored section writes with advisory read-before-write enforcement (v1: warns, v2: hard block)
- `propose_user_memory_write` — stage user_memory proposals for Beacon post-conversation review
- `search_context` / `search_memory` — v1 stubs (API final; pgvector impl deferred to v2)
- `grep_context` — ILIKE text search over node section bodies

### Updated: `read_context`
- New params: `conversation_id` (optional, enables scope envelope), `M` (detail level), `N` (scope edges), `source` ('sections'|'memory'|'both')
- Scope envelope: nodes outside N tree-edges of conversation's context_node return `{error: 'out_of_scope', ...}` 
- Backward-compatible: existing callers without `conversation_id` get legacy behavior + a logged warning
- Logs read credits to `node_read_log` on every call

## Test plan
- [ ] CI postgres-tests lane: 33 schema tests in `tests/db/test_memory_context_schema.py` — expected green after `alembic upgrade head`
- [ ] CI verifies migration applies cleanly from current head (j1k2l3m4n5o6)
- [ ] Existing postgres-tests still pass (node_sections backward-compatible, read_context params are all additive with defaults)
- [ ] No breaking changes to existing MCP tool signatures