### PR TITLE
feat(frontend): Stream D event renderer — action pills, status indicator

### DIFF
--- a/frontend/src/components/AgentActionPill.vue
+++ b/frontend/src/components/AgentActionPill.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { useChatStore } from '../stores/chat'
+
+const chatStore = useChatStore()
+</script>
+
+<template>
+  <div v-if="chatStore.activeActions.size > 0" class="flex flex-col gap-1 px-3 py-2">
+    <div
+      v-for="[id, action] in chatStore.activeActions"
+      :key="id"
+      data-pill
+      class="flex items-center gap-2 px-3 py-1.5 rounded-full bg-[--bg-elev-2] text-xs text-[--fg-3] w-fit"
+      :class="action.status === 'complete' ? 'opacity-40' : 'opacity-100'"
+    >
+      <!-- Spinner for starting/running -->
+      <span
+        v-if="action.status !== 'complete'"
+        :data-status="action.status"
+        class="inline-block w-3 h-3 border-2 border-[--fg-4] border-t-[--accent] rounded-full animate-spin"
+      />
+      <!-- Checkmark for complete -->
+      <span
+        v-else
+        :data-status="action.status"
+        class="inline-flex items-center justify-center w-3 h-3 text-[--status-done-fg]"
+      >
+        <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" class="w-3 h-3">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M2 6l3 3 5-5" />
+        </svg>
+      </span>
+      <span>{{ action.friendly_text }}</span>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/BotChat.vue
+++ b/frontend/src/components/BotChat.vue
@@ -5,6 +5,8 @@ import { useAgentPickerStore } from '../stores/agentPicker'
 import MessageBubble from './MessageBubble.vue'
 import AgentPicker from './AgentPicker.vue'
 import PermissionModal from './PermissionModal.vue'
+import AgentActionPill from './AgentActionPill.vue'
+import StatusIndicator from './StatusIndicator.vue'
 
 const emit = defineEmits<{ close: [] }>()
 
