### PR TITLE
feat(layer): Stream B event schema migration (agent_action, permission_request, status)

### DIFF
--- a/config/agent_translations.yaml
+++ b/config/agent_translations.yaml
@@ -13,6 +13,44 @@ search:
   type: background
   phrase: "Searching for '{query}'"
 
+# Memory-context tools (2.5 agent)
+read_context:
+  type: background
+  phrase: "Looking at {node_title}"
+
+read_memory:
+  type: background
+  phrase: "Checking memory"
+
+read_node_memory:
+  type: background
+  phrase: "Reading notes on {node_title}"
+
+search_context:
+  type: background
+  phrase: "Searching context"
+
+search_memory:
+  type: background
+  phrase: "Searching memory"
+
+grep_context:
+  type: background
+  phrase: "Scanning context"
+
+# MCP-namespaced aliases used by 2.0 agent via tether MCP server
+mcp__tether__upsert_tasks:
+  type: background
+  phrase: "Updating tasks"
+
+mcp__tether__get_anchors:
+  type: background
+  phrase: "Reading your schedule"
+
+mcp__tether__get_plan:
+  type: background
+  phrase: "Reading your plan"
+
 # Premium internal tools — kept opaque
 consult_advisor:
   type: background_hidden
@@ -34,29 +72,49 @@ send_status_update:
   type: passthrough
 
 # Channel 2 — user-action tools (permission-eligible)
+# kind: "user_section_edit" | "destructive" | "read_out_of_scope"
+
 upsert_tasks:
   type: user_action
   phrase_short: "Updating tasks"
   permission_summary: "Update {count} tasks"
   permission_detail_field: "tasks"
+  kind: "user_section_edit"
 
 delete_tasks:
   type: user_action
   phrase_short: "Removing tasks"
   permission_summary: "Delete {count} items"
   permission_detail_field: "operations"
+  kind: "destructive"
 
 upsert_context:
   type: user_action
   phrase_short: "Updating context"
   permission_summary: "Update context: {subject}"
   permission_detail_field: "nodes"
+  kind: "user_section_edit"
 
 delete_context:
   type: user_action
   phrase_short: "Removing context"
   permission_summary: "Delete context: {subject}"
   permission_detail_field: "operations"
+  kind: "destructive"
+
+write_node_memory:
+  type: user_action
+  phrase_short: "Noting: {title}"
+  permission_summary: "Save note: {title}"
+  permission_detail_field: "value"
+  kind: "user_section_edit"
+
+propose_user_memory_write:
+  type: user_action
+  phrase_short: "Proposing memory update"
+  permission_summary: "Propose memory: {key}"
+  permission_detail_field: "value"
+  kind: "user_section_edit"
 
 # Fallback
 _unknown:

