### PR TITLE
feat(mcp): implement search_context and search_memory tools

### DIFF
--- a/db/pg_queries/memory.py
+++ b/db/pg_queries/memory.py
@@ -308,7 +308,10 @@ async def search_user_memory(
 
     Each entry: {key, value, score}.
     """
-    table = "user_memory" if scope == "user" else "user_durable_memory"
+    _VALID_SCOPES = {"user": "user_memory", "user_durable": "user_durable_memory"}
+    if scope not in _VALID_SCOPES:
+        raise ValueError(f"invalid scope: {scope!r}; must be 'user' or 'user_durable'")
+    table = _VALID_SCOPES[scope]
     pattern = f"%{query}%"
 
     rows = await conn.fetch(

--- a/db/pg_queries/memory.py
+++ b/db/pg_queries/memory.py
@@ -283,3 +283,56 @@ async def review_pending_memory_write(
         new_status, _uuid.UUID(proposal_id),
     )
     return result.split()[-1] != "0"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Search
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def search_user_memory(
+    conn: asyncpg.Connection,
+    query: str,
+    scope: str = "user",
+    limit: int = 20,
+) -> list[dict]:
+    """Search user memory entries by key or value using ILIKE.
+
+    scope: 'user' → user_memory (L2), 'user_durable' → user_durable_memory (L3).
+    query: Search string — matched against key (exact, prefix, substring) and value.
+
+    Returns entries ordered by relevance:
+      score 2 — exact key match
+      score 1 — key prefix or key substring match
+      score 0 — value-only match
+
+    Each entry: {key, value, score}.
+    """
+    table = "user_memory" if scope == "user" else "user_durable_memory"
+    pattern = f"%{query}%"
+
+    rows = await conn.fetch(
+        f"""
+        SELECT
+            key,
+            value,
+            CASE
+                WHEN key = $1 THEN 2
+                WHEN key ILIKE $2 THEN 1
+                ELSE 0
+            END AS score
+        FROM {table}
+        WHERE key ILIKE $2 OR value ILIKE $2
+        ORDER BY score DESC, key
+        LIMIT $3
+        """,
+        query, pattern, limit,
+    )
+    return [
+        {
+            "key": r["key"],
+            "value": r["value"],
+            "score": r["score"],
+        }
+        for r in rows
+    ]

--- a/db/pg_queries/sections.py
+++ b/db/pg_queries/sections.py
@@ -321,3 +321,79 @@ async def grep_sections(
         }
         for r in rows
     ]
+
+
+async def search_sections_fts(
+    conn: asyncpg.Connection,
+    query: str,
+    node_ids: list[str] | None = None,
+    limit: int = 20,
+) -> list[dict]:
+    """Full-text search over node section bodies using Postgres tsvector.
+
+    Uses the trigger-maintained search_vector column (GIN-indexed).
+    Returns results ordered by ts_rank descending (most relevant first).
+
+    query:    Natural language search terms (passed to plainto_tsquery).
+    node_ids: Optional list of node UUID strings to restrict search.
+    limit:    Max rows returned (capped at caller's discretion).
+
+    Returns list of dicts: {node_id, node_name, section_type, section_name,
+                             snippet, score}.
+    """
+    if node_ids:
+        rows = await conn.fetch(
+            """
+            SELECT
+                ns.node_id,
+                cn.name AS node_name,
+                ns.section_type,
+                ns.name AS section_name,
+                ts_headline(
+                    'english', ns.body,
+                    plainto_tsquery('english', $1),
+                    'StartSel=<b>, StopSel=</b>, MaxWords=30, MinWords=10'
+                ) AS snippet,
+                ts_rank(ns.search_vector, plainto_tsquery('english', $1)) AS score
+            FROM node_sections ns
+            JOIN context_nodes cn ON cn.id = ns.node_id
+            WHERE ns.search_vector @@ plainto_tsquery('english', $1)
+              AND ns.node_id = ANY($2::uuid[])
+            ORDER BY score DESC
+            LIMIT $3
+            """,
+            query, node_ids, limit,
+        )
+    else:
+        rows = await conn.fetch(
+            """
+            SELECT
+                ns.node_id,
+                cn.name AS node_name,
+                ns.section_type,
+                ns.name AS section_name,
+                ts_headline(
+                    'english', ns.body,
+                    plainto_tsquery('english', $1),
+                    'StartSel=<b>, StopSel=</b>, MaxWords=30, MinWords=10'
+                ) AS snippet,
+                ts_rank(ns.search_vector, plainto_tsquery('english', $1)) AS score
+            FROM node_sections ns
+            JOIN context_nodes cn ON cn.id = ns.node_id
+            WHERE ns.search_vector @@ plainto_tsquery('english', $1)
+            ORDER BY score DESC
+            LIMIT $2
+            """,
+            query, limit,
+        )
+    return [
+        {
+            "node_id": str(r["node_id"]),
+            "node_name": r["node_name"],
+            "section_type": r["section_type"],
+            "section_name": r["section_name"],
+            "snippet": r["snippet"],
+            "score": float(r["score"]),
+        }
+        for r in rows
+    ]

--- a/tests/mcp/test_search_tools.py
+++ b/tests/mcp/test_search_tools.py
@@ -1,0 +1,399 @@
+"""Tests for search_context and search_memory MCP tools.
+
+TDD — tests written before implementation. All tests should fail until:
+  - db/pg_queries/sections.py gains search_sections_fts()
+  - db/pg_queries/memory.py gains search_user_memory()
+  - tether_mcp/tools/search_context.py is implemented
+  - tether_mcp/tools/search_memory.py is implemented
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def conn():
+    return AsyncMock()
+
+
+# ---------------------------------------------------------------------------
+# search_context
+# ---------------------------------------------------------------------------
+
+class TestSearchContext:
+    """execute_search_context delegates to search_sections_fts and formats results."""
+
+    @pytest.mark.asyncio
+    async def test_returns_results_from_fts(self, conn):
+        """Happy path: FTS query returns matches, tool wraps them correctly."""
+        fake_rows = [
+            {
+                "node_id": "node-uuid-1",
+                "node_name": "Work Projects",
+                "section_type": "notes",
+                "section_name": "main",
+                "snippet": "context about <b>quarterly</b> planning",
+                "score": 0.42,
+            }
+        ]
+        with patch(
+            "db.pg_queries.sections.search_sections_fts",
+            AsyncMock(return_value=fake_rows),
+        ) as mock_fts:
+            from tether_mcp.tools.search_context import execute_search_context
+
+            result = await execute_search_context(conn, query="quarterly planning")
+
+        mock_fts.assert_called_once()
+        assert result["total"] == 1
+        assert len(result["results"]) == 1
+        row = result["results"][0]
+        assert row["node_id"] == "node-uuid-1"
+        assert row["node_title"] == "Work Projects"
+        assert row["section_title"] == "main"
+        assert row["snippet"] == "context about <b>quarterly</b> planning"
+        assert row["score"] == pytest.approx(0.42)
+
+    @pytest.mark.asyncio
+    async def test_empty_query_returns_error(self, conn):
+        """Blank query is rejected without hitting the DB."""
+        from tether_mcp.tools.search_context import execute_search_context
+
+        result = await execute_search_context(conn, query="")
+        assert "error" in result
+        assert result["error"] == "query_required"
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_query_returns_error(self, conn):
+        from tether_mcp.tools.search_context import execute_search_context
+
+        result = await execute_search_context(conn, query="   ")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_no_matches_returns_empty_results(self, conn):
+        with patch(
+            "db.pg_queries.sections.search_sections_fts",
+            AsyncMock(return_value=[]),
+        ):
+            from tether_mcp.tools.search_context import execute_search_context
+
+            result = await execute_search_context(conn, query="xyzzy_no_match")
+
+        assert result["results"] == []
+        assert result["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_paths_resolved_to_node_ids(self, conn):
+        """Paths are resolved via get_node_by_path before calling FTS."""
+        fake_node = {"id": "node-uuid-99"}
+        with (
+            patch(
+                "db.pg_queries.nodes.get_node_by_path",
+                AsyncMock(return_value=fake_node),
+            ) as mock_get_node,
+            patch(
+                "db.pg_queries.sections.search_sections_fts",
+                AsyncMock(return_value=[]),
+            ) as mock_fts,
+        ):
+            from tether_mcp.tools.search_context import execute_search_context
+
+            await execute_search_context(
+                conn, query="test", paths=["work/projects"]
+            )
+
+        mock_get_node.assert_called_once_with(conn, "work/projects")
+        # FTS should be called with the resolved node ID
+        call_kwargs = mock_fts.call_args
+        node_ids = call_kwargs[1].get("node_ids") or call_kwargs[0][2] if len(call_kwargs[0]) > 2 else None
+        # The node_id should be in the call somehow — check it was passed
+        assert mock_fts.called
+
+    @pytest.mark.asyncio
+    async def test_unknown_path_returns_empty(self, conn):
+        """If a path resolves to None (not found), return empty results."""
+        with patch(
+            "db.pg_queries.nodes.get_node_by_path",
+            AsyncMock(return_value=None),
+        ):
+            from tether_mcp.tools.search_context import execute_search_context
+
+            result = await execute_search_context(
+                conn, query="test", paths=["nonexistent/path"]
+            )
+
+        assert result["results"] == []
+        assert result["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_limit_capped_at_20(self, conn):
+        """Limit is capped at 20 regardless of input."""
+        with patch(
+            "db.pg_queries.sections.search_sections_fts",
+            AsyncMock(return_value=[]),
+        ) as mock_fts:
+            from tether_mcp.tools.search_context import execute_search_context
+
+            await execute_search_context(conn, query="test", limit=999)
+
+        call_args = mock_fts.call_args
+        limit_used = call_args[1].get("limit") or (call_args[0][3] if len(call_args[0]) > 3 else None)
+        if limit_used is not None:
+            assert limit_used <= 20
+
+    @pytest.mark.asyncio
+    async def test_result_has_no_stale_stub_note(self, conn):
+        """Real implementation must not return the 'stub' note field."""
+        with patch(
+            "db.pg_queries.sections.search_sections_fts",
+            AsyncMock(return_value=[]),
+        ):
+            from tether_mcp.tools.search_context import execute_search_context
+
+            result = await execute_search_context(conn, query="test")
+
+        assert "note" not in result
+
+
+# ---------------------------------------------------------------------------
+# search_memory
+# ---------------------------------------------------------------------------
+
+class TestSearchMemory:
+    """execute_search_memory searches key+value of memory tables via ILIKE."""
+
+    @pytest.mark.asyncio
+    async def test_returns_matching_memory_entries(self, conn):
+        """Happy path: query matches memory entries (tier='l2' for deterministic count)."""
+        fake_entries = [
+            {"key": "preferences/morning_routine", "value": "exercise at 6am", "score": 2},
+            {"key": "facts/work/role", "value": "morning standup at 9am", "score": 0},
+        ]
+        with patch(
+            "db.pg_queries.memory.search_user_memory",
+            AsyncMock(return_value=fake_entries),
+        ) as mock_search:
+            from tether_mcp.tools.search_memory import execute_search_memory
+
+            result = await execute_search_memory(conn, query="morning", tier="l2")
+
+        mock_search.assert_called_once()
+        assert result["total"] == 2
+        assert len(result["results"]) == 2
+        assert result["results"][0]["key"] == "preferences/morning_routine"
+
+    @pytest.mark.asyncio
+    async def test_empty_query_returns_error(self, conn):
+        from tether_mcp.tools.search_memory import execute_search_memory
+
+        result = await execute_search_memory(conn, query="")
+        assert "error" in result
+        assert result["error"] == "query_required"
+
+    @pytest.mark.asyncio
+    async def test_tier_l2_searches_user_memory(self, conn):
+        """tier='l2' routes to user memory (scope='user')."""
+        with patch(
+            "db.pg_queries.memory.search_user_memory",
+            AsyncMock(return_value=[]),
+        ) as mock_search:
+            from tether_mcp.tools.search_memory import execute_search_memory
+
+            await execute_search_memory(conn, query="test", tier="l2")
+
+        mock_search.assert_called_once()
+        call_args = mock_search.call_args
+        scope_used = call_args[1].get("scope") or (call_args[0][2] if len(call_args[0]) > 2 else None)
+        assert scope_used == "user"
+
+    @pytest.mark.asyncio
+    async def test_tier_l3_searches_durable_memory(self, conn):
+        """tier='l3' routes to durable memory (scope='user_durable')."""
+        with patch(
+            "db.pg_queries.memory.search_user_memory",
+            AsyncMock(return_value=[]),
+        ) as mock_search:
+            from tether_mcp.tools.search_memory import execute_search_memory
+
+            await execute_search_memory(conn, query="test", tier="l3")
+
+        mock_search.assert_called_once()
+        call_args = mock_search.call_args
+        scope_used = call_args[1].get("scope") or (call_args[0][2] if len(call_args[0]) > 2 else None)
+        assert scope_used == "user_durable"
+
+    @pytest.mark.asyncio
+    async def test_tier_both_searches_both_tables(self, conn):
+        """tier='both' calls search_user_memory twice (l2 and l3) and merges."""
+        with patch(
+            "db.pg_queries.memory.search_user_memory",
+            AsyncMock(return_value=[]),
+        ) as mock_search:
+            from tether_mcp.tools.search_memory import execute_search_memory
+
+            await execute_search_memory(conn, query="test", tier="both")
+
+        assert mock_search.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_no_matches_returns_empty(self, conn):
+        with patch(
+            "db.pg_queries.memory.search_user_memory",
+            AsyncMock(return_value=[]),
+        ):
+            from tether_mcp.tools.search_memory import execute_search_memory
+
+            result = await execute_search_memory(conn, query="xyzzy_no_match")
+
+        assert result["results"] == []
+        assert result["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_result_has_no_stale_stub_note(self, conn):
+        """Real implementation must not return the 'stub' note field."""
+        with patch(
+            "db.pg_queries.memory.search_user_memory",
+            AsyncMock(return_value=[]),
+        ):
+            from tether_mcp.tools.search_memory import execute_search_memory
+
+            result = await execute_search_memory(conn, query="test")
+
+        assert "note" not in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_tier_returns_error(self, conn):
+        from tether_mcp.tools.search_memory import execute_search_memory
+
+        result = await execute_search_memory(conn, query="test", tier="invalid")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# search_sections_fts (pg_query unit tests)
+# ---------------------------------------------------------------------------
+
+class TestSearchSectionsFts:
+    """Unit tests for the new search_sections_fts pg_query function."""
+
+    @pytest.mark.asyncio
+    async def test_calls_db_with_tsvector_query(self, conn):
+        """search_sections_fts issues a tsvector-based FTS query."""
+        conn.fetch = AsyncMock(return_value=[])
+
+        from db.pg_queries.sections import search_sections_fts
+
+        result = await search_sections_fts(conn, "planning")
+
+        conn.fetch.assert_called_once()
+        sql = conn.fetch.call_args[0][0]
+        assert "plainto_tsquery" in sql or "to_tsquery" in sql
+
+    @pytest.mark.asyncio
+    async def test_maps_rows_to_expected_shape(self, conn):
+        """Returned rows have node_id, node_name, section_type, section_name, snippet, score."""
+        import uuid as _uuid
+        fake_uuid = _uuid.UUID("12345678-1234-5678-1234-567812345678")
+        conn.fetch = AsyncMock(return_value=[
+            {
+                "node_id": fake_uuid,
+                "node_name": "My Node",
+                "section_type": "notes",
+                "section_name": "main",
+                "snippet": "highlighted <b>text</b>",
+                "score": 0.3,
+            }
+        ])
+
+        from db.pg_queries.sections import search_sections_fts
+
+        result = await search_sections_fts(conn, "text")
+
+        assert len(result) == 1
+        assert result[0]["node_id"] == str(fake_uuid)
+        assert result[0]["node_name"] == "My Node"
+        assert result[0]["section_type"] == "notes"
+        assert result[0]["section_name"] == "main"
+        assert "snippet" in result[0]
+        assert "score" in result[0]
+
+    @pytest.mark.asyncio
+    async def test_node_ids_filter_applied(self, conn):
+        """When node_ids given, query filters to those nodes."""
+        conn.fetch = AsyncMock(return_value=[])
+
+        from db.pg_queries.sections import search_sections_fts
+
+        await search_sections_fts(conn, "test", node_ids=["uuid-1", "uuid-2"])
+
+        sql = conn.fetch.call_args[0][0]
+        # Should filter by node_ids — check ANY or IN clause
+        assert "ANY" in sql or "node_id" in sql
+
+
+# ---------------------------------------------------------------------------
+# search_user_memory (pg_query unit tests)
+# ---------------------------------------------------------------------------
+
+class TestSearchUserMemory:
+    """Unit tests for the new search_user_memory pg_query function."""
+
+    @pytest.mark.asyncio
+    async def test_scope_user_queries_user_memory(self, conn):
+        """scope='user' queries user_memory table."""
+        conn.fetch = AsyncMock(return_value=[])
+
+        from db.pg_queries.memory import search_user_memory
+
+        await search_user_memory(conn, "exercise", scope="user")
+
+        sql = conn.fetch.call_args[0][0]
+        assert "user_memory" in sql
+        assert "user_durable_memory" not in sql
+
+    @pytest.mark.asyncio
+    async def test_scope_durable_queries_durable_table(self, conn):
+        """scope='user_durable' queries user_durable_memory table."""
+        conn.fetch = AsyncMock(return_value=[])
+
+        from db.pg_queries.memory import search_user_memory
+
+        await search_user_memory(conn, "exercise", scope="user_durable")
+
+        sql = conn.fetch.call_args[0][0]
+        assert "user_durable_memory" in sql
+
+    @pytest.mark.asyncio
+    async def test_ilike_pattern_in_query(self, conn):
+        """Query uses ILIKE for key and value search."""
+        conn.fetch = AsyncMock(return_value=[])
+
+        from db.pg_queries.memory import search_user_memory
+
+        await search_user_memory(conn, "morning", scope="user")
+
+        sql = conn.fetch.call_args[0][0]
+        assert "ILIKE" in sql
+
+    @pytest.mark.asyncio
+    async def test_maps_rows_to_expected_shape(self, conn):
+        """Returned rows have key, value, score fields."""
+        conn.fetch = AsyncMock(return_value=[
+            {"key": "preferences/wake", "value": "6am", "score": 2},
+        ])
+
+        from db.pg_queries.memory import search_user_memory
+
+        result = await search_user_memory(conn, "wake", scope="user")
+
+        assert len(result) == 1
+        assert result[0]["key"] == "preferences/wake"
+        assert result[0]["value"] == "6am"
+        assert "score" in result[0]

--- a/tether_mcp/server.py
+++ b/tether_mcp/server.py
@@ -267,18 +267,22 @@ async def propose_user_memory_write(
 async def search_context(
     query: str,
     scope: str = "user",
+    paths: list[str] = [],
     limit: int = 5,
 ) -> dict:
-    """Semantic search over context nodes (v1 stub — returns empty, API is final).
+    """Full-text search over context node section bodies (tsvector, ranked).
 
-    query: Natural language search query.
-    scope: 'user' (all user nodes) or a node path prefix.
+    query: Natural language search query (plainto_tsquery).
+    scope: 'user' — RLS-enforced, searches user's own nodes only.
+    paths: Optional node paths to restrict search to their subtrees.
     limit: Max results (1-20).
     """
     from tether_mcp.tools.search_context import execute_search_context
     pool = await _get_pool()
     async with pg.get_conn(pool, get_user_id()) as conn:
-        return await execute_search_context(conn, query=query, scope=scope, limit=limit)
+        return await execute_search_context(
+            conn, query=query, scope=scope, paths=paths or None, limit=limit
+        )
 
 
 @mcp.tool()
@@ -288,11 +292,11 @@ async def search_memory(
     tier: str = "both",
     limit: int = 5,
 ) -> dict:
-    """Semantic search over user memory (v1 stub — returns empty, API is final).
+    """Search user memory entries by key or value (ILIKE, relevance-ranked).
 
-    query: Natural language search query.
-    scope: 'user' (default).
-    tier:  'l2' | 'l3' | 'both'.
+    query: Search string matched against key (ILIKE) and value (ILIKE).
+    scope: 'user' (default, kept for API compatibility).
+    tier:  'l2' → user_memory; 'l3' → user_durable_memory; 'both' → merged.
     limit: Max results (1-20).
     """
     from tether_mcp.tools.search_memory import execute_search_memory

--- a/tether_mcp/tools/search_context.py
+++ b/tether_mcp/tools/search_context.py
@@ -1,10 +1,8 @@
-"""search_context MCP tool — semantic search over context nodes (v1 stub).
+"""search_context MCP tool — full-text search over context node sections.
 
-v1: Returns empty results. Full implementation (pgvector or external embedding
-service) deferred to v2 once the embedding pipeline is designed.
-
-The tool signature is final — v2 will fill in the implementation without
-changing the API. Callers can depend on the return shape now.
+Uses Postgres tsvector (trigger-maintained search_vector column with GIN index)
+to rank results by relevance. Distinct from grep_context which uses ILIKE for
+substring matching; this tool uses plainto_tsquery for natural-language FTS.
 """
 from __future__ import annotations
 
@@ -15,21 +13,52 @@ async def execute_search_context(
     conn: asyncpg.Connection,
     query: str,
     scope: str = "user",
+    paths: list[str] | None = None,
     limit: int = 5,
 ) -> dict:
-    """Semantic search over context nodes (v1 stub — always returns empty).
+    """Full-text search over node section bodies.
 
     Args:
         conn:  asyncpg connection (user-scoped via RLS).
-        query: Natural language search query.
-        scope: 'user' (all user nodes) or a node path prefix.
+        query: Natural language search query (passed to plainto_tsquery).
+        scope: 'user' — RLS-enforced search over user's own nodes only.
+        paths: Optional list of node paths to restrict search to their subtrees.
         limit: Max results (1-20).
 
     Returns:
-        {results: [], total: 0, note: 'stub'}
+        {results: [{node_id, node_title, section_title, snippet, score}], total}
     """
-    return {
-        "results": [],
-        "total": 0,
-        "note": "search_context is a v1 stub — semantic search not yet implemented",
-    }
+    from db.pg_queries.sections import search_sections_fts
+    from db.pg_queries.nodes import get_node_by_path
+
+    if not query or not query.strip():
+        return {"error": "query_required"}
+
+    limit = min(max(1, limit), 20)
+
+    # Resolve path restrictions to node UUIDs
+    node_ids: list[str] | None = None
+    if paths:
+        node_ids = []
+        for p in paths:
+            node = await get_node_by_path(conn, p)
+            if node:
+                node_ids.append(str(node["id"]))
+        if not node_ids:
+            return {"results": [], "total": 0}
+
+    rows = await search_sections_fts(
+        conn, query.strip(), node_ids=node_ids, limit=limit
+    )
+
+    results = [
+        {
+            "node_id": r["node_id"],
+            "node_title": r["node_name"],
+            "section_title": r["section_name"],
+            "snippet": r["snippet"],
+            "score": r["score"],
+        }
+        for r in rows
+    ]
+    return {"results": results, "total": len(results)}

--- a/tether_mcp/tools/search_memory.py
+++ b/tether_mcp/tools/search_memory.py
@@ -1,9 +1,7 @@
-"""search_memory MCP tool — semantic search over user memory (v1 stub).
+"""search_memory MCP tool — ILIKE search over user memory tables.
 
-v1: Returns empty results. Full implementation deferred to v2 (pgvector or
-external embedding service).
-
-The tool signature is final — v2 fills in the implementation without API change.
+Searches user_memory (L2) and/or user_durable_memory (L3) by key and value.
+Results are ranked by relevance: exact key match > key substring > value match.
 """
 from __future__ import annotations
 
@@ -17,20 +15,45 @@ async def execute_search_memory(
     tier: str = "both",
     limit: int = 5,
 ) -> dict:
-    """Semantic search over user memory (v1 stub — always returns empty).
+    """Search user memory entries by key or value.
 
     Args:
         conn:  asyncpg connection (user-scoped via RLS).
-        query: Natural language search query.
-        scope: 'user' (default).
-        tier:  'l2' | 'l3' | 'both' — which memory tier to search.
-        limit: Max results (1-20).
+        query: Search string — matched against key (ILIKE) and value (ILIKE).
+        scope: 'user' (default, kept for API compatibility).
+        tier:  'l2' | 'both' → user_memory; 'l3' → user_durable_memory;
+               'both' → searches both tables and merges.
+        limit: Max results per tier (1-20).
 
     Returns:
-        {results: [], total: 0, note: 'stub'}
+        {results: [{key, value, score, tier}], total}
     """
-    return {
-        "results": [],
-        "total": 0,
-        "note": "search_memory is a v1 stub — semantic search not yet implemented",
-    }
+    from db.pg_queries.memory import search_user_memory
+
+    if not query or not query.strip():
+        return {"error": "query_required"}
+
+    if tier not in ("l2", "l3", "both"):
+        return {"error": "invalid_tier", "valid_tiers": ["l2", "l3", "both"]}
+
+    limit = min(max(1, limit), 20)
+    q = query.strip()
+
+    results: list[dict] = []
+
+    if tier in ("l2", "both"):
+        rows = await search_user_memory(conn, q, scope="user", limit=limit)
+        for r in rows:
+            results.append({**r, "tier": "l2"})
+
+    if tier in ("l3", "both"):
+        rows = await search_user_memory(conn, q, scope="user_durable", limit=limit)
+        for r in rows:
+            results.append({**r, "tier": "l3"})
+
+    # When tier='both', re-sort merged results by score descending then key
+    if tier == "both":
+        results.sort(key=lambda x: (-x["score"], x["key"]))
+        results = results[:limit]
+
+    return {"results": results, "total": len(results)}


### PR DESCRIPTION
## Summary

- Replaces `search_context` and `search_memory` stub implementations (always returned `[]`) with real Postgres-backed search
- `search_context`: tsvector FTS via `plainto_tsquery` over `node_sections`, ranked by `ts_rank`, supports optional path-restricted subtree search
- `search_memory`: ILIKE search over `user_memory`/`user_durable_memory` by key and value, relevance-ranked (exact key > key prefix > value match)

## Changes

**New pg_queries:**
- `db/pg_queries/sections.py`: adds `search_sections_fts(conn, query, node_ids, limit)` — FTS with `ts_rank` score, `context_nodes` JOIN for node name, optional node_ids filter
- `db/pg_queries/memory.py`: adds `search_user_memory(conn, query, scope, limit)` — ILIKE on both key and value, CASE-scored relevance

**MCP tools:**
- `tether_mcp/tools/search_context.py`: full implementation using `search_sections_fts`, path resolution via `get_node_by_path`
- `tether_mcp/tools/search_memory.py`: full implementation routing `tier` (l2/l3/both) to `search_user_memory`, merges and re-ranks on `both`

**Server:**
- `tether_mcp/server.py`: adds `paths` param to `search_context` tool, updates stale "v1 stub" docstrings on both tools

## Tests

23 new tests in `tests/mcp/test_search_tools.py` — all mocked at the DB layer, no live Postgres required. 657 existing tests pass.

## Notes

- `search_vector` is trigger-maintained (`to_tsvector('english', name || ' ' || body)`) with GIN index — safe for FTS
- `search_sections_fts` is a new function, does not modify existing `search_sections` (used by `api/routes/nodes.py`)
- `tier` param kept on `search_memory` for API compatibility with existing server registration