@@ -78,6 +80,7 @@ function onKeydown(e: KeyboardEvent) {
       <p v-if="chatStore.messages.length === 0" class="text-xs text-[--fg-5] text-center pt-8">
         Send a message to start chatting.
       </p>
+      <AgentActionPill />
       <p v-if="chatStore.statusMessage" class="text-xs text-[--fg-4] text-center animate-pulse">
         {{ chatStore.statusMessage }}
       </p>
@@ -88,11 +91,13 @@ function onKeydown(e: KeyboardEvent) {
       class="border-t border-[--border-1] p-3 flex gap-2 flex-shrink-0"
       @submit.prevent="onSubmit"
     >
+      <StatusIndicator />
       <textarea
         v-model="draft"
         rows="1"
         placeholder="Message Tether…"
         class="flex-1 bg-[--bg-input] text-[--fg-1] border border-[--border-input] rounded-lg px-3 py-2 text-sm outline-none resize-none focus:ring-1 focus:ring-[--accent]"
+        :disabled="chatStore.isStreaming || !!chatStore.pendingPermissionRequest"
         @keydown.enter.exact.prevent="onSubmit"
       />
       <button
@@ -106,7 +111,7 @@ function onKeydown(e: KeyboardEvent) {
       </button>
       <button
         type="submit"
-        :disabled="chatStore.isStreaming || !draft.trim()"
+        :disabled="chatStore.isStreaming || !draft.trim() || !!chatStore.pendingPermissionRequest"
         class="text-xs px-3 rounded-lg bg-[--bg-elev-2] text-[--fg-2] hover:bg-[--bg-elev-3] disabled:opacity-30 transition-colors self-end py-2"
       >
         Send

--- a/frontend/src/components/StatusIndicator.vue
+++ b/frontend/src/components/StatusIndicator.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useChatStore } from '../stores/chat'
+import type { StatusPhase } from '../types/chat'
+
+const PHASE_LABELS: Record<StatusPhase, string> = {
+  classifier: 'Classifying…',
+  main_reasoning: 'Thinking…',
+  tool_call: 'Using tools…',
+  summarization: 'Summarizing…',
+}
+
+const chatStore = useChatStore()
+
+const phaseLabel = computed(() =>
+  chatStore.currentPhase ? PHASE_LABELS[chatStore.currentPhase] : null
+)
+</script>
+
+<template>
+  <div v-if="chatStore.currentPhase" class="flex flex-col items-center gap-0.5 py-1">
+    <span class="text-xs text-[--fg-4] animate-pulse">{{ phaseLabel }}</span>
+    <span v-if="chatStore.statusMessage" class="text-xs text-[--fg-5]">
+      {{ chatStore.statusMessage }}
+    </span>
+  </div>
+</template>

--- a/frontend/src/components/__tests__/AgentActionPill.test.ts
+++ b/frontend/src/components/__tests__/AgentActionPill.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { vi } from 'vitest'
+import AgentActionPill from '../AgentActionPill.vue'
+import { useChatStore } from '../../stores/chat'
+import { setBotTransport } from '../../composables/useBotTransport'
+import { makeTransport } from '../../stores/__tests__/testHelpers'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ path: '/dashboard' }),
+}))
+
+describe('AgentActionPill', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    setBotTransport(makeTransport([]))
+  })
+
+  it('renders nothing when activeActions map is empty', () => {
+    const wrapper = mount(AgentActionPill)
+    expect(wrapper.text()).toBe('')
+  })
+
+  it('shows a pill when an action with status starting is in the store', async () => {
+    const store = useChatStore()
+    store.activeActions.set('act1', {
+      id: 'act1',
+      tool_name: 'reason',
+      friendly_text: 'Thinking hard',
+      status: 'starting',
+    })
+    const wrapper = mount(AgentActionPill)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('Thinking hard')
+  })
+
+  it('shows friendly_text as label', async () => {
+    const store = useChatStore()
+    store.activeActions.set('act1', {
+      id: 'act1',
+      tool_name: 'bash',
+      friendly_text: 'Running bash command',
+      status: 'running',
+    })
+    const wrapper = mount(AgentActionPill)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('Running bash command')
+  })
+
+  it('shows spinner indicator for starting status', async () => {
+    const store = useChatStore()
+    store.activeActions.set('act1', {
+      id: 'act1',
+      tool_name: 'reason',
+      friendly_text: 'Starting up',
+      status: 'starting',
+    })
+    const wrapper = mount(AgentActionPill)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-status="starting"]').exists()).toBe(true)
+  })
+
+  it('shows spinner indicator for running status', async () => {
+    const store = useChatStore()
+    store.activeActions.set('act1', {
+      id: 'act1',
+      tool_name: 'bash',
+      friendly_text: 'Running',
+      status: 'running',
+    })
+    const wrapper = mount(AgentActionPill)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-status="running"]').exists()).toBe(true)
+  })
+
+  it('shows checkmark indicator for complete status', async () => {
+    const store = useChatStore()
+    store.activeActions.set('act1', {
+      id: 'act1',
+      tool_name: 'reason',
+      friendly_text: 'Done thinking',
+      status: 'complete',
+    })
+    const wrapper = mount(AgentActionPill)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-status="complete"]').exists()).toBe(true)
+  })
+
+  it('multiple actions render multiple pills', async () => {
+    const store = useChatStore()
+    store.activeActions.set('act1', {
+      id: 'act1',
+      tool_name: 'reason',
+      friendly_text: 'Thinking',
+      status: 'starting',
+    })
+    store.activeActions.set('act2', {
+      id: 'act2',
+      tool_name: 'bash',
+      friendly_text: 'Running bash',
+      status: 'running',
+    })
+    const wrapper = mount(AgentActionPill)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('Thinking')
+    expect(wrapper.text()).toContain('Running bash')
+    expect(wrapper.findAll('[data-pill]').length).toBe(2)
+  })
+
+  it('complete actions have reduced opacity class', async () => {
+    const store = useChatStore()
+    store.activeActions.set('act1', {
+      id: 'act1',
+      tool_name: 'reason',
+      friendly_text: 'Done',
+      status: 'complete',
+    })
+    const wrapper = mount(AgentActionPill)
+    await wrapper.vm.$nextTick()
+    const pill = wrapper.find('[data-pill]')
+    expect(pill.classes().some(c => c.includes('opacity'))).toBe(true)
+  })
+})