--- a/db/migrations/versions/k1l2m3n4o5p6_permission_grants.py
+++ b/db/migrations/versions/k1l2m3n4o5p6_permission_grants.py
@@ -1,0 +1,80 @@
+"""Add permission_grants table — per-conversation tool permission grants.
+
+When a user approves a permission_request for a specific (target, kind), a grant
+is stored here so the PermissionGate can skip the interactive flow on subsequent
+calls within the same conversation.
+
+Design:
+  - Grants live as long as the conversation does; no explicit TTL.
+  - expires_at is NULL by default; may be used for future time-bounded grants.
+  - The (user_id, conversation_id, target, kind) tuple is the natural lookup key.
+  - ON DELETE CASCADE from users ensures no orphan grants.
+
+Security:
+  - ENABLE ROW LEVEL SECURITY + FORCE ROW LEVEL SECURITY
+  - Policy: USING (user_id = current_setting('app.current_user_id', true)::uuid)
+
+Revision ID: k1l2m3n4o5p6
+Revises: j1k2l3m4n5o6
+Create Date: 2026-06-02
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "k1l2m3n4o5p6"
+down_revision = "j1k2l3m4n5o6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "permission_grants",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text("gen_random_uuid()")),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("conversation_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("target", sa.Text, nullable=False),
+        sa.Column("kind", sa.Text, nullable=False),
+        sa.Column("granted_at", sa.TIMESTAMP(timezone=True), nullable=False,
+                  server_default=sa.text("now()")),
+        sa.Column("expires_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+
+    # Index for the primary lookup: does a grant exist for this (user, conv, target, kind)?
+    op.create_index(
+        "ix_permission_grants_lookup",
+        "permission_grants",
+        ["user_id", "conversation_id", "target", "kind"],
+    )
+
+    # Foreign key back to users (cascade on delete)
+    op.create_foreign_key(
+        "fk_permission_grants_user_id",
+        "permission_grants",
+        "users",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # RLS
+    op.execute("ALTER TABLE permission_grants ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE permission_grants FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY permission_grants_user_isolation ON permission_grants
+        USING (user_id = current_setting('app.current_user_id', true)::uuid)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS permission_grants_user_isolation ON permission_grants")
+    op.drop_index("ix_permission_grants_lookup", table_name="permission_grants")
+    op.drop_constraint("fk_permission_grants_user_id", "permission_grants", type_="foreignkey")
+    op.drop_table("permission_grants")

--- a/frontend/src/components/PermissionModal.vue
+++ b/frontend/src/components/PermissionModal.vue
@@ -1,12 +1,24 @@
 <script setup lang="ts">
-import { ref, watch, onUnmounted } from 'vue'
+import { ref, computed, watch, onUnmounted } from 'vue'
 import { useChatStore } from '../stores/chat'
+import type { PermissionKind } from '../types/chat'
 
 const TIMEOUT_MS = 60_000
 
+const KIND_LABELS: Record<PermissionKind, string> = {
+  read_out_of_scope: 'Read out-of-scope content',
+  user_section_edit: 'Edit your section',
+  destructive: 'Destructive action',
+}
+
 const chatStore = useChatStore()
-const showDetails = ref(false)
+const showReason = ref(false)
 let timer: ReturnType<typeof setTimeout> | null = null
+
+const kindLabel = computed(() => {
+  const req = chatStore.pendingPermissionRequest
+  return req ? KIND_LABELS[req.kind] : ''
+})
 
 function clearTimer() {
   if (timer !== null) {
@@ -27,7 +39,7 @@ function startTimer() {
 watch(
   () => chatStore.pendingPermissionRequest,
   (req) => {
-    showDetails.value = false
+    showReason.value = false
     if (req) startTimer()
     else clearTimer()
   },
@@ -51,25 +63,22 @@ function respond(approve: boolean) {
     >
       <div class="bg-[--bg-elev-1] border border-[--border-1] rounded-xl shadow-xl p-6 max-w-sm w-full mx-4">
         <h2 class="text-sm font-semibold text-[--fg-1] mb-2">Permission Request</h2>
-        <p class="text-sm text-[--fg-2] mb-4">{{ chatStore.pendingPermissionRequest.summary }}</p>
+        <p class="text-sm text-[--fg-2] mb-1">
+          <span class="font-medium">{{ kindLabel }}</span>
+        </p>
+        <p class="text-xs text-[--fg-3] font-mono mb-4 break-all">{{ chatStore.pendingPermissionRequest.target }}</p>
 
         <button
-          v-if="chatStore.pendingPermissionRequest.details.length"
+          v-if="chatStore.pendingPermissionRequest.reason_from_bot"
           type="button"
           class="text-xs text-[--fg-4] hover:text-[--fg-2] mb-3 transition-colors block"
-          @click="showDetails = !showDetails"
+          @click="showReason = !showReason"
         >
-          {{ showDetails ? 'Hide details' : 'Show more details' }}
+          {{ showReason ? 'Hide reason' : 'Show reason' }}
         </button>
 
-        <div v-if="showDetails" class="mb-4 space-y-1">
-          <div
-            v-for="d in chatStore.pendingPermissionRequest.details"
-            :key="d.label"
-            class="text-xs text-[--fg-3]"
-          >
-            <span class="font-medium text-[--fg-2]">{{ d.label }}:</span> {{ d.value }}
-          </div>
+        <div v-if="showReason && chatStore.pendingPermissionRequest.reason_from_bot" class="mb-4">
+          <p class="text-xs text-[--fg-3]">{{ chatStore.pendingPermissionRequest.reason_from_bot }}</p>
         </div>
 
         <div class="flex gap-2 justify-end">

--- a/frontend/src/components/__tests__/PermissionModal.test.ts
+++ b/frontend/src/components/__tests__/PermissionModal.test.ts
@@ -36,50 +36,72 @@ describe('PermissionModal', () => {
     const store = useChatStore()
     store.pendingPermissionRequest = {
       request_id: 'req1',
-      summary: 'Tether wants to delete tasks',
-      details: [],
+      kind: 'destructive',
+      target: 'tasks/2024-01-15',
+      reason_from_bot: null,
     }
     await wrapper.vm.$nextTick()
     expect(document.body.textContent).toContain('Permission Request')
-    expect(document.body.textContent).toContain('Tether wants to delete tasks')
+    expect(document.body.textContent).toContain('tasks/2024-01-15')
     wrapper.unmount()
   })
 
-  it('shows summary text', async () => {
+  it('shows kind label and target', async () => {
     const wrapper = mountModal()
     const store = useChatStore()
     store.pendingPermissionRequest = {
       request_id: 'req1',
-      summary: 'Allow reading calendar',
-      details: [],
+      kind: 'read_out_of_scope',
+      target: '/calendar/events',
+      reason_from_bot: null,
     }
     await wrapper.vm.$nextTick()
-    expect(document.body.textContent).toContain('Allow reading calendar')
+    expect(document.body.textContent).toContain('Read out-of-scope content')
+    expect(document.body.textContent).toContain('/calendar/events')
     wrapper.unmount()
   })
 
-  it('Show more details button toggles detail rows', async () => {
+  it('Show reason button toggles reason text', async () => {
     const wrapper = mountModal()
     const store = useChatStore()
     store.pendingPermissionRequest = {
       request_id: 'req1',
-      summary: 'Summary',
-      details: [{ label: 'File', value: '/etc/passwd' }],
+      kind: 'user_section_edit',
+      target: 'section/work',
+      reason_from_bot: 'Need to update your work section with new tasks.',
     }
     await wrapper.vm.$nextTick()
 
-    // Details hidden by default
-    expect(document.body.textContent).not.toContain('/etc/passwd')
+    // Reason hidden by default
+    expect(document.body.textContent).not.toContain('Need to update your work section')
 
-    // Click "Show more details"
+    // Click "Show reason"
     const showBtn = Array.from(document.querySelectorAll('button')).find(
-      b => b.textContent?.includes('Show more details')
+      b => b.textContent?.includes('Show reason')
     )
     expect(showBtn).toBeDefined()
     showBtn!.click()
     await wrapper.vm.$nextTick()
 
-    expect(document.body.textContent).toContain('/etc/passwd')
+    expect(document.body.textContent).toContain('Need to update your work section')
+    wrapper.unmount()
+  })
+
+  it('does not show reason button when reason_from_bot is null', async () => {
+    const wrapper = mountModal()
+    const store = useChatStore()
+    store.pendingPermissionRequest = {
+      request_id: 'req1',
+      kind: 'destructive',
+      target: 'tasks/old',
+      reason_from_bot: null,
+    }
+    await wrapper.vm.$nextTick()
+
+    const showBtn = Array.from(document.querySelectorAll('button')).find(
+      b => b.textContent?.includes('Show reason')
+    )
+    expect(showBtn).toBeUndefined()
     wrapper.unmount()
   })
 
@@ -89,8 +111,9 @@ describe('PermissionModal', () => {
     const spy = vi.spyOn(store, 'respondToPermission')
     store.pendingPermissionRequest = {
       request_id: 'req1',
-      summary: 'Ok?',
-      details: [],
+      kind: 'destructive',
+      target: 'tasks/old',
+      reason_from_bot: null,
     }
     await wrapper.vm.$nextTick()
 
@@ -109,8 +132,9 @@ describe('PermissionModal', () => {
     const spy = vi.spyOn(store, 'respondToPermission')
     store.pendingPermissionRequest = {
       request_id: 'req1',
-      summary: 'Ok?',
-      details: [],
+      kind: 'destructive',
+      target: 'tasks/old',
+      reason_from_bot: null,
     }
     await wrapper.vm.$nextTick()
 
@@ -131,8 +155,9 @@ describe('PermissionModal', () => {
       const spy = vi.spyOn(store, 'respondToPermission')
       store.pendingPermissionRequest = {
         request_id: 'req-timeout',
-        summary: 'Will you approve?',
-        details: [],
+        kind: 'destructive',
+        target: 'tasks/all',
+        reason_from_bot: null,
       }
       await wrapper.vm.$nextTick()
 
@@ -152,8 +177,9 @@ describe('PermissionModal', () => {
       const spy = vi.spyOn(store, 'respondToPermission')
       store.pendingPermissionRequest = {
         request_id: 'req1',
-        summary: 'Ok?',
-        details: [],
+        kind: 'destructive',
+        target: 'tasks/old',
+        reason_from_bot: null,
       }
       await wrapper.vm.$nextTick()
 
@@ -178,8 +204,9 @@ describe('PermissionModal', () => {
       const spy = vi.spyOn(store, 'respondToPermission')
       store.pendingPermissionRequest = {
         request_id: 'req1',
-        summary: 'Ok?',
-        details: [],
+        kind: 'destructive',
+        target: 'tasks/old',
+        reason_from_bot: null,
       }
       await wrapper.vm.$nextTick()
 
@@ -203,8 +230,9 @@ describe('PermissionModal', () => {
       const spy = vi.spyOn(store, 'respondToPermission')
       store.pendingPermissionRequest = {
         request_id: 'req1',
-        summary: 'Ok?',
-        details: [],
+        kind: 'destructive',
+        target: 'tasks/old',
+        reason_from_bot: null,
       }
       await wrapper.vm.$nextTick()
 

--- a/frontend/src/stores/__tests__/chat.test.ts
+++ b/frontend/src/stores/__tests__/chat.test.ts
@@ -97,8 +97,8 @@ describe('useChatStore', () => {
 
   it('send accumulates agent_action pills on bot message', async () => {
     setBotTransport(makeTransport([
-      { type: 'agent_action', session_id: 'test', action: 'Thinking', tool: 'reason' },
-      { type: 'agent_action', session_id: 'test', action: 'Running', tool: 'bash' },
+      { type: 'agent_action', session_id: 'test', id: 'id1', tool_name: 'reason', friendly_text: 'Thinking', status: 'starting' },
+      { type: 'agent_action', session_id: 'test', id: 'id2', tool_name: 'bash', friendly_text: 'Running', status: 'starting' },
       { type: 'turn_complete', session_id: 'test', final_text: 'done' },
     ]))
     setActivePinia(createPinia())
@@ -106,13 +106,13 @@ describe('useChatStore', () => {
     await store.send('hi')
     const bot = store.messages[1]
     expect(bot.actions).toHaveLength(2)
-    expect(bot.actions![0]).toMatchObject({ action: 'Thinking', tool: 'reason' })
-    expect(bot.actions![1]).toMatchObject({ action: 'Running', tool: 'bash' })
+    expect(bot.actions![0]).toMatchObject({ friendly_text: 'Thinking', tool_name: 'reason' })
+    expect(bot.actions![1]).toMatchObject({ friendly_text: 'Running', tool_name: 'bash' })
   })
 
   it('send sets statusMessage from status event, clears on turn_complete', async () => {
     setBotTransport(makeTransport([
-      { type: 'status', session_id: 'test', message: 'Thinking...' },
+      { type: 'status', session_id: 'test', phase: 'main_reasoning', text: 'Thinking...' },
       { type: 'turn_complete', session_id: 'test', final_text: 'done' },
     ]))
     setActivePinia(createPinia())
@@ -151,8 +151,9 @@ describe('useChatStore', () => {
         type: 'permission_request',
         session_id: 'sess1',
         request_id: 'req1',
-        summary: 'Allow file read',
-        details: [{ label: 'path', value: '/etc/passwd' }],
+        kind: 'user_section_edit',
+        target: 'Allow file read',
+        reason_from_bot: null,
       },
       { type: 'turn_complete', session_id: 'sess1', final_text: '' },
     ], { sendRaw }))
@@ -161,7 +162,8 @@ describe('useChatStore', () => {
     await store.send('hi')
     expect(store.pendingPermissionRequest).toMatchObject({
       request_id: 'req1',
-      summary: 'Allow file read',
+      kind: 'user_section_edit',
+      target: 'Allow file read',
     })
   })
 
@@ -171,15 +173,17 @@ describe('useChatStore', () => {
         type: 'permission_request',
         session_id: 'sess1',
         request_id: 'req1',
-        summary: 'First request',
-        details: [],
+        kind: 'user_section_edit',
+        target: 'First request',
+        reason_from_bot: null,
       },
       {
         type: 'permission_request',
         session_id: 'sess1',
         request_id: 'req2',
-        summary: 'Second request',
-        details: [],
+        kind: 'destructive',
+        target: 'Second request',
+        reason_from_bot: null,
       },
       { type: 'turn_complete', session_id: 'sess1', final_text: '' },
     ]))
@@ -199,8 +203,9 @@ describe('useChatStore', () => {
     // Manually set up a pending permission request
     store.pendingPermissionRequest = {
       request_id: 'req1',
-      summary: 'Test',
-      details: [],
+      kind: 'user_section_edit',
+      target: 'Test',
+      reason_from_bot: null,
     }
     store.respondToPermission('req1', true)
     expect(sendRaw).toHaveBeenCalledWith({
@@ -215,8 +220,8 @@ describe('useChatStore', () => {
     setBotTransport(makeTransport([], { sendRaw }))
     setActivePinia(createPinia())
     const store = useChatStore()
-    store.pendingPermissionRequest = { request_id: 'req1', summary: 'First', details: [] }
-    store.permissionQueue = [{ request_id: 'req2', summary: 'Second', details: [] }]
+    store.pendingPermissionRequest = { request_id: 'req1', kind: 'user_section_edit', target: 'First', reason_from_bot: null }
+    store.permissionQueue = [{ request_id: 'req2', kind: 'destructive', target: 'Second', reason_from_bot: null }]
     store.respondToPermission('req1', false)
     expect(store.pendingPermissionRequest?.request_id).toBe('req2')
     expect(store.permissionQueue).toHaveLength(0)

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -80,6 +80,12 @@ export const useChatStore = defineStore('chat', () => {
             statusMessage.value = ''
             isSessionActive.value = false
             return
+          case 'interrupted':
+            // Pool cancelled the stream (e.g. HTTP client disconnect).
+            // Clear in-progress indicators; bot message content is preserved.
+            statusMessage.value = ''
+            isSessionActive.value = false
+            return
           case 'session_ended':
             statusMessage.value = ''
             isSessionActive.value = false

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -45,15 +45,23 @@ export const useChatStore = defineStore('chat', () => {
           case 'agent_action': {
             activeSessionId.value = event.session_id
             const bot = messages.value[botMsgIndex]
-            ;(bot.actions ??= []).push({ action: event.action, tool: event.tool })
+            // Only track starting/running pills; complete just clears in-progress.
+            // Wave 2 (frontend-events-renderer) will render rich pill UI.
+            if (event.status !== 'complete') {
+              const existing = (bot.actions ??= []).find(a => a.friendly_text === event.friendly_text)
+              if (!existing) {
+                bot.actions!.push({ friendly_text: event.friendly_text, tool_name: event.tool_name })
+              }
+            }
             break
           }
           case 'permission_request': {
             activeSessionId.value = event.session_id
             const req: PermissionRequest = {
               request_id: event.request_id,
-              summary: event.summary,
-              details: event.details,
+              kind: event.kind,
+              target: event.target,
+              reason_from_bot: event.reason_from_bot,
             }
             if (!pendingPermissionRequest.value) {
               pendingPermissionRequest.value = req
@@ -64,7 +72,7 @@ export const useChatStore = defineStore('chat', () => {
           }
           case 'status':
             activeSessionId.value = event.session_id
-            statusMessage.value = event.message
+            statusMessage.value = event.text
             break
           case 'turn_complete':
             // final_text is canonical — overwrite accumulated deltas

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -10,27 +10,33 @@ export interface ChatMessage {
   role: ChatRole
   content: string
   ts: number     // epoch ms
-  actions?: Array<{ action: string; tool?: string }>
+  actions?: Array<{ friendly_text: string; tool_name?: string }>
   // Optional: Beacon-assigned priority for system messages. Absent = 'normal'.
   priority?: SystemMessagePriority
 }
 
-export interface PermissionDetail {
-  label: string
-  value: string
-}
+// permission_request event schema (v2 — Stream B)
+export type PermissionKind = 'read_out_of_scope' | 'user_section_edit' | 'destructive'
 
 export interface PermissionRequest {
   request_id: string
-  summary: string
-  details: PermissionDetail[]
+  kind: PermissionKind
+  target: string
+  reason_from_bot: string | null
 }
+
+// Status phase enum (v2 — Stream B)
+export type StatusPhase = 'classifier' | 'main_reasoning' | 'tool_call' | 'summarization'
+
+// AgentAction status lifecycle (v2 — Stream B)
+export type AgentActionStatus = 'starting' | 'running' | 'complete'
 
 export type WsIncomingEvent =
   | { type: 'agent_text_delta'; session_id: string; delta: string }
-  | { type: 'agent_action'; session_id: string; action: string; tool?: string }
-  | { type: 'permission_request'; session_id: string; request_id: string; summary: string; details: PermissionDetail[] }
-  | { type: 'status'; session_id: string; message: string }
+  | { type: 'agent_action'; session_id: string; id: string; tool_name: string; friendly_text: string; status: AgentActionStatus }
+  | { type: 'permission_request'; session_id: string; request_id: string; kind: PermissionKind; target: string; reason_from_bot: string | null }
+  | { type: 'status'; session_id: string; phase: StatusPhase; text: string }
   | { type: 'turn_complete'; session_id: string; final_text: string; tokens_used?: number }
+  | { type: 'interrupted'; session_id: string }
   | { type: 'session_ended'; session_id: string }
   | { type: 'trial_usage_update'; session_id: string; remaining: number }

--- a/interactive_agent_layer/permissions.py
+++ b/interactive_agent_layer/permissions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import uuid
+from collections.abc import Callable, Awaitable
 from typing import Any
 
 from interactive_agent_layer.config import get_permission_timeout
@@ -18,7 +19,6 @@ from interactive_agent_layer.translation import (
 )
 
 
-
 @dataclasses.dataclass
 class PermissionResultAllow:
     pass
@@ -27,6 +27,11 @@ class PermissionResultAllow:
 @dataclasses.dataclass
 class PermissionResultDeny:
     reason: str = "denied"
+
+
+# Type aliases for injected grant functions
+CheckGrantFn = Callable[[str, str, str, str], Awaitable[bool]]
+InsertGrantFn = Callable[[str, str, str, str], Awaitable[None]]
 
 
 class PermissionGate:
@@ -39,6 +44,14 @@ class PermissionGate:
     ``outbound_events`` receives permission_request dicts when a user_action tool
     needs approval.  Callers (run_turn) drain this queue and yield the events on
     the SSE stream so they cross the process boundary to the API / dispatch layer.
+
+    Grant functions (optional, injected for testability and DB-decoupling):
+        check_grant_fn(user_id, conversation_id, target, kind) -> bool
+            Returns True if a stored grant already covers this request; the gate
+            auto-allows and skips the interactive permission_request flow.
+        insert_grant_fn(user_id, conversation_id, target, kind) -> None
+            Called after the user approves to persist the grant for the
+            remainder of the conversation.
     """
 
     def __init__(
@@ -47,11 +60,15 @@ class PermissionGate:
         session: Any,       # Session — avoid circular import
         outbound_events: asyncio.Queue,
         auto_approve_user_actions: bool = False,
+        check_grant_fn: CheckGrantFn | None = None,
+        insert_grant_fn: InsertGrantFn | None = None,
     ) -> None:
         self._table = translation_table
         self._session = session
         self._outbound_events = outbound_events
         self._auto_approve = auto_approve_user_actions
