### PR TITLE
feat(mcp): harden write_node_memory read-before-write + read_context conversation_id enforcement

### DIFF
--- a/tests/mcp/test_read_context_enforcement.py
+++ b/tests/mcp/test_read_context_enforcement.py
@@ -1,0 +1,160 @@
+"""Tests for read_context v2 enforcement: conversation_id required.
+
+All tests mock the DB layer — no Postgres required.
+
+Enforcement rules (v2):
+  1. conversation_id is required — returns {"error": "conversation_id_required", ...}
+     immediately if absent (no scope enforcement, no reads).
+  2. Scope envelope (out_of_scope errors) are already structured dicts — verified here.
+  3. When conversation_id is provided, execution proceeds normally.
+"""
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+NODE_ID = "cccccccc-0000-0000-0000-000000000001"
+CONV_ID = "dddddddd-0000-0000-0000-000000000002"
+CURRENT_NODE = "eeeeeeee-0000-0000-0000-000000000003"
+
+# Patch targets for execute_read_context internals
+PATCH_TARGETS = [
+    "db.pg_queries.get_node",
+    "db.pg_queries.get_node_by_path",
+    "db.pg_queries.get_children",
+    "db.pg_queries.node_memory.log_node_read",
+    "db.pg_queries.node_memory.get_context_node_id_for_conversation",
+    "db.pg_queries.node_memory.get_node_tree_distance",
+]
+
+
+@pytest.fixture
+def conn():
+    return AsyncMock()
+
+
+def _make_mocks() -> dict:
+    mocks = {t.split(".")[-1]: AsyncMock() for t in PATCH_TARGETS}
+    # Default: conversation is linked to CURRENT_NODE, nodes are in scope
+    mocks["get_context_node_id_for_conversation"].return_value = CURRENT_NODE
+    mocks["get_node_tree_distance"].return_value = 1  # within N=3
+    mocks["get_node"].return_value = {
+        "id": NODE_ID, "name": "Test Node",
+        "section_types": [], "children_count": 0,
+    }
+    mocks["get_node_by_path"].return_value = {
+        "id": NODE_ID, "name": "Test Node",
+        "section_types": [], "children_count": 0,
+    }
+    mocks["get_children"].return_value = []
+    return mocks
+
+
+@contextlib.contextmanager
+def _patch_all(mocks: dict):
+    with contextlib.ExitStack() as stack:
+        for t in PATCH_TARGETS:
+            key = t.split(".")[-1]
+            stack.enter_context(patch(t, mocks[key]))
+        yield mocks
+
+
+async def _run(conn, mocks, **kwargs):
+    with _patch_all(mocks):
+        from tether_mcp.tools.read_context import execute_read_context
+        return await execute_read_context(conn, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# B-1: conversation_id required
+# ---------------------------------------------------------------------------
+
+class TestConversationIdRequired:
+    @pytest.mark.asyncio
+    async def test_no_conversation_id_returns_error_dict(self, conn):
+        mocks = _make_mocks()
+        result = await _run(conn, mocks, conversation_id=None)
+        assert isinstance(result, dict), (
+            "Without conversation_id, result must be a dict error envelope, got list"
+        )
+        assert result.get("error") == "conversation_id_required"
+
+    @pytest.mark.asyncio
+    async def test_no_conversation_id_error_has_message(self, conn):
+        mocks = _make_mocks()
+        result = await _run(conn, mocks, conversation_id=None)
+        assert "message" in result
+
+    @pytest.mark.asyncio
+    async def test_no_conversation_id_does_not_query_db(self, conn):
+        """No DB calls should happen when conversation_id is missing."""
+        mocks = _make_mocks()
+        await _run(conn, mocks, conversation_id=None)
+        mocks["get_node"].assert_not_called()
+        mocks["get_node_by_path"].assert_not_called()
+        mocks["get_children"].assert_not_called()
+        mocks["get_context_node_id_for_conversation"].assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_conversation_id_with_paths_returns_error(self, conn):
+        mocks = _make_mocks()
+        result = await _run(conn, mocks, paths=["Work/Alpha"], conversation_id=None)
+        assert isinstance(result, dict)
+        assert result.get("error") == "conversation_id_required"
+
+    @pytest.mark.asyncio
+    async def test_no_conversation_id_with_node_ids_returns_error(self, conn):
+        mocks = _make_mocks()
+        result = await _run(conn, mocks, node_ids=[NODE_ID], conversation_id=None)
+        assert isinstance(result, dict)
+        assert result.get("error") == "conversation_id_required"
+
+
+# ---------------------------------------------------------------------------
+# B-2: happy path — conversation_id provided
+# ---------------------------------------------------------------------------
+
+class TestReadContextWithConversationId:
+    @pytest.mark.asyncio
+    async def test_with_conversation_id_returns_list(self, conn):
+        mocks = _make_mocks()
+        result = await _run(conn, mocks, conversation_id=CONV_ID)
+        assert isinstance(result, list)
+
+    @pytest.mark.asyncio
+    async def test_with_node_id_and_conversation_id_returns_list(self, conn):
+        mocks = _make_mocks()
+        result = await _run(conn, mocks, node_ids=[NODE_ID], conversation_id=CONV_ID)
+        assert isinstance(result, list)
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_scope_check_is_called_when_conversation_id_provided(self, conn):
+        mocks = _make_mocks()
+        await _run(conn, mocks, node_ids=[NODE_ID], conversation_id=CONV_ID, N=3)
+        mocks["get_context_node_id_for_conversation"].assert_called_once_with(conn, CONV_ID)
+
+    @pytest.mark.asyncio
+    async def test_out_of_scope_node_returns_structured_error_dict(self, conn):
+        """Out-of-scope nodes return {error: 'out_of_scope', ...} dicts, not exceptions."""
+        mocks = _make_mocks()
+        # Node is too far away — distance exceeds N
+        mocks["get_node_tree_distance"].return_value = None
+        result = await _run(conn, mocks, node_ids=[NODE_ID], conversation_id=CONV_ID, N=3)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        entry = result[0]
+        assert entry.get("error") == "out_of_scope"
+        assert "target" in entry
+        assert "message" in entry
+
+    @pytest.mark.asyncio
+    async def test_out_of_scope_does_not_raise_exception(self, conn):
+        """Scope violations must be structured responses, never unhandled exceptions."""
+        mocks = _make_mocks()
+        mocks["get_node_tree_distance"].return_value = None
+        # Should complete without raising
+        result = await _run(conn, mocks, node_ids=[NODE_ID], conversation_id=CONV_ID)
+        assert result is not None

--- a/tests/mcp/test_write_node_memory_enforcement.py
+++ b/tests/mcp/test_write_node_memory_enforcement.py
@@ -1,0 +1,226 @@
+"""Tests for write_node_memory v2 hard enforcement of read-before-write.
+
+All tests mock the DB layer — no Postgres required.
+
+Enforcement rules (v2):
+  1. conversation_id is required — returns error if absent.
+  2. A read of the target node must exist in node_read_log for the given
+     conversation_id before any write is allowed (additive, edit, delete).
+  3. If both requirements are met the write proceeds normally.
+"""
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+NODE_ID = "aaaaaaaa-0000-0000-0000-000000000001"
+CONV_ID = "bbbbbbbb-0000-0000-0000-000000000002"
+
+PATCH_TARGETS = [
+    "db.pg_queries.node_memory.has_read_node_in_conversation",
+    "db.pg_queries.node_memory.log_node_read",
+    "db.pg_queries.sections.get_section",
+    "db.pg_queries.sections.upsert_section",
+    "db.pg_queries.sections.append_section",
+    "db.pg_queries.sections.delete_section",
+]
+
+
+@pytest.fixture
+def conn():
+    return AsyncMock()
+
+
+def _make_mocks(has_read: bool = True) -> dict:
+    mocks = {t.split(".")[-1]: AsyncMock() for t in PATCH_TARGETS}
+    mocks["has_read_node_in_conversation"].return_value = has_read
+    mocks["get_section"].return_value = {"id": "sec-1", "body": "existing"}
+    return mocks
+
+
+@contextlib.contextmanager
+def _patch_all(mocks: dict):
+    with contextlib.ExitStack() as stack:
+        for t in PATCH_TARGETS:
+            key = t.split(".")[-1]
+            stack.enter_context(patch(t, mocks[key]))
+        yield mocks
+
+
+async def _run(conn, mocks, **kwargs):
+    with _patch_all(mocks):
+        from tether_mcp.tools.write_node_memory import execute_write_node_memory
+        return await execute_write_node_memory(conn, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# A-1: conversation_id required
+# ---------------------------------------------------------------------------
+
+class TestConversationIdRequired:
+    @pytest.mark.asyncio
+    async def test_additive_without_conversation_id_returns_error(self, conn):
+        mocks = _make_mocks()
+        result = await _run(
+            conn, mocks,
+            node_id=NODE_ID, title="notes", data_type="text", value="hello",
+            mode="additive",
+            conversation_id=None,
+        )
+        assert result.get("error") == "conversation_id_required"
+        mocks["append_section"].assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_edit_without_conversation_id_returns_error(self, conn):
+        mocks = _make_mocks()
+        result = await _run(
+            conn, mocks,
+            node_id=NODE_ID, title="notes", data_type="text", value="hello",
+            mode="edit",
+            conversation_id=None,
+        )
+        assert result.get("error") == "conversation_id_required"
+        mocks["upsert_section"].assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_without_conversation_id_returns_error(self, conn):
+        mocks = _make_mocks()
+        result = await _run(
+            conn, mocks,
+            node_id=NODE_ID, title="notes", data_type="text", value="",
+            mode="delete",
+            conversation_id=None,
+        )
+        assert result.get("error") == "conversation_id_required"
+        mocks["delete_section"].assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# A-2: read-before-write enforcement
+# ---------------------------------------------------------------------------
+
+class TestReadBeforeWriteEnforcement:
+    @pytest.mark.asyncio
+    async def test_additive_without_prior_read_returns_error(self, conn):
+        mocks = _make_mocks(has_read=False)
+        result = await _run(
+            conn, mocks,
+            node_id=NODE_ID, title="notes", data_type="text", value="hello",
+            mode="additive",
+            conversation_id=CONV_ID,
+        )
+        assert result.get("error") == "read_before_write_required"
+        mocks["append_section"].assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_edit_without_prior_read_returns_error(self, conn):
+        mocks = _make_mocks(has_read=False)
+        result = await _run(
+            conn, mocks,
+            node_id=NODE_ID, title="notes", data_type="text", value="hello",
+            mode="edit",
+            conversation_id=CONV_ID,
+        )
+        assert result.get("error") == "read_before_write_required"
+        mocks["upsert_section"].assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_without_prior_read_returns_error(self, conn):
+        mocks = _make_mocks(has_read=False)
+        result = await _run(
+            conn, mocks,
+            node_id=NODE_ID, title="notes", data_type="text", value="",
+            mode="delete",
+            conversation_id=CONV_ID,
+        )
+        assert result.get("error") == "read_before_write_required"
+        mocks["delete_section"].assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_has_read_check_uses_correct_args(self, conn):
+        """has_read_node_in_conversation is called with (conn, node_id, conversation_id)."""
+        mocks = _make_mocks(has_read=False)
+        await _run(
+            conn, mocks,
+            node_id=NODE_ID, title="notes", data_type="text", value="hi",
+            mode="edit",
+            conversation_id=CONV_ID,
+        )
+        mocks["has_read_node_in_conversation"].assert_called_once_with(conn, NODE_ID, CONV_ID)
+
+
+# ---------------------------------------------------------------------------
+# A-3: success path — read logged before write
+# ---------------------------------------------------------------------------
+
+class TestWriteSucceedsAfterRead:
+    @pytest.mark.asyncio
+    async def test_additive_with_prior_read_succeeds(self, conn):
+        mocks = _make_mocks(has_read=True)
+        result = await _run(
+            conn, mocks,
+            node_id=NODE_ID, title="notes", data_type="text", value="hello",
+            mode="additive",
+            conversation_id=CONV_ID,
+        )
+        assert result.get("status") == "ok"
+        assert result.get("mode") == "additive"
+        mocks["append_section"].assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_edit_with_prior_read_succeeds(self, conn):
+        mocks = _make_mocks(has_read=True)
+        result = await _run(
+            conn, mocks,
+            node_id=NODE_ID, title="notes", data_type="text", value="hello",
+            mode="edit",
+            conversation_id=CONV_ID,
+        )
+        assert result.get("status") == "ok"
+        assert result.get("mode") == "edit"
+        mocks["upsert_section"].assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_with_prior_read_succeeds(self, conn):
+        mocks = _make_mocks(has_read=True)
+        result = await _run(
+            conn, mocks,
+            node_id=NODE_ID, title="notes", data_type="text", value="",
+            mode="delete",
+            conversation_id=CONV_ID,
+        )
+        assert result.get("status") == "ok"
+        assert result.get("mode") == "delete"
+        mocks["delete_section"].assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_warning_in_success_response(self, conn):
+        """v2 success path must not include the advisory warning field."""
+        mocks = _make_mocks(has_read=True)
+        result = await _run(
+            conn, mocks,
+            node_id=NODE_ID, title="notes", data_type="text", value="hello",
+            mode="edit",
+            conversation_id=CONV_ID,
+        )
+        assert "warning" not in result
+
+
+# ---------------------------------------------------------------------------
+# A-4: invalid mode still errors before read check
+# ---------------------------------------------------------------------------
+
+class TestInvalidMode:
+    @pytest.mark.asyncio
+    async def test_invalid_mode_returns_error_regardless_of_conversation_id(self, conn):
+        mocks = _make_mocks()
+        result = await _run(
+            conn, mocks,
+            node_id=NODE_ID, title="notes", data_type="text", value="hi",
+            mode="INVALID",
+            conversation_id=CONV_ID,
+        )
+        assert result.get("error") == "invalid_mode"
+        mocks["has_read_node_in_conversation"].assert_not_called()

--- a/tests/tether_mcp/test_server.py
+++ b/tests/tether_mcp/test_server.py
@@ -58,11 +58,12 @@ async def test_read_tasks_all(seeded):
 
 
 @pytest.mark.asyncio
-async def test_read_context_roots(seeded):
+async def test_read_context_requires_conversation_id(seeded):
+    """v2: read_context without conversation_id returns a structured error, not a list."""
     from tether_mcp.server import read_context
     result = await read_context()
-    assert isinstance(result, list)
-    assert any("Work" in (r.get("path") or r.get("name", "")) for r in result)
+    assert isinstance(result, dict), "Expected error dict when conversation_id is absent"
+    assert result.get("error") == "conversation_id_required"
 
 
 @pytest.mark.asyncio

--- a/tether_mcp/server.py
+++ b/tether_mcp/server.py
@@ -127,8 +127,8 @@ async def read_context(
     """Read context nodes. No params=roots. depth: 0=node only, 1=children, -1=full subtree.
     Section bodies in cat-n format (1-indexed line numbers with tabs).
 
-    conversation_id: Current conversation UUID. Required for scope-envelope enforcement.
-        When absent, scope is not enforced (legacy/debug use — logs a warning).
+    conversation_id: Current conversation UUID. REQUIRED (v2) — returns
+        {error: 'conversation_id_required'} if absent.
     M: Detail level for node data summary (1=title, 2=one-liner, 3=themes, 4=full sections).
     N: Scope envelope — max tree-edges from conversation's context node. Nodes outside
         N edges return {error: 'out_of_scope', target: ...} instead of data.
@@ -213,11 +213,13 @@ async def write_node_memory(
     data_type:       Content type hint: 'text' | 'list' | 'json' | 'file'.
     value:           Content to write.
     mode:            'additive' (append) | 'edit' (replace) | 'delete'.
-    conversation_id: Current conversation UUID (for read-before-write advisory).
+    conversation_id: Current conversation UUID. REQUIRED (v2) — returns
+                     {error: 'conversation_id_required'} if absent.
     visible_to_user: False hides this section from user-facing reads.
 
-    Advisory: edit/delete without a prior read in this conversation logs a warning
-    but still allows the write (v1). v2 will hard-block on violation.
+    Enforcement (v2): conversation_id is required and a prior read_node_memory
+    call for this node in the same conversation must exist in node_read_log.
+    Returns {error: 'read_before_write_required'} if the read has not occurred.
     """
     from tether_mcp.tools.write_node_memory import execute_write_node_memory
     pool = await _get_pool()

--- a/tether_mcp/tools/read_context.py
+++ b/tether_mcp/tools/read_context.py
@@ -1,17 +1,15 @@
 """read_context tool — batched reads with depth traversal, sections (cat -n), tasks,
 M-level summary, scope envelope enforcement, and source filtering.
 
-New params added in memory-context v2:
-  conversation_id — when provided, enables N scope envelope enforcement.
-                    Optional (legacy callers without it get unscoped reads with a warning).
-                    Required for scope-envelope; v2 will make this mandatory.
+Params added/hardened in memory-context v2:
+  conversation_id — REQUIRED (v2). Returns {error: 'conversation_id_required'} if absent.
+                    Enables N scope envelope enforcement.
   M               — M-level detail for node data summary.
                     1=title only, 2=one-liner, 3=themes+abstract, 4=full (default: 4).
                     When M < last, returns from node_data_summary if cached;
-                    falls back to node_sections at M=4 (no descent gating in v1).
+                    falls back to node_sections at M=4.
   N               — Scope envelope in tree-edges from current_node.
-                    Requests outside N edges are rejected with {error: 'out_of_scope'}.
-                    Only enforced when conversation_id is provided.
+                    Requests outside N edges return {error: 'out_of_scope'}.
                     Note: children returned during depth traversal are also scope-checked;
                     out-of-scope children are replaced with {error: 'out_of_scope', ...}.
   source          — 'sections' | 'memory' | 'both' (default: 'sections').
@@ -190,7 +188,7 @@ async def execute_read_context(
     M: int = 4,
     N: int = 3,
     source: str = "sections",
-) -> list:
+) -> list | dict:
     """Fetch context nodes with optional depth traversal, section content, and linked tasks.
 
     Args:
@@ -204,22 +202,20 @@ async def execute_read_context(
         include_sections: If True, add "sections" dict grouped by section_type.
             Each section entry has {name, body (cat-n format), line_count, origin}.
         include_tasks: If True, add "tasks" list from get_node_tasks.
-        conversation_id: Current conversation UUID.
-            Required for scope-envelope enforcement (N param). When absent,
-            scope is not enforced and a warning is logged (legacy/debug use only).
-            v2 will make this mandatory once Stream C callers always provide it.
+        conversation_id: Current conversation UUID. Required (v2) — returns
+            {error: 'conversation_id_required'} if absent.
         M: M-level detail for node data (1=title, 2=one-liner, 3=themes, 4=full).
             When M < 4, returns from node_data_summary cache if available;
-            falls back to node_sections at M=4. No descent gating in v1.
+            falls back to node_sections at M=4.
         N: Scope envelope — max tree-edges from conversation's current_node.
             Requests outside N edges return {error: 'out_of_scope', ...}.
-            Only enforced when conversation_id is provided.
             Children during depth traversal are also scope-checked.
         source: 'sections' (default, user-authored) | 'memory' (bot-authored) | 'both'.
 
     Returns:
         List of node dicts (or error dicts for out-of-scope entries).
         If no paths and no node_ids, returns root nodes.
+        {error: 'conversation_id_required', message: str} if conversation_id is absent.
     """
     from db.pg_queries import get_node, get_node_by_path, get_children
     from db.pg_queries.node_memory import (
@@ -228,16 +224,15 @@ async def execute_read_context(
         get_node_tree_distance,
     )
 
-    # Resolve conversation scope
-    current_node_id: str | None = None
-    if conversation_id:
-        current_node_id = await get_context_node_id_for_conversation(conn, conversation_id)
-        # current_node_id may be None for conversations not linked to a context node
-    else:
-        logger.warning(
-            "read_context called without conversation_id (legacy/unscoped path) "
-            "— scope envelope not enforced"
-        )
+    # v2: conversation_id is required
+    if not conversation_id:
+        return {
+            "error": "conversation_id_required",
+            "message": "conversation_id is required for read_context in v2.",
+        }
+
+    # Resolve conversation scope (current_node_id may be None if conversation is unlinked)
+    current_node_id = await get_context_node_id_for_conversation(conn, conversation_id)
 
     async def _fetch_and_check(node: dict) -> dict:
         """Apply scope check, log read, build response."""

--- a/tether_mcp/tools/write_node_memory.py
+++ b/tether_mcp/tools/write_node_memory.py
@@ -5,13 +5,11 @@ Writes to node_sections with origin='conversation_agent'. Supports three modes:
   edit     — replace existing body entirely
   delete   — remove the named section
 
-Read-before-write enforcement (v1 ADVISORY):
-  On mode='edit' or mode='delete', checks node_read_log for any read of this
-  node in the current conversation. If no read is logged, emits a warning in
-  the response but allows the write.
-
-  v2 (post-Stream-C-stable): flip to hard block by returning
-  {error: 'read_before_write_violated', ...} instead of warning.
+Read-before-write enforcement (v2 HARD):
+  conversation_id is required. A read of the target node must exist in
+  node_read_log for the given conversation_id before any write is allowed
+  (additive, edit, or delete). Returns a structured error if either condition
+  is not met — no warning, no fallthrough.
 
 All SQL lives in db/pg_queries/sections.py and db/pg_queries/node_memory.py.
 """
@@ -45,13 +43,16 @@ async def execute_write_node_memory(
                          Used as the section_type; defaults to 'bot_notes'.
         value:           Content body to write.
         mode:            'additive' | 'edit' | 'delete'.
-        conversation_id: Current conversation ID for read-before-write advisory.
+        conversation_id: Current conversation UUID. Required — writes are rejected
+                         without it (v2 enforcement).
         visible_to_user: False hides this section from user-facing reads.
 
     Returns:
-        On success: {status: 'ok', node_id, title, mode, warning?: str}
+        On success: {status: 'ok', node_id, title, mode, section_type}
         On delete not found: {status: 'not_found', node_id, title}
         On bad mode: {error: 'invalid_mode', valid_modes: [...]}
+        On missing conversation_id: {error: 'conversation_id_required', message: str}
+        On missing prior read: {error: 'read_before_write_required', message: str}
     """
     from db.pg_queries.node_memory import has_read_node_in_conversation, log_node_read
     from db.pg_queries.sections import get_section, upsert_section, append_section, delete_section
@@ -62,19 +63,23 @@ async def execute_write_node_memory(
             "valid_modes": ["additive", "edit", "delete"],
         }
 
-    # Advisory read-before-write check for edit / delete
-    warning: str | None = None
-    if mode in ("edit", "delete") and conversation_id is not None:
-        has_read = await has_read_node_in_conversation(conn, node_id, conversation_id)
-        if not has_read:
-            warning = (
-                f"read_before_write_advisory: no read of node {node_id} logged "
-                f"in conversation {conversation_id} — writing anyway (v1 advisory mode)"
-            )
-            logger.warning(warning)
-    elif mode in ("edit", "delete") and conversation_id is None:
-        warning = "read_before_write_advisory: conversation_id not provided — skipping read check"
-        logger.warning(warning)
+    # v2: conversation_id is required for all writes
+    if conversation_id is None:
+        return {
+            "error": "conversation_id_required",
+            "message": "conversation_id is required for write_node_memory in v2.",
+        }
+
+    # v2: a read of this node must exist in node_read_log for this conversation
+    has_read = await has_read_node_in_conversation(conn, node_id, conversation_id)
+    if not has_read:
+        return {
+            "error": "read_before_write_required",
+            "message": (
+                "Must call read_node_memory for this node before writing "
+                "in the same conversation."
+            ),
+        }
 
     section_type = data_type if data_type else "bot_notes"
 
@@ -83,10 +88,7 @@ async def execute_write_node_memory(
         if existing is None:
             return {"status": "not_found", "node_id": node_id, "title": title}
         await delete_section(conn, node_id, section_type, name=title)
-        result = {"status": "ok", "node_id": node_id, "title": title, "mode": "delete"}
-        if warning:
-            result["warning"] = warning
-        return result
+        return {"status": "ok", "node_id": node_id, "title": title, "mode": "delete"}
 
     if mode == "additive":
         await append_section(
@@ -100,21 +102,17 @@ async def execute_write_node_memory(
         )
 
     # Log write as a read credit so future reads know this conversation touched the node
-    if conversation_id is not None:
-        try:
-            await log_node_read(
-                conn, node_id, 999, conversation_id=conversation_id, title=title
-            )
-        except Exception:
-            pass  # don't fail the write if log fails
+    try:
+        await log_node_read(
+            conn, node_id, 999, conversation_id=conversation_id, title=title
+        )
+    except Exception:
+        pass  # don't fail the write if log fails
 
-    result = {
+    return {
         "status": "ok",
         "node_id": node_id,
         "title": title,
         "mode": mode,
         "section_type": section_type,
     }
-    if warning:
-        result["warning"] = warning
-    return result


### PR DESCRIPTION
## Summary

Upgrades both memory MCP tools from advisory/optional to hard enforcement (v2):

**A — write_node_memory**
- `conversation_id` is now required; returns `{error: conversation_id_required}` if absent
- Read-before-write promoted from advisory WARN → hard block for all write modes (additive, edit, delete)
- Returns `{error: read_before_write_required}` when no `node_read_log` entry exists for `(conversation_id, node_id)` in the current conversation
- Removed v1 advisory `warning` field from success responses

**B — read_context**
- `conversation_id` is now required; returns `{error: conversation_id_required}` immediately if absent
- Scope envelope enforcement (`out_of_scope` structured errors) confirmed already correct — no exceptions thrown
- Updated return type annotation to `list | dict`

## Changes

- `tether_mcp/tools/write_node_memory.py` — hard enforcement logic
- `tether_mcp/tools/read_context.py` — required conversation_id guard + updated docstring
- `tether_mcp/server.py` — updated tool docstrings to reflect v2 requirements
- `tests/mcp/test_write_node_memory_enforcement.py` — 12 new mock-based tests
- `tests/mcp/test_read_context_enforcement.py` — 10 new mock-based tests
- `tests/tether_mcp/test_server.py` — updated `test_read_context_roots` → `test_read_context_requires_conversation_id` to reflect new behavior

## Test plan

- [ ] All 22 new enforcement tests pass (mock-based, no Postgres required)
- [ ] 471 existing non-Postgres tests pass with zero regressions
- [ ] Postgres CI tests (`tests/db/`, `tests/api/`) — awaiting CI green
- [ ] `write_node_memory` additive-mode enforcement applied (all modes, not just edit/delete)