--- a/frontend/src/components/__tests__/StatusIndicator.test.ts
+++ b/frontend/src/components/__tests__/StatusIndicator.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { vi } from 'vitest'
+import StatusIndicator from '../StatusIndicator.vue'
+import { useChatStore } from '../../stores/chat'
+import { setBotTransport } from '../../composables/useBotTransport'
+import { makeTransport } from '../../stores/__tests__/testHelpers'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ path: '/dashboard' }),
+}))
+
+describe('StatusIndicator', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    setBotTransport(makeTransport([]))
+  })
+
+  it('renders nothing when currentPhase is null', () => {
+    const wrapper = mount(StatusIndicator)
+    expect(wrapper.text()).toBe('')
+  })
+
+  it('shows "Classifying…" for phase classifier', async () => {
+    const store = useChatStore()
+    store.currentPhase = 'classifier'
+    const wrapper = mount(StatusIndicator)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('Classifying…')
+  })
+
+  it('shows "Thinking…" for phase main_reasoning', async () => {
+    const store = useChatStore()
+    store.currentPhase = 'main_reasoning'
+    const wrapper = mount(StatusIndicator)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('Thinking…')
+  })
+
+  it('shows "Using tools…" for phase tool_call', async () => {
+    const store = useChatStore()
+    store.currentPhase = 'tool_call'
+    const wrapper = mount(StatusIndicator)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('Using tools…')
+  })
+
+  it('shows "Summarizing…" for phase summarization', async () => {
+    const store = useChatStore()
+    store.currentPhase = 'summarization'
+    const wrapper = mount(StatusIndicator)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('Summarizing…')
+  })
+
+  it('shows statusMessage text when present', async () => {
+    const store = useChatStore()
+    store.currentPhase = 'main_reasoning'
+    store.statusMessage = 'Processing your request...'
+    const wrapper = mount(StatusIndicator)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('Processing your request...')
+  })
+
+  it('does not show statusMessage when currentPhase is null', async () => {
+    const store = useChatStore()
+    store.currentPhase = null
+    store.statusMessage = 'Some message'
+    const wrapper = mount(StatusIndicator)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toBe('')
+  })
+})