+        self._check_grant_fn = check_grant_fn
+        self._insert_grant_fn = insert_grant_fn
 
     async def can_use_tool(
         self,
@@ -75,26 +92,37 @@ class PermissionGate:
         if self._auto_approve:
             return PermissionResultAllow()
 
-        # Emit permission_request, await user response
+        # Human-readable target derived from the permission_summary template.
+        target = entry.permission_summary.format_map(ForgivingMap(args))
+        kind = entry.kind
+        conv_id: str = getattr(self._session, "conversation_id", None) or ""
+
+        # Check existing per-conversation grant — skip the interactive flow if found.
+        if self._check_grant_fn is not None:
+            granted = await self._check_grant_fn(
+                self._session.user_id, conv_id, target, kind
+            )
+            if granted:
+                return PermissionResultAllow()
+
+        # Emit permission_request on the outbound queue — run_turn drains this and
+        # yields the event on the SSE stream so it crosses the process boundary to
+        # dispatch / the API layer.  WSPublisher is intentionally not used here: it
+        # only works within the same OS process.
         request_id = str(uuid.uuid4())
-        detail = args.get(entry.permission_detail_field, [])
-        summary = entry.permission_summary.format_map(ForgivingMap(args))
 
         loop = asyncio.get_running_loop()
         future: asyncio.Future[bool] = loop.create_future()
         self._session.permission_pending[request_id] = future
 
-        # Emit on the outbound queue — run_turn drains this and yields the
-        # event on the SSE stream so it crosses the process boundary to
-        # dispatch / the API layer.  WSPublisher is intentionally not used
-        # here: it only works within the same OS process.
         await self._outbound_events.put(
             {
                 "type": "permission_request",
                 "session_id": self._session.session_id,
                 "request_id": request_id,
-                "summary": summary,
-                "details": detail,
+                "kind": kind,
+                "target": target,
+                "reason_from_bot": None,
             }
         )
 
@@ -107,5 +135,10 @@ class PermissionGate:
             approved = False
         finally:
             self._session.permission_pending.pop(request_id, None)
+
+        if approved and self._insert_grant_fn is not None:
+            await self._insert_grant_fn(
+                self._session.user_id, conv_id, target, kind
+            )
 
         return PermissionResultAllow() if approved else PermissionResultDeny()

--- a/interactive_agent_layer/session.py
+++ b/interactive_agent_layer/session.py
@@ -43,6 +43,11 @@ class Session:
     created_at: float = dataclasses.field(default_factory=time.time)
     permission_pending: dict = dataclasses.field(default_factory=dict)
     coalescing_buffer: CoalescingBuffer = dataclasses.field(default_factory=CoalescingBuffer)
+    # Optional: linked conversation for per-conversation permission grants.
+    conversation_id: str | None = None
+    # Tracks the last emitted agent_action so we can synthesize a 'complete'
+    # status when the next distinct tool_use or turn_complete arrives.
+    last_emitted_action: dict | None = None
 
 
 def _stable_options_hash(options: dict) -> str:
@@ -84,6 +89,8 @@ class Layer:
         user_ws_id: str,
         agent_version: str,
         options: dict,
+        *,
+        conversation_id: str | None = None,
     ) -> Session:
         session_id = str(uuid.uuid4())
         session = Session(
@@ -92,6 +99,7 @@ class Layer:
             user_ws_id=user_ws_id,
             agent_version=agent_version,
             options=options,
+            conversation_id=conversation_id,
         )
         self.sessions[session_id] = session
         return session
@@ -246,10 +254,22 @@ async def _translate_event(
     table: TranslationTable,
     session: Session,
 ) -> AsyncIterator[dict]:
-    """Translate a raw SDK event to one or more layer events."""
+    """Translate a raw SDK event to one or more layer events.
+
+    agent_action lifecycle (heuristic — no tool_result in pool stream):
+      - First tool_use for a (tool_name, phrase) key  → status='starting'
+      - Repeat within coalescing window              → status='running', same id
+      - New tool_use with a different id arrives     → emit 'complete' for the
+                                                       previous, then 'starting'
+      - turn_complete (result event) arrives         → emit 'complete' for any
+                                                       in-flight action, then
+                                                       emit turn_complete
+    """
     # Pool uses {"event": "cancelled"} (SSE event-field convention) when the
     # subprocess is interrupted — check this key first before the type dispatch.
     if sdk_event.get("event") == "cancelled":
+        # Clear any in-flight action without emitting complete on interrupt.
+        session.last_emitted_action = None
         yield {"type": "interrupted", "session_id": session_id}
         return
 
@@ -264,6 +284,10 @@ async def _translate_event(
         return
 
     if event_type == "result":
+        # Synthesize 'complete' for any action still in flight.
+        if session.last_emitted_action:
+            yield {**session.last_emitted_action, "status": "complete"}
+            session.last_emitted_action = None
         yield {
             "type": "turn_complete",
             "session_id": session_id,
@@ -278,31 +302,52 @@ async def _translate_event(
         entry = table.lookup(tool_name)
 
         if isinstance(entry, PassthroughEntry):
+            # Passthrough tools (e.g. send_status_update) emit a status event
+            # with phase='tool_call' so the frontend can show inline progress.
             yield {
                 "type": "status",
                 "session_id": session_id,
-                "message": args.get("text", ""),
+                "phase": "tool_call",
+                "text": args.get("text", ""),
             }
             return
 
         phrase = table.interpolate_phrase(entry, args)
         action_id, coalesced = session.coalescing_buffer.record(tool_name, phrase)
-        yield {
+
+        # If a DIFFERENT action is in flight, mark it complete before this one starts.
+        if session.last_emitted_action and session.last_emitted_action["id"] != action_id:
+            yield {**session.last_emitted_action, "status": "complete"}
+
+        status = "running" if coalesced else "starting"
+        event: dict = {
             "type": "agent_action",
             "session_id": session_id,
-            "action_id": action_id,
-            "action": phrase,
-            "coalesced": coalesced,
+            "id": action_id,
+            "tool_name": tool_name,
+            "friendly_text": phrase,
+            "status": status,
         }
+        session.last_emitted_action = event
+        yield event
         return
 
     if event_type == "status":
+        # Forwarded from bot pipeline phase signals (bot.py / register.py calls
+        # status_fn at classifier, main_reasoning, summarization transitions).
+        # The caller is responsible for supplying 'phase'; default to 'main_reasoning'.
         yield {
             "type": "status",
             "session_id": session_id,
-            "message": sdk_event.get("message", ""),
+            "phase": sdk_event.get("phase", "main_reasoning"),
+            "text": sdk_event.get("text", sdk_event.get("message", "")),
         }
         return
 
-    # Unknown event — forward as status for visibility
-    yield {"type": "status", "session_id": session_id, "message": str(sdk_event)}
+    # Unknown event — forward as status for visibility (phase unknown → main_reasoning)
+    yield {
+        "type": "status",
+        "session_id": session_id,
+        "phase": "main_reasoning",
+        "text": str(sdk_event),
+    }

--- a/interactive_agent_layer/translation.py
+++ b/interactive_agent_layer/translation.py
@@ -36,6 +36,7 @@ class UserActionEntry:
     phrase_short: str
     permission_summary: str
     permission_detail_field: str
+    kind: str  # "user_section_edit" | "destructive" | "read_out_of_scope"
 
 
 TranslationEntry = Union[BackgroundEntry, BackgroundHiddenEntry, PassthroughEntry, UserActionEntry]
@@ -99,5 +100,6 @@ def _parse_entry(data: dict) -> TranslationEntry:
             phrase_short=data["phrase_short"],
             permission_summary=data["permission_summary"],
             permission_detail_field=data["permission_detail_field"],
+            kind=data["kind"],
         )
     raise ValueError(f"Unknown translation entry type: {t!r}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ premium = [
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
+    "pytest-timeout>=0.5",
     "httpx>=0.27",
     "fakeredis>=2.20",
 ]
@@ -58,4 +59,5 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 markers = [
     "integration: mark test as requiring a real claude binary",
+    "timeout: abort test after N seconds (requires pytest-timeout)",
 ]

--- a/tests/interactive_agent_layer/test_control_protocol.py
+++ b/tests/interactive_agent_layer/test_control_protocol.py
@@ -215,7 +215,7 @@ async def test_control_request_user_action_user_approves():
 
     perm_events = [e for e in events if e.get("type") == "permission_request"]
     assert len(perm_events) == 1
-    assert perm_events[0]["summary"] == "Update 1 tasks"
+    assert perm_events[0]["target"] == "Update 1 tasks"
 
     assert len(pool._send_control_calls) == 1
     assert pool._send_control_calls[0]["decision"] == "allow"

--- a/tests/interactive_agent_layer/test_new_event_schemas.py
+++ b/tests/interactive_agent_layer/test_new_event_schemas.py
@@ -14,6 +14,8 @@ import pathlib
 
 import pytest
 
+pytestmark = pytest.mark.timeout(60)
+
 from interactive_agent_layer.permissions import (
     PermissionGate,
     PermissionResultAllow,

--- a/tests/interactive_agent_layer/test_new_event_schemas.py
+++ b/tests/interactive_agent_layer/test_new_event_schemas.py
@@ -1,0 +1,432 @@
+"""Failing tests for new event schemas (TDD — written before implementation).
+
+Tests here are pure-Python (no DB). They define the TARGET schemas for
+agent_action, permission_request, and status and will fail against the
+current implementation, serving as the green line to work toward.
+
+permission_grants DB tests live in tests/db/test_permission_grants.py and
+run in the postgres-tests CI lane.
+"""
+from __future__ import annotations
+
+import asyncio
+import pathlib
+
+import pytest
+
+from interactive_agent_layer.permissions import (
+    PermissionGate,
+    PermissionResultAllow,
+    PermissionResultDeny,
+)
+from interactive_agent_layer.session import Layer, Session
+from interactive_agent_layer.translation import TranslationTable
+from interactive_agent_layer.ws_publisher import WSPublisher
+
+
+# ---------------------------------------------------------------------------
+# Helpers / pool stubs
+# ---------------------------------------------------------------------------
+
+def _yaml_path() -> pathlib.Path:
+    return (
+        pathlib.Path(__file__).parent.parent.parent
+        / "config"
+        / "agent_translations.yaml"
+    )
+
+
+def _make_layer(pool_client) -> Layer:
+    return Layer(
+        pool_client=pool_client,
+        ws_publisher=WSPublisher(),
+        translation_table=TranslationTable.from_yaml(_yaml_path()),
+    )
+
+
+class _SingleToolPool:
+    """One tool_use then result."""
+    async def acquire(self, user_id, options_hash, options, timeout_seconds=None):
+        return f"h-{user_id}"
+    async def query_stream(self, handle_id, prompt, session_id="default"):
+        yield {"type": "tool_use", "tool_name": "get_anchors", "args": {}}
+        yield {"type": "result", "final_text": "done", "tokens_used": 1}
+    async def release(self, handle_id, *, reusable=False): pass
+    async def interrupt(self, handle_id): pass
+
+
+class _SameToolTwicePool:
+    """Same tool_use twice (within coalescing window) then result."""
+    async def acquire(self, user_id, options_hash, options, timeout_seconds=None):
+        return f"h-{user_id}"
+    async def query_stream(self, handle_id, prompt, session_id="default"):
+        yield {"type": "tool_use", "tool_name": "get_anchors", "args": {}}
+        yield {"type": "tool_use", "tool_name": "get_anchors", "args": {}}
+        yield {"type": "result", "final_text": "done", "tokens_used": 1}
+    async def release(self, handle_id, *, reusable=False): pass
+    async def interrupt(self, handle_id): pass
+
+
+class _TwoToolPool:
+    """Two different tool_use events then result."""
+    async def acquire(self, user_id, options_hash, options, timeout_seconds=None):
+        return f"h-{user_id}"
+    async def query_stream(self, handle_id, prompt, session_id="default"):
+        yield {"type": "tool_use", "tool_name": "get_anchors", "args": {}}
+        yield {"type": "tool_use", "tool_name": "get_plan", "args": {}}
+        yield {"type": "result", "final_text": "done", "tokens_used": 1}
+    async def release(self, handle_id, *, reusable=False): pass
+    async def interrupt(self, handle_id): pass
+
+
+class _StatusEventPool:
+    """Raw SDK status event (phase signal from bot pipeline)."""
+    async def acquire(self, user_id, options_hash, options, timeout_seconds=None):
+        return f"h-{user_id}"
+    async def query_stream(self, handle_id, prompt, session_id="default"):
+        yield {"type": "status", "phase": "main_reasoning", "text": "Thinking…"}
+        yield {"type": "result", "final_text": "done", "tokens_used": 1}
+    async def release(self, handle_id, *, reusable=False): pass
+    async def interrupt(self, handle_id): pass
+
+
+class _PassthroughPool:
+    """send_status_update tool_use (passthrough entry)."""
+    async def acquire(self, user_id, options_hash, options, timeout_seconds=None):
+        return f"h-{user_id}"
+    async def query_stream(self, handle_id, prompt, session_id="default"):
+        yield {"type": "tool_use", "tool_name": "send_status_update",
+               "args": {"text": "Still working"}}
+        yield {"type": "result", "final_text": "done", "tokens_used": 1}
+    async def release(self, handle_id, *, reusable=False): pass
+    async def interrupt(self, handle_id): pass
+
+
+# ---------------------------------------------------------------------------
+# agent_action — new schema
+# ---------------------------------------------------------------------------
+
+async def test_agent_action_has_new_schema_fields():
+    """tool_use -> agent_action must carry id, tool_name, friendly_text, status."""
+    layer = _make_layer(_SingleToolPool())
+    s = layer.create_session("u1", "ws1", "v1", {})
+    events = [e async for e in layer.run_turn(s.session_id, "hi")]
+
+    actions = [e for e in events if e["type"] == "agent_action"]
+    assert actions, "Expected at least one agent_action"
+    a = actions[0]
+
+    # New required fields
+    assert "id" in a, "agent_action must have 'id' (was action_id)"
+    assert "tool_name" in a, "agent_action must have 'tool_name'"
+    assert "friendly_text" in a, "agent_action must have 'friendly_text' (was action)"
+    assert "status" in a, "agent_action must have 'status'"
+
+    # Old fields gone
+    assert "action_id" not in a, "must not carry old 'action_id'"
+    assert "action" not in a, "must not carry old 'action'"
+    assert "coalesced" not in a, "must not carry old 'coalesced'"
+
+
+async def test_agent_action_friendly_text_from_translation_table():
+    """friendly_text is populated from the YAML translation table."""
+    layer = _make_layer(_SingleToolPool())
+    s = layer.create_session("u1", "ws1", "v1", {})
+    events = [e async for e in layer.run_turn(s.session_id, "hi")]
+
+    starting = [e for e in events
+                if e["type"] == "agent_action" and e.get("status") == "starting"]
+    assert starting
+    assert starting[0]["friendly_text"] == "Reading your schedule"
+    assert starting[0]["tool_name"] == "get_anchors"
+
+
+async def test_agent_action_status_starting_on_first_call():
+    """First tool_use for a tool -> status='starting'."""
+    layer = _make_layer(_SingleToolPool())
+    s = layer.create_session("u1", "ws1", "v1", {})
+    events = [e async for e in layer.run_turn(s.session_id, "hi")]
+
+    starting = [e for e in events
+                if e["type"] == "agent_action" and e.get("status") == "starting"]
+    assert starting, "Expected at least one agent_action with status='starting'"
+
+
+async def test_agent_action_status_running_on_repeated_call():
+    """Repeated tool_use within coalescing window -> same id, status='running'."""
+    layer = _make_layer(_SameToolTwicePool())
+    s = layer.create_session("u1", "ws1", "v1", {})
+    events = [e async for e in layer.run_turn(s.session_id, "hi")]
+
+    # Filter to the non-complete agent_action events (starting + running).
+    # The complete event is also emitted for the same tool when result arrives.
+    actions = [
+        e for e in events
+        if e["type"] == "agent_action"
+        and e.get("tool_name") == "get_anchors"
+        and e.get("status") != "complete"
+    ]
+    assert len(actions) == 2, f"Expected 2 non-complete agent_action for get_anchors, got {len(actions)}"
+    assert actions[0]["id"] == actions[1]["id"], "Coalesced calls must share 'id'"
+    assert actions[0]["status"] == "starting"
+    assert actions[1]["status"] == "running"
+
+
+async def test_agent_action_complete_emitted_before_turn_complete():
+    """turn_complete arrival -> complete event for in-flight action emitted first."""
+    layer = _make_layer(_SingleToolPool())
+    s = layer.create_session("u1", "ws1", "v1", {})
+    events = [e async for e in layer.run_turn(s.session_id, "hi")]
+
+    complete = [e for e in events
+                if e["type"] == "agent_action" and e.get("status") == "complete"]
+    assert complete, "Expected agent_action with status='complete'"
+
+    complete_idx = next(i for i, e in enumerate(events)
+                        if e["type"] == "agent_action" and e.get("status") == "complete")
+    tc_idx = next(i for i, e in enumerate(events) if e["type"] == "turn_complete")
+    assert complete_idx < tc_idx, "complete must precede turn_complete"
+
+
+async def test_agent_action_complete_id_matches_starting():
+    """complete event carries same id as the starting event for that call."""
+    layer = _make_layer(_SingleToolPool())
+    s = layer.create_session("u1", "ws1", "v1", {})
+    events = [e async for e in layer.run_turn(s.session_id, "hi")]
+
+    actions = [e for e in events if e["type"] == "agent_action"]
+    starting = [a for a in actions if a["status"] == "starting"]
+    complete = [a for a in actions if a["status"] == "complete"]
+    assert starting and complete
+    assert starting[0]["id"] == complete[0]["id"]
+
+
+async def test_agent_action_complete_emitted_when_different_tool_arrives():
+    """When a second different tool arrives, previous tool gets complete first."""
+    layer = _make_layer(_TwoToolPool())
+    s = layer.create_session("u1", "ws1", "v1", {})
+    events = [e async for e in layer.run_turn(s.session_id, "hi")]
+
+    actions = [e for e in events if e["type"] == "agent_action"]
+    # get_anchors must be complete before get_plan starts
+    anchors_complete = next(
+        (i for i, a in enumerate(actions)
+         if a.get("tool_name") == "get_anchors" and a.get("status") == "complete"),
+        None,
+    )
+    plan_start = next(
+        (i for i, a in enumerate(actions)
+         if a.get("tool_name") == "get_plan" and a.get("status") == "starting"),
+        None,
+    )
+    assert anchors_complete is not None, "get_anchors must emit complete"
+    assert plan_start is not None, "get_plan must emit starting"
+    assert anchors_complete < plan_start, "complete(get_anchors) must precede starting(get_plan)"
+
+
+# ---------------------------------------------------------------------------
+# permission_request — new schema
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _patch_timeout(monkeypatch):
+    monkeypatch.setattr(
+        "interactive_agent_layer.permissions.get_permission_timeout",
+        lambda: 30,
+    )
+
+
+async def _gate_emit_event(
+    table, session, tool_name, args, *, resolve=True,
+    check_grant_fn=None, insert_grant_fn=None,
+):
+    """Run PermissionGate.can_use_tool, capture the emitted event, resolve the future."""
+    queue: asyncio.Queue = asyncio.Queue()
+    gate = PermissionGate(
+        translation_table=table,
+        session=session,
+        outbound_events=queue,
+        auto_approve_user_actions=False,
+        check_grant_fn=check_grant_fn,
+        insert_grant_fn=insert_grant_fn,
+    )
+    task = asyncio.create_task(gate.can_use_tool(tool_name, args, None))
+    event = await asyncio.wait_for(queue.get(), timeout=5.0)
+    fut = session.permission_pending.get(event.get("request_id"))
+    if fut and not fut.done():
+        fut.set_result(resolve)
+    result = await task
+    return result, event
+
+
+@pytest.fixture
+def table():
+    return TranslationTable.from_yaml(_yaml_path())
+
+
+@pytest.fixture
+def session():
+    return Session(
+        session_id="s1", user_id="u1", user_ws_id="ws1",
+        agent_version="v1", options={},
+    )
+
+
+async def test_permission_request_new_schema_fields(table, session):
+    """permission_request must carry kind, target, reason_from_bot (not summary/details)."""
+    _, event = await _gate_emit_event(table, session, "upsert_tasks",
+                                      {"count": 3, "tasks": ["t1"]})
+    assert "kind" in event, "must have 'kind'"
+    assert "target" in event, "must have 'target'"
+    assert "reason_from_bot" in event, "must have 'reason_from_bot' (may be None)"
+    assert "summary" not in event, "must NOT have old 'summary'"
+    assert "details" not in event, "must NOT have old 'details'"
+
+
+async def test_permission_request_kind_upsert_tasks_is_user_section_edit(table, session):
+    _, event = await _gate_emit_event(table, session, "upsert_tasks",
+                                      {"count": 1, "tasks": ["t1"]})
+    assert event["kind"] == "user_section_edit"
+
+
+async def test_permission_request_kind_delete_tasks_is_destructive(table, session):
+    _, event = await _gate_emit_event(table, session, "delete_tasks",
+                                      {"count": 1, "operations": []})
+    assert event["kind"] == "destructive"
+
+
+async def test_permission_request_kind_upsert_context_is_user_section_edit(table, session):
+    _, event = await _gate_emit_event(table, session, "upsert_context",
+                                      {"subject": "work notes", "nodes": []})
+    assert event["kind"] == "user_section_edit"
+
+
+async def test_permission_request_kind_delete_context_is_destructive(table, session):
+    _, event = await _gate_emit_event(table, session, "delete_context",
+                                      {"subject": "old notes", "operations": []})
+    assert event["kind"] == "destructive"
+
+
+async def test_permission_request_kind_is_valid_enum(table, session):
+    valid_kinds = {"read_out_of_scope", "user_section_edit", "destructive"}
+    _, event = await _gate_emit_event(table, session, "upsert_tasks",
+                                      {"count": 1, "tasks": []})
+    assert event["kind"] in valid_kinds
+
+
+async def test_permission_request_target_is_human_readable_string(table, session):
+    _, event = await _gate_emit_event(table, session, "upsert_tasks",
+                                      {"count": 2, "tasks": ["t1", "t2"]})
+    assert isinstance(event["target"], str) and event["target"]
+
+
+async def test_permission_gate_skips_request_when_grant_exists(table, session):
+    """check_grant_fn returning True auto-allows without emitting permission_request."""
+    async def _has_grant(user_id, conversation_id, target, kind):
+        return True
+
+    queue: asyncio.Queue = asyncio.Queue()
+    gate = PermissionGate(
+        translation_table=table,
+        session=session,
+        outbound_events=queue,
+        auto_approve_user_actions=False,
+        check_grant_fn=_has_grant,
+    )
+    result = await gate.can_use_tool("upsert_tasks", {"count": 1, "tasks": []}, None)
+    assert isinstance(result, PermissionResultAllow)
+    assert queue.empty(), "No permission_request should be emitted when grant exists"
+
+
+async def test_permission_gate_inserts_grant_on_approval(table):
+    """On user approval, insert_grant_fn is called with user_id, conversation_id, target, kind."""
+    session_with_conv = Session(
+        session_id="s2", user_id="u2", user_ws_id="ws2",
+        agent_version="v1", options={}, conversation_id="conv-123",
+    )
+    inserted: list[dict] = []
+
+    async def _no_grant(user_id, conversation_id, target, kind):
+        return False
+
+    async def _insert(user_id, conversation_id, target, kind):
+        inserted.append({"user_id": user_id, "conv": conversation_id,
+                         "target": target, "kind": kind})
+
+    _, event = await _gate_emit_event(
+        table, session_with_conv, "upsert_tasks", {"count": 1, "tasks": ["t"]},
+        resolve=True, check_grant_fn=_no_grant, insert_grant_fn=_insert,
+    )
+    assert len(inserted) == 1
+    assert inserted[0]["user_id"] == "u2"
+    assert inserted[0]["conv"] == "conv-123"
+
+
+async def test_permission_gate_no_insert_on_denial(table, session):
+    """On user denial, insert_grant_fn is NOT called."""
+    inserted: list = []
+
+    async def _no_grant(uid, cid, target, kind):
+        return False
+
+    async def _insert(uid, cid, target, kind):
+        inserted.append(kind)
+
+    _, _ = await _gate_emit_event(
+        table, session, "upsert_tasks", {"count": 1, "tasks": []},
+        resolve=False, check_grant_fn=_no_grant, insert_grant_fn=_insert,
+    )
+    assert inserted == []
+
+
+# ---------------------------------------------------------------------------
+# status — new schema (phase + text, not message)
+# ---------------------------------------------------------------------------
+
+async def test_status_event_has_phase_and_text_not_message():
+    """SDK status event -> layer status with 'phase' and 'text', not 'message'."""
+    layer = _make_layer(_StatusEventPool())
+    s = layer.create_session("u1", "ws1", "v1", {})
+    events = [e async for e in layer.run_turn(s.session_id, "hi")]
+
+    status_evts = [e for e in events if e["type"] == "status"]
+    assert status_evts, "Expected at least one status event"
+    ev = status_evts[0]
+    assert "phase" in ev, "status must have 'phase'"
+    assert "text" in ev, "status must have 'text'"
+    assert "message" not in ev, "status must NOT have old 'message'"
+
+
+async def test_status_phase_forwarded_from_sdk_event():
+    """status.phase carries the phase from the SDK event."""
+    layer = _make_layer(_StatusEventPool())
+    s = layer.create_session("u1", "ws1", "v1", {})
+    events = [e async for e in layer.run_turn(s.session_id, "hi")]
+
+    status_evts = [e for e in events if e["type"] == "status"]
+    assert status_evts[0]["phase"] == "main_reasoning"
+    assert status_evts[0]["text"] == "Thinking…"
+
+
+async def test_passthrough_tool_emits_status_with_phase_tool_call():
+    """send_status_update passthrough -> status with phase='tool_call'."""
+    layer = _make_layer(_PassthroughPool())
+    s = layer.create_session("u1", "ws1", "v1", {})
+    events = [e async for e in layer.run_turn(s.session_id, "hi")]
+
+    status_evts = [e for e in events if e["type"] == "status"]
+    assert status_evts, "Expected status from send_status_update"
+    assert status_evts[0]["phase"] == "tool_call"
+    assert status_evts[0]["text"] == "Still working"
+
+
+async def test_status_phase_valid_enum():
+    """status.phase must be a member of the defined enum."""
+    layer = _make_layer(_StatusEventPool())
+    s = layer.create_session("u1", "ws1", "v1", {})
+    events = [e async for e in layer.run_turn(s.session_id, "hi")]
+
+    valid = {"classifier", "main_reasoning", "tool_call", "summarization"}
+    for ev in events:
+        if ev["type"] == "status":
+            assert ev["phase"] in valid, f"Invalid phase: {ev['phase']!r}"

--- a/tests/interactive_agent_layer/test_permissions.py
+++ b/tests/interactive_agent_layer/test_permissions.py
@@ -6,6 +6,8 @@ import pathlib
 
 import pytest
 
+pytestmark = pytest.mark.timeout(60)
+
 from interactive_agent_layer.permissions import (
     PermissionGate,
     PermissionResultAllow,

--- a/tests/interactive_agent_layer/test_permissions.py
+++ b/tests/interactive_agent_layer/test_permissions.py
@@ -163,8 +163,9 @@ async def test_user_action_no_auto_approve_and_user_approves(table, session):
     assert event["type"] == "permission_request"
     assert event["session_id"] == "sess-1"
     assert "request_id" in event
-    assert "summary" in event
-    assert "details" in event
+    assert "kind" in event
+    assert "target" in event
+    assert "reason_from_bot" in event
 
 
 # ---------------------------------------------------------------------------
@@ -202,15 +203,15 @@ async def test_user_action_denied_by_user(table, session):
 
 
 # ---------------------------------------------------------------------------
-# 8. permission_summary interpolation
+# 8. target interpolation (was: permission_summary interpolation)
 # ---------------------------------------------------------------------------
 
-async def test_permission_summary_interpolation(table, session):
+async def test_permission_target_interpolation(table, session):
     _, event = await _run_with_queue(
         table, session, "upsert_tasks", {"count": 3, "tasks": []},
         resolve_value=True,
     )
-    assert event["summary"] == "Update 3 tasks"
+    assert event["target"] == "Update 3 tasks"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/interactive_agent_layer/test_session.py
+++ b/tests/interactive_agent_layer/test_session.py
@@ -187,7 +187,7 @@ async def test_tool_use_emits_agent_action(layer):
     agent_actions = [e for e in events if e["type"] == "agent_action"]
     assert len(agent_actions) >= 1
     # get_anchors maps to "Reading your schedule"
-    actions_text = [e["action"] for e in agent_actions]
+    actions_text = [e["friendly_text"] for e in agent_actions]
     assert "Reading your schedule" in actions_text
 
 
@@ -199,12 +199,12 @@ async def test_passthrough_emits_status(layer):
         events.append(event)
 
     status_events = [e for e in events if e["type"] == "status"]
-    messages = [e["message"] for e in status_events]
-    assert "Still working" in messages
+    texts = [e["text"] for e in status_events]
+    assert "Still working" in texts
 
 
 async def test_coalescing_same_tool_deduplicates(layer):
-    """Two calls to same background tool within window → same action_id, second coalesced."""
+    """Two calls to same background tool within window → same id, second status='running'."""
     s = layer.create_session("user1", "wsid1", "v1", {})
     events = []
     async for event in layer.run_turn(s.session_id, "first turn"):
@@ -212,14 +212,23 @@ async def test_coalescing_same_tool_deduplicates(layer):
     async for event in layer.run_turn(s.session_id, "second turn"):
         events.append(event)
 
-    # get_anchors appears in both turns — second should be coalesced
-    get_anchors_events = [
+    # get_anchors appears in both turns — the starting events share the same id
+    # within the coalescing window; the second call emits status='running'.
+    get_anchors_starting = [
         e for e in events
-        if e["type"] == "agent_action" and e.get("action") == "Reading your schedule"
+        if e["type"] == "agent_action"
+        and e.get("friendly_text") == "Reading your schedule"
+        and e.get("status") == "starting"
     ]
-    assert len(get_anchors_events) == 2
-    assert get_anchors_events[0]["action_id"] == get_anchors_events[1]["action_id"]
-    assert get_anchors_events[1]["coalesced"] is True
+    get_anchors_running = [
+        e for e in events
+        if e["type"] == "agent_action"
+        and e.get("friendly_text") == "Reading your schedule"
+        and e.get("status") == "running"
+    ]
+    assert len(get_anchors_starting) >= 1
+    assert len(get_anchors_running) >= 1
+    assert get_anchors_starting[0]["id"] == get_anchors_running[0]["id"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Migrates all three interactive-layer event types** to the memory-context-v2 spec (breaking schema change; frontend updated in same PR to avoid 2.0 regression)
- **`agent_action`**: `action_id/action/coalesced` → `id/tool_name/friendly_text/status`; adds `starting|running|complete` lifecycle heuristic (complete synthesized when next tool arrives or turn ends)
- **`permission_request`**: `summary/details` → `kind/target/reason_from_bot`; adds `kind` enum (`user_section_edit|destructive|read_out_of_scope`); adds `check_grant_fn`/`insert_grant_fn` injection to `PermissionGate` for per-conversation grant skip
- **`status`**: `message` → `phase+text`; `phase` forwarded from SDK event (bot pipeline emits at transitions); passthrough tools (`send_status_update`) emit `phase='tool_call'`
- **`permission_grants` table** (migration `k1l2m3n4o5p6`): per-conversation grant storage with RLS; gate functions are injected (not wired to DB in production yet — intentionally staged for Wave 2 wiring)
- **Frontend minimal update**: `src/types/chat.ts` + `src/stores/chat.ts` field renames; `interrupted` event now clears statusMessage
- **Translation YAML**: added `kind` to user_action entries; added new 2.5 tools (`read_context`, `write_node_memory`, etc.)

## Test plan

- [ ] `pytest tests/interactive_agent_layer/ -v` — 139 passing (21 new in `test_new_event_schemas.py`)
- [ ] `cd frontend && npm run test -- --run` — 913 passing (5 pre-existing `usePoolWarm` failures are unrelated and on `dev` already)
- [ ] `vue-tsc --noEmit` — exit 0
- [ ] CI postgres-tests lane: `k1l2m3n4o5p6_permission_grants` migration (new table, RLS, FK, index)
- [ ] Note: `permission_grants` table is created but DB wiring of grant functions is not in this PR — Wave 2 / Stream C follow-up

## Locked schemas (for Wave 2 frontend-events-renderer)

```json
agent_action:      { "type": "agent_action", "session_id": str, "id": str, "tool_name": str, "friendly_text": str, "status": "starting"|"running"|"complete" }
permission_request: { "type": "permission_request", "session_id": str, "request_id": str, "kind": "read_out_of_scope"|"user_section_edit"|"destructive", "target": str, "reason_from_bot": str|null }
status:            { "type": "status", "session_id": str, "phase": "classifier"|"main_reasoning"|"tool_call"|"summarization", "text": str }
```