### PR TITLE
db: merge alembic migration heads (stream A + stream B)

### DIFF
--- a/db/migrations/versions/f6232ca1d274_merge_stream_a_and_stream_b_migration_.py
+++ b/db/migrations/versions/f6232ca1d274_merge_stream_a_and_stream_b_migration_.py
@@ -1,0 +1,28 @@
+"""merge stream A and stream B migration heads
+
+Revision ID: f6232ca1d274
+Revises: l1m2n3o4p5q6, k1l2m3n4o5p6
+Create Date: 2026-06-04 12:35:25.837234
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f6232ca1d274'
+down_revision: Union[str, Sequence[str], None] = ('l1m2n3o4p5q6', 'k1l2m3n4o5p6')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
Resolves dual alembic head state introduced when PRs #443 and #444 both branched migration chains from j1k2l3m4n5o6. No schema changes — merge point only.