--- a/frontend/src/stores/__tests__/chat.activeActions.test.ts
+++ b/frontend/src/stores/__tests__/chat.activeActions.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useChatStore } from '../chat'
+import { setBotTransport } from '../../composables/useBotTransport'
+import { makeTransport } from './testHelpers'
+import type { WsIncomingEvent } from '../../types/chat'
+
+describe('useChatStore — activeActions & currentPhase', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    setBotTransport(makeTransport([]))
+  })
+
+  it('activeActions map is empty initially', () => {
+    const store = useChatStore()
+    expect(store.activeActions.size).toBe(0)
+  })
+
+  it('activeActions is updated when agent_action events arrive (starting)', async () => {
+    setBotTransport(makeTransport([
+      { type: 'agent_action', session_id: 'test', id: 'act1', tool_name: 'reason', friendly_text: 'Thinking', status: 'starting' },
+      { type: 'turn_complete', session_id: 'test', final_text: 'done' },
+    ]))
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    await store.send('hi')
+    // After turn_complete activeActions is cleared
+    expect(store.activeActions.size).toBe(0)
+  })
+
+  it('activeActions holds all actions during streaming', async () => {
+    let capturedSize = -1
+    const events: WsIncomingEvent[] = [
+      { type: 'agent_action', session_id: 'test', id: 'act1', tool_name: 'reason', friendly_text: 'Thinking', status: 'starting' },
+      { type: 'agent_action', session_id: 'test', id: 'act2', tool_name: 'bash', friendly_text: 'Running bash', status: 'running' },
+    ]
+    // Use a transport that lets us capture mid-stream state
+    const transport = makeTransport([
+      ...events,
+      { type: 'turn_complete', session_id: 'test', final_text: 'done' },
+    ])
+    const origSend = transport.send.bind(transport)
+    transport.send = async function* (text: string, av: string) {
+      for await (const event of origSend(text, av)) {
+        yield event
+        if (event.type === 'agent_action' && event.id === 'act2') {
+          // Capture size after second action
+          capturedSize = store.activeActions.size
+        }
+      }
+    }
+    setBotTransport(transport)
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    await store.send('hi')
+    expect(capturedSize).toBe(2)
+  })
+
+  it('activeActions entries have correct shape', async () => {
+    let capturedAction: unknown = null
+    const transport = makeTransport([
+      { type: 'agent_action', session_id: 'test', id: 'act1', tool_name: 'reason', friendly_text: 'Thinking', status: 'starting' },
+      { type: 'turn_complete', session_id: 'test', final_text: 'done' },
+    ])
+    const origSend = transport.send.bind(transport)
+    transport.send = async function* (text: string, av: string) {
+      for await (const event of origSend(text, av)) {
+        yield event
+        if (event.type === 'agent_action') {
+          capturedAction = store.activeActions.get('act1')
+        }
+      }
+    }
+    setBotTransport(transport)
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    await store.send('hi')
+    expect(capturedAction).toMatchObject({
+      id: 'act1',
+      tool_name: 'reason',
+      friendly_text: 'Thinking',
+      status: 'starting',
+    })
+  })
+
+  it('activeActions upserts on same id (status transition)', async () => {
+    let capturedAfterComplete: unknown = null
+    const transport = makeTransport([
+      { type: 'agent_action', session_id: 'test', id: 'act1', tool_name: 'reason', friendly_text: 'Thinking', status: 'starting' },
+      { type: 'agent_action', session_id: 'test', id: 'act1', tool_name: 'reason', friendly_text: 'Thinking', status: 'complete' },
+      { type: 'turn_complete', session_id: 'test', final_text: 'done' },
+    ])
+    const origSend = transport.send.bind(transport)
+    let eventCount = 0
+    transport.send = async function* (text: string, av: string) {
+      for await (const event of origSend(text, av)) {
+        yield event
+        if (event.type === 'agent_action' && ++eventCount === 2) {
+          // After second agent_action (complete), map should still have 1 entry
+          capturedAfterComplete = store.activeActions.get('act1')
+        }
+      }
+    }
+    setBotTransport(transport)
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    await store.send('hi')
+    expect((capturedAfterComplete as { status: string })?.status).toBe('complete')
+  })
+
+  it('activeActions is cleared on turn_complete', async () => {
+    setBotTransport(makeTransport([
+      { type: 'agent_action', session_id: 'test', id: 'act1', tool_name: 'r', friendly_text: 'X', status: 'running' },
+      { type: 'turn_complete', session_id: 'test', final_text: 'done' },
+    ]))
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    await store.send('hi')
+    expect(store.activeActions.size).toBe(0)
+  })
+
+  it('activeActions is cleared on session_ended', async () => {
+    setBotTransport(makeTransport([
+      { type: 'agent_action', session_id: 'test', id: 'act1', tool_name: 'r', friendly_text: 'X', status: 'running' },
+      { type: 'session_ended', session_id: 'test' },
+    ]))
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    await store.send('hi')
+    expect(store.activeActions.size).toBe(0)
+  })
+
+  it('activeActions is cleared on interrupted', async () => {
+    setBotTransport(makeTransport([
+      { type: 'agent_action', session_id: 'test', id: 'act1', tool_name: 'r', friendly_text: 'X', status: 'running' },
+      { type: 'interrupted', session_id: 'test' },
+    ]))
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    await store.send('hi')
+    expect(store.activeActions.size).toBe(0)
+  })
+
+  it('currentPhase is null initially', () => {
+    const store = useChatStore()
+    expect(store.currentPhase).toBeNull()
+  })
+
+  it('currentPhase is set from status events', async () => {
+    let capturedPhase: string | null = null
+    const transport = makeTransport([
+      { type: 'status', session_id: 'test', phase: 'main_reasoning', text: 'Thinking...' },
+      { type: 'turn_complete', session_id: 'test', final_text: 'done' },
+    ])
+    const origSend = transport.send.bind(transport)
+    transport.send = async function* (text: string, av: string) {
+      for await (const event of origSend(text, av)) {
+        yield event
+        if (event.type === 'status') {
+          capturedPhase = store.currentPhase
+        }
+      }
+    }
+    setBotTransport(transport)
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    await store.send('hi')
+    expect(capturedPhase).toBe('main_reasoning')
+  })
+
+  it('currentPhase is cleared on turn_complete', async () => {
+    setBotTransport(makeTransport([
+      { type: 'status', session_id: 'test', phase: 'classifier', text: 'Classifying' },
+      { type: 'turn_complete', session_id: 'test', final_text: 'done' },
+    ]))
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    await store.send('hi')
+    expect(store.currentPhase).toBeNull()
+  })
+
+  it('currentPhase is cleared on session_ended', async () => {
+    setBotTransport(makeTransport([
+      { type: 'status', session_id: 'test', phase: 'tool_call', text: 'Using tools' },
+      { type: 'session_ended', session_id: 'test' },
+    ]))
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    await store.send('hi')
+    expect(store.currentPhase).toBeNull()
+  })
+
+  it('respondToPermission sends decision: approve when approve=true', () => {
+    const sendRaw = vi.fn()
+    setBotTransport(makeTransport([], { sendRaw }))
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    store.pendingPermissionRequest = {
+      request_id: 'req1',
+      kind: 'user_section_edit',
+      target: 'Test',
+      reason_from_bot: null,
+    }
+    store.respondToPermission('req1', true)
+    expect(sendRaw).toHaveBeenCalledWith({
+      type: 'permission_response',
+      request_id: 'req1',
+      decision: 'approve',
+    })
+  })
+
+  it('respondToPermission sends decision: deny when approve=false', () => {
+    const sendRaw = vi.fn()
+    setBotTransport(makeTransport([], { sendRaw }))
+    setActivePinia(createPinia())
+    const store = useChatStore()
+    store.pendingPermissionRequest = {
+      request_id: 'req1',
+      kind: 'destructive',
+      target: 'Test',
+      reason_from_bot: null,
+    }
+    store.respondToPermission('req1', false)
+    expect(sendRaw).toHaveBeenCalledWith({
+      type: 'permission_response',
+      request_id: 'req1',
+      decision: 'deny',
+    })
+  })
+})

--- a/frontend/src/stores/__tests__/chat.test.ts
+++ b/frontend/src/stores/__tests__/chat.test.ts
@@ -211,7 +211,7 @@ describe('useChatStore', () => {
     expect(sendRaw).toHaveBeenCalledWith({
       type: 'permission_response',
       request_id: 'req1',
-      approve: true,
+      decision: 'approve',
     })
   })
 

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -1,8 +1,15 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import type { ChatMessage, PermissionRequest } from '../types/chat'
+import type { ChatMessage, PermissionRequest, AgentActionStatus, StatusPhase } from '../types/chat'
 import { getBotTransport } from '../composables/useBotTransport'
 import { useAgentPickerStore } from './agentPicker'
+
+interface LiveAgentAction {
+  id: string
+  tool_name: string
+  friendly_text: string
+  status: AgentActionStatus
+}
 
 function makeId(): string {
   if (location.protocol === 'https:') return crypto.randomUUID()
@@ -18,6 +25,8 @@ export const useChatStore = defineStore('chat', () => {
   const statusMessage = ref('')
   const pendingPermissionRequest = ref<PermissionRequest | null>(null)
   const permissionQueue = ref<PermissionRequest[]>([])
+  const activeActions = ref<Map<string, LiveAgentAction>>(new Map())
+  const currentPhase = ref<StatusPhase | null>(null)
 
   // Register heartbeat via a stable wrapper so it always reflects the current
   // transport, even after setBotTransport() replaces it post-auth.
@@ -45,14 +54,21 @@ export const useChatStore = defineStore('chat', () => {
           case 'agent_action': {
             activeSessionId.value = event.session_id
             const bot = messages.value[botMsgIndex]
-            // Only track starting/running pills; complete just clears in-progress.
-            // Wave 2 (frontend-events-renderer) will render rich pill UI.
+            // Only track starting/running pills on bot.actions for legacy display;
+            // complete just clears in-progress for that path.
             if (event.status !== 'complete') {
               const existing = (bot.actions ??= []).find(a => a.friendly_text === event.friendly_text)
               if (!existing) {
                 bot.actions!.push({ friendly_text: event.friendly_text, tool_name: event.tool_name })
               }
             }
+            // Upsert into activeActions for rich pill UI (all statuses)
+            activeActions.value.set(event.id, {
+              id: event.id,
+              tool_name: event.tool_name,
+              friendly_text: event.friendly_text,
+              status: event.status,
+            })
             break
           }
           case 'permission_request': {
@@ -73,21 +89,28 @@ export const useChatStore = defineStore('chat', () => {
           case 'status':
             activeSessionId.value = event.session_id
             statusMessage.value = event.text
+            currentPhase.value = event.phase
             break
           case 'turn_complete':
             // final_text is canonical — overwrite accumulated deltas
             messages.value[botMsgIndex].content = event.final_text
             statusMessage.value = ''
+            currentPhase.value = null
+            activeActions.value.clear()
             isSessionActive.value = false
             return
           case 'interrupted':
             // Pool cancelled the stream (e.g. HTTP client disconnect).
             // Clear in-progress indicators; bot message content is preserved.
             statusMessage.value = ''
+            currentPhase.value = null
+            activeActions.value.clear()
             isSessionActive.value = false
             return
           case 'session_ended':
             statusMessage.value = ''
+            currentPhase.value = null
+            activeActions.value.clear()
             isSessionActive.value = false
             return
           case 'trial_usage_update':
@@ -102,7 +125,7 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   function respondToPermission(requestId: string, approve: boolean): void {
-    getBotTransport().sendRaw({ type: 'permission_response', request_id: requestId, approve })
+    getBotTransport().sendRaw({ type: 'permission_response', request_id: requestId, decision: approve ? 'approve' : 'deny' })
     pendingPermissionRequest.value = permissionQueue.value.shift() ?? null
   }
 
@@ -120,6 +143,8 @@ export const useChatStore = defineStore('chat', () => {
     statusMessage,
     pendingPermissionRequest,
     permissionQueue,
+    activeActions,
+    currentPhase,
     send,
     respondToPermission,
     sendInterrupt,


### PR DESCRIPTION
## Summary
- Adds `AgentActionPill.vue`: live pill display for agent tool use (starting/running/complete lifecycle)
- Adds `StatusIndicator.vue`: subtle pipeline phase indicator (classifier/main_reasoning/tool_call/summarization)
- Updates `chat.ts` store: `activeActions` Map ref, `currentPhase` ref, fixes `permission_response` to send `decision: 'approve'|'deny'`
- Wires components into `BotChat.vue`; blocks input while permission modal is pending
- PermissionModal already updated in prior PR (no schema changes needed)

## Test plan
- [ ] AgentActionPill unit tests pass (new)
- [ ] StatusIndicator unit tests pass (new)
- [ ] Store activeActions/currentPhase tests pass (new)
- [ ] Existing PermissionModal tests pass (no regression)
- [ ] Existing BotChat tests pass (no regression)
- [ ] `npm run build` zero